### PR TITLE
Colouring 'when' keyword in guarded pattern

### DIFF
--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -112,6 +112,15 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java" type="org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightingReconciler$PositionCollector">
+        <filter comment="This is a Java 19 preview feature" id="640712815">
+            <message_arguments>
+                <message_argument value="GuardedPattern"/>
+                <message_argument value="PositionCollector"/>
+                <message_argument value="getRestrictedIdentifierStartPosition()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java" type="org.eclipse.jdt.internal.ui.text.JavaOutlineInformationControl$OutlineTreeViewer">
         <filter id="571473929">
             <message_arguments>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -39,6 +43,7 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.GuardedPattern;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
@@ -296,6 +301,28 @@ public class SemanticHighlightingReconciler implements IJavaReconcilingListener,
 					fNOfRemovedPositions--;
 				}
 			}
+		}
+
+		@Override
+		public boolean visit(GuardedPattern node) {
+			try {
+				if (node != null) {
+					int offset= node.getRestrictedIdentifierStartPosition();
+					int length= 4; // length of 'when'
+					if (offset > -1) {
+						for (int i= 0; i < fJobSemanticHighlightings.length; i++) {
+							SemanticHighlighting semanticHighlighting= fJobSemanticHighlightings[i];
+							if (semanticHighlighting instanceof RestrictedIdentifiersHighlighting) {
+								addPosition(offset, length, fJobHighlightings[i]);
+								return true;
+							}
+						}
+					}
+				}
+			} catch (UnsupportedOperationException e) {
+				// do nothing
+			}
+			return true;
 		}
 	}
 


### PR DESCRIPTION
Colouring 'when' keyword in guarded pattern. Fixes #65.

Signed-off-by: Kalyan Prasad Tatavarthi <kalyan_prasad@in.ibm.com>


