### PR TITLE
Add parameter name code mining support for records.

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -78,7 +78,7 @@ public class ParameterNamesCodeMiningTest {
 			closeIntro(PlatformUI.getWorkbench());
 		}
 		fProject= JavaProjectHelper.createJavaProject(getClass().getName(), "bin");
-		JavaProjectHelper.addRTJar_16(fProject, true);
+		JavaProjectHelper.addRTJar_17(fProject, true);
 
 		Map<String, String> options= fProject.getOptions(false);
 		JavaProjectHelper.set17_CompilerOptions(options);

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
@@ -77,7 +78,12 @@ public class ParameterNamesCodeMiningTest {
 			closeIntro(PlatformUI.getWorkbench());
 		}
 		fProject= JavaProjectHelper.createJavaProject(getClass().getName(), "bin");
-		JavaProjectHelper.addRTJar(fProject);
+		JavaProjectHelper.addRTJar_16(fProject, true);
+
+		Map<String, String> options= fProject.getOptions(false);
+		JavaProjectHelper.set17_CompilerOptions(options);
+		fProject.setOptions(options);
+
 		IPackageFragmentRoot root= JavaProjectHelper.addSourceContainer(fProject, "src");
 		fPackage= root.getPackageFragment("");
 		fParameterNameCodeMiningProvider= new JavaMethodParameterCodeMiningProvider();
@@ -363,6 +369,41 @@ public class ParameterNamesCodeMiningTest {
 		assertEquals(2, fParameterNameCodeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get().size());
 	}
 
+	@Test
+	public void testRecordConstructorOK() throws Exception {
+		String contents= "import java.util.Map;\n"
+				+ "public record Edge(int fromNodeId,\n"
+				+ "        int toNodeId,\n"
+				+ "        Map.Entry<Integer, Integer> fromPoint,\n"
+				+ "        Map.Entry<Integer, Integer> toPoint,\n"
+				+ "        double length,\n"
+				+ "        String profile) {\n"
+				+ "}\n"
+				+ "";
+		fPackage.createCompilationUnit("Edge.java", contents, true, new NullProgressMonitor());
+
+		contents = "import java.util.Map;\n"
+				+ "public class Test {\n"
+				+ "    public void test () {\n"
+				+ "        Edge e = new Edge(\n"
+				+ "        0,\n"
+				+ "        1,\n"
+				+ "        Map.entry(0, 0),\n"
+				+ "        Map.entry(1, 1),\n"
+				+ "        1,\n"
+				+ "        \"dev\");\n"
+				+ "    }\n"
+				+ "}";
+		ICompilationUnit compilationUnit= fPackage.createCompilationUnit("Test.java", contents, true, new NullProgressMonitor());
+		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(compilationUnit);
+		fParameterNameCodeMiningProvider.setContext(editor);
+		JavaSourceViewer viewer= (JavaSourceViewer)editor.getViewer();
+		waitReconciled(viewer);
+
+		// 6 parameter names from Edge
+		// 4 parameter names from the 2 Map.entry(int, int) calls
+		assertEquals(10, fParameterNameCodeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get().size());
+	}
 
 	private static boolean welcomeClosed;
 	private static void closeIntro(final IWorkbench wb) {

--- a/org.eclipse.jdt.ui.tests/test plugin/org/eclipse/jdt/testplugin/JavaProjectHelper.java
+++ b/org.eclipse.jdt.ui.tests/test plugin/org/eclipse/jdt/testplugin/JavaProjectHelper.java
@@ -1006,6 +1006,12 @@ public class JavaProjectHelper {
 		return addLibrary(jproject, rtJarPath[0], rtJarPath[1], rtJarPath[2]);
 	}
 
+	public static IPackageFragmentRoot addRTJar_17(IJavaProject jproject, boolean enable_preview_feature) throws CoreException {
+		IPath[] rtJarPath= findRtJar(RT_STUBS17);
+		set17CompilerOptions(jproject, enable_preview_feature);
+		return addLibrary(jproject, rtJarPath[0], rtJarPath[1], rtJarPath[2]);
+	}
+
 	/**
 	 * Adds a variable entry with source attachment to a IJavaProject.
 	 * Can return null if variable can not be resolved.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/CalleeJavaMethodParameterVisitor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/CalleeJavaMethodParameterVisitor.java
@@ -20,7 +20,6 @@ import org.eclipse.jface.text.codemining.ICodeMiningProvider;
 
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
@@ -49,24 +48,17 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 		List<?> arguments= constructorInvocation.arguments();
 		if (!arguments.isEmpty()) {
 			IMethodBinding constructorBinding= constructorInvocation.resolveConstructorBinding();
-			if (constructorBinding != null) {
-				IMethod method = resolveMethodBinding(constructorBinding);
-				collectParameterNamesCodeMinings(method, arguments, constructorBinding);
-			}
+			collectParameterNameCodeMinings(constructorBinding, arguments);
 		}
 		return super.visit(constructorInvocation);
 	}
-
 
 	@Override
 	public boolean visit(ClassInstanceCreation classInstanceCreation) {
 		List<?> arguments= classInstanceCreation.arguments();
 		if (!arguments.isEmpty()) {
 			IMethodBinding constructorBinding= classInstanceCreation.resolveConstructorBinding();
-			if (constructorBinding != null) {
-				IMethod method = resolveMethodBinding(constructorBinding);
-				collectParameterNamesCodeMinings(method, arguments, constructorBinding);
-			}
+			collectParameterNameCodeMinings(constructorBinding, arguments);
 		}
 		return super.visit(classInstanceCreation);
 	}
@@ -76,10 +68,7 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 		List<?> arguments= superConstructorInvocation.arguments();
 		if (!arguments.isEmpty()) {
 			IMethodBinding constructorBinding= superConstructorInvocation.resolveConstructorBinding();
-			if (constructorBinding != null) {
-				IMethod method = resolveMethodBinding(constructorBinding);
-				collectParameterNamesCodeMinings(method, arguments, constructorBinding);
-			}
+			collectParameterNameCodeMinings(constructorBinding, arguments);
 		}
 		return super.visit(superConstructorInvocation);
 	}
@@ -89,10 +78,7 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 		List<?> arguments= enumConstantDeclaration.arguments();
 		if (!arguments.isEmpty()) {
 			IMethodBinding constructorBinding= enumConstantDeclaration.resolveConstructorBinding();
-			if (constructorBinding != null) {
-				IMethod method = resolveMethodBinding(constructorBinding);
-				collectParameterNamesCodeMinings(method, arguments, constructorBinding);
-			}
+			collectParameterNameCodeMinings(constructorBinding, arguments);
 		}
 		return super.visit(enumConstantDeclaration);
 	}
@@ -102,34 +88,45 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 		List<?> arguments= methodInvocation.arguments();
 		if (!arguments.isEmpty()) {
 			IMethodBinding methodBinding= methodInvocation.resolveMethodBinding();
-			if (methodBinding != null) {
-				IMethod method = resolveMethodBinding(methodBinding);
-				collectParameterNamesCodeMinings(method, arguments, methodBinding);
-			}
+			collectParameterNameCodeMinings(methodBinding, arguments);
 		}
 		return super.visit(methodInvocation);
 	}
 
-	protected void collectParameterNamesCodeMinings(IMethod method, List<?> arguments, IMethodBinding mbinding) {
-		if (method != null) {
-			if (!skipParameterNamesCodeMinings(method)) {
-				try {
-					for (int i= 0; i < Math.min(arguments.size(), method.getParameterNames().length); i++) {
-						if (!skipParameterNameCodeMining(method, arguments, i)) {
-							minings.add(new JavaMethodParameterCodeMining((Expression)arguments.get(i), i, method, mbinding.isVarargs(), provider));
-						}
-					}
-				} catch (Exception e) {
-					JavaPlugin.log(e);
-				}
+	protected void collectParameterNameCodeMinings(IMethodBinding mBinding, List<?> arguments) {
+		if (mBinding != null) {
+			boolean isVarArgs = mBinding.isVarargs();
+			IMethod method= resolveMethodBinding(mBinding);
+			if (method != null) {
+				collectParameterNamesCodeMinings(method, arguments, isVarArgs);
+			} else {
+				collectParameterNamesCodeMinings(mBinding, arguments, isVarArgs);
 			}
-		} else {
-			// synthetic method of a record
-			if (mbinding.getDeclaringClass().isRecord()) {
-				for (int i= 0; i < Math.min(arguments.size(), mbinding.getParameterNames().length); i++) {
-					if (!skipParameterNameCodeMining(mbinding, arguments, i)) {
-						minings.add(new JavaMethodParameterCodeMining((Expression)arguments.get(i), i, mbinding, mbinding.isVarargs(), provider));
+		}
+	}
+
+	protected void collectParameterNamesCodeMinings(IMethod method, List<?> arguments, boolean isVarArgs) {
+		if (!skipParameterNamesCodeMinings(method)) {
+			try {
+				String[] parameterNames= method.getParameterNames();
+				for (int i= 0; i < Math.min(arguments.size(), parameterNames.length); i++) {
+					if (!skipParameterNameCodeMining(parameterNames, arguments, i)) {
+						minings.add(new JavaMethodParameterCodeMining((Expression) arguments.get(i), i, parameterNames, isVarArgs, provider));
 					}
+				}
+			} catch (Exception e) {
+				JavaPlugin.log(e);
+			}
+		}
+	}
+
+	protected void collectParameterNamesCodeMinings(IMethodBinding mbinding, List<?> arguments, boolean isVarArgs) {
+		// synthetic method of a record
+		if (mbinding.getDeclaringClass().isRecord()) {
+			String[] parameterNames= mbinding.getParameterNames();
+			for (int i= 0; i < Math.min(arguments.size(), parameterNames.length); i++) {
+				if (!skipParameterNameCodeMining(parameterNames, arguments, i)) {
+					minings.add(new JavaMethodParameterCodeMining((Expression) arguments.get(i), i, parameterNames, isVarArgs, provider));
 				}
 			}
 		}
@@ -139,39 +136,19 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 		if (binding == null) {
 			return null;
 		}
-		IJavaElement javaElement = binding.getJavaElement();
+		IJavaElement javaElement= binding.getJavaElement();
 		if (javaElement == null || !(javaElement instanceof IMethod)) {
 			return null;
 		}
-		return (IMethod)javaElement;
+		return (IMethod) javaElement;
 	}
 
-	private boolean skipParameterNameCodeMining(IMethod method, List<?> arguments, int parameterIndex) {
-		if (method == null) {
-			return false;
-		}
-		try {
-			if (method.getParameterNames().length < parameterIndex) {
-				return true;
-			}
-			String parameterName = method.getParameterNames()[parameterIndex].toLowerCase();
-			String expression = arguments.get(parameterIndex).toString().toLowerCase();
-			return expression.contains(parameterName);
-		} catch (JavaModelException ex) {
-			JavaPlugin.log(ex);
-			return false;
-		}
-	}
-
-	private boolean skipParameterNameCodeMining(IMethodBinding mbinding, List<?> arguments, int parameterIndex) {
-		if (mbinding == null) {
-			return false;
-		}
-		if (mbinding.getParameterNames().length < parameterIndex) {
+	private boolean skipParameterNameCodeMining(String[] parameterNames, List<?> arguments, int parameterIndex) {
+		if (parameterNames.length < parameterIndex) {
 			return true;
 		}
-		String parameterName = mbinding.getParameterNames()[parameterIndex].toLowerCase();
-		String expression = arguments.get(parameterIndex).toString().toLowerCase();
+		String parameterName= parameterNames[parameterIndex].toLowerCase();
+		String expression= arguments.get(parameterIndex).toString().toLowerCase();
 		return expression.contains(parameterName);
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaMethodParameterCodeMining.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaMethodParameterCodeMining.java
@@ -17,35 +17,15 @@ import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.codemining.ICodeMiningProvider;
 import org.eclipse.jface.text.codemining.LineContentCodeMining;
 
-import org.eclipse.jdt.core.IMethod;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.Expression;
-import org.eclipse.jdt.core.dom.IMethodBinding;
-
-import org.eclipse.jdt.internal.ui.JavaPlugin;
 
 public class JavaMethodParameterCodeMining extends LineContentCodeMining {
 
-	public JavaMethodParameterCodeMining(Expression parameterNode, int parameterIndex, IMethod method, boolean isVarargs, ICodeMiningProvider provider) {
+	public JavaMethodParameterCodeMining(Expression parameterNode, int parameterIndex, String [] parameterNames, boolean isVarargs, ICodeMiningProvider provider) {
 		super(new Position(parameterNode.getStartPosition(), parameterNode.getLength()), provider, null);
 		StringBuilder text = new StringBuilder();
-		try {
-			text.append(method.getParameterNames()[parameterIndex]);
-			if (isVarargs && parameterIndex == method.getParameterNames().length - 1) {
-				text.append('…');
-			}
-			text.append(": "); //$NON-NLS-1$
-			setLabel(text.toString());
-		} catch (JavaModelException e) {
-			JavaPlugin.log(e);
-		}
-	}
-
-	public JavaMethodParameterCodeMining(Expression parameterNode, int parameterIndex, IMethodBinding mbinding, boolean isVarargs, ICodeMiningProvider provider) {
-		super(new Position(parameterNode.getStartPosition(), parameterNode.getLength()), provider, null);
-		StringBuilder text = new StringBuilder();
-		text.append(mbinding.getParameterNames()[parameterIndex]);
-		if (isVarargs && parameterIndex == mbinding.getParameterNames().length - 1) {
+		text.append(parameterNames[parameterIndex]);
+		if (isVarargs && parameterIndex == parameterNames.length - 1) {
 			text.append('…');
 		}
 		text.append(": "); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaMethodParameterCodeMining.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaMethodParameterCodeMining.java
@@ -20,6 +20,7 @@ import org.eclipse.jface.text.codemining.LineContentCodeMining;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IMethodBinding;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -38,6 +39,17 @@ public class JavaMethodParameterCodeMining extends LineContentCodeMining {
 		} catch (JavaModelException e) {
 			JavaPlugin.log(e);
 		}
+	}
+
+	public JavaMethodParameterCodeMining(Expression parameterNode, int parameterIndex, IMethodBinding mbinding, boolean isVarargs, ICodeMiningProvider provider) {
+		super(new Position(parameterNode.getStartPosition(), parameterNode.getLength()), provider, null);
+		StringBuilder text = new StringBuilder();
+		text.append(mbinding.getParameterNames()[parameterIndex]);
+		if (isVarargs && parameterIndex == mbinding.getParameterNames().length - 1) {
+			text.append('…');
+		}
+		text.append(": "); //$NON-NLS-1$
+		setLabel(text.toString());
 	}
 
 	@Override


### PR DESCRIPTION
- Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/148
- Use IMethodBinding#getParameterNames() to support parameter name code
  mining for records

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This change requires https://github.com/eclipse-jdt/eclipse.jdt.core/pull/201 to use the new API for IMethodBinding.