### PR TITLE
Fix while loop to enhanced for loop conversion issue with EntrySet github issue 109

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -425,16 +425,12 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 			looptargettype= type2.resolveBinding().getErasure().getQualifiedName();
 			Type collectionType= ast.newSimpleType(addImport(looptargettype, cuRewrite, ast));
 			ParameterizedType genericType= ast.newParameterizedType(collectionType);
-			if(typeArguments.size()==1) {
-				object= typeArguments.get(0);
-				String fullyQualifiedName= object.getName().getFullyQualifiedName();
-				genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName)));
-			} else if(typeArguments.size()==2){
-				object= typeArguments.get(0);
+			object= typeArguments.get(0);
+			String fullyQualifiedName= object.getName().getFullyQualifiedName();
+			genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName)));
+			if(typeArguments.size()==2){
 				SimpleType object2= typeArguments.get(1);
-				String fullyQualifiedName= object.getName().getFullyQualifiedName();
 				String fullyQualifiedName2= object2.getName().getFullyQualifiedName();
-				genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName)));
 				genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName2)));
 			}
 			result.setType(genericType);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -408,7 +408,6 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 			type= typedAncestor.getType();
 		}
 		ParameterizedType mytype= null;
-		SimpleType object= null;
 		Type type2= null;
 		if (type == null) {
 			looptargettype= "java.lang.Object"; //$NON-NLS-1$

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -421,12 +421,22 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 		} else if (type instanceof ParameterizedType) {
 			mytype= (ParameterizedType) type;
 			type2= mytype.getType();
-			object= (SimpleType) mytype.typeArguments().get(0);
+			List<SimpleType> typeArguments= mytype.typeArguments();
 			looptargettype= type2.resolveBinding().getErasure().getQualifiedName();
 			Type collectionType= ast.newSimpleType(addImport(looptargettype, cuRewrite, ast));
 			ParameterizedType genericType= ast.newParameterizedType(collectionType);
-			String fullyQualifiedName= object.getName().getFullyQualifiedName();
-			genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName)));
+			if(typeArguments.size()==1) {
+				object= typeArguments.get(0);
+				String fullyQualifiedName= object.getName().getFullyQualifiedName();
+				genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName)));
+			} else if(typeArguments.size()==2){
+				object= typeArguments.get(0);
+				SimpleType object2= typeArguments.get(1);
+				String fullyQualifiedName= object.getName().getFullyQualifiedName();
+				String fullyQualifiedName2= object2.getName().getFullyQualifiedName();
+				genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName)));
+				genericType.typeArguments().add(ast.newSimpleType(ast.newName(fullyQualifiedName2)));
+			}
 			result.setType(genericType);
 		} else {
 			looptargettype= type.resolveBinding().getQualifiedName();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -4381,7 +4381,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		                + "        }\n"
 		                + "    }\n"
 		                + "}\n";
-		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
+		ICompilationUnit cu1= pack1.createCompilationUnit("Test.java", sample, false, null);
 
 		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
 
@@ -4398,6 +4398,48 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String expected1= sample;
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
+	/**
+	 * https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/109
+	 *
+	 * @throws CoreException
+	 */
+	@Test
+	public void testWhileIssue109_EntrySet() throws CoreException {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "import java.util.Map.Entry;\n"
+				+ "public class Test {\n"
+				+ "		void m() {\n"
+				+ "			Map<String, Object> map = Map.of(\"Hello\", new Object());\n"
+				+ "			Iterator<Entry<String, Object>> iterator = map.entrySet().iterator();\n"
+				+ "			while (iterator.hasNext()) {\n"
+				+ "				Entry<String, Object> entry = iterator.next();\n"
+				+ "				System.out.println(entry);\n"
+				+ "			}\n"
+				+ "		}\n"
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		String expected= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "import java.util.Map.Entry;\n"
+				+ "public class Test {\n"
+				+ "		void m() {\n"
+				+ "			Map<String, Object> map = Map.of(\"Hello\", new Object());\n"
+				+ "			for (Entry<String, Object> entry : map.entrySet()) {\n"
+				+ "				System.out.println(entry);\n"
+				+ "			}\n"
+				+ "		}\n"
+				+ "}\n";
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -4443,6 +4443,46 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
 	}
 
+	/**
+	 * https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/109
+	 *
+	 * @throws CoreException
+	 */
+	@Test
+	public void testWhileIssue109_EntrySet_2() throws CoreException {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "import java.util.Map.Entry;\n"
+				+ "public class Test {\n"
+				+ "		void m(Map<List<String>, Object> map) {\n"
+				+ "			Iterator<Entry<List<String>, Object>> iterator = map.entrySet().iterator();\n"
+				+ "			while (iterator.hasNext()) {\n"
+				+ "				Entry<List<String>, Object> entry = iterator.next();\n"
+				+ "				System.out.println(entry);\n"
+				+ "			}\n"
+				+ "		}\n"
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		String expected= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "import java.util.Map.Entry;\n"
+				+ "public class Test {\n"
+				+ "		void m(Map<List<String>, Object> map) {\n"
+				+ "			for (Entry<List<String>, Object> entry : map.entrySet()) {\n"
+				+ "				System.out.println(entry);\n"
+				+ "			}\n"
+				+ "		}\n"
+				+ "}\n";
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
 	@Test
 	public void testWhileSelf() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/109

	public static void before() {
		Map<String, Object> map = Map.of("Hello", new Object());
		Iterator<Entry<String, Object>> iterator = map.entrySet().iterator();
		while (iterator.hasNext()) {
			Entry<String, Object> entry = iterator.next();
			System.out.println(entry);
		}
	}

	public static void after() {
		Map<String, Object> map = Map.of("Hello", new Object());
		for (Entry<String> entry : map.entrySet()) {
			System.out.println(entry);
		}
	}

In this case the Entry<String> is wrong and should be Entry<String,Object>


## What it does
The code now considers a more complex case Entry<String,Object>

## How to test
Run the junit test case or a code sample as given above where loop if over a map.entrySet()

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

