### PR TITLE
remove unused import

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/TokenScanner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/TokenScanner.java
@@ -31,8 +31,6 @@ import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.core.manipulation.JavaManipulation;
 
-import org.eclipse.jdt.internal.corext.dom.TokenScanner;
-
 /**
  * Wraps a scanner and offers convenient methods for finding tokens
  */


### PR DESCRIPTION
Unfortunately eclipse is unable to detect unused import if the import
references the class itself. The "organize imports" is able to find it
thought.