### PR TITLE
Bug 579635 - NPE in MatchLocator.findIndexMatches(MatchLocator.java:306)

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringSearchEngine2.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringSearchEngine2.java
@@ -674,10 +674,15 @@ public final class RefactoringSearchEngine2 {
 		Assert.isNotNull(elements);
 		Assert.isTrue(elements.length > 0);
 		SearchPattern pattern= SearchPattern.createPattern(elements[0], limitTo, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		Assert.isNotNull(pattern);
 		IJavaElement element= null;
 		for (int index= 1; index < elements.length; index++) {
 			element= elements[index];
-			pattern= SearchPattern.createOrPattern(pattern, SearchPattern.createPattern(element, limitTo, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE));
+			SearchPattern searchPattern= SearchPattern.createPattern(element, limitTo, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			if (searchPattern == null) {
+				continue;
+			}
+			pattern= SearchPattern.createOrPattern(pattern, searchPattern);
 		}
 		setPattern(pattern);
 	}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
@@ -921,7 +921,11 @@ public class InlineConstantRefactoring extends Refactoring {
 	}
 
 	private SearchResultGroup[] findReferences(IProgressMonitor pm, RefactoringStatus status) throws JavaModelException {
-		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(SearchPattern.createPattern(fField, IJavaSearchConstants.REFERENCES));
+		SearchPattern pattern= SearchPattern.createPattern(fField, IJavaSearchConstants.REFERENCES);
+		if (pattern == null) {
+			return new SearchResultGroup[0];
+		}
+		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(pattern);
 		engine.setFiltering(true, true);
 		engine.setScope(RefactoringScopeFactory.create(fField));
 		engine.setStatus(status);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/TargetProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/TargetProvider.java
@@ -452,6 +452,7 @@ public abstract class TargetProvider {
 			Assert.isTrue(method != null);
 
 			SearchPattern pattern= SearchPattern.createPattern(method, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			Assert.isNotNull(pattern);
 			IJavaSearchScope scope= RefactoringScopeFactory.create(method, true, false);
 			final HashSet<ICompilationUnit> affectedCompilationUnits= new HashSet<>();
 			CollectingSearchRequestor requestor= new CollectingSearchRequestor(binaryRefs) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/ConstructorReferenceFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/ConstructorReferenceFinder.java
@@ -181,6 +181,9 @@ public class ConstructorReferenceFinder {
 	private List<SearchMatch> getImplicitConstructorReferencesInClassCreations(WorkingCopyOwner owner, IProgressMonitor pm, RefactoringStatus status) throws JavaModelException {
 		//XXX workaround for jdt core bug 23112
 		SearchPattern pattern= SearchPattern.createPattern(fType, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return List.of();
+		}
 		IJavaSearchScope scope= RefactoringScopeFactory.create(fType);
 		SearchResultGroup[] refs= RefactoringSearchEngine.search(pattern, owner, scope, pm, status);
 		List<SearchMatch> result= new ArrayList<>();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
@@ -551,7 +551,11 @@ public final class MemberVisibilityAdjustor {
 	 * @throws JavaModelException if an error occurs during search
 	 */
 	private SearchResultGroup[] findReferences(final IMember member, final IProgressMonitor monitor) throws JavaModelException {
-		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(SearchPattern.createPattern(member, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE));
+		SearchPattern pattern= SearchPattern.createPattern(member, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return new SearchResultGroup[0];
+		}
+		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(pattern);
 		engine.setOwner(fOwner);
 		engine.setFiltering(true, true);
 		engine.setScope(RefactoringScopeFactory.create(member));

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
@@ -1138,7 +1138,11 @@ public final class MoveInnerToTopRefactoring extends Refactoring {
 	}
 
 	private Map<ICompilationUnit, SearchMatch[]> createTypeReferencesMapping(IProgressMonitor pm, RefactoringStatus status) throws JavaModelException {
-		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(SearchPattern.createPattern(fType, IJavaSearchConstants.ALL_OCCURRENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE));
+		SearchPattern pattern= SearchPattern.createPattern(fType, IJavaSearchConstants.ALL_OCCURRENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return Map.of();
+		}
+		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(pattern);
 		engine.setFiltering(true, true);
 		engine.setScope(RefactoringScopeFactory.create(fType));
 		engine.setStatus(status);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -1540,6 +1540,9 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 			monitor.beginTask("", 1); //$NON-NLS-1$
 			monitor.setTaskName(RefactoringCoreMessages.MoveInstanceMethodProcessor_checking);
 			SearchPattern pattern= SearchPattern.createPattern(fMethod, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			if (pattern == null) {
+				return new SearchResultGroup[0];
+			}
 			IJavaSearchScope scope= RefactoringScopeFactory.create(fMethod, true, false);
 
 			String binaryRefsDescription= Messages.format(RefactoringCoreMessages.ReferencesInBinaryContext_ref_in_binaries_description , BasicElementLabels.getJavaElementName(fMethod.getElementName()));

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveStaticMembersProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveStaticMembersProcessor.java
@@ -631,7 +631,11 @@ public final class MoveStaticMembersProcessor extends MoveProcessor implements I
 	}
 
 	private static SearchResultGroup[] getReferences(IMember member, IProgressMonitor monitor, RefactoringStatus status) throws JavaModelException {
-		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(SearchPattern.createPattern(member, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE));
+		SearchPattern pattern= SearchPattern.createPattern(member, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return new SearchResultGroup[0];
+		}
+		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(pattern);
 		engine.setFiltering(true, true);
 		engine.setScope(RefactoringScopeFactory.create(member));
 		engine.setStatus(status);

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodSelectionDialog.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodSelectionDialog.java
@@ -184,6 +184,9 @@ public class TestMethodSelectionDialog extends ElementListSelectionDialog {
 	private TestReferenceCollector doSearchTestMethods(IJavaElement element, IType testType, IProgressMonitor pm) throws CoreException{
 		int matchRule= SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE | SearchPattern.R_ERASURE_MATCH;
 		SearchPattern pattern= SearchPattern.createPattern(element, IJavaSearchConstants.REFERENCES, matchRule);
+		if (pattern == null) {
+			return new TestReferenceCollector();
+		}
 		SearchParticipant[] participants= new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()};
 		IJavaSearchScope scope= SearchEngine.createHierarchyScope(testType);
 		TestReferenceCollector requestor= new TestReferenceCollector();

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceFactoryRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceFactoryRefactoring.java
@@ -483,7 +483,11 @@ public class IntroduceFactoryRefactoring extends Refactoring {
 	 */
 	private SearchResultGroup[] searchForCallsTo(IMethodBinding methodBinding, IProgressMonitor pm, RefactoringStatus status) throws JavaModelException {
 		IMethod method= (IMethod) methodBinding.getJavaElement();
-		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(createSearchPattern(method, methodBinding));
+		SearchPattern searchPattern= createSearchPattern(method, methodBinding);
+		if (searchPattern == null) {
+			return new SearchResultGroup[0];
+		}
+		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(searchPattern);
 		engine.setFiltering(true, true);
 		engine.setScope(createSearchScope(method, methodBinding));
 		engine.setStatus(status);
@@ -512,6 +516,9 @@ public class IntroduceFactoryRefactoring extends Refactoring {
 
 	private IType findNonPrimaryType(String fullyQualifiedName, IProgressMonitor pm, RefactoringStatus status) throws JavaModelException {
 		SearchPattern p= SearchPattern.createPattern(fullyQualifiedName, IJavaSearchConstants.TYPE, IJavaSearchConstants.DECLARATIONS, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (p == null) {
+			return null;
+		}
 		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(p);
 
 		engine.setFiltering(true, true);

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameFieldProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameFieldProcessor.java
@@ -627,6 +627,9 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 	private RefactoringStatus checkAccessorDeclarations(IProgressMonitor pm, IMethod existingAccessor) throws CoreException{
 		RefactoringStatus result= new RefactoringStatus();
 		SearchPattern pattern= SearchPattern.createPattern(existingAccessor, IJavaSearchConstants.DECLARATIONS, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return result;
+		}
 		IJavaSearchScope scope= SearchEngine.createHierarchyScope(fField.getDeclaringType());
 		SearchResultGroup[] groupDeclarations= RefactoringSearchEngine.search(pattern, scope, pm, result);
 		Assert.isTrue(groupDeclarations.length > 0);
@@ -712,7 +715,11 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 		String binaryRefsDescription= Messages.format(RefactoringCoreMessages.ReferencesInBinaryContext_ref_in_binaries_description , BasicElementLabels.getJavaElementName(getCurrentElementName()));
 		ReferencesInBinaryContext binaryRefs= new ReferencesInBinaryContext(binaryRefsDescription);
 
-		SearchResultGroup[] result= RefactoringSearchEngine.search(createSearchPattern(), createRefactoringScope(),
+		SearchPattern searchPattern= createSearchPattern();
+		if (searchPattern == null) {
+			return new SearchResultGroup[0];
+		}
+		SearchResultGroup[] result= RefactoringSearchEngine.search(searchPattern, createRefactoringScope(),
 				new CuCollectingSearchRequestor(binaryRefs), pm, status);
 		binaryRefs.addErrorIfNecessary(status);
 		result= filterAccessorMethods(result, true);
@@ -975,6 +982,9 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 
 		IJavaSearchScope scope= RefactoringScopeFactory.create(accessor);
 		SearchPattern pattern= SearchPattern.createPattern(accessor, IJavaSearchConstants.ALL_OCCURRENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return;
+		}
 		SearchResultGroup[] groupedResults= RefactoringSearchEngine.search(
 			pattern, scope, new MethodOccurenceCollector(accessor.getElementName()), pm, status);
 
@@ -1017,7 +1027,11 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 		String binaryRefsDescription= Messages.format(RefactoringCoreMessages.ReferencesInBinaryContext_ref_in_binaries_description , BasicElementLabels.getJavaElementName(getCurrentElementName()));
 		ReferencesInBinaryContext binaryRefs= new ReferencesInBinaryContext(binaryRefsDescription);
 
-		SearchResultGroup[] result= RefactoringSearchEngine.search(createSearchPattern(), scope,
+		SearchPattern searchPattern= createSearchPattern();
+		if (searchPattern == null) {
+			return;
+		}
+		SearchResultGroup[] result= RefactoringSearchEngine.search(searchPattern, scope,
 				new CuCollectingSearchRequestor(binaryRefs), pm, status);
 		binaryRefs.addErrorIfNecessary(status);
 		result= filterAccessorMethods(result, false);
@@ -1115,6 +1129,9 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 			requestor= new CollectingSearchRequestor();
 
 		SearchPattern newPattern= SearchPattern.createPattern(field, IJavaSearchConstants.REFERENCES);
+		if (newPattern == null) {
+			return new SearchResultGroup[0];
+		}
 		IJavaSearchScope scope= RefactoringScopeFactory.create(fField, true, true);
 		return RefactoringSearchEngine.search(newPattern, owner, scope, requestor, new SubProgressMonitor(pm, 1), status);
 	}

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
@@ -446,6 +446,9 @@ public abstract class RenameMethodProcessor extends JavaRenameProcessor implemen
 	private IMethod[] searchForDeclarationsOfClashingMethods(IProgressMonitor pm) throws CoreException {
 		final List<IMethod> results= new ArrayList<>();
 		SearchPattern pattern= createNewMethodPattern();
+		if (pattern == null) {
+			return new IMethod[0];
+		}
 		IJavaSearchScope scope= RefactoringScopeFactory.create(getMethod().getJavaProject());
 		SearchRequestor requestor= new SearchRequestor() {
 			@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameModuleProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameModuleProcessor.java
@@ -311,6 +311,9 @@ public class RenameModuleProcessor extends JavaRenameProcessor implements IRefer
 		CollectingSearchRequestor requestor= new CollectingSearchRequestor();
 
 		SearchPattern newPattern= SearchPattern.createPattern(module, IJavaSearchConstants.REFERENCES);
+		if (newPattern == null) {
+			return new SearchResultGroup[0];
+		}
 		IJavaSearchScope scope= RefactoringScopeFactory.create(fModule, true, true);
 		return RefactoringSearchEngine.search(newPattern, owner, scope, requestor, new SubProgressMonitor(pm, 1), status);
 	}
@@ -438,7 +441,11 @@ public class RenameModuleProcessor extends JavaRenameProcessor implements IRefer
 		String binaryRefsDescription= Messages.format(RefactoringCoreMessages.ReferencesInBinaryContext_ref_in_binaries_description , BasicElementLabels.getJavaElementName(getCurrentElementName()));
 		ReferencesInBinaryContext binaryRefs= new ReferencesInBinaryContext(binaryRefsDescription);
 
-		SearchResultGroup[] result= RefactoringSearchEngine.search(createSearchPattern(), createRefactoringScope(),
+		SearchPattern searchPattern= createSearchPattern();
+		if (searchPattern == null) {
+			return new SearchResultGroup[0];
+		}
+		SearchResultGroup[] result= RefactoringSearchEngine.search(searchPattern, createRefactoringScope(),
 				new CuCollectingSearchRequestor(binaryRefs), pm, status);
 		binaryRefs.addErrorIfNecessary(status);
 		return result;

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenamePackageProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenamePackageProcessor.java
@@ -736,6 +736,9 @@ public class RenamePackageProcessor extends JavaRenameProcessor implements
 		private SearchResultGroup[] getReferences(IProgressMonitor pm, ReferencesInBinaryContext binaryRefs, RefactoringStatus status) throws CoreException {
 			IJavaSearchScope scope= RefactoringScopeFactory.create(fPackage, true, false);
 			SearchPattern pattern= SearchPattern.createPattern(fPackage, IJavaSearchConstants.REFERENCES);
+			if (pattern == null) {
+				return new SearchResultGroup[0];
+			}
 			CollectingSearchRequestor requestor= new CuCollectingSearchRequestor(binaryRefs);
 			return RefactoringSearchEngine.search(pattern, scope, requestor, pm, status);
 		}
@@ -902,7 +905,9 @@ public class RenamePackageProcessor extends JavaRenameProcessor implements
 		 */
 		private IPackageFragment[] getNamesakePackages(IJavaSearchScope scope, IProgressMonitor pm) throws CoreException {
 			SearchPattern pattern= SearchPattern.createPattern(fPackage.getElementName(), IJavaSearchConstants.PACKAGE, IJavaSearchConstants.DECLARATIONS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
-
+			if (pattern == null) {
+				return new IPackageFragment[0];
+			}
 			final HashSet<IPackageFragment> packageFragments= new HashSet<>();
 			SearchRequestor requestor= new SearchRequestor() {
 				@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
@@ -616,6 +616,7 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 
 		try {
 			SearchPattern pattern= SearchPattern.createPattern(fType, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			Assert.isNotNull(pattern);
 
 			String binaryRefsDescription= Messages.format(RefactoringCoreMessages.ReferencesInBinaryContext_ref_in_binaries_description , BasicElementLabels.getJavaElementName(fType.getElementName()));
 			ReferencesInBinaryContext binaryRefs= new ReferencesInBinaryContext(binaryRefsDescription);
@@ -981,6 +982,9 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 		IJavaSearchScope scope= RefactoringScopeFactory.create(fType);
 		SearchPattern pattern= SearchPattern.createPattern(getNewElementName(),
 				IJavaSearchConstants.TYPE, IJavaSearchConstants.ALL_OCCURRENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return result;
+		}
 		ICompilationUnit[] cusWithReferencesToConflictingTypes= RefactoringSearchEngine.findAffectedCompilationUnits(pattern, scope, pm, result);
 		if (cusWithReferencesToConflictingTypes.length == 0)
 			return result;

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RippleMethodFinder2.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RippleMethodFinder2.java
@@ -453,6 +453,9 @@ public class RippleMethodFinder2 {
 		int limitTo= IJavaSearchConstants.DECLARATIONS | IJavaSearchConstants.IGNORE_DECLARING_TYPE | IJavaSearchConstants.IGNORE_RETURN_TYPE;
 		int matchRule= SearchPattern.R_ERASURE_MATCH | SearchPattern.R_CASE_SENSITIVE;
 		SearchPattern pattern= SearchPattern.createPattern(fMethod, limitTo, matchRule);
+		if (pattern == null) {
+			return;
+		}
 		SearchParticipant[] participants= SearchUtils.getDefaultSearchParticipants();
 		IJavaSearchScope scope;
 		if (fSearchOnlyInCompilationUnit) {

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/CreateCopyOfCompilationUnitChange.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/CreateCopyOfCompilationUnitChange.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchPattern;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.refactoring.IRefactoringSearchRequestor;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringSearchEngine;
@@ -55,7 +56,6 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 public final class CreateCopyOfCompilationUnitChange extends CreateTextFileChange {
 
@@ -80,6 +80,9 @@ public final class CreateCopyOfCompilationUnitChange extends CreateTextFileChang
 
 	private static SearchPattern createSearchPattern(IType type) throws JavaModelException {
 		SearchPattern pattern= SearchPattern.createPattern(type, IJavaSearchConstants.ALL_OCCURRENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return null;
+		}
 		IMethod[] constructors= JavaElementUtil.getAllConstructors(type);
 		if (constructors.length == 0)
 			return pattern;
@@ -105,6 +108,9 @@ public final class CreateCopyOfCompilationUnitChange extends CreateTextFileChang
 		if (type == null)
 			return null;
 		SearchPattern pattern= createSearchPattern(type);
+		if (pattern == null) {
+			return null;
+		}
 		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(pattern);
 		engine.setScope(scope);
 		engine.setWorkingCopies(copies);

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/sef/SelfEncapsulateFieldRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/sef/SelfEncapsulateFieldRefactoring.java
@@ -357,8 +357,12 @@ public class SelfEncapsulateFieldRefactoring extends Refactoring {
 			return result;
 		pm.setTaskName(RefactoringCoreMessages.SelfEncapsulateField_searching_for_cunits);
 		final SubProgressMonitor subPm= new SubProgressMonitor(pm, 5);
+		SearchPattern pattern= SearchPattern.createPattern(fField, IJavaSearchConstants.REFERENCES);
+		if (pattern == null) {
+			return result;
+		}
 		ICompilationUnit[] affectedCUs= RefactoringSearchEngine.findAffectedCompilationUnits(
-			SearchPattern.createPattern(fField, IJavaSearchConstants.REFERENCES),
+			pattern,
 			RefactoringScopeFactory.create(fField, fConsiderVisibility),
 			subPm,
 			result, true);

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeSignatureProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeSignatureProcessor.java
@@ -1571,7 +1571,13 @@ public class ChangeSignatureProcessor extends RefactoringProcessor implements ID
 
 //			SearchPattern occPattern= SearchPattern.createPattern(fMethod, IJavaSearchConstants.ALL_OCCURRENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
 			SearchPattern declPattern= SearchPattern.createPattern(fMethod, IJavaSearchConstants.DECLARATIONS, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			if (declPattern == null) {
+				return new SearchResultGroup[0];
+			}
 			SearchPattern refPattern= SearchPattern.createPattern(fMethod, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			if (refPattern == null) {
+				return new SearchResultGroup[0];
+			}
 //			pattern= SearchPattern.createOrPattern(declPattern, refPattern);
 //			pattern= occPattern;
 

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeTypeRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeTypeRefactoring.java
@@ -1571,6 +1571,10 @@ public class ChangeTypeRefactoring extends Refactoring {
 			}
 			SearchPattern pattern= SearchPattern.createPattern(
 					iField, IJavaSearchConstants.ALL_OCCURRENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			if (pattern == null) {
+				fAffectedUnits = new ICompilationUnit[0];
+				return fAffectedUnits;
+			}
 			IJavaSearchScope scope= RefactoringScopeFactory.create(iField);
 			CollectingSearchRequestor csr= new CollectingSearchRequestor();
 			SearchResultGroup[] groups=

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/HierarchyProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/HierarchyProcessor.java
@@ -666,7 +666,11 @@ public abstract class HierarchyProcessor extends SuperTypeRefactoringProcessor {
 
 	protected boolean hasNonMovedReferences(final IMember member, final IProgressMonitor monitor, final RefactoringStatus status) throws JavaModelException {
 		if (!fCachedMembersReferences.containsKey(member)) {
-			final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(SearchPattern.createPattern(member, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE));
+			SearchPattern pattern= SearchPattern.createPattern(member, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			if (pattern == null) {
+				return false;
+			}
+			final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(pattern);
 			engine.setFiltering(true, true);
 			engine.setStatus(status);
 			engine.setOwner(fOwner);

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
@@ -301,8 +301,12 @@ public final class PushDownRefactoringProcessor extends HierarchyProcessor {
 
 	private static IJavaElement[] getReferencingElementsFromSameClass(IMember member, IProgressMonitor pm, RefactoringStatus status) throws JavaModelException {
 		Assert.isNotNull(member);
-		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(SearchPattern.createPattern(member,
-				IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE));
+		SearchPattern pattern= SearchPattern.createPattern(member,
+				IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+		if (pattern == null) {
+			return new IJavaElement[0];
+		}
+		final RefactoringSearchEngine2 engine= new RefactoringSearchEngine2(pattern);
 		engine.setFiltering(true, true);
 		IType declaringType= member.getDeclaringType();
 		engine.setScope(SearchEngine.createJavaSearchScope(new IJavaElement[] { declaringType }));

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeRefactoringProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeRefactoringProcessor.java
@@ -597,7 +597,11 @@ public abstract class SuperTypeRefactoringProcessor extends RefactoringProcessor
 			engine.setFiltering(true, true);
 			engine.setStatus(status);
 			engine.setScope(RefactoringScopeFactory.create(type));
-			engine.setPattern(SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE));
+			SearchPattern pattern= SearchPattern.createPattern(type, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+			if (pattern == null) {
+				return Map.of();
+			}
+			engine.setPattern(pattern);
 			engine.searchPattern(new SubProgressMonitor(monitor, 100));
 			@SuppressWarnings("unchecked")
 			Map<IJavaProject, Set<SearchResultGroup>> result= (Map<IJavaProject, Set<SearchResultGroup>>) engine.getAffectedProjects();

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchQuery.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchQuery.java
@@ -40,6 +40,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSRefactoring;
 import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
@@ -48,7 +49,6 @@ import org.eclipse.jdt.ui.JavaElementLabels;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaUIStatus;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 
 public class NLSSearchQuery implements ISearchQuery {
@@ -86,6 +86,9 @@ public class NLSSearchQuery implements ISearchQuery {
 					return JavaUIStatus.createError(0, Messages.format(NLSSearchMessages.NLSSearchQuery_propertiesNotExists, BasicElementLabels.getResourceName(propertieFile)), null);
 
 				SearchPattern pattern= SearchPattern.createPattern(wrapperClass, IJavaSearchConstants.REFERENCES, SearchUtils.GENERICS_AGNOSTIC_MATCH_RULE);
+				if (pattern == null) {
+					continue;
+				}
 				SearchParticipant[] participants= new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()};
 
 				NLSSearchResultRequestor requestor= new NLSSearchResultRequestor(propertieFile, fResult);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaReferenceCodeMining.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaReferenceCodeMining.java
@@ -140,6 +140,9 @@ public class JavaReferenceCodeMining extends AbstractJavaElementLineHeaderCodeMi
 		}
 		final AtomicLong count= new AtomicLong(0);
 		SearchPattern pattern= SearchPattern.createPattern(element, IJavaSearchConstants.REFERENCES);
+		if (pattern == null) {
+			return 0;
+		}
 		SearchEngine engine= new SearchEngine();
 		final boolean ignoreInaccurate= NewSearchUI.arePotentialMatchesIgnored();
 		engine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
@@ -180,6 +183,9 @@ public class JavaReferenceCodeMining extends AbstractJavaElementLineHeaderCodeMi
 		}
 		final SearchMatch[] matches= new SearchMatch[1];
 		SearchPattern pattern= SearchPattern.createPattern(element, IJavaSearchConstants.REFERENCES);
+		if (pattern == null) {
+			return null;
+		}
 		SearchEngine engine= new SearchEngine();
 		engine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
 				createSourceSearchScope(), new SearchRequestor() {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/DefaultModulepathFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/DefaultModulepathFixProcessor.java
@@ -87,6 +87,9 @@ public class DefaultModulepathFixProcessor extends DefaultClasspathFixProcessor 
 		};
 		SearchPattern searchPattern= SearchPattern.createPattern(name, IJavaSearchConstants.MODULE, IJavaSearchConstants.DECLARATIONS,
 				SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+		if (searchPattern == null) {
+			return;
+		}
 		SearchParticipant[] participants= new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() };
 		try {
 			new SearchEngine().search(searchPattern, participants, scope, requestor, null);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ModuleCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ModuleCorrectionsSubProcessor.java
@@ -212,6 +212,9 @@ public class ModuleCorrectionsSubProcessor {
 
 		SearchPattern searchPattern= SearchPattern.createPattern(node.getFullyQualifiedName(), IJavaSearchConstants.MODULE, IJavaSearchConstants.DECLARATIONS,
 				SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+		if (searchPattern == null) {
+			return;
+		}
 		SearchParticipant[] participants= new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() };
 		try {
 			new SearchEngine().search(searchPattern, participants, scope, requestor, null);


### PR DESCRIPTION
SearchPattern.createPattern() can return null pattern if the input is
not valid. So don't pass null patterns down to the Search engine, it
doesn't like that.