### PR TITLE
this fix explicitly calls the active JavaEditor refresh of semantic highlighting to highlight newly added content of the editor, Fixes #25.

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
@@ -3584,6 +3584,21 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 	}
 
 	/**
+	 * Calls the SemanticHighlightingReconciler refresh function which does the semantic 
+	 * highlighting of the editor content
+	 * 
+	 * @since 3.26 
+	 */
+	public void refreshSemanticHighlighting() {
+		if (fSemanticManager != null) {
+			SemanticHighlightingReconciler reconciler= fSemanticManager.getReconciler();
+			if (reconciler != null) {
+				reconciler.refresh();
+			}
+		}
+	}
+
+	/**
 	 * Returns the Java element wrapped by this editors input.
 	 *
 	 * @return the Java element wrapped by this editors input.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
@@ -72,6 +72,8 @@ import org.eclipse.jdt.ui.wizards.NewTypeWizardPage;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 import org.eclipse.jdt.internal.ui.text.correction.UnresolvedElementsSubProcessor;
 import org.eclipse.jdt.internal.ui.util.ASTHelper;
@@ -109,12 +111,17 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 	private ITypeBinding fSuperType;
 
 	private boolean fShowDialog;
+	private boolean fCallSemanticHighlightingReconciler;
 
 	public NewCUUsingWizardProposal(ICompilationUnit cu, Name node, int typeKind, IJavaElement typeContainer, int severity) {
-		this(cu, node, typeKind, typeContainer, null, severity);
+		this(cu, node, typeKind, typeContainer, null, severity, false);
 	}
 
 	public NewCUUsingWizardProposal(ICompilationUnit cu, Name node, int typeKind, IJavaElement typeContainer, ITypeBinding superType, int severity) {
+		this(cu, node, typeKind, typeContainer, superType, severity, true);
+	}
+
+	private NewCUUsingWizardProposal(ICompilationUnit cu, Name node, int typeKind, IJavaElement typeContainer, ITypeBinding superType, int severity, boolean callSemanticHighlightingReconciler) {
 		super("", null, severity, null); //$NON-NLS-1$
 
 		fCompilationUnit= cu;
@@ -126,6 +133,7 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 		}
 		fSuperType = superType;
 		fCreatedType= null;
+		fCallSemanticHighlightingReconciler= callSemanticHighlightingReconciler;
 
 		String containerName;
 		if (fNode != null) {
@@ -335,6 +343,12 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 				}
 			}
 			fCreatedType= createdType;
+			if (fCallSemanticHighlightingReconciler) {
+				JavaEditor javaEditor= EditorUtility.getActiveJavaEditor();
+				if (javaEditor != null) {
+					javaEditor.refreshSemanticHighlighting();
+				}
+			}
 		}
 
 	}


### PR DESCRIPTION
this fix explicitly calls the active JavaEditor refresh of semantic highlighting to highlight newly added content of the editor, Fixes #25.

Signed-off-by: Kalyan Prasad Tatavarthi <kalyan_prasad@in.ibm.com>