### PR TITLE
Bug 514816 - [type wizards] Better validation for Enums and Annotations

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
@@ -229,6 +229,7 @@ public final class NewWizardMessages extends NLS {
 	public static String NewAnnotationWizardPage_add_target;
 	public static String NewAnnotationWizardPage_title;
 	public static String NewAnnotationWizardPage_description;
+	public static String NewAnnotationWizardPage_error_invalidTypeParameters;
 
 	public static String JavaCapabilityConfigurationPage_title;
 	public static String JavaCapabilityConfigurationPage_description;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
@@ -231,6 +231,7 @@ NewAnnotationWizardPage_add_retention=Add @&Retention:
 NewAnnotationWizardPage_add_target=Add @T&arget:
 NewAnnotationWizardPage_title=Annotation Type
 NewAnnotationWizardPage_description=Create a new annotation type.
+NewAnnotationWizardPage_error_invalidTypeParameters=Specifying type parameters for an annotation is illegal
 
 # ------- JavaCapabilityConfigurationPage -------
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewAnnotationWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewAnnotationWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corporation and others.
+ * Copyright (c) 2004, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -48,6 +48,7 @@ import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
+import org.eclipse.jdt.internal.ui.dialogs.StatusInfo;
 import org.eclipse.jdt.internal.ui.wizards.NewWizardMessages;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.DialogField;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.SelectionButtonDialogField;
@@ -166,6 +167,30 @@ public class NewAnnotationWizardPage extends NewTypeWizardPage {
 		doStatusUpdate();
 	}
 
+	private String getTypeNameWithoutParameters(String typeNameWithParameters) {
+		int angleBracketOffset= typeNameWithParameters.indexOf('<');
+		if (angleBracketOffset == -1) {
+			return typeNameWithParameters;
+		} else {
+			return typeNameWithParameters.substring(0, angleBracketOffset);
+		}
+	}
+
+	/**
+	 * @since 3.26
+	 */
+	@Override
+	protected IStatus typeNameChanged() {
+		StatusInfo status= new StatusInfo();
+
+		String typeName= getTypeName();
+
+		if (!typeName.isEmpty() && typeName != getTypeNameWithoutParameters(typeName)) {
+			status.setError(NewWizardMessages.NewAnnotationWizardPage_error_invalidTypeParameters);
+			return status;
+		}
+		return super.typeNameChanged();
+	}
 
 	// ------ UI --------
 


### PR DESCRIPTION
  - add override for typeNameChanged() method in NewAnnotationWizardPage
    to ensure that user does not specify type parameters for annotation