### PR TITLE
add ignored test for jdt.ui issue 120

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -260,6 +260,7 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 		});
 		return !hit.isInvalid;
 	}
+
 	private static String computeNextVarname(WhileStatement whilestatement) {
 		String name= null;
 		Expression exp= whilestatement.getExpression();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -5818,6 +5818,86 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testWhileIssue120_WithOptionVarUsed() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+						+ "import java.util.*;\n"
+						+ "public class Test {\n"
+						+ "    private static <K, V> List<V> method(Map<K, List<V>> map) {\n"
+						+ "       List<V> results = new ArrayList<>();\n"
+						+ "       Iterator<List<V>> iterator = map.values().iterator();\n"
+						+ "       while (iterator.hasNext()) {\n"
+						+ "          results.addAll(iterator.next());\n"
+						+ "       }\n"
+						+ "       return results;\n"
+						+ "    }\n"
+						+ "}\n";
+		ICompilationUnit cu1= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED,
+				CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_ONLY_IF_LOOP_VAR_USED);
+
+		sample= "" //
+				+ "package test;\n"
+						+ "import java.util.*;\n"
+						+ "public class Test {\n"
+						+ "    private static <K, V> List<V> method(Map<K, List<V>> map) {\n"
+						+ "       List<V> results = new ArrayList<>();\n"
+						+ "       Iterator<List<V>> iterator = map.values().iterator();\n"
+						+ "       while (iterator.hasNext()) {\n"
+						+ "          results.addAll(iterator.next());\n"
+						+ "       }\n"
+						+ "       return results;\n"
+						+ "    }\n"
+						+ "}\n";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
+	@Ignore("java.lang.IllegalArgumentException: Invalid identifier : >List<V><")
+	@Test
+	public void testWhileIssue120_WithoutOptionVarUsed() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+						+ "import java.util.*;\n"
+						+ "public class Test {\n"
+						+ "    private static <K, V> List<V> method(Map<K, List<V>> map) {\n"
+						+ "       List<V> results = new ArrayList<>();\n"
+						+ "       Iterator<List<V>> iterator = map.values().iterator();\n"
+						+ "       while (iterator.hasNext()) {\n"
+						+ "          results.addAll(iterator.next());\n"
+						+ "       }\n"
+						+ "       return results;\n"
+						+ "    }\n"
+						+ "}\n";
+		ICompilationUnit cu1= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		sample= "" //
+				+ "package test;\n"
+						+ "import java.util.*;\n"
+						+ "public class Test {\n"
+						+ "    private static <K, V> List<V> method(Map<K, List<V>> map) {\n"
+						+ "       List<V> results = new ArrayList<>();\n"
+						+ "       Iterator<List<V>> iterator = map.values().iterator();\n"
+						+ "       while (iterator.hasNext()) {\n"
+						+ "          results.addAll(iterator.next());\n"
+						+ "       }\n"
+						+ "       return results;\n"
+						+ "    }\n"
+						+ "}\n";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
+	@Test
 	public void testWhileSubtype() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -5857,7 +5857,6 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
 	}
 
-	@Ignore("java.lang.IllegalArgumentException: Invalid identifier : >List<V><")
 	@Test
 	public void testWhileIssue120_WithoutOptionVarUsed() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTestCase.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTestCase.java
@@ -153,6 +153,13 @@ public abstract class CleanUpTestCase extends QuickFixTest {
 		commitProfile();
 	}
 
+	protected void enable(String... keys) throws CoreException {
+		for(String key:keys) {
+			fProfile.getSettings().put(key, CleanUpOptions.TRUE);
+		}
+		commitProfile();
+	}
+
 	private void commitProfile() throws CoreException {
 		List<Profile> profiles= CleanUpPreferenceUtil.getBuiltInProfiles();
 		profiles.add(fProfile);


### PR DESCRIPTION
tbd fix ignore test case provided in 
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/120

```
private static <K, V> List<V> method(Map<K, List<V>> map) {
	List<V> results = new ArrayList<>();
	Iterator<List<V>> iterator = map.values().iterator();
	while (iterator.hasNext()) {
		results.addAll(iterator.next());
	}
	return results;
}
```

## What it does
Should allow the code above to be processed using "Only if loop variable used" option

![image](https://user-images.githubusercontent.com/3164220/175828407-c760059e-d7db-4f1b-86b7-397cfa35c64a.png)


## How to test
Test the code shown above from issue 120 

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

