### PR TITLE
Character methods should not be used in some cases

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RenamingNameSuggestor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RenamingNameSuggestor.java
@@ -13,10 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.refactoring.rename;
 
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.List;
-
-import java.text.BreakIterator;
 
 import org.eclipse.core.runtime.Assert;
 
@@ -473,21 +472,21 @@ public class RenamingNameSuggestor {
 
 	private String getLowerCased(String name) {
 		if (name.length() > 1)
-			return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+			return name.substring(0, 1).toLowerCase() + name.substring(1);
 		else
 			return name.toLowerCase();
 	}
 
 	private String getUpperCased(String name) {
 		if (name.length() > 1)
-			return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+			return name.substring(0, 1).toUpperCase() + name.substring(1);
 		else
 			return name.toLowerCase();
 	}
 
 	private String getFirstUpperRestLowerCased(String name) {
 		if (name.length() > 1)
-			return Character.toUpperCase(name.charAt(0)) + name.substring(1).toLowerCase();
+			return name.substring(0, 1).toUpperCase() + name.substring(1).toLowerCase();
 		else
 			return name.toLowerCase();
 	}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
@@ -1208,7 +1208,7 @@ public final class MoveInnerToTopRefactoring extends Refactoring {
 		String name= enclosingType.getElementName();
 		if (name.isEmpty())
 			return ""; //$NON-NLS-1$
-		return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+		return name.substring(0,1).toLowerCase()+name.substring(1);
 	}
 
 	public IType getInputType() {

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/LineColumnSelectionTestCase.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/LineColumnSelectionTestCase.java
@@ -67,8 +67,7 @@ public abstract class LineColumnSelectionTestCase extends AbstractJunit4CUTestCa
 		int separator= name.indexOf('_');
 		assertNotEquals(-1, separator);
 		assertTrue(separator >= 5);
-		return Character.toLowerCase(name.charAt(4))
-				+ name.substring(5, separator);
+		return name.substring(4, 5).toLowerCase() + name.substring(5, separator);
 	}
 
 	/*

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceParameterRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceParameterRefactoring.java
@@ -489,7 +489,7 @@ public class IntroduceParameterRefactoring extends Refactoring implements IDeleg
 			if (! Character.isUpperCase(firstAfterPrefix))
 				continue; //not uppercase after prefix
 			//found matching prefix
-			String proposal= Character.toLowerCase(firstAfterPrefix) + methodName.substring(prefix.length() + 1);
+			String proposal= methodName.substring(prefix.length(), prefix.length()+1).toLowerCase() + methodName.substring(prefix.length()+1);
 			methodName= proposal;
 			break;
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/AdvancedQuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/AdvancedQuickAssistProcessor.java
@@ -2111,7 +2111,7 @@ public class AdvancedQuickAssistProcessor implements IQuickAssistProcessor {
 		if (oldIdentifier.startsWith(notString)) {
 			int notLength= notString.length();
 			if (oldIdentifier.length() > notLength) {
-				newIdentifier= Character.toLowerCase(oldIdentifier.charAt(notLength)) + oldIdentifier.substring(notLength + 1);
+				newIdentifier= oldIdentifier.substring(notLength, notLength+1).toUpperCase() + oldIdentifier.substring(notLength+1);
 			} else {
 				newIdentifier= oldIdentifier;
 			}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
@@ -695,9 +695,10 @@ public class JavadocContentAccess2 {
 	}
 
 	private static String firstToLower(String propertyName) {
-		char[] c = propertyName.toCharArray();
-		c[0] = Character.toLowerCase(c[0]);
-		return String.valueOf(c);
+		if (propertyName == null || propertyName.length() == 0) {
+			return propertyName;
+		}
+	    return propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);
 	}
 
 	private static Javadoc getJavadocNode(IJavaElement element, String rawJavadoc) {


### PR DESCRIPTION
For full support of unicode for java identifiers some code needs changes. Character.toLowerCase and Character.toUpperCase have issues with unicode.

Eclipse has some issues to process java files written making use of full java spec.
While it is not recommended to make use of it in some cases it might make sense in the long run to allow some more freedom.
To start support at one day we need some preparation and change some coding to allow that in future.

see
https://bugs.eclipse.org/bugs/show_bug.cgi?id=26529
https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Character.html#supplementary
http://www.javawenti.com/?post=26640
