### PR TITLE
Fix indentation of Text Block

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/IndentActionTest15.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/IndentActionTest15.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2005, 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.text.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ListResourceBundle;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestName;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.text.tests.performance.EditorTestHelper;
+import org.eclipse.jdt.text.tests.performance.ResourceTestHelper;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.source.SourceViewer;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+
+import org.eclipse.jdt.internal.ui.actions.IndentAction;
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
+
+/**
+ *
+ * @since 3.2
+ */
+public class IndentActionTest15 {
+	@Rule
+	public TestName tn= new TestName();
+
+	private static final String PROJECT= "IndentTests";
+
+	private final static class IndentTestSetup extends ExternalResource {
+		private IJavaProject fJavaProject;
+
+		@Override
+		protected void before() throws Exception {
+			fJavaProject= EditorTestHelper.createJavaProject15(PROJECT, "testResources/indentation15");
+			fJavaProject.setOption(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);
+			fJavaProject.setOption(DefaultCodeFormatterConstants.FORMATTER_INDENT_EMPTY_LINES, DefaultCodeFormatterConstants.FALSE);
+			fJavaProject.setOption(DefaultCodeFormatterConstants.FORMATTER_NEVER_INDENT_BLOCK_COMMENTS_ON_FIRST_COLUMN, DefaultCodeFormatterConstants.TRUE);
+			fJavaProject.setOption(DefaultCodeFormatterConstants.FORMATTER_NEVER_INDENT_LINE_COMMENTS_ON_FIRST_COLUMN, DefaultCodeFormatterConstants.TRUE);
+		}
+
+		@Override
+		protected void after () {
+			if (fJavaProject != null)
+				try {
+					JavaProjectHelper.delete(fJavaProject);
+				} catch (CoreException e) {
+					e.printStackTrace();
+				}
+		}
+
+		public IJavaProject getProject() {
+			IProject project= ResourcesPlugin.getWorkspace().getRoot().getProject(PROJECT);
+			return JavaCore.create(project);
+		}
+	}
+
+	private static final class EmptyBundle extends ListResourceBundle {
+		@Override
+		protected Object[][] getContents() {
+			return new Object[0][];
+		}
+	}
+
+	@Rule
+	public IndentTestSetup indentTestSetup=new IndentTestSetup();
+
+	private JavaEditor fEditor;
+	private SourceViewer fSourceViewer;
+	private IDocument fDocument;
+
+	@Before
+	public void setUp() throws Exception {
+		String filename= createFileName("Before");
+		fEditor= (JavaEditor) EditorTestHelper.openInEditor(ResourceTestHelper.findFile(filename), true);
+		fSourceViewer= EditorTestHelper.getSourceViewer(fEditor);
+		fDocument= fSourceViewer.getDocument();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		EditorTestHelper.closeEditor(fEditor);
+		fEditor= null;
+		fSourceViewer= null;
+	}
+
+	private void assertIndentResult() throws Exception {
+		String afterFile= createFileName("Modified");
+		String expected= ResourceTestHelper.read(afterFile).toString();
+
+		new IndentAction(new EmptyBundle(), "prefix", fEditor, false).run();
+
+		assertEquals(expected, fDocument.get());
+	}
+
+	private String createFileName(String qualifier) {
+		String name= tn.getMethodName();
+		name= name.substring(4, 5).toLowerCase() + name.substring(5);
+		return "/" + PROJECT + "/src/" + name + "/" + qualifier + ".java";
+	}
+
+	private void selectAll() {
+		fSourceViewer.setSelectedRange(0, fDocument.getLength());
+	}
+
+
+	@Test
+	public void testIssue30_1() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_BY_ONE));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+
+	@Test
+	public void testIssue30_2() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_DEFAULT));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+
+	@Test
+	public void testIssue30_3() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_ON_COLUMN));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+
+	@Test
+	public void testIssue30_4() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_PRESERVE));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/EditorTestHelper.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/EditorTestHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -443,6 +443,26 @@ public class EditorTestHelper {
 	public static IJavaProject createJavaProject(String project, String externalSourceFolder, boolean linkSourceFolder) throws CoreException, JavaModelException {
 		IJavaProject javaProject= JavaProjectHelper.createJavaProject(project, "bin");
 		Assert.assertNotNull("JRE is null", JavaProjectHelper.addRTJar(javaProject));
+		IFolder folder;
+		if (linkSourceFolder)
+			folder= ResourceHelper.createLinkedFolder((IProject) javaProject.getUnderlyingResource(), new Path("src"), JdtTextTestPlugin.getDefault(), new Path(externalSourceFolder));
+		else {
+			folder= ((IProject) javaProject.getUnderlyingResource()).getFolder("src");
+			importFilesFromDirectory(FileTool.getFileInPlugin(JdtTextTestPlugin.getDefault(), new Path(externalSourceFolder)), folder.getFullPath(), null);
+		}
+		Assert.assertNotNull(folder);
+		Assert.assertTrue(folder.exists());
+		JavaProjectHelper.addSourceContainer(javaProject, "src");
+		return javaProject;
+	}
+
+	public static IJavaProject createJavaProject15(String project, String externalSourceFolder) throws CoreException, JavaModelException {
+		return createJavaProject15(project, externalSourceFolder, false);
+	}
+
+	public static IJavaProject createJavaProject15(String project, String externalSourceFolder, boolean linkSourceFolder) throws CoreException, JavaModelException {
+		IJavaProject javaProject= JavaProjectHelper.createJavaProject(project, "bin");
+		Assert.assertNotNull("JRE is null", JavaProjectHelper.addRTJar_15(javaProject, true));
 		IFolder folder;
 		if (linkSourceFolder)
 			folder= ResourceHelper.createLinkedFolder((IProject) javaProject.getUnderlyingResource(), new Path("src"), JdtTextTestPlugin.getDefault(), new Path(externalSourceFolder));

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_1/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_1/Before.java
@@ -1,0 +1,10 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = """
+				This is a text block
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_1/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_1/Modified.java
@@ -1,0 +1,10 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = """
+			This is a text block
+			   with an indent
+			""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_2/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_2/Before.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = """
+				This is a text block
+				
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_2/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_2/Modified.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = """
+				This is a text block
+
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_3/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_3/Before.java
@@ -1,0 +1,10 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = """
+				This is a text block
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_3/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_3/Modified.java
@@ -1,0 +1,10 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = """
+					This is a text block
+					   with an indent
+					""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_4/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_4/Before.java
@@ -1,0 +1,10 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = """
+				This is a text block
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_4/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue30_4/Modified.java
@@ -1,0 +1,10 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = """
+This is a text block
+   with an indent
+""";
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMultiLineStringAutoIndentStrategy.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMultiLineStringAutoIndentStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -60,7 +60,7 @@ public class JavaMultiLineStringAutoIndentStrategy extends JavaStringAutoIndentS
 		boolean isTextBlock= JavaModelUtil.is15OrHigher(fProject) && fullStr.endsWith(IndentAction.TEXT_BLOCK_STR);
 		boolean isLineDelimiter= isLineDelimiter(document, command.text);
 		if (isEditorWrapStrings() && isLineDelimiter && isTextBlock) {
-			indentation= IndentAction.getTextBlockIndentationString(document, command.offset, command.offset, fProject);
+			indentation= IndentAction.getTextBlockIndentationString(document, command.offset, command.offset, -1, fProject);
 			if (hasTextBlockEnded) {
 				command.text= command.text + indentation;
 			} else {
@@ -68,7 +68,7 @@ public class JavaMultiLineStringAutoIndentStrategy extends JavaStringAutoIndentS
 				if (isCloseStringsPreferenceSet(fProject)) {
 					command.caretOffset= command.offset + command.text.length();
 					command.shiftsCaret= false;
-					command.text= command.text + System.lineSeparator() + IndentAction.getTextBlockIndentationString(document, offset, command.offset, fProject) + IndentAction.TEXT_BLOCK_STR;
+					command.text= command.text + System.lineSeparator() + IndentAction.getTextBlockIndentationString(document, offset, command.offset, 0, fProject) + IndentAction.TEXT_BLOCK_STR;
 				}
 			}
 		} else if (command.text.length() > 1 && !isLineDelimiter && isEditorEscapeStrings()) {


### PR DESCRIPTION
- fixes #30
- Text block indentation affects the final string and each line
  is considered in relation to the minimum indentation used so
  this relative indentation for lines that are more indented than
  the minimum must be preserved across indentation strategies
- added a class to store Text block info across multiple lines
  and pass this across calls in IndentAction when indenting lines
- changed IndentAction.getTextBlockIndentationString() to add any
  additional indentation for the line if it has indentation past
  the minimum for the text block
- added new IndentActionTest15