### PR TITLE
This fix explicitly calls the active JavaEditor refresh of semantic highlighting to highlight newly added content of the editor, Fixes #25.

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
@@ -3584,6 +3584,21 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 	}
 
 	/**
+	 * Calls the SemanticHighlightingReconciler refresh function which does the semantic
+	 * highlighting of the editor content
+	 *
+	 * @since 3.26
+	 */
+	public void refreshSemanticHighlighting() {
+		if (fSemanticManager != null) {
+			SemanticHighlightingReconciler reconciler= fSemanticManager.getReconciler();
+			if (reconciler != null) {
+				reconciler.refresh();
+			}
+		}
+	}
+
+	/**
 	 * Returns the Java element wrapped by this editors input.
 	 *
 	 * @return the Java element wrapped by this editors input.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -1344,13 +1344,13 @@ public class LocalCorrectionsSubProcessor {
 		IPackageFragment fragment= sealedType.getPackageFragment();
 
 		if (sealedType.isInterface()) {
-			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_INTERFACE, fragment, typeBinding, relevance + 4));
-			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_INTERFACE, sealedTypeElement,  typeBinding, relevance + 4));
-			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_RECORD, fragment,  typeBinding, relevance + 5));
-			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_RECORD, sealedTypeElement,  typeBinding, relevance + 5));
+			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_INTERFACE, fragment, typeBinding, relevance + 4, true));
+			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_INTERFACE, sealedTypeElement,  typeBinding, relevance + 4, false));
+			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_RECORD, fragment,  typeBinding, relevance + 5, true));
+			proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_RECORD, sealedTypeElement,  typeBinding, relevance + 5, false));
 		}
-		proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_CLASS, fragment,  typeBinding, relevance + 6));
-		proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_CLASS, sealedTypeElement,  typeBinding, relevance + 6));
+		proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_CLASS, fragment,  typeBinding, relevance + 6, true));
+		proposals.add(new NewCUUsingWizardProposal(compilationUnit, null, NewCUUsingWizardProposal.K_CLASS, sealedTypeElement,  typeBinding, relevance + 6, false));
 	}
 
 	public static void addTypeAsPermittedSubTypeProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) throws JavaModelException {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
@@ -72,6 +72,8 @@ import org.eclipse.jdt.ui.wizards.NewTypeWizardPage;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 import org.eclipse.jdt.internal.ui.text.correction.UnresolvedElementsSubProcessor;
 import org.eclipse.jdt.internal.ui.util.ASTHelper;
@@ -109,12 +111,13 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 	private ITypeBinding fSuperType;
 
 	private boolean fShowDialog;
+	private boolean fCallSemanticHighlightingReconciler;
 
 	public NewCUUsingWizardProposal(ICompilationUnit cu, Name node, int typeKind, IJavaElement typeContainer, int severity) {
-		this(cu, node, typeKind, typeContainer, null, severity);
+		this(cu, node, typeKind, typeContainer, null, severity, false);
 	}
 
-	public NewCUUsingWizardProposal(ICompilationUnit cu, Name node, int typeKind, IJavaElement typeContainer, ITypeBinding superType, int severity) {
+	public NewCUUsingWizardProposal(ICompilationUnit cu, Name node, int typeKind, IJavaElement typeContainer, ITypeBinding superType, int severity, boolean callSemanticHighlightingReconciler) {
 		super("", null, severity, null); //$NON-NLS-1$
 
 		fCompilationUnit= cu;
@@ -126,6 +129,7 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 		}
 		fSuperType = superType;
 		fCreatedType= null;
+		fCallSemanticHighlightingReconciler= callSemanticHighlightingReconciler;
 
 		String containerName;
 		if (fNode != null) {
@@ -335,6 +339,12 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 				}
 			}
 			fCreatedType= createdType;
+			if (fCallSemanticHighlightingReconciler) {
+				JavaEditor javaEditor= EditorUtility.getActiveJavaEditor();
+				if (javaEditor != null) {
+					javaEditor.refreshSemanticHighlighting();
+				}
+			}
 		}
 
 	}


### PR DESCRIPTION
This fix explicitly calls the active JavaEditor refresh of semantic highlighting to highlight newly added content of the editor, Fixes #25.

Signed-off-by: Kalyan Prasad Tatavarthi <kalyan_prasad@in.ibm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

