### PR TITLE
Remove overridden assignment can result in two semicolons

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -17444,6 +17444,7 @@ public class CleanUpTest extends CleanUpTestCase {
 
 		enable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT);
 		disable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL);
+		disable(CleanUpConstants.REMOVE_REDUNDANT_SEMICOLONS);
 
 		String output= "" //
 				+ "package test1;\n" //
@@ -17482,6 +17483,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { output },
 				new HashSet<>(Arrays.asList(MultiFixMessages.OverriddenAssignmentCleanUp_description)));
 		enable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL);
+		disable(CleanUpConstants.REMOVE_REDUNDANT_SEMICOLONS);
 
 		output= "" //
 				+ "package test1;\n" //

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
@@ -200,7 +200,7 @@ public class OverriddenAssignmentCleanUp extends AbstractMultiFix {
 				var copy= rewrite.createCopyTarget(this.overridingAssignment.getRightHandSide());
 				rewrite.replace(fragment.getInitializer(), copy , group);
 				copy= rewrite.createCopyTarget(declaration);
-				rewrite.replace(overridingAssignment, copy, group);
+				rewrite.replace(overridingAssignment.getParent(), copy, group);
 				rewrite.remove(declaration, group);
 			} else {
 				rewrite.remove(fragment.getInitializer(), group);


### PR DESCRIPTION
- Fixes #36
- fix OverriddenAssignmentCleanUp.OverriddenAssignmentOperation
  to replace the ExpressionStatement with the new VarDeclaration
  statement instead of replacing the assignment which is just
  an expression
- disable removing of redundant semicolons in the CleanUpTest test
  so it verifies no additional semicolons are added