### PR TITLE
Use platform line separator in hover. Fixes #85

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
@@ -153,7 +153,7 @@ public class JavadocHover extends AbstractJavaEditorTextHover {
 			presentation.clear();
 
 			String content= super.updatePresentation(drawable, hoverInfo, presentation, maxWidth, maxHeight);
-			return content + "\n\n" + warning; //$NON-NLS-1$
+			return content + System.lineSeparator()+System.lineSeparator() + warning;
 		}
 	}
 	/**


### PR DESCRIPTION
## What it does
Fixes #85 by using the platform line separator

## How to test
Since this only happens in the case where the platform browser widget is not available, you can use the testing procedure from https://github.com/eclipse-platform/eclipse.platform.text/pull/37 .

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

