### PR TITLE
Add Junit5 Test suite to start VisitorTest

### DIFF
--- a/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTView.java
+++ b/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTView.java
@@ -1647,8 +1647,7 @@ public class ASTView extends ViewPart implements IShowInSource, IShowInTargetLis
 	protected void performDelete() {
 		boolean removed= false;
 		IStructuredSelection selection= (IStructuredSelection) fTray.getSelection();
-		for (Iterator<?> iter= selection.iterator(); iter.hasNext();) {
-			Object obj= iter.next();
+		for (Object obj : selection) {
 			if (obj instanceof DynamicAttributeProperty)
 				obj= ((DynamicAttributeProperty) obj).getParent();
 			if (obj instanceof DynamicBindingProperty)

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -589,9 +588,7 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 				fIgnoreLowerCaseNames,
 				unresolvableImportMatcher);
 
-		Iterator<SimpleName> refIterator= typeReferences.iterator();
-		while (refIterator.hasNext()) {
-			SimpleName typeRef= refIterator.next();
+		for (SimpleName typeRef : typeReferences) {
 			processor.add(typeRef);
 		}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
@@ -807,8 +807,8 @@ public final class StubUtility2Core {
 
 		List<IMethodBinding> allInterfaceMethods= new ArrayList<>();
 
-		for (int i= 0; i < interfaceMethods.length; i++) {
-			for (IMethodBinding method : interfaceMethods[i]) {
+		for (Collection<IMethodBinding> interfaceMethod : interfaceMethods) {
+			for (IMethodBinding method : interfaceMethod) {
 				if (isDefault(method) || isAbstract(method)) {
 					IMethodBinding previouslyFound= findSubSignatureMethod(method, allMethods);
 					if (previouslyFound == null) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/ConvertAnonymousToNestedRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/ConvertAnonymousToNestedRefactoring.java
@@ -365,9 +365,7 @@ public class ConvertAnonymousToNestedRefactoring extends Refactoring {
     private boolean accessesAnonymousFields() {
         List<IVariableBinding> anonymousInnerFieldTypes = getAllEnclosingAnonymousTypesField();
         List<IBinding> accessedField = getAllAccessedFields();
-        final Iterator<IVariableBinding> it = anonymousInnerFieldTypes.iterator();
-        while(it.hasNext()) {
-            final IVariableBinding variableBinding = it.next();
+        for (IVariableBinding variableBinding : anonymousInnerFieldTypes) {
             final Iterator<IBinding> it2 = accessedField.iterator();
             while (it2.hasNext()) {
                 IVariableBinding variableBinding2 = (IVariableBinding) it2.next();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/template/java/JavaContextCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/template/java/JavaContextCore.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -207,9 +206,8 @@ public class JavaContextCore extends CompilationUnitContext implements IJavaCont
 		if (fCompatibleContextTypeIds == null)
 			return false;
 
-		Iterator<String> iter= fCompatibleContextTypeIds.iterator();
-		while (iter.hasNext()) {
-			if (template.matches(key, iter.next()))
+		for (String fCompatibleContextTypeId : fCompatibleContextTypeIds) {
+			if (template.matches(key, fCompatibleContextTypeId))
 				return true;
 		}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/MethodOverrideTester.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/MethodOverrideTester.java
@@ -199,8 +199,8 @@ public class MethodOverrideTester {
 			ans.addAll(findAllOverriddenMethodsInHierarchy(superClass, overriding));
 		}
 		IType[] superInterfaces= fHierarchy.getSuperInterfaces(type);
-		for (int i= 0; i < superInterfaces.length; i++) {
-			ans.addAll(findAllOverriddenMethodsInHierarchy(superInterfaces[i], overriding));
+		for (IType element : superInterfaces) {
+			ans.addAll(findAllOverriddenMethodsInHierarchy(element, overriding));
 		}
 		return ans;
 	}
@@ -243,8 +243,7 @@ public class MethodOverrideTester {
 		if (Flags.isPrivate(flags) || Flags.isStatic(flags) || overriding.isConstructor())
 			return ans;
 		IMethod[] overriddenMethods= overriddenType.getMethods();
-		for (int i= 0; i < overriddenMethods.length; i++) {
-			IMethod overridden= overriddenMethods[i];
+		for (IMethod overridden : overriddenMethods) {
 			flags= overridden.getFlags();
 			if (Flags.isPrivate(flags) || Flags.isStatic(flags) || overridden.isConstructor())
 				continue;

--- a/org.eclipse.jdt.jeview/src/org/eclipse/jdt/jeview/views/JavaElementView.java
+++ b/org.eclipse.jdt.jeview/src/org/eclipse/jdt/jeview/views/JavaElementView.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -222,8 +221,7 @@ public class JavaElementView extends ViewPart implements IShowInSource, IShowInT
 		public IStructuredSelection getSelection() {
 			IStructuredSelection selection= (IStructuredSelection) fViewer.getSelection();
 			ArrayList<Object> externalSelection= new ArrayList<>();
-			for (Iterator<?> iter= selection.iterator(); iter.hasNext();) {
-				Object element= iter.next();
+			for (Object element : selection) {
 				if (element instanceof JavaElement) {
 					IJavaElement javaElement= ((JavaElement) element).getJavaElement();
 					if (javaElement != null && ! (javaElement instanceof IJavaModel)) // various selection listeners assume getJavaProject() is non-null
@@ -943,8 +941,7 @@ public class JavaElementView extends ViewPart implements IShowInSource, IShowInT
 			IStructuredSelection structuredSelection= ((IStructuredSelection) selection);
 			if (structuredSelection.size() >= 1) {
 				List<Object> input= new ArrayList<>();
-				for (Iterator<?> iter = structuredSelection.iterator(); iter.hasNext();) {
-					Object item= iter.next();
+				for (Object item : structuredSelection) {
 					if (item instanceof IJavaElement || item instanceof IResource || item instanceof IJarEntryResource) {
 						input.add(item);
 					}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/EditorTestHelper.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/EditorTestHelper.java
@@ -17,7 +17,6 @@ package org.eclipse.jdt.text.tests.performance;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -527,9 +526,7 @@ public class EditorTestHelper {
 				subDirs.add(file);
 			}
 		}
-		Iterator<File> iter= subDirs.iterator();
-		while (iter.hasNext()) {
-			File subDir= iter.next();
+		for (File subDir : subDirs) {
 			addJavaFiles(subDir, collection);
 		}
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/ScrollVerticalRulerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/ScrollVerticalRulerTest.java
@@ -79,9 +79,7 @@ public abstract class ScrollVerticalRulerTest extends ScrollEditorTest {
 		IEclipsePreferences editorsNode= InstanceScope.INSTANCE.getNode(EditorsUI.PLUGIN_ID);
 
 		MarkerAnnotationPreferences markerAnnotationPreferences= EditorsPlugin.getDefault().getMarkerAnnotationPreferences();
-		Iterator<AnnotationPreference> iterator= markerAnnotationPreferences.getAnnotationPreferences().iterator();
-		while (iterator.hasNext()) {
-			AnnotationPreference pref= iterator.next();
+		for (AnnotationPreference pref : markerAnnotationPreferences.getAnnotationPreferences()) {
 			String preferenceKey= pref.getVerticalRulerPreferenceKey();
 			if ("spellingIndicationInVerticalRuler".equals(preferenceKey)) {
 				editorsNode.putBoolean(preferenceKey, true);
@@ -101,9 +99,7 @@ public abstract class ScrollVerticalRulerTest extends ScrollEditorTest {
 		IEclipsePreferences editorsNode= InstanceScope.INSTANCE.getNode(EditorsUI.PLUGIN_ID);
 
 		MarkerAnnotationPreferences markerAnnotationPreferences= EditorsPlugin.getDefault().getMarkerAnnotationPreferences();
-		Iterator<AnnotationPreference> iterator= markerAnnotationPreferences.getAnnotationPreferences().iterator();
-		while (iterator.hasNext()) {
-			AnnotationPreference pref= iterator.next();
+		for (AnnotationPreference pref : markerAnnotationPreferences.getAnnotationPreferences()) {
 			String preferenceKey= pref.getVerticalRulerPreferenceKey();
 			if ("spellingIndicationInVerticalRuler".equals(preferenceKey)) {
 				editorsNode.putBoolean(preferenceKey, false);

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/util/History.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/util/History.java
@@ -21,7 +21,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.util.Collection;
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -288,9 +287,7 @@ public abstract class History<K, V> {
 			Element rootElement = document.createElement(fRootNodeName);
 			document.appendChild(rootElement);
 
-			Iterator<V> values= getValues().iterator();
-			while (values.hasNext()) {
-				Object object= values.next();
+			for (Object object : getValues()) {
 				Element element= document.createElement(fInfoNodeName);
 				setAttributes(object, element);
 				rootElement.appendChild(element);

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsConstraintsSolver.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsConstraintsSolver.java
@@ -210,11 +210,8 @@ public class InferTypeArgumentsConstraintsSolver {
 	 * to process
 	 */
 	private void processConstraints(List<ITypeConstraint2> usedIn) {
-		Iterator<ITypeConstraint2> iter= usedIn.iterator();
-		while (iter.hasNext()) {
-			ITypeConstraint2 tc= iter.next();
-
-				maintainSimpleConstraint(tc);
+		for (ITypeConstraint2 tc : usedIn) {
+			maintainSimpleConstraint(tc);
 				//TODO: prune tcs which cannot cause further changes
 				// Maybe these should be pruned after a special first loop over all ConstraintVariables,
 				// Since this can only happen once for every CV in the work list.

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/nls/NLSHintHelper.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/nls/NLSHintHelper.java
@@ -17,7 +17,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -310,10 +309,7 @@ public class NLSHintHelper {
 		if (fieldName != null)
 			return (String)resultCollector.get(fieldName);
 
-		// Now try hard-coded bundle name String field names from NLS tooling:
-		Iterator<Object> iter= resultCollector.keySet().iterator();
-		while (iter.hasNext()) {
-			Object o= iter.next();
+		for (Object o : resultCollector.keySet()) {
 			if (!(o instanceof IBinding))
 				continue;
 			IBinding binding= (IBinding)o;

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeSignatureProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeSignatureProcessor.java
@@ -1457,9 +1457,7 @@ public class ChangeSignatureProcessor extends RefactoringProcessor implements ID
 	}
 
 	private void addArgumentsToNewSuperConstructorCall(SuperConstructorInvocation superCall, CompilationUnitRewrite cuRewrite) {
-		Iterator<ParameterInfo> iter= getNotDeletedInfos().iterator();
-		while (iter.hasNext()) {
-			ParameterInfo info= iter.next();
+		for (ParameterInfo info : getNotDeletedInfos()) {
 			Expression newExpression= createNewExpression(info, getParameterInfos(), superCall.arguments(), cuRewrite, ASTNodes.getParent(superCall, MethodDeclaration.class));
 			if (newExpression != null)
 				superCall.arguments().add(newExpression);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/CreateModuleInfoAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/CreateModuleInfoAction.java
@@ -16,9 +16,7 @@ package org.eclipse.jdt.internal.ui.actions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.swt.layout.GridData;
@@ -211,9 +209,7 @@ public class CreateModuleInfoAction implements IObjectActionDelegate {
 	private void updateComplianceSettings(IJavaProject project, String compliance) {
 		HashMap<String, String> defaultOptions= new HashMap<>();
 		JavaCore.setComplianceOptions(compliance, defaultOptions);
-		Iterator<Map.Entry<String, String>> it= defaultOptions.entrySet().iterator();
-		while (it.hasNext()) {
-			Entry<String, String> pair= it.next();
+		for (Entry<String, String> pair : defaultOptions.entrySet()) {
 			project.setOption(pair.getKey(), pair.getValue());
 		}
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/EnablePreviewFeaturesAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/EnablePreviewFeaturesAction.java
@@ -14,7 +14,6 @@
 package org.eclipse.jdt.internal.ui.actions;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -155,9 +154,7 @@ public class EnablePreviewFeaturesAction implements IObjectActionDelegate {
 	private void updateComplianceSettings(IJavaProject project, String compliance) {
 		HashMap<String, String> defaultOptions= new HashMap<>();
 		JavaCore.setComplianceOptions(compliance, defaultOptions);
-		Iterator<Map.Entry<String, String>> it= defaultOptions.entrySet().iterator();
-		while (it.hasNext()) {
-			Entry<String, String> pair= it.next();
+		for (Entry<String, String> pair : defaultOptions.entrySet()) {
 			project.setOption(pair.getKey(), pair.getValue());
 		}
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/PackagesViewHierarchicalContentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/PackagesViewHierarchicalContentProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.ui.browsing;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.swt.widgets.Control;
@@ -335,9 +334,7 @@ class PackagesViewHierarchicalContentProvider extends LogicalPackagesProvider im
 			if(!fragments.isEmpty()) {
 				LogicalPackage logicalPackage= new LogicalPackage(pkgFragment);
 				fMapToLogicalPackage.put(getKey(pkgFragment), logicalPackage);
-				Iterator<IPackageFragment> iter= fragments.iterator();
-				while(iter.hasNext()){
-					IPackageFragment f= iter.next();
+				for (IPackageFragment f : fragments) {
 					if(logicalPackage.belongs(f)){
 						logicalPackage.add(f);
 						fMapToLogicalPackage.put(getKey(f), logicalPackage);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/compare/JavaStructureCreator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/compare/JavaStructureCreator.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.ui.compare;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -428,11 +427,7 @@ public class JavaStructureCreator extends StructureCreator {
 			rewriteTree(differencer, diff);
 		}
 
-		// now we have to rebuild the diff tree according to the combined
-		// changes
-		Iterator<String> it= map.keySet().iterator();
-		while (it.hasNext()) {
-			String name= it.next();
+		for (String name : map.keySet()) {
 			RewriteInfo i= map.get(name);
 			if (i.matches()) { // we found a RewriteInfo that could be successfully combined
 
@@ -441,9 +436,7 @@ public class JavaStructureCreator extends StructureCreator {
 				DiffNode d= (DiffNode) differencer.findDifferences(true, null, root, i.fAncestor, i.fLeft, i.fRight);
 				if (d != null) {// there better should be a difference
 					d.setDontExpand(true);
-					Iterator<IDiffElement> it2= i.fChildren.iterator();
-					while (it2.hasNext()) {
-						IDiffElement rd= it2.next();
+					for (IDiffElement rd : i.fChildren) {
 						root.removeToRoot(rd);
 						d.add(rd);
 					}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filtertable/FilterManager.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filtertable/FilterManager.java
@@ -78,9 +78,9 @@ public class FilterManager {
 		ArrayList<String> active = new ArrayList<>();
 		ArrayList<String> inactive = new ArrayList<>();
 		String name = ""; //$NON-NLS-1$
-		for (int i = 0; i < filters.length; i++) {
-			name = filters[i].getName();
-			if (filters[i].isChecked()) {
+		for (Filter filter : filters) {
+			name = filter.getName();
+			if (filter.isChecked()) {
 				active.add(name);
 			} else {
 				inactive.add(name);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filtertable/JavaFilterTable.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filtertable/JavaFilterTable.java
@@ -500,8 +500,8 @@ public class JavaFilterTable {
 			Object[] packages= dialog.getResult();
 			if (packages != null) {
 				IJavaElement pkg= null;
-				for (int i= 0; i < packages.length; i++) {
-					pkg= (IJavaElement) packages[i];
+				for (Object package1 : packages) {
+					pkg= (IJavaElement) package1;
 					String filter= pkg.getElementName() + ".*"; //$NON-NLS-1$
 					addFilter(filter, true);
 				}
@@ -533,9 +533,9 @@ public class JavaFilterTable {
 	 */
 	private void initTableState(boolean defaults) {
 		Filter[] filters= getAllStoredFilters(defaults);
-		for (int i= 0; i < filters.length; i++) {
-			fTableViewer.add(filters[i]);
-			setChecked(filters[i], filters[i].isChecked());
+		for (Filter filter : filters) {
+			fTableViewer.add(filter);
+			setChecked(filter, filter.isChecked());
 		}
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarFileExportOperation.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarFileExportOperation.java
@@ -256,9 +256,7 @@ public class JarFileExportOperation extends WorkspaceModifyOperation implements 
 		if (fJarPackage.areOutputFoldersExported()) {
 			if (!fJarPackage.areJavaFilesExported())
 				count= 0;
-			Iterator<IJavaProject> iter= enclosingJavaProjects.iterator();
-			while (iter.hasNext()) {
-				IJavaProject javaProject= iter.next();
+			for (IJavaProject javaProject : enclosingJavaProjects) {
 				IContainer[] outputContainers;
 				try {
 					outputContainers= getOutputContainers(javaProject);
@@ -647,9 +645,7 @@ public class JarFileExportOperation extends WorkspaceModifyOperation implements 
 		if (javaProjects == null)
 			return;
 
-		Iterator<IJavaProject> iter= javaProjects.iterator();
-		while (iter.hasNext()) {
-			IJavaProject javaProject= iter.next();
+		for (IJavaProject javaProject : javaProjects) {
 			IContainer[] outputContainers;
 			try {
 				outputContainers= getOutputContainers(javaProject);
@@ -687,9 +683,7 @@ public class JarFileExportOperation extends WorkspaceModifyOperation implements 
 
 		// Convert paths to containers
 		Set<IContainer> outputContainers= new HashSet<>(outputPaths.size());
-		Iterator<IPath> iter= outputPaths.iterator();
-		while (iter.hasNext()) {
-			IPath path= iter.next();
+		for (IPath path : outputPaths) {
 			if (javaProject.getProject().getFullPath().equals(path))
 				outputContainers.add(javaProject.getProject());
 			else {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarPackageWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarPackageWizardPage.java
@@ -669,10 +669,8 @@ class JarPackageWizardPage extends AbstractJarDestinationWizardPage {
 	private Set<Object> removeContainedChildren(Set<Object> elements) {
 		Set<Object> newList= new HashSet<>(elements.size());
 		Set<Object> javaElementResources= getCorrespondingContainers(elements);
-		Iterator<Object> iter= elements.iterator();
 		boolean removedOne= false;
-		while (iter.hasNext()) {
-			Object element= iter.next();
+		for (Object element : elements) {
 			Object parent;
 			if (element instanceof IResource)
 				parent= ((IResource)element).getParent();
@@ -737,9 +735,7 @@ class JarPackageWizardPage extends AbstractJarDestinationWizardPage {
 	 */
 	private Set<Object> getCorrespondingContainers(Set<Object> elements) {
 		Set<Object> javaElementResources= new HashSet<>(elements.size());
-		Iterator<Object> iter= elements.iterator();
-		while (iter.hasNext()) {
-			Object element= iter.next();
+		for (Object element : elements) {
 			if (element instanceof IJavaElement) {
 				IJavaElement je= (IJavaElement)element;
 				int type= je.getElementType();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarPackagerUtil.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarPackagerUtil.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -225,9 +224,7 @@ public final class JarPackagerUtil {
 		if (resources.contains(file))
 			return true;
 
-		Iterator<IResource> iter= resources.iterator();
-		while (iter.hasNext()) {
-			IResource resource= iter.next();
+		for (IResource resource : resources) {
 			if (resource != null && resource.getType() != IResource.FILE) {
 				List<IResource> children= null;
 				try {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javadocexport/JavadocWizard.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javadocexport/JavadocWizard.java
@@ -25,7 +25,6 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.w3c.dom.Element;
@@ -375,9 +374,7 @@ public class JavadocWizard extends Wizard implements IExportWizard {
 	}
 
 	private static String getEncoding(ArrayList<String> vmArgs) {
-		Iterator<String> iter= vmArgs.iterator();
-		while (iter.hasNext()) {
-			String argument= iter.next();
+		for (String argument : vmArgs) {
 			if (argument.length() > ENCODING_ARGUMENT_PREFIX.length() && argument.startsWith(ENCODING_ARGUMENT_PREFIX)) {
 				String encoding= argument.substring(ENCODING_ARGUMENT_PREFIX.length());
 				if (Charset.isSupported(encoding))

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javadocexport/JavadocWriter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javadocexport/JavadocWriter.java
@@ -17,7 +17,6 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -287,14 +286,12 @@ public class JavadocWriter {
 
 	private String toSeparatedList(List<String> packages) {
 		StringBuilder buf= new StringBuilder();
-		Iterator<String> iter= packages.iterator();
 		int nAdded= 0;
-		while (iter.hasNext()) {
+		for (String curr : packages) {
 			if (nAdded > 0) {
 				buf.append(',');
 			}
 			nAdded++;
-			String curr= iter.next();
 			buf.append(curr);
 		}
 		return buf.toString();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitDocumentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitDocumentProvider.java
@@ -691,15 +691,13 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 
 				if (reportedProblems != null && reportedProblems.size() > 0) {
 
-					Iterator<IProblem> e= reportedProblems.iterator();
-					while (e.hasNext()) {
+					for (IProblem problem : reportedProblems) {
 
 						if (fProgressMonitor != null && fProgressMonitor.isCanceled()) {
 							isCanceled= true;
 							break;
 						}
 
-						IProblem problem= e.next();
 						Position position= createPositionFromProblem(problem);
 						if (position != null) {
 
@@ -729,9 +727,7 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 			if (isCanceled) {
 				fCurrentlyOverlaid.addAll(fPreviouslyOverlaid);
 			} else if (fPreviouslyOverlaid != null) {
-				Iterator<JavaMarkerAnnotation> e= fPreviouslyOverlaid.iterator();
-				while (e.hasNext()) {
-					JavaMarkerAnnotation annotation= e.next();
+				for (JavaMarkerAnnotation annotation : fPreviouslyOverlaid) {
 					annotation.setOverlay(null);
 				}
 			}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
@@ -1873,9 +1873,7 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 			fProjectionSupport= new ProjectionSupport((ProjectionViewer)sourceViewer, getAnnotationAccess(), getSharedColors());
 			MarkerAnnotationPreferences markerAnnotationPreferences= getAdapter(MarkerAnnotationPreferences.class);
 			if (markerAnnotationPreferences != null) {
-				Iterator<AnnotationPreference> e= markerAnnotationPreferences.getAnnotationPreferences().iterator();
-				while (e.hasNext()) {
-					AnnotationPreference annotationPreference= e.next();
+				for (AnnotationPreference annotationPreference : markerAnnotationPreferences.getAnnotationPreferences()) {
 					Object annotationType= annotationPreference.getAnnotationType();
 					if (annotationType instanceof String)
 						fProjectionSupport.addSummarizableAnnotationType((String)annotationType);
@@ -3251,9 +3249,7 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 					((IAnnotationModelExtension)annotationModel).replaceAnnotations(fOccurrenceAnnotations, annotationMap);
 				} else {
 					removeOccurrenceAnnotations();
-					Iterator<Entry<Annotation, Position>> iter= annotationMap.entrySet().iterator();
-					while (iter.hasNext()) {
-						Entry<Annotation, Position> mapEntry= iter.next();
+					for (Entry<Annotation, Position> mapEntry : annotationMap.entrySet()) {
 						annotationModel.addAnnotation(mapEntry.getKey(), mapEntry.getValue());
 					}
 				}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OverrideIndicatorManager.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OverrideIndicatorManager.java
@@ -15,7 +15,6 @@
 package org.eclipse.jdt.internal.ui.javaeditor;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -218,9 +217,7 @@ class OverrideIndicatorManager implements IJavaReconcilingListener {
 				((IAnnotationModelExtension)fAnnotationModel).replaceAnnotations(fOverrideAnnotations, annotationMap);
 			} else {
 				removeAnnotations();
-				Iterator<Entry<Annotation, Position>> iter= annotationMap.entrySet().iterator();
-				while (iter.hasNext()) {
-					Entry<Annotation, Position> mapEntry= iter.next();
+				for (Entry<Annotation, Position> mapEntry : annotationMap.entrySet()) {
 					fAnnotationModel.addAnnotation(mapEntry.getKey(), mapEntry.getValue());
 				}
 			}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/BreadcrumbViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/BreadcrumbViewer.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.internal.ui.javaeditor.breadcrumb;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
@@ -721,9 +720,7 @@ public abstract class BreadcrumbViewer extends StructuredViewer {
 		}
 
 		if (fBreadcrumbItems != null) {
-			Iterator<BreadcrumbItem> iterator= fBreadcrumbItems.iterator();
-			while (iterator.hasNext()) {
-				BreadcrumbItem item= iterator.next();
+			for (BreadcrumbItem item : fBreadcrumbItems) {
 				item.dispose();
 			}
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/FileTransferDragAdapter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/FileTransferDragAdapter.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.internal.ui.packageview;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -142,9 +141,7 @@ public class FileTransferDragAdapter extends DragSourceAdapter implements Transf
 				try {
 					monitor.beginTask(PackagesMessages.DragAdapter_deleting, elements.size());
 					MultiStatus status= createMultiStatus();
-					Iterator<IResource> iter= elements.iterator();
-					while(iter.hasNext()) {
-						IResource resource= iter.next();
+					for (IResource resource : elements) {
 						try {
 							monitor.subTask(BasicElementLabels.getPathLabel(resource.getFullPath(), true));
 							resource.delete(true, null);
@@ -175,9 +172,7 @@ public class FileTransferDragAdapter extends DragSourceAdapter implements Transf
 				try {
 					monitor.beginTask(PackagesMessages.DragAdapter_refreshing, roots.size());
 					MultiStatus status= createMultiStatus();
-					Iterator<IResource> iter= roots.iterator();
-					while (iter.hasNext()) {
-						IResource r= iter.next();
+					for (IResource r : roots) {
 						try {
 							r.refreshLocal(IResource.DEPTH_ONE, new SubProgressMonitor(monitor, 1));
 						} catch (CoreException e) {
@@ -199,9 +194,7 @@ public class FileTransferDragAdapter extends DragSourceAdapter implements Transf
 	protected Set<IResource> collectRoots(final List<IResource> elements) {
 		final Set<IResource> roots= new HashSet<>(10);
 
-		Iterator<IResource> iter= elements.iterator();
-		while (iter.hasNext()) {
-			IResource resource= iter.next();
+		for (IResource resource : elements) {
 			IResource parent= resource.getParent();
 			if (parent == null) {
 				roots.add(resource);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/AbstractConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/AbstractConfigurationBlock.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.internal.ui.preferences;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -393,11 +392,8 @@ abstract class AbstractConfigurationBlock implements IPreferenceConfigurationBlo
 			t.setText(fStore.getString(keyForStore));
 		}
 
-        // Update slaves
-        Iterator<SelectionListener> iter3= fMasterSlaveListeners.iterator();
-        while (iter3.hasNext()) {
-            SelectionListener listener= iter3.next();
-			listener.widgetSelected((SelectionEvent) null);
+        for (SelectionListener listener : fMasterSlaveListeners) {
+            listener.widgetSelected((SelectionEvent) null);
         }
 
         updateStatus(new StatusInfo());

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorHoverConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorHoverConfigurationBlock.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.ui.preferences;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.StringTokenizer;
 
@@ -398,9 +397,7 @@ class JavaEditorHoverConfigurationBlock implements IPreferenceConfigurationBlock
 	void initializeFields() {
 		fModifierEditor.setEnabled(false);
 
-		Iterator<Button> e= fCheckBoxes.keySet().iterator();
-		while (e.hasNext()) {
-			Button b= e.next();
+		for (Button b : fCheckBoxes.keySet()) {
 			String key= fCheckBoxes.get(b);
 			b.setSelection(fStore.getBoolean(key));
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/MarkOccurrencesConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/MarkOccurrencesConfigurationBlock.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.internal.ui.preferences;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.swt.SWT;
@@ -246,18 +245,13 @@ class MarkOccurrencesConfigurationBlock implements IPreferenceConfigurationBlock
 
 	void initializeFields() {
 
-		Iterator<Button> iter= fCheckBoxes.keySet().iterator();
-		while (iter.hasNext()) {
-			Button b= iter.next();
+		for (Button b : fCheckBoxes.keySet()) {
 			String key= fCheckBoxes.get(b);
 			b.setSelection(fStore.getBoolean(key));
 		}
 
-        // Update slaves
-        Iterator<SelectionListener> iter2= fMasterSlaveListeners.iterator();
-        while (iter2.hasNext()) {
-            SelectionListener listener= iter2.next();
-			listener.widgetSelected((SelectionEvent) null);
+        for (SelectionListener listener : fMasterSlaveListeners) {
+            listener.widgetSelected((SelectionEvent) null);
         }
 
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/UserLibraryPreferencePage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/UserLibraryPreferencePage.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -949,10 +948,7 @@ public class UserLibraryPreferencePage extends PreferencePage implements IWorkbe
 			monitor.worked(1);
 		}
 
-		Iterator<String> iter= oldNames.iterator();
-		while (iter.hasNext()) {
-			String name= iter.next();
-
+		for (String name : oldNames) {
 			IPath path= new Path(JavaCore.USER_LIBRARY_CONTAINER_ID).append(name);
 			try {
 				initializer.requestClasspathContainerUpdate(path, jproject, null);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ProfileStore.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ProfileStore.java
@@ -26,7 +26,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -315,10 +314,7 @@ public class ProfileStore {
 		element.setAttribute(XML_ATTRIBUTE_VERSION, Integer.toString(profile.getVersion()));
 		element.setAttribute(XML_ATTRIBUTE_PROFILE_KIND, profileVersioner.getProfileKind());
 
-		final Iterator<String> keyIter= profile.getSettings().keySet().iterator();
-
-		while (keyIter.hasNext()) {
-			final String key= keyIter.next();
+		for (String key : profile.getSettings().keySet()) {
 			final String value= profile.getSettings().get(key);
 			if (value != null) {
 				final Element setting= document.createElement(XML_NODE_SETTING);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/LRUWorkingSetsList.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/LRUWorkingSetsList.java
@@ -58,9 +58,7 @@ public class LRUWorkingSetsList {
 	}
 
 	private void removeDeletedWorkingSets() {
-		Iterator<IWorkingSet[]> iter= new ArrayList<>(fLRUList).iterator();
-		while (iter.hasNext()) {
-			IWorkingSet[] workingSets= iter.next();
+		for (IWorkingSet[] workingSets : new ArrayList<>(fLRUList)) {
 			for (IWorkingSet workingSet : workingSets) {
 				if (PlatformUI.getWorkbench().getWorkingSetManager().getWorkingSet(workingSet.getName()) == null) {
 					fLRUList.remove(workingSets);
@@ -72,9 +70,7 @@ public class LRUWorkingSetsList {
 
 	private IWorkingSet[] find(ArrayList<IWorkingSet[]> list, IWorkingSet[] workingSets) {
 		Set<IWorkingSet> workingSetList= new HashSet<>(Arrays.asList(workingSets));
-		Iterator<IWorkingSet[]> iter= list.iterator();
-		while (iter.hasNext()) {
-			IWorkingSet[] lruWorkingSets= iter.next();
+		for (IWorkingSet[] lruWorkingSets : list) {
 			Set<IWorkingSet> lruWorkingSetList= new HashSet<>(Arrays.asList(lruWorkingSets));
 			if (lruWorkingSetList.equals(workingSetList))
 				return lruWorkingSets;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchParticipantsExtensionPoint.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchParticipantsExtensionPoint.java
@@ -20,7 +20,6 @@
 package org.eclipse.jdt.internal.ui.search;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
@@ -59,10 +58,8 @@ public class SearchParticipantsExtensionPoint {
 	}
 
 	private void collectParticipants(Set<SearchParticipantRecord> participants, IProject[] projects) {
-		Iterator<SearchParticipantDescriptor> activeParticipants= getAllParticipants().iterator();
 		Set<String> seenParticipants= new HashSet<>();
-		while (activeParticipants.hasNext()) {
-			SearchParticipantDescriptor participant= activeParticipants.next();
+		for (SearchParticipantDescriptor participant : getAllParticipants()) {
 			String id= participant.getID();
 			if (participant.isEnabled() && !seenParticipants.contains(id)) {
 				for (IProject project : projects) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -3319,8 +3319,8 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		}
 
 		if (modifyExistingTry) {
-			for (int i= 0; i < coveredAutoClosableNodes.size(); i++) {
-				rewrite.remove(coveredAutoClosableNodes.get(i), null);
+			for (ASTNode coveredAutoClosableNode : coveredAutoClosableNodes) {
+				rewrite.remove(coveredAutoClosableNode, null);
 			}
 		} else {
 			if (!nodesInRange.isEmpty()) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/DefaultJavaFoldingPreferenceBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/DefaultJavaFoldingPreferenceBlock.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.ui.text.folding;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.swt.SWT;
@@ -122,9 +121,7 @@ public class DefaultJavaFoldingPreferenceBlock implements IJavaFoldingPreference
 	}
 
 	private void initializeFields() {
-		Iterator<Button> it= fCheckBoxes.keySet().iterator();
-		while (it.hasNext()) {
-			Button b= it.next();
+		for (Button b : fCheckBoxes.keySet()) {
 			String key= fCheckBoxes.get(b);
 			b.setSelection(fOverlayStore.getBoolean(key));
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDoc2HTMLTextReader.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDoc2HTMLTextReader.java
@@ -19,7 +19,6 @@ package org.eclipse.jdt.internal.ui.text.javadoc;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.jface.internal.text.html.HTMLPrinter;
@@ -132,9 +131,7 @@ public class JavaDoc2HTMLTextReader extends SubstitutionTextReader {
 	}
 
 	private void printDefinitions(StringBuilder buffer, List<String> list, boolean firstword) {
-		Iterator<String> e= list.iterator();
-		while (e.hasNext()) {
-			String s= e.next();
+		for (String s : list) {
 			buffer.append("<dd>"); //$NON-NLS-1$
 			if (!firstword)
 				buffer.append(s);
@@ -200,9 +197,7 @@ public class JavaDoc2HTMLTextReader extends SubstitutionTextReader {
 
 	private void printRest(StringBuilder buffer) {
 		if ( !fRest.isEmpty()) {
-			Iterator<Pair> e= fRest.iterator();
-			while (e.hasNext()) {
-				Pair p= e.next();
+			for (Pair p : fRest) {
 				buffer.append("<dt>"); //$NON-NLS-1$
 				if (p.fTag != null)
 					buffer.append(p.fTag);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/SpellCheckEngine.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/SpellCheckEngine.java
@@ -169,9 +169,7 @@ public class SpellCheckEngine implements ISpellCheckEngine, IPropertyChangeListe
 
 		// Try same language
 		String language= locale.getLanguage();
-		Iterator<Entry<Locale, ISpellDictionary>> iter= fLocaleDictionaries.entrySet().iterator();
-		while (iter.hasNext()) {
-			Entry<Locale, ISpellDictionary> entry= iter.next();
+		for (Entry<Locale, ISpellDictionary> entry : fLocaleDictionaries.entrySet()) {
 			Locale dictLocale= entry.getKey();
 			if (dictLocale.getLanguage().equals(language))
 				return entry.getValue();
@@ -193,9 +191,7 @@ public class SpellCheckEngine implements ISpellCheckEngine, IPropertyChangeListe
 
 		// Try same language
 		String language= locale.getLanguage();
-		Iterator<Locale> iter= getLocalesWithInstalledDictionaries().iterator();
-		while (iter.hasNext()) {
-			Locale dictLocale= iter.next();
+		for (Locale dictLocale : getLocalesWithInstalledDictionaries()) {
 			if (dictLocale.getLanguage().equals(language))
 				return dictLocale;
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/AbstractSpellDictionary.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/AbstractSpellDictionary.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -665,9 +664,7 @@ public abstract class AbstractSpellDictionary implements ISpellDictionary {
 	 * @since 3.3.
 	 */
 	private void compact() {
-		Iterator<Object> iter= fHashBuckets.values().iterator();
-		while (iter.hasNext()) {
-			Object element= iter.next();
+		for (Object element : fHashBuckets.values()) {
 			if (element instanceof ArrayList)
 				((ArrayList<?>)element).trimToSize();
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/util/SelectionUtil.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/util/SelectionUtil.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.ui.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.core.resources.IResource;
@@ -98,10 +97,7 @@ public class SelectionUtil {
 		}
 
 		final ISelection selection= new StructuredSelection(resources);
-		Iterator<IWorkbenchPart> itr= parts.iterator();
-		while (itr.hasNext()) {
-			IWorkbenchPart part= itr.next();
-
+		for (IWorkbenchPart part : parts) {
 			// get the part's ISetSelectionTarget implementation
 			ISetSelectionTarget target= null;
 			if (part instanceof ISetSelectionTarget) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/StorageLabelProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/StorageLabelProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.ui.viewsupport;
 
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.swt.graphics.Image;
@@ -71,9 +70,7 @@ public class StorageLabelProvider extends LabelProvider {
 	@Override
 	public void dispose() {
 		if (fJarImageMap != null) {
-			Iterator<Image> each= fJarImageMap.values().iterator();
-			while (each.hasNext()) {
-				Image image= each.next();
+			for (Image image : fJarImageMap.values()) {
 				image.dispose();
 			}
 			fJarImageMap= null;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/newsourcepage/BuildpathModifierAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/newsourcepage/BuildpathModifierAction.java
@@ -14,7 +14,6 @@
 package org.eclipse.jdt.internal.ui.wizards.buildpaths.newsourcepage;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.swt.widgets.Shell;
@@ -174,10 +173,7 @@ public abstract class BuildpathModifierAction extends Action implements ISelecti
 			}
 		}
 
-		Iterator<IWorkbenchPart> itr= parts.iterator();
-		while (itr.hasNext()) {
-			IWorkbenchPart part= itr.next();
-
+		for (IWorkbenchPart part : parts) {
 			// get the part's ISetSelectionTarget implementation
 			ISetSelectionTarget target= null;
 			if (part instanceof ISetSelectionTarget)

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/ConfigureWorkingSetAssignementAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/ConfigureWorkingSetAssignementAction.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -214,9 +213,7 @@ public final class ConfigureWorkingSetAssignementAction extends SelectionDispatc
 
 		@Override
 		public void dispose() {
-			Iterator<Image> iterator= fIcons.values().iterator();
-			while (iterator.hasNext()) {
-				Image icon= iterator.next();
+			for (Image icon : fIcons.values()) {
 				icon.dispose();
 			}
 			super.dispose();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/WorkingSetConfigurationDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/WorkingSetConfigurationDialog.java
@@ -71,9 +71,7 @@ public class WorkingSetConfigurationDialog extends SelectionDialog {
 		}
 		@Override
 		public void dispose() {
-			Iterator<Image> iterator= fIcons.values().iterator();
-			while (iterator.hasNext()) {
-				Image icon= iterator.next();
+			for (Image icon : fIcons.values()) {
 				icon.dispose();
 			}
 			super.dispose();
@@ -474,10 +472,7 @@ public class WorkingSetConfigurationDialog extends SelectionDialog {
 	 * Rolls back changes to working sets.
 	 */
 	private void restoreChangedWorkingSets() {
-		Iterator<IWorkingSet> iterator= fEditedWorkingSets.keySet().iterator();
-
-		while (iterator.hasNext()) {
-			IWorkingSet editedWorkingSet= iterator.next();
+		for (IWorkingSet editedWorkingSet : fEditedWorkingSets.keySet()) {
 			IWorkingSet originalWorkingSet= fEditedWorkingSets.get(editedWorkingSet);
 
 			if (editedWorkingSet.getName().equals(originalWorkingSet.getName()) == false) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/CustomFiltersActionGroup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/CustomFiltersActionGroup.java
@@ -655,9 +655,7 @@ public class CustomFiltersActionGroup extends ActionGroup {
 	private void saveLRUFilters(IMemento memento) {
 		if(fLRUFilterIdsStack != null && !fLRUFilterIdsStack.isEmpty()) {
 			IMemento lruFilters= memento.createChild(TAG_LRU_FILTERS);
-			Iterator<String> iter= fLRUFilterIdsStack.iterator();
-			while (iter.hasNext()) {
-				String id= iter.next();
+			for (String id : fLRUFilterIdsStack) {
 				IMemento child= lruFilters.createChild(TAG_CHILD);
 				child.putString(TAG_FILTER_ID, id);
 			}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -899,9 +899,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		Map<JavaProjectionAnnotation, Position> newStructure= ctx.fMap;
 		Map<IJavaElement, List<Tuple>> oldStructure= computeCurrentStructure(ctx);
 
-		Iterator<JavaProjectionAnnotation> e= newStructure.keySet().iterator();
-		while (e.hasNext()) {
-			JavaProjectionAnnotation newAnnotation= e.next();
+		for (JavaProjectionAnnotation newAnnotation : newStructure.keySet()) {
 			Position newPosition= newStructure.get(newAnnotation);
 
 			IJavaElement element= newAnnotation.getElement();
@@ -951,9 +949,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			}
 		}
 
-		Iterator<List<Tuple>> iter= oldStructure.values().iterator();
-		while (iter.hasNext()) {
-			List<Tuple> list= iter.next();
+		for (List<Tuple> list : oldStructure.values()) {
 			int size= list.size();
 			for (int i= 0; i < size; i++)
 				deletions.add(list.get(i).annotation);


### PR DESCRIPTION
This Junit5 test suite got lost in the last touches on the while to for loop patch.
It can be used to start the VisitorTest and is referenced in the pom.

## What it does
It is just an entry point

```
  <build>
    <plugins>
      <plugin>
        <groupId>org.eclipse.tycho</groupId>
        <artifactId>tycho-surefire-plugin</artifactId>
        <version>${tycho.version}</version>
        <configuration>
          <useUIHarness>true</useUIHarness>
          <useUIThread>true</useUIThread>
          <includes>
            <include>org/eclipse/jdt/ui/tests/AutomatedSuite.class</include>
            <include>org/eclipse/jdt/internal/common/JUnit5TestSuite.class</include>
             <!--<include>org/eclipse/jdt/ui/tests/LeakTestSuite.class</include> -->
          </includes>
          <dependencies>
```
In fact it does not need tycho and would be fine with a simple non tycho based start.

## How to test
Should make VisitorTest show up in the junit test results.

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

