### PR TITLE
NPE in ChainCompletionProposalComputer using CompletionProposalCollector

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/ChainCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/ChainCompletionProposalComputer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010, 2020 Darmstadt University of Technology and others
+ * Copyright (c) 2010, 2022 Darmstadt University of Technology and others
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -83,6 +83,9 @@ public class ChainCompletionProposalComputer implements IJavaCompletionProposalC
 		}
 
 		ctx= (JavaContentAssistInvocationContext) context;
+		if (ctx.getCompilationUnit() == null) {
+			return false;
+		}
 		collector= new CompletionProposalCollector(ctx.getCompilationUnit());
 		collector.setInvocationContext(ctx);
 		ICompilationUnit cu= ctx.getCompilationUnit();


### PR DESCRIPTION
- fixes #45
- add check in ChainCompletionProposalComputer.initializeRequiredContext
  method