### PR TITLE
Bug 462038 - [inline] Inlining method changes (breaks) loop condition

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -739,6 +739,10 @@ public class CallInliner {
 					}
 				});
 			}
+		}
+		// if there is only 1 argument that has assignment and no others use it, there is no issue
+		if (result.size() == 1) {
+			return new HashSet<>();
 		}
 		return result;
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_462038.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_462038.java
@@ -1,0 +1,16 @@
+package bugs_in;
+
+public class Test_462038 {
+	public static void main(String[] args) {
+		Object [] keys = new Object [] {};
+		int slot = 0;
+		Object o;
+		while (!/*]*/isEmptyKey(o = keys[slot])/*[*/) {
+			slot++;
+		}
+	}
+
+	private static boolean isEmptyKey(Object object) {
+		return object == null;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_462038.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_462038.java
@@ -1,0 +1,16 @@
+package bugs_out;
+
+public class Test_462038 {
+	public static void main(String[] args) {
+		Object [] keys = new Object [] {};
+		int slot = 0;
+		Object o;
+		while (!/*]*/((o = keys[slot]) == null)/*[*/) {
+			slot++;
+		}
+	}
+
+	private static boolean isEmptyKey(Object object) {
+		return object == null;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -421,6 +421,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_462038() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- fix CallInliner.crossCheckArguments() so that it does not bother
  marking a single assignment expression
- add new test to InlineMethodTests

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

