### PR TITLE
[dogfooding] Apply new Combine declaration and init removing overriding

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filtertable/FilterManager.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filtertable/FilterManager.java
@@ -48,7 +48,6 @@ public class FilterManager {
 	}
 
 	public Filter[] getAllStoredFilters(IPreferenceStore store, boolean defaults) {
-		Filter[] filters = null;
 		String[] activefilters, inactivefilters;
 		if (defaults) {
 			activefilters = getDefaultActiveFilters(store);
@@ -57,7 +56,7 @@ public class FilterManager {
 			activefilters = getActiveList(store);
 			inactivefilters = getInactiveList(store);
 		}
-		filters = new Filter[activefilters.length + inactivefilters.length];
+		Filter[] filters = new Filter[activefilters.length + inactivefilters.length];;
 		for (int i = 0; i < activefilters.length; i++) {
 			filters[i] = new Filter(activefilters[i], true);
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -801,8 +801,7 @@ public class LocalCorrectionsSubProcessor {
 				return;
 			}
 			Type type= vds.getType();
-			ITypeBinding binding= null;
-			binding= type == null ? null : type.resolveBinding();
+			ITypeBinding binding= type == null ? null : type.resolveBinding();
 			if (binding == null) {
 				return;
 			}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -2181,8 +2181,6 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 			return true;
 		}
 
-		// statement is VariableDeclarationStatement
-		Statement newStatement= null;
 		int insertIndex= list.indexOf(statement);
 		ITypeBinding binding= fragment.getInitializer().resolveTypeBinding();
 		Expression placeholder= (Expression) rewrite.createMoveTarget(fragment.getInitializer());
@@ -2204,7 +2202,8 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		assignment.setRightHandSide(placeholder);
 		assignment.setLeftHandSide(ast.newSimpleName(fragment.getName().getIdentifier()));
 
-		newStatement= ast.newExpressionStatement(assignment);
+		// statement is VariableDeclarationStatement
+		Statement newStatement= ast.newExpressionStatement(assignment);;
 		insertIndex+= 1; // add after declaration
 
 		if (isVarType) {


### PR DESCRIPTION
assignment cleanup on JDT UI

To ensure that new JDT cleanups are stable and work as intended we
should apply them to the Eclipse code base. This change uses the changes
from Bug 572440 on the jdt ui plug-in