### PR TITLE
Fix "Remove overridden assignment" cleanup preview

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
@@ -82,7 +82,7 @@ public class OverriddenAssignmentCleanUp extends AbstractMultiFix {
 				bld.append("String separator = System.lineSeparator();\n"); //$NON-NLS-1$
 				bld.append("long time = System.currentTimeMillis();\n"); //$NON-NLS-1$
 			} else {
-				bld.append("long time = 0;\n"); //$NON-NLS-1$
+				bld.append("long time;\n"); //$NON-NLS-1$
 				bld.append("String separator = System.lineSeparator();\n"); //$NON-NLS-1$
 				bld.append("time = System.currentTimeMillis();\n"); //$NON-NLS-1$
 			}


### PR DESCRIPTION
Fix the preview of the _Remove overridden assignment_ cleanup (in the _Unnecessary Code_ tab) when the option _Move declaration if necessary_ is not enabled.

See also https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/27

