### PR TITLE
Add unit-test case for #120 and fix generic-import bug of enhanced-for-loop cleanUp

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -4523,6 +4523,47 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
 	}
 
+	/**
+	 * https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/120
+	 *
+	 * @throws CoreException
+	 */
+	@Test
+	public void testWhileIssue120_CollectionTypeResolution() throws CoreException {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "public class Test {\n"
+				+ "    private static <K, V> List<V> m(Map<K, List<V>> map) {\n"
+				+ "        List<V> results = new ArrayList<>();\n"
+				+ "        Iterator<List<V>> iterator = map.values().iterator();\n"
+				+ "        while (iterator.hasNext()) {\n"
+				+ "            results.addAll(iterator.next());\n"
+				+ "        }\n"
+				+ "        return results;\n"
+				+ "    }"
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		String expected= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "public class Test {\n"
+				+ "    private static <K, V> List<V> m(Map<K, List<V>> map) {\n"
+				+ "        List<V> results = new ArrayList<>();\n"
+				+ "        for (List<V> element : map.values()) {\n"
+				+ "            results.addAll(element);\n"
+				+ "        }\n"
+				+ "        return results;\n"
+				+ "    }"
+				+ "}\n";
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
 	@Test
 	public void testWhileSelf() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);


### PR DESCRIPTION
## What it does

Add a unit test case for issu e#120 with the reproducer presented there.

This test case also shows that the fix for #120, PR #123, falsely adds an additional import for the generic type `V`.


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

