### PR TITLE
Forloopbug2

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
@@ -885,7 +885,7 @@ public class ConvertForLoopOperation extends ConvertLoopOperation {
 				if (fElementDeclaration != null && node.getLocationInParent() == VariableDeclarationFragment.INITIALIZER_PROPERTY) {
 					VariableDeclarationFragment fragment= (VariableDeclarationFragment)node.getParent();
 					IBinding targetBinding= fragment.getName().resolveBinding();
-					if (targetBinding != null) {
+					if (targetBinding != null && fragment.getName().getFullyQualifiedName().equals(parameterName)) {
 						VariableDeclarationStatement statement= (VariableDeclarationStatement)fragment.getParent();
 
 						if (statement.fragments().size() == 1) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
@@ -462,7 +462,6 @@ public class ConvertForLoopOperation extends ConvertLoopOperation {
 		Statement body= statement.getBody();
 		try {
 			body.accept(new GenericVisitor() {
-				private boolean fGetSeen= false;
 				@Override
 				protected boolean visitNode(ASTNode node) {
 					if (node instanceof ContinueStatement) {
@@ -568,11 +567,6 @@ public class ConvertForLoopOperation extends ConvertLoopOperation {
 									!GET_QUERY.equals(methodName) &&
 									!ISEMPTY_QUERY.equals(methodName)) {
 								throw new InvalidBodyError();
-							} else if (GET_QUERY.equals(methodName)) {
-								if (fGetSeen) {
-									throw new InvalidBodyError();
-								}
-								fGetSeen= true;
 							}
 						}
 					}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -1297,7 +1297,55 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}
 
-	@Test
+    @Test
+    public void testJava50ForLoopIssue109() throws Exception {
+            IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+            String sample= "" //
+                            + "package test1;\n" //
+                            + "import java.util.List;\n" //
+                            + "import java.util.ArrayList;\n" //
+                            + "public class E1 {\n" //
+                            + "    public void foo() {\n" //
+                            + "        List<String> list1 = new ArrayList();\n" //
+                            + "        for (int i = 0; i < list1.size(); i++) {\n" //
+                            + "            String s1 = list1.get(i);\n" //
+                            + "            String s2 = list1.get(i);\n" //
+                            + "            System.out.println(s1 + \",\" + s2); //$NON-NLS-1\n" //
+                            + "        }\n" //
+                            + "        for (int i = 0; i < list1.size(); i++) {\n" //
+                            + "            System.out.println(list1.get(i));\n" //
+                            + "            System.out.println(list1.get(i));\n"	//
+                            + "        }\n" //
+                            + "    }\n" //
+                            + "}\n";
+
+            ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
+
+            enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+            sample= "" //
+                    + "package test1;\n" //
+                    + "import java.util.List;\n" //
+                    + "import java.util.ArrayList;\n" //
+                    + "public class E1 {\n" //
+                    + "    public void foo() {\n" //
+                    + "        List<String> list1 = new ArrayList();\n" //
+                    + "        for (String s1 : list1) {\n" //
+                    + "            String s2 = s1;\n" //
+                    + "            System.out.println(s1 + \",\" + s2); //$NON-NLS-1\n" //
+                    + "        }\n" //
+                    + "        for (String element : list1) {\n" //
+                    + "            System.out.println(element);\n" //
+                    + "            System.out.println(element);\n"	//
+                    + "        }\n" //
+                    + "    }\n" //
+                    + "}\n";
+            String expected1= sample;
+
+    		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+    }
+
+    @Test
 	public void testBug550726() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= "" //

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -1298,31 +1298,6 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 	}
 
 	@Test
-	public void testJava50ForLoopIssue109() throws Exception {
-		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		String sample= "" //
-				+ "package test1;\n" //
-				+ "import java.util.List;\n" //
-				+ "import java.util.ArrayList;\n" //
-				+ "public class E1 {\n" //
-				+ "    public void foo() {\n" //
-				+ "        List<String> list1 = new ArrayList();\n" //
-				+ "        for (int i = 0; i < list1.size(); i++) {\n" //
-				+ "            String s1 = list1.get(i);\n" //
-				+ "            String s2 = list1.get(i);\n" //
-				+ "            System.out.println(s1 + \",\" + s2); //$NON-NLS-1$\n" //
-				+ "        }\n" //
-				+ "    }\n" //
-				+ "}\n";
-
-		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
-
-		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
-
-		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
-	}
-
-	@Test
 	public void testBug550726() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= "" //


### PR DESCRIPTION
	public void foo() {
		List<String> list1 = List.of(""); //$NON-NLS-1$
		for (int i = 0; i < list1.size(); i++) {
			String s1 = list1.get(i);
			String s2 = list1.get(i);
			System.out.println(s1 + "," + s2); //$NON-NLS-1$
		}
		List<String> stringList = List.of("Hello", "World"); //$NON-NLS-1$ //$NON-NLS-2$
		for (int i = 0; i < stringList.size(); i++) {
			System.out.println(stringList.get(i));
			System.out.println(stringList.get(i));
		}
	}

should convert to enhanced for loops as follows:

	public void foo() {
		List<String> list1 = List.of(""); //$NON-NLS-1$
		for (String s1 : list1) {
			String s2 = s1;
			System.out.println(s1 + "," + s2); //$NON-NLS-1$
		}
		List<String> stringList = List.of("Hello", "World"); //$NON-NLS-1$ //$NON-NLS-2$
		for (String element : stringList) {
			System.out.println(element);
			System.out.println(element);
		}
	}

## What it does

This patch replaces the previous fix which was to not perform the enhanced for cleanup if multiple get() calls were used.

## How to test

Run the CleanUpTest1d5 test.

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

