### PR TITLE
Forloopbug

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
@@ -462,6 +462,7 @@ public class ConvertForLoopOperation extends ConvertLoopOperation {
 		Statement body= statement.getBody();
 		try {
 			body.accept(new GenericVisitor() {
+				private boolean fGetSeen= false;
 				@Override
 				protected boolean visitNode(ASTNode node) {
 					if (node instanceof ContinueStatement) {
@@ -567,6 +568,11 @@ public class ConvertForLoopOperation extends ConvertLoopOperation {
 									!GET_QUERY.equals(methodName) &&
 									!ISEMPTY_QUERY.equals(methodName)) {
 								throw new InvalidBodyError();
+							} else if (GET_QUERY.equals(methodName)) {
+								if (fGetSeen) {
+									throw new InvalidBodyError();
+								}
+								fGetSeen= true;
 							}
 						}
 					}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -1298,6 +1298,31 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testJava50ForLoopIssue109() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "import java.util.List;\n" //
+				+ "import java.util.ArrayList;\n" //
+				+ "public class E1 {\n" //
+				+ "    public void foo() {\n" //
+				+ "        List<String> list1 = new ArrayList();\n" //
+				+ "        for (int i = 0; i < list1.size(); i++) {\n" //
+				+ "            String s1 = list1.get(i);\n" //
+				+ "            String s2 = list1.get(i);\n" //
+				+ "            System.out.println(s1 + \",\" + s2); //$NON-NLS-1$\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "}\n";
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
+	}
+
+	@Test
 	public void testBug550726() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= "" //


### PR DESCRIPTION
## What it does
Fixes part of issue 109

Don't convert a for loop to enhanced for loop that refers to a collection's get() method more than once in the loop body.

## How to test
Try the Convert to enhanced for loop cleanup on:

	public void before1() {
		List<String> list1 = List.of(""); //$NON-NLS-1$
		for (int i = 0; i < list1.size(); i++) {
			String s1 = list1.get(i);
			String s2 = list1.get(i);
			System.out.println(s1 + "," + s2); //$NON-NLS-1$
		}
	}


## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

