### PR TITLE
Fix type logic for while iterator to enhanced for cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -53,7 +53,6 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
 
 import org.eclipse.jdt.internal.common.HelperVisitor;
 import org.eclipse.jdt.internal.common.ReferenceHolder;
-import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
@@ -473,30 +472,6 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 	private Type importType(final ITypeBinding toImport, final ASTNode accessor, ImportRewrite imports, final CompilationUnit compilationUnit, TypeLocation location) {
 		ImportRewriteContext importContext= new ContextSensitiveImportRewriteContext(compilationUnit, accessor.getStartPosition(), imports);
 		return imports.addImport(toImport, compilationUnit.getAST(), importContext, location);
-	}
-
-	/**
-	 * Returns the type of elements returned by the iterator.
-	 *
-	 * @param iterator
-	 *            the iterator type binding, or <code>null</code>
-	 * @param ast
-	 *            the AST
-	 * @return the element type
-	 */
-	private ITypeBinding getElementType(final ITypeBinding iterator, AST ast) {
-		if (iterator != null) {
-			ITypeBinding[] bindings= iterator.getTypeArguments();
-			if (bindings.length > 0) {
-				ITypeBinding arg= bindings[0];
-				if (arg.isWildcardType()) {
-					arg= ASTResolving.normalizeWildcardType(arg, true, ast);
-				}
-				return arg;
-			}
-			return iterator;
-		}
-		return ast.resolveWellKnownType(Object.class.getCanonicalName());
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -405,6 +405,7 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 
 		String looptargettype;
 		Type type;
+		ITypeBinding varBinding= null;
 		if (hit.nextWithoutVariableDeclaration || !hit.nextFound) {
 			type= null;
 		} else {
@@ -413,8 +414,9 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 			looptargettype= variable.resolveTypeBinding().getErasure().getQualifiedName();
 			VariableDeclarationStatement typedAncestor= ASTNodes.getTypedAncestor(hit.loopVarDeclaration, VariableDeclarationStatement.class);
 			type= typedAncestor.getType();
+			varBinding= type.resolveBinding();
 		}
-		if (type == null) {
+		if (type == null || varBinding == null) {
 			looptargettype= "java.lang.Object"; //$NON-NLS-1$
 			ITypeBinding binding= computeTypeArgument(hit.iteratorDeclaration);
 			if (binding != null) {
@@ -423,9 +425,7 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 			Type collectionType= ast.newSimpleType(addImport(looptargettype, cuRewrite, ast));
 			result.setType(collectionType);
 		} else {
-			ITypeBinding varBinding= hit.iteratorDeclaration.getType().resolveBinding();
-			ITypeBinding elementType= getElementType(varBinding, ast);
-			Type importType= importType(elementType, hit.iteratorDeclaration, importRewrite, (CompilationUnit)hit.iteratorDeclaration.getRoot(), TypeLocation.LOCAL_VARIABLE);
+			Type importType= importType(varBinding, hit.iteratorDeclaration, importRewrite, (CompilationUnit)hit.iteratorDeclaration.getRoot(), TypeLocation.LOCAL_VARIABLE);
 			remover.registerAddedImports(importType);
 
 			result.setType(importType);
@@ -494,6 +494,7 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 				}
 				return arg;
 			}
+			return iterator;
 		}
 		return ast.resolveWellKnownType(Object.class.getCanonicalName());
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -4483,6 +4483,46 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
 	}
 
+	/**
+	 * https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/109
+	 *
+	 * @throws CoreException
+	 */
+	@Test
+	public void testWhileIssue109_EntrySet_3() throws CoreException {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "import java.util.Map.Entry;\n"
+				+ "public class Test {\n"
+				+ "		void m(Map<List<Date>[], Date[]> map) {\n"
+				+ "         Iterator<Entry<List<Date>[], Date[]>> iterator = map.entrySet().iterator();\n" //
+				+ "         while (iterator.hasNext()) {\n" //
+				+ "             Entry<List<Date>[], Date[]> entry = iterator.next();\n" //
+				+ "             System.out.println(entry);\n" //
+				+ "         }\n" //
+				+ "		}\n"
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		String expected= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "import java.util.Map.Entry;\n"
+				+ "public class Test {\n"
+				+ "		void m(Map<List<Date>[], Date[]> map) {\n"
+				+ "         for (Entry<List<Date>[], Date[]> entry : map.entrySet()) {\n" //
+				+ "             System.out.println(entry);\n" //
+				+ "         }\n" //
+				+ "		}\n"
+				+ "}\n";
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
 	@Test
 	public void testWhileSelf() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);


### PR DESCRIPTION
- Fix EntrySet issue 109 with complex iterator types

  https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/109

- use same logic from for-with-iterator to enhanced for cleanup
  to properly set the type of the enhanced for loop variable


## What it does
Fix the while loop to enhanced for loop cleanup to properly set the loop var type for all cases

## How to test
Run CleanUpTest1d8 as new test has been added with generic array

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

