### PR TITLE
Improve the Annotate command to support more eea-path configurations

### DIFF
--- a/org.eclipse.jdt.ui.tests/examples/org/eclipse/jdt/ui/examples/MyClasspathContainerInitializer.java
+++ b/org.eclipse.jdt.ui.tests/examples/org/eclipse/jdt/ui/examples/MyClasspathContainerInitializer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,14 @@ import org.eclipse.jdt.core.JavaCore;
  */
 public class MyClasspathContainerInitializer extends ClasspathContainerInitializer {
 
+	public static ClasspathContainerInitializer initializerDelegate;
+
+	public static final String CONTAINER_NAME= "org.eclipse.jdt.EXAMPLE_CONTAINER";
+
+	public static void setInitializer(ClasspathContainerInitializer initializer) {
+		initializerDelegate = initializer;
+	}
+
 	public static class MyClasspathContainer implements IClasspathContainer {
 
 		private final IPath fPath;
@@ -55,8 +63,11 @@ public class MyClasspathContainerInitializer extends ClasspathContainerInitializ
 
 	@Override
 	public void initialize(IPath containerPath, IJavaProject project) throws CoreException {
-		IClasspathContainer[] containers= { new MyClasspathContainer(containerPath) };
-		JavaCore.setClasspathContainer(containerPath, new IJavaProject[] { project }, containers, null);
+		if (initializerDelegate != null) {
+			initializerDelegate.initialize(containerPath, project);
+		} else {
+			IClasspathContainer[] containers= { new MyClasspathContainer(containerPath) };
+			JavaCore.setClasspathContainer(containerPath, new IJavaProject[] { project }, containers, null);
+		}
 	}
-
 }

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ExternalNullAnnotationChangeProposals.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ExternalNullAnnotationChangeProposals.java
@@ -34,10 +34,10 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -46,7 +46,6 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 
-import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -529,15 +528,12 @@ public class ExternalNullAnnotationChangeProposals {
 		if (root != null) {
 			try {
 				IClasspathEntry resolvedClasspathEntry= root.getResolvedClasspathEntry();
-				for (IClasspathAttribute cpa : resolvedClasspathEntry.getExtraAttributes()) {
-					if (IClasspathAttribute.EXTERNAL_ANNOTATION_PATH.equals(cpa.getName())) {
-						Path annotationPath= new Path(cpa.getValue());
-						IProject project= javaProject.getProject();
-						if (project.exists(annotationPath))
-							return true;
-						IWorkspaceRoot wsRoot= project.getWorkspace().getRoot();
-						return wsRoot.exists(annotationPath);
-					}
+				IProject project= javaProject.getProject();
+				IPath externalAnnotationPath= resolvedClasspathEntry.getExternalAnnotationPath(project, false);
+				if (externalAnnotationPath != null) {
+					IWorkspaceRoot wsRoot= project.getWorkspace().getRoot();
+					if (wsRoot.exists(externalAnnotationPath))
+						return true;
 				}
 			} catch (JavaModelException jme) {
 				return false;


### PR DESCRIPTION
Specifically, JDT/Core now supports locating annotation paths relative
to a classpath container. If any entry in a container resolves to a
workspace project, that project is indeed a candidate to write eea-files
to, and will now be used by the Annotated command.
