### PR TITLE
Don't move up initializer when using undefined vars. Fixes #38

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -17818,6 +17818,47 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testDontMoveUpOverriddenAssignment() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
+		String input= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public boolean dontMoveUpIfUsingUndefined() {\n" //
+				+ "        	    int totalHeight = 0;\n" //;
+				+ "             int innerHeight = 0;\n" //
+				+ "             int topMargin= 0;" //
+				+ "             int bottomMargin = 0;" //
+				+ "             totalHeight = topMargin + innerHeight + bottomMargin;" //
+				+ "    }\n" //
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("E.java", input, false, null);
+
+		enable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT);
+		disable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL);
+
+		String output= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public boolean dontMoveUpIfUsingUndefined() {\n" //
+				+ "        	    int totalHeight;\n" //;
+				+ "             int innerHeight = 0;\n" //
+				+ "             int topMargin= 0;" //
+				+ "             int bottomMargin = 0;" //
+				+ "             totalHeight = topMargin + innerHeight + bottomMargin;" //
+				+ "    }\n" //
+				+ "}\n";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { output },
+				new HashSet<>(Arrays.asList(MultiFixMessages.OverriddenAssignmentCleanUp_description)));
+	}
+
+	@Test
 	public void testDoNotRemoveAssignment() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= "" //

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -17827,11 +17827,12 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "\n" //
 				+ "public class E {\n" //
 				+ "    public boolean dontMoveUpIfUsingUndefined() {\n" //
-				+ "        	    int totalHeight = 0;\n" //;
-				+ "             int innerHeight = 0;\n" //
-				+ "             int topMargin= 0;" //
-				+ "             int bottomMargin = 0;" //
-				+ "             totalHeight = topMargin + innerHeight + bottomMargin;" //
+				+ "        int totalHeight = 0;\n" //;
+				+ "        int innerHeight = 0;\n" //
+				+ "        int topMargin= 0;\n" //
+				+ "        int bottomMargin = 0;\n" //
+				+ "        totalHeight = topMargin + innerHeight + bottomMargin;\n" //
+				+ "        return true;\n" //
 				+ "    }\n" //
 				+ "}\n";
 		ICompilationUnit cu= pack.createCompilationUnit("E.java", input, false, null);
@@ -17846,11 +17847,12 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "\n" //
 				+ "public class E {\n" //
 				+ "    public boolean dontMoveUpIfUsingUndefined() {\n" //
-				+ "        	    int totalHeight;\n" //;
-				+ "             int innerHeight = 0;\n" //
-				+ "             int topMargin= 0;" //
-				+ "             int bottomMargin = 0;" //
-				+ "             totalHeight = topMargin + innerHeight + bottomMargin;" //
+				+ "        int totalHeight;\n" //;
+				+ "        int innerHeight = 0;\n" //
+				+ "        int topMargin= 0;\n" //
+				+ "        int bottomMargin = 0;\n" //
+				+ "        totalHeight = topMargin + innerHeight + bottomMargin;\n" //
+				+ "        return true;\n" //
 				+ "    }\n" //
 				+ "}\n";
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpTabPage.java
@@ -150,6 +150,18 @@ public abstract class CleanUpTabPage extends ModifyDialogTabPage implements ICle
 
 	}
 
+	/* Register a preference that is an option for a cleanup. Checking it does not change the number of clean ups.
+	 */
+	protected void registerOptionPreference(final CheckboxPreference main, final CheckboxPreference... options) {
+		registerPreference(main);
+		fCheckboxes.addAll(Arrays.asList(options));
+		main.addObserver((source, arg)-> {
+			for (CheckboxPreference option : options) {
+				option.setEnabled(main.getChecked());
+			}
+		});
+	}
+
 	protected void registerSlavePreference(final CheckboxPreference master, final RadioPreference[] slaves) {
 		internalRegisterSlavePreference(master, slaves);
 		registerPreference(master);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/UnnecessaryCodeTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/UnnecessaryCodeTabPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -154,7 +154,7 @@ public final class UnnecessaryCodeTabPage extends AbstractCleanUpTabPage {
 		CheckboxPreference overriddenAssignment= createCheckboxPref(unnecessaryGroup, numColumns, CleanUpMessages.UnnecessaryCodeTabPage_CheckboxName_OverriddenAssignment, CleanUpConstants.OVERRIDDEN_ASSIGNMENT, CleanUpModifyDialog.FALSE_TRUE);
 		intent(unnecessaryGroup);
 		CheckboxPreference moveDeclaration= createCheckboxPref(unnecessaryGroup, numColumns-1, CleanUpMessages.UnnecessaryCodeTabPage_CheckboxName_MoveDeclaration, CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL, CleanUpModifyDialog.FALSE_TRUE);
-		registerSlavePreference(overriddenAssignment, new CheckboxPreference[] { moveDeclaration });
+		registerOptionPreference(overriddenAssignment, moveDeclaration);
 
 		CheckboxPreference modifiers= createCheckboxPref(unnecessaryGroup, numColumns, CleanUpMessages.UnnecessaryCodeTabPage_CheckboxName_RedundantModifiers, CleanUpConstants.REMOVE_REDUNDANT_MODIFIERS, CleanUpModifyDialog.FALSE_TRUE);
 		registerPreference(modifiers);


### PR DESCRIPTION
## What it does
Prevent the initializer in a overriden assignment cleanup from being moved up when the initializer uses variable which are undefined at the location the initilizer is being moved to.
Fixes #38 

## How to test
On the unnecessary code cleanup page, enable "Remove overridden assignement" and disable "Move declaration if necessary". Write some code that overrrides an initializer (see issue for example) and play with cases where the initializer uses identifiers that are undefined at the variable declaration site: think of local variables and fields of local classes.

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

