### PR TITLE
NPE in StringConcatToTextBlockFixCore (#81)

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -92,7 +92,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 		@Override
 		public boolean visit(final Assignment visited) {
 			ITypeBinding typeBinding= visited.resolveTypeBinding();
-			if (!typeBinding.getQualifiedName().equals(JAVA_STRING)) {
+			if (typeBinding == null || !typeBinding.getQualifiedName().equals(JAVA_STRING)) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
## What it does
Avoid NPE in StringConcat cleanup. `resolveTypeBinding()` might return null, and is similarly guarded 13 lines below.

## How to test
Not sure about the actual code that triggered the NPE.

## Author checklist
- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)