### PR TITLE
Enhance SwitchExpression cleanup to support return statements

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
@@ -89,7 +89,6 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 		private boolean isInvalidStatement(Statement statement) {
 			return statement instanceof ContinueStatement
 					|| statement instanceof ForStatement
-					|| statement instanceof ReturnStatement
 					|| statement instanceof IfStatement
 					|| statement instanceof DoStatement
 					|| statement instanceof EnhancedForStatement
@@ -100,6 +99,7 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 		}
 		private SwitchExpressionsFixOperation getOperation(SwitchStatement switchStatement) {
 			final List<SwitchCase> throwList= new ArrayList<>();
+			final List<SwitchCase> returnList= new ArrayList<>();
 			boolean defaultFound= false;
 			List<Statement> currentBlock= null;
 			SwitchCase currentCase= null;
@@ -119,6 +119,15 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 					}
 					currentBlock= new ArrayList<>();
 					currentCase= switchCase;
+				} else if (statement instanceof ReturnStatement) {
+					returnList.add(currentCase);
+					if (currentBlock == null) {
+						return null;
+					}
+					currentBlock.add(statement);
+					caseMap.put(currentCase, currentBlock);
+					currentBlock= null;
+					currentCase= null;
 				} else if (isInvalidStatement(statement)) {
 					return null;
 				} else if (statement instanceof BreakStatement) {
@@ -143,6 +152,7 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 					if (currentBlock == null) {
 						return null;
 					}
+					boolean blockComplete= false;
 					if (statement instanceof Block) {
 						Block block= (Block)statement;
 						// allow one level of block with no invalid statements inside
@@ -152,11 +162,27 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 								return null;
 							}
 							if (blockStatement instanceof ThrowStatement) {
+								if (blockIter.hasNext()) {
+									return null;
+								}
+								blockComplete= true;
 								throwList.add(currentCase);
+							}
+							if (blockStatement instanceof ReturnStatement) {
+								if (blockIter.hasNext()) {
+									return null;
+								}
+								blockComplete= true;
+								returnList.add(currentCase);
 							}
 						}
 					}
 					currentBlock.add(statement);
+					if (blockComplete) {
+						caseMap.put(currentCase, currentBlock);
+						currentBlock= null;
+						currentCase= null;
+					}
 				}
 			}
 
@@ -167,56 +193,73 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 				}
 				caseMap.put(currentCase,  currentBlock);
 			}
-
 			String commonAssignmentName= null;
 			IBinding assignmentBinding= null;
-			for (Map.Entry<SwitchCase, List<Statement>> entry : caseMap.entrySet()) {
-				SwitchCase entryCase= entry.getKey();
-				List<Statement> entryStatements= entry.getValue();
-				if (throwList.contains(entryCase) || entryStatements.size() == 0) {
-					continue;
+			boolean createReturnStatement= false;
+
+			// returns are allowed only if every case ends in either a return or throws statement
+			if (returnList.size() > 0) {
+				createReturnStatement= true;
+				int caseCount= 0;
+				for (Map.Entry<SwitchCase, List<Statement>> entry : caseMap.entrySet()) {
+					List<Statement> entryStatements= entry.getValue();
+					if (entryStatements.size() > 0) {
+						++caseCount;
+					}
 				}
-				Statement lastStatement= entryStatements.get(entryStatements.size() - 1);
-				if (lastStatement instanceof Block) {
-					@SuppressWarnings("rawtypes")
-					List blockStatements= ((Block)lastStatement).statements();
-					if (blockStatements.isEmpty()) {
+				if ((returnList.size() + throwList.size()) < caseCount) {
+					return null;
+				}
+			} else {
+				for (Map.Entry<SwitchCase, List<Statement>> entry : caseMap.entrySet()) {
+					SwitchCase entryCase= entry.getKey();
+					List<Statement> entryStatements= entry.getValue();
+					if (throwList.contains(entryCase) || entryStatements.size() == 0) {
 						continue;
 					}
-					lastStatement= (Statement)(blockStatements.get(blockStatements.size() - 1));
-				}
-				// case must end in an assignment
-				if (!(lastStatement instanceof ExpressionStatement) || !(((ExpressionStatement)lastStatement).getExpression() instanceof Assignment)) {
-					return null;
-				}
-				Assignment assignment= (Assignment)((ExpressionStatement) lastStatement).getExpression();
-				// must be simple assign operator
-				if (assignment.getOperator() != Assignment.Operator.ASSIGN) {
-					return null;
-				}
-				if (commonAssignmentName == null) {
-					Expression exp= assignment.getLeftHandSide();
-					if (exp instanceof Name) {
-						commonAssignmentName= ((Name)exp).getFullyQualifiedName();
-						assignmentBinding= ((Name) exp).resolveBinding();
-					} else {
+					Statement lastStatement= entryStatements.get(entryStatements.size() - 1);
+					if (lastStatement instanceof Block) {
+						@SuppressWarnings("rawtypes")
+						List blockStatements= ((Block)lastStatement).statements();
+						if (blockStatements.isEmpty()) {
+							continue;
+						}
+						lastStatement= (Statement)(blockStatements.get(blockStatements.size() - 1));
+					}
+					// case must end in an assignment
+					if (!(lastStatement instanceof ExpressionStatement) || !(((ExpressionStatement)lastStatement).getExpression() instanceof Assignment)) {
 						return null;
 					}
-				} else {
-					Expression exp= assignment.getLeftHandSide();
-					if (exp instanceof Name) {
-						Name name= (Name)exp;
-						if (!name.getFullyQualifiedName().equals(commonAssignmentName)) {
+					Assignment assignment= (Assignment)((ExpressionStatement) lastStatement).getExpression();
+					// must be simple assign operator
+					if (assignment.getOperator() != Assignment.Operator.ASSIGN) {
+						return null;
+					}
+					if (commonAssignmentName == null) {
+						Expression exp= assignment.getLeftHandSide();
+						if (exp instanceof Name) {
+							commonAssignmentName= ((Name)exp).getFullyQualifiedName();
+							assignmentBinding= ((Name) exp).resolveBinding();
+						} else {
 							return null;
 						}
 					} else {
-						return null;
+						Expression exp= assignment.getLeftHandSide();
+						if (exp instanceof Name) {
+							Name name= (Name)exp;
+							if (!name.getFullyQualifiedName().equals(commonAssignmentName)) {
+								return null;
+							}
+						} else {
+							return null;
+						}
 					}
 				}
+				if (assignmentBinding == null) {
+					return null;
+				}
 			}
-			if (assignmentBinding == null) {
-				return null;
-			}
+
 			// ensure either we have default case or else expression is enum and all constants specified
 			ITypeBinding binding= switchStatement.getExpression().resolveTypeBinding();
 			if (binding != null && binding.isEnum()) {
@@ -233,7 +276,7 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			} else if (!defaultFound) {
 				return null;
 			}
-			return new SwitchExpressionsFixOperation(switchStatement, caseMap, commonAssignmentName, assignmentBinding);
+			return new SwitchExpressionsFixOperation(switchStatement, caseMap, createReturnStatement, commonAssignmentName, assignmentBinding);
 		}
 	}
 
@@ -241,13 +284,15 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 
 		private final SwitchStatement switchStatement;
 		private final Map<SwitchCase, List<Statement>> caseMap;
+		private final boolean createReturnStatement;
 		private final String varName;
 		private final IBinding assignmentBinding;
 
 		public SwitchExpressionsFixOperation(SwitchStatement switchStatement, Map<SwitchCase, List<Statement>> caseMap,
-				String varName, IBinding assignmentBinding) {
+				boolean createReturnStatement, String varName, IBinding assignmentBinding) {
 			this.switchStatement= switchStatement;
 			this.caseMap= caseMap;
+			this.createReturnStatement= createReturnStatement;
 			this.varName= varName;
 			this.assignmentBinding= assignmentBinding;
 		}
@@ -339,6 +384,8 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 						if (oldStatement instanceof ThrowStatement) {
 							ThrowStatement throwStatement= (ThrowStatement)oldStatement;
 							newStatement= (Statement)rewrite.createCopyTarget(throwStatement);
+						} else if (oldStatement instanceof ReturnStatement && createReturnStatement) {
+							newStatement= getNewStatementFromReturn(cuRewrite, rewrite, (ReturnStatement)oldStatement);
 						} else if (forceOldStyle) {
 							newStatement= getNewYieldStatement(cuRewrite, rewrite, (ExpressionStatement)oldStatement);
 						} else {
@@ -352,7 +399,13 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 							Statement oldSwitchCaseStatement= oldStatements.get(i);
 							newBlock.statements().add(rewrite.createCopyTarget(oldSwitchCaseStatement));
 						}
-						YieldStatement newYield= getNewYieldStatement(cuRewrite, rewrite, (ExpressionStatement)oldStatements.get(statementsLen-1));
+						Statement lastStatement= oldStatements.get(statementsLen - 1);
+						YieldStatement newYield= null;
+						if (lastStatement instanceof ReturnStatement) {
+							newYield= getNewYieldStatementFromReturn(cuRewrite, rewrite, (ReturnStatement)oldStatements.get(statementsLen-1));
+						} else {
+							newYield= getNewYieldStatement(cuRewrite, rewrite, (ExpressionStatement)oldStatements.get(statementsLen-1));
+						}
 						newBlock.statements().add(newYield);
 						newSwitchExpression.statements().add(newBlock);
 					}
@@ -368,61 +421,69 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 				}
 			}
 
-			// see if we can make new switch expression the initializer of assignment variable
-			if (assignmentBinding instanceof IVariableBinding) {
-				VariableDeclarationStatement varDeclarationStatement= null;
-				int varIndex= -2;
-				IVariableBinding binding= (IVariableBinding)assignmentBinding;
-				if (!binding.isField() && !binding.isParameter() && !binding.isSynthetic()) {
-					ASTNode parent= switchStatement.getParent();
-					if (parent instanceof Block) {
-						Block block= (Block)parent;
-						List statements= block.statements();
-						ListRewrite listRewrite= rewrite.getListRewrite(block, Block.STATEMENTS_PROPERTY);
-						for (int i= 0; i < statements.size(); ++i) {
-							Statement statement= (Statement)statements.get(i);
-							if (statement instanceof VariableDeclarationStatement) {
-								VariableDeclarationStatement decl= (VariableDeclarationStatement)statement;
-								List fragments= decl.fragments();
-								if (fragments.size() == 1) { // must be single var declaration
-									VariableDeclarationFragment fragment= (VariableDeclarationFragment)fragments.get(0);
-									if (fragment.getInitializer() == null) { // must not already be initialized
-										IVariableBinding fragBinding= fragment.resolveBinding();
-										if (fragBinding != null && fragBinding.isEqualTo(binding)) {
-											varDeclarationStatement= decl;
-											varIndex= i;
+			Statement newExpressionStatement= null;
+
+			if (createReturnStatement) {
+				ReturnStatement newReturnStatement= ast.newReturnStatement();
+				newReturnStatement.setExpression(newSwitchExpression);
+				newExpressionStatement= newReturnStatement;
+			} else {
+				// see if we can make new switch expression the initializer of assignment variable
+				if (assignmentBinding instanceof IVariableBinding) {
+					VariableDeclarationStatement varDeclarationStatement= null;
+					int varIndex= -2;
+					IVariableBinding binding= (IVariableBinding)assignmentBinding;
+					if (!binding.isField() && !binding.isParameter() && !binding.isSynthetic()) {
+						ASTNode parent= switchStatement.getParent();
+						if (parent instanceof Block) {
+							Block block= (Block)parent;
+							List statements= block.statements();
+							ListRewrite listRewrite= rewrite.getListRewrite(block, Block.STATEMENTS_PROPERTY);
+							for (int i= 0; i < statements.size(); ++i) {
+								Statement statement= (Statement)statements.get(i);
+								if (statement instanceof VariableDeclarationStatement) {
+									VariableDeclarationStatement decl= (VariableDeclarationStatement)statement;
+									List fragments= decl.fragments();
+									if (fragments.size() == 1) { // must be single var declaration
+										VariableDeclarationFragment fragment= (VariableDeclarationFragment)fragments.get(0);
+										if (fragment.getInitializer() == null) { // must not already be initialized
+											IVariableBinding fragBinding= fragment.resolveBinding();
+											if (fragBinding != null && fragBinding.isEqualTo(binding)) {
+												varDeclarationStatement= decl;
+												varIndex= i;
+											}
 										}
 									}
-								}
-							} else if (statement instanceof SwitchStatement) {
-								if (statement.subtreeMatch(new ASTMatcher(), switchStatement)) {
-									// if previous statement declares assignment variable, we can set initializer
-									if (varIndex == i - 1) {
-										VariableDeclarationFragment newVarFragment= ast.newVariableDeclarationFragment();
-										newVarFragment.setName(ast.newSimpleName(varName));
-										newVarFragment.setInitializer(newSwitchExpression);
-										VariableDeclarationStatement newVar= ast.newVariableDeclarationStatement(newVarFragment);
-										ImportRewrite importRewrite= cuRewrite.getImportRewrite();
-										newVar.setType(importRewrite.addImport(((IVariableBinding) assignmentBinding).getType(), ast));
-										if (varDeclarationStatement != null && Modifier.isFinal(varDeclarationStatement.getModifiers())) {
-											newVar.modifiers().add(ast.newModifier(ModifierKeyword.FINAL_KEYWORD));
+								} else if (statement instanceof SwitchStatement) {
+									if (statement.subtreeMatch(new ASTMatcher(), switchStatement)) {
+										// if previous statement declares assignment variable, we can set initializer
+										if (varIndex == i - 1) {
+											VariableDeclarationFragment newVarFragment= ast.newVariableDeclarationFragment();
+											newVarFragment.setName(ast.newSimpleName(varName));
+											newVarFragment.setInitializer(newSwitchExpression);
+											VariableDeclarationStatement newVar= ast.newVariableDeclarationStatement(newVarFragment);
+											ImportRewrite importRewrite= cuRewrite.getImportRewrite();
+											newVar.setType(importRewrite.addImport(((IVariableBinding) assignmentBinding).getType(), ast));
+											if (varDeclarationStatement != null && Modifier.isFinal(varDeclarationStatement.getModifiers())) {
+												newVar.modifiers().add(ast.newModifier(ModifierKeyword.FINAL_KEYWORD));
+											}
+											replaceWithLeadingComments(cuRewrite, listRewrite, varDeclarationStatement, group, newVar);
+											listRewrite.remove(switchStatement, group);
+											return;
 										}
-										replaceWithLeadingComments(cuRewrite, listRewrite, varDeclarationStatement, group, newVar);
-										listRewrite.remove(switchStatement, group);
-										return;
+										break;
 									}
-									break;
 								}
 							}
 						}
 					}
 				}
+				// otherwise just assign new switch expression to varName
+				Assignment newAssignment= ast.newAssignment();
+				newExpressionStatement= ast.newExpressionStatement(newAssignment);
+				newAssignment.setLeftHandSide(ast.newName(varName));
+				newAssignment.setRightHandSide(newSwitchExpression);
 			}
-			// otherwise just assign new switch expression to varName
-			Assignment newAssignment= ast.newAssignment();
-			ExpressionStatement newExpressionStatement= ast.newExpressionStatement(newAssignment);
-			newAssignment.setLeftHandSide(ast.newName(varName));
-			newAssignment.setRightHandSide(newSwitchExpression);
 
 			ASTNode parent= switchStatement.getParent();
 			if (parent instanceof Block) {
@@ -433,6 +494,25 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			}
 		}
 
+		private Statement getNewStatementFromReturn(CompilationUnitRewrite cuRewrite, final ASTRewrite rewrite, ReturnStatement oldStatement) throws JavaModelException {
+			Statement newStatement;
+			Expression exp= oldStatement.getExpression();
+			// Ugly hack to tack on trailing comments
+			IBuffer buffer= cuRewrite.getCu().getBuffer();
+			StringBuilder b= new StringBuilder();
+			List<Comment> leadingComments= ASTNodes.getLeadingComments(oldStatement);
+			for (Comment comment : leadingComments) {
+				b.append(buffer.getText(comment.getStartPosition(), comment.getLength()) + " "); //$NON-NLS-1$
+			}
+			b.append(buffer.getText(exp.getStartPosition(), exp.getLength()) + ";"); //$NON-NLS-1$
+			List<Comment> trailingComments= ASTNodes.getTrailingComments(oldStatement);
+			for (Comment comment : trailingComments) {
+				b.append(" " + buffer.getText(comment.getStartPosition(), comment.getLength())); //$NON-NLS-1$
+			}
+			newStatement= (Statement) rewrite.createStringPlaceholder(b.toString(), ASTNode.EXPRESSION_STATEMENT);
+			return newStatement;
+		}
+
 		private Statement getNewStatementForCase(CompilationUnitRewrite cuRewrite, final ASTRewrite rewrite, Statement oldStatement) throws JavaModelException {
 			Statement newStatement;
 			ExpressionStatement oldExpStatement= (ExpressionStatement)oldStatement;
@@ -441,6 +521,10 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			// Ugly hack to tack on trailing comments
 			IBuffer buffer= cuRewrite.getCu().getBuffer();
 			StringBuilder b= new StringBuilder();
+			List<Comment> leadingComments= ASTNodes.getLeadingComments(oldExpStatement);
+			for (Comment comment : leadingComments) {
+				b.append(buffer.getText(comment.getStartPosition(), comment.getLength()) + " "); //$NON-NLS-1$
+			}
 			b.append(buffer.getText(rhs.getStartPosition(), rhs.getLength()) + ";"); //$NON-NLS-1$
 			List<Comment> trailingComments= ASTNodes.getTrailingComments(oldExpStatement);
 			for (Comment comment : trailingComments) {
@@ -468,6 +552,27 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 
 			YieldStatement newYield = (YieldStatement)rewrite.createStringPlaceholder(b.toString(), ASTNode.YIELD_STATEMENT);
 			Expression newYieldExpression= (Expression) rewrite.createStringPlaceholder(b.toString(), rhs.getNodeType());
+			newYield.setExpression(newYieldExpression);
+			return newYield;
+		}
+
+		private YieldStatement getNewYieldStatementFromReturn(CompilationUnitRewrite cuRewrite, final ASTRewrite rewrite, ReturnStatement oldStatement) throws JavaModelException {
+			Expression exp= oldStatement.getExpression();
+			IBuffer buffer= cuRewrite.getCu().getBuffer();
+			StringBuilder b= new StringBuilder();
+			List<Comment> leadingComments= ASTNodes.getLeadingComments(oldStatement);
+			for (Comment comment : leadingComments) {
+				b.append(buffer.getText(comment.getStartPosition(), comment.getLength()) + "\n"); //$NON-NLS-1$
+			}
+			b.append("yield "); //$NON-NLS-1$
+			List<Comment> trailingComments= ASTNodes.getTrailingComments(oldStatement);
+			b.append(buffer.getText(exp.getStartPosition(), exp.getLength()) + ";"); //$NON-NLS-1$
+			for (Comment comment : trailingComments) {
+				b.append(" " + buffer.getText(comment.getStartPosition(), comment.getLength())); //$NON-NLS-1$
+			}
+
+			YieldStatement newYield = (YieldStatement)rewrite.createStringPlaceholder(b.toString(), ASTNode.YIELD_STATEMENT);
+			Expression newYieldExpression= (Expression) rewrite.createStringPlaceholder(b.toString(), exp.getNodeType());
 			newYield.setExpression(newYieldExpression);
 			return newYield;
 		}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
@@ -502,7 +502,11 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			StringBuilder b= new StringBuilder();
 			List<Comment> leadingComments= ASTNodes.getLeadingComments(oldStatement);
 			for (Comment comment : leadingComments) {
-				b.append(buffer.getText(comment.getStartPosition(), comment.getLength()) + " "); //$NON-NLS-1$
+				if (comment.isLineComment()) {
+					b.append("/*" + buffer.getText(comment.getStartPosition() + 2, comment.getLength() - 2) + " */ "); //$NON-NLS-1$ //$NON-NLS-2$
+				} else {
+					b.append(buffer.getText(comment.getStartPosition(), comment.getLength()) + " "); //$NON-NLS-1$
+				}
 			}
 			b.append(buffer.getText(exp.getStartPosition(), exp.getLength()) + ";"); //$NON-NLS-1$
 			List<Comment> trailingComments= ASTNodes.getTrailingComments(oldStatement);
@@ -523,7 +527,11 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			StringBuilder b= new StringBuilder();
 			List<Comment> leadingComments= ASTNodes.getLeadingComments(oldExpStatement);
 			for (Comment comment : leadingComments) {
-				b.append(buffer.getText(comment.getStartPosition(), comment.getLength()) + " "); //$NON-NLS-1$
+				if (comment.isLineComment()) {
+					b.append("/*" + buffer.getText(comment.getStartPosition() + 2, comment.getLength() - 2) + " */ "); //$NON-NLS-1$ //$NON-NLS-2$
+				} else {
+					b.append(buffer.getText(comment.getStartPosition(), comment.getLength()) + " "); //$NON-NLS-1$
+				}
 			}
 			b.append(buffer.getText(rhs.getStartPosition(), rhs.getLength()) + ";"); //$NON-NLS-1$
 			List<Comment> trailingComments= ASTNodes.getTrailingComments(oldExpStatement);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
@@ -493,6 +493,203 @@ public class CleanUpTest14 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testConvertToReturnSwitchExpressionIssue104_1() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public enum InnerEnum {\n"
+				+ "        A, B, C, D;\n"
+				+ "    }\n"
+				+ "    public int foo(InnerEnum k) {\n"
+				+ "        switch (k) {\n"
+				+ "            case A:\n"
+				+ "            case B:\n"
+				+ "                /* comment 1 */\n"
+				+ "                return 6; /* abc */\n"
+				+ "            case C: {\n"
+				+ "                System.out.println(\"x\"); //$NON-NLS-1$\n"
+				+ "                /* comment 2 */\n"
+				+ "                return 8; /* def */\n"
+				+ "            }\n"
+				+ "            case D:\n"
+				+ "                return 9;\n"
+				+ "            default:\n"
+				+ "                throw new NullPointerException();\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public enum InnerEnum {\n"
+				+ "        A, B, C, D;\n"
+				+ "    }\n"
+				+ "    public int foo(InnerEnum k) {\n"
+				+ "        return switch (k) {\n"
+				+ "            case A, B -> /* comment 1 */ 6; /* abc */\n"
+				+ "            case C -> {\n"
+				+ "                System.out.println(\"x\"); //$NON-NLS-1$\n"
+				+ "                /* comment 2 */\n"
+				+ "                yield 8; /* def */\n"
+				+ "            }\n"
+				+ "            case D -> 9;\n"
+				+ "            default -> throw new NullPointerException();\n"
+				+ "        };\n"
+				+ "    }\n"
+				+ "}\n";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testConvertToReturnSwitchExpressionIssue104_2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public enum InnerEnum {\n"
+				+ "        A, B, C, D;\n"
+				+ "    }\n"
+				+ "    public int foo(InnerEnum k) {\n"
+				+ "        switch (k) {\n"
+				+ "            case A:\n"
+				+ "            case B:\n"
+				+ "                /* comment 1 */\n"
+				+ "                return 6; /* abc */\n"
+				+ "            case C:\n"
+				+ "                System.out.println(\"x\"); //$NON-NLS-1$\n"
+				+ "                /* comment 2 */\n"
+				+ "                return 8; /* def */\n"
+				+ "            case D:\n"
+				+ "                return 9;\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public enum InnerEnum {\n"
+				+ "        A, B, C, D;\n"
+				+ "    }\n"
+				+ "    public int foo(InnerEnum k) {\n"
+				+ "        return switch (k) {\n"
+				+ "            case A, B -> /* comment 1 */ 6; /* abc */\n"
+				+ "            case C -> {\n"
+				+ "                System.out.println(\"x\"); //$NON-NLS-1$\n"
+				+ "                /* comment 2 */\n"
+				+ "                yield 8; /* def */\n"
+				+ "            }\n"
+				+ "            case D -> 9;\n"
+				+ "        };\n"
+				+ "    }\n"
+				+ "}\n";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testDoNotConvertToReturnSwitchExpressionIssue104_1() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public enum InnerEnum {\n"
+				+ "        A, B, C, D;\n"
+				+ "    }\n"
+				+ "    public int foo(InnerEnum k) {\n"
+				+ "        switch (k) {\n"
+				+ "            case A:\n"
+				+ "                System.out.println(\"a\");\n"
+				+ "            case B:\n"
+				+ "                /* comment 1 */\n"
+				+ "                return 6; /* abc */\n"
+				+ "            case C: {\n"
+				+ "                System.out.println(\"x\"); //$NON-NLS-1$\n"
+				+ "                /* comment 2 */\n"
+				+ "                return 8; /* def */\n"
+				+ "            }\n"
+				+ "            case D:\n"
+				+ "                return 9;\n"
+				+ "            default:\n"
+				+ "                throw new NullPointerException();\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
+	}
+
+	@Test
+	public void testDoNotConvertToReturnSwitchExpressionIssue104_2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public enum InnerEnum {\n"
+				+ "        A, B, C, D;\n"
+				+ "    }\n"
+				+ "    public int foo(InnerEnum k, int x) {\n"
+				+ "        switch (k) {\n"
+				+ "            case A:\n"
+				+ "                System.out.println(\"a\");\n"
+				+ "            case B:\n"
+				+ "                /* comment 1 */\n"
+				+ "                if (x > 3)\n"
+				+ "                    return 6; /* abc */\n"
+				+ "                else\n"
+				+ "                    return 10;\n"
+				+ "            case C: {\n"
+				+ "                System.out.println(\"x\"); //$NON-NLS-1$\n"
+				+ "                /* comment 2 */\n"
+				+ "                return 8; /* def */\n"
+				+ "            }\n"
+				+ "            case D:\n"
+				+ "                return 9;\n"
+				+ "            default:\n"
+				+ "                throw new NullPointerException();\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
+	}
+
+	@Test
 	public void testDoNotConvertToSwitchExpressionNoBreak() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= "" //

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
@@ -448,6 +448,7 @@ public class CleanUpTest14 extends CleanUpTestCase {
 			    + "            case 13:\n" //
 			    + "            case 32:\n" //
 			    + "            case 9:\n" //
+			    + "                // comment 1\n"
 			    + "                isWhiteSpace = true; /* comment x */\n" //
 			    + "                break;\n" //
 			    + "            case 0:\n" //
@@ -473,7 +474,7 @@ public class CleanUpTest14 extends CleanUpTestCase {
 				+ "public class E {\n" //
 			    + "    public void foo(String[] args) throws Exception {\n" //
 			    + "        boolean isWhiteSpace = switch (args[0].charAt(0)) {\n" //
-			    + "            case 10, 12, 13, 32, 9 -> true; /* comment x */\n" //
+			    + "            case 10, 12, 13, 32, 9 -> /* comment 1 */ true; /* comment x */\n" //
 			    + "            case 0 -> throw new Exception(\"invalid char\"); //$NON-NLS-1$\n" //
 			    + "            case 95 -> {\n" //
 			    + "                System.out.println(\"non-whitespace\");\n" //
@@ -516,6 +517,7 @@ public class CleanUpTest14 extends CleanUpTestCase {
 				+ "                return 8; /* def */\n"
 				+ "            }\n"
 				+ "            case D:\n"
+				+ "                // comment 3\n"
 				+ "                return 9;\n"
 				+ "            default:\n"
 				+ "                throw new NullPointerException();\n"
@@ -543,7 +545,7 @@ public class CleanUpTest14 extends CleanUpTestCase {
 				+ "                /* comment 2 */\n"
 				+ "                yield 8; /* def */\n"
 				+ "            }\n"
-				+ "            case D -> 9;\n"
+				+ "            case D -> /* comment 3 */ 9;\n"
 				+ "            default -> throw new NullPointerException();\n"
 				+ "        };\n"
 				+ "    }\n"


### PR DESCRIPTION
- fixes #104
- recognize switches that have return statements or throw statements
  from every case and convert switch statement to a return of a
  switch expression
- add new tests to CleanUpTest14

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

