### PR TITLE
Bug 99622 - [rename] Rename method misses ambiguously overridden method

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/RenameLinkedMode.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/RenameLinkedMode.java
@@ -280,7 +280,10 @@ public class RenameLinkedMode {
 				if (javaElement instanceof IMethod) {
 					IMethod[] relatedMethods= RippleMethodFinder2.getRelatedMethodsInCompilationUnit((IMethod) javaElement, new NullProgressMonitor(), null);
 					for (IMethod iMethod : relatedMethods) {
-						sameNodes.add(NodeFinder.perform(root, iMethod.getNameRange()));
+						ASTNode n= NodeFinder.perform(root, iMethod.getNameRange());
+						if (n != null) {
+							sameNodes.add(n);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- add null check to prevent NPE in TreeSet comparator