### PR TITLE
Fix source range computer for while -> enhanced for cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UseIteratorToForLoopFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UseIteratorToForLoopFixCore.java
@@ -21,14 +21,14 @@ import org.eclipse.text.edits.TextEditGroup;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
-import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.fix.helper.AbstractTool;
 import org.eclipse.jdt.internal.corext.fix.helper.WhileLoopToChangeHit;
 import org.eclipse.jdt.internal.corext.fix.helper.WhileToForEach;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.refactoring.util.TightSourceRangeComputer;
 
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 
@@ -65,19 +65,18 @@ public enum UseIteratorToForLoopFixCore {
 			@Override
 			public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 				TextEditGroup group= createTextEditGroup(MultiFixMessages.Java50CleanUp_ConvertToEnhancedForLoop_description, cuRewrite);
-				cuRewrite.getASTRewrite().setTargetSourceRangeComputer(computer);
+				TightSourceRangeComputer rangeComputer;
+				ASTRewrite rewrite= cuRewrite.getASTRewrite();
+				if (rewrite.getExtendedSourceRangeComputer() instanceof TightSourceRangeComputer) {
+					rangeComputer= (TightSourceRangeComputer)rewrite.getExtendedSourceRangeComputer();
+				} else {
+					rangeComputer= new TightSourceRangeComputer();
+				}
+				rangeComputer.addTightSourceNode(hit.whileStatement);
+				rewrite.setTargetSourceRangeComputer(rangeComputer);
 				iteratortofor.rewrite(UseIteratorToForLoopFixCore.this, hit, cuRewrite, group);
 			}
 		};
 	}
 
-	final static TargetSourceRangeComputer computer= new TargetSourceRangeComputer() {
-		@Override
-		public SourceRange computeSourceRange(final ASTNode nodeWithComment) {
-			if (Boolean.TRUE.equals(nodeWithComment.getProperty(ASTNodes.UNTOUCH_COMMENT))) {
-				return new SourceRange(nodeWithComment.getStartPosition(), nodeWithComment.getLength());
-			}
-			return super.computeSourceRange(nodeWithComment);
-		}
-	};
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -390,7 +390,6 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 		AST ast= cuRewrite.getRoot().getAST();
 
 		EnhancedForStatement newEnhancedForStatement= ast.newEnhancedForStatement();
-		newEnhancedForStatement.setBody(ASTNodes.createMoveTarget(rewrite, hit.whileStatement.getBody()));
 
 		SingleVariableDeclaration result= ast.newSingleVariableDeclaration();
 
@@ -463,6 +462,7 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 				ASTNodes.removeButKeepComment(rewrite, ASTNodes.getTypedAncestor(hit.loopVarDeclaration, VariableDeclarationStatement.class), group);
 			}
 		}
+		newEnhancedForStatement.setBody(ASTNodes.createMoveTarget(rewrite, hit.whileStatement.getBody()));
 		ASTNodes.replaceButKeepComment(rewrite, hit.whileStatement, newEnhancedForStatement, group);
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -4319,6 +4319,54 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testWhileNested5() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n"
+		                + "import java.util.*;\n"
+		                + "public class Test {\n"
+		                + "    void m(List<String> strings,List<String> strings2) {\n"
+		                + "        Collections.reverse(strings);\n"
+		                + "        Iterator it = strings.iterator();\n"
+		                + "        while (it.hasNext()) {\n"
+		                + "            String s = (String)it.next();\n"
+		                + "            Iterator it2 = strings2.iterator();\n"
+		                + "            while (it2.hasNext()) {\n"
+		                + "                String s2 = (String) it2.next();\n"
+		                + "                System.out.println(s2);\n"
+		                + "            }\n"
+		                + "            // end line comment\n"
+		                + "        }\n"
+		                + "        System.out.println();\n"
+		                + "    }\n"
+		                + "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_ONLY_IF_LOOP_VAR_USED);
+
+		sample= "" //
+				+ "package test1;\n"
+                        + "import java.util.*;\n"
+                        + "public class Test {\n"
+                        + "    void m(List<String> strings,List<String> strings2) {\n"
+                        + "        Collections.reverse(strings);\n"
+		                + "        for (String s : strings) {\n"
+                        + "            for (String s2 : strings2) {\n"
+                        + "                System.out.println(s2);\n"
+                        + "            }\n"
+		                + "            // end line comment\n"
+                        + "        }\n"
+                        + "        System.out.println();\n"
+                        + "    }\n"
+                        + "}\n";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
+	@Test
 	public void testWhileGenericSubtype() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= "" //


### PR DESCRIPTION
- fixes #100
- use TightSourceRangeComputer for new cleanup and tie it to the
  while loop being transformed
- add new test

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

