### PR TITLE
Default Execution Environment for Y build is 9 (fixes #131 )

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -607,12 +607,12 @@ public class NewJavaProjectWizardPageOne extends WizardPage {
 
 			for (IExecutionEnvironment environment : environments) {
 				String eeCompliance= JavaModelUtil.getExecutionEnvironmentCompliance(environment);
-				if (defaultCC.endsWith(eeCompliance)) {
+				if (defaultCC.equals(eeCompliance)) {
 					return environment.getId();
 				}
 			}
 
-			return "JavaSE-1.7"; //$NON-NLS-1$
+			return "JavaSE-11"; //$NON-NLS-1$
 		}
 
 		private String getDefaultJVMLabel() {


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/131

Launch Y build using Java 19 and create a java project. The old logic of ends with will not work for 19 and 9. Since 19 ends with 9. I have changed that logic
How to test

Launch Y build using Java 19 and create a java project
Author checklist

    I have thoroughly tested my changes