### PR TITLE
Detect/avoid illegal combination of --release and --add-exports

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
@@ -848,6 +848,7 @@ public final class PreferencesMessages extends NLS {
 	public static String ComplianceConfigurationBlock_src_greater_compliance;
 	public static String ComplianceConfigurationBlock_classfile_greater_compliance;
 	public static String ComplianceConfigurationBlock_classfile_greater_source;
+	public static String ComplianceConfigurationBlock_release_notWith_addExports_error;
 	public static String ProblemSeveritiesConfigurationBlock_enable_syntactic_null_analysis_for_fields;
 	public static String ProblemSeveritiesConfigurationBlock_inherit_null_annotations;
 	public static String ProblemSeveritiesConfigurationBlock_external_annotations_from_all_locations;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -632,6 +632,7 @@ ComplianceConfigurationBlock_jrecompliance_info_project=When selecting {0} compl
 ComplianceConfigurationBlock_jrecompliance_backwardcompatibility_info=The system libraries from the selected release {0} will be used with ''--release'' compiler option using current JRE {1}.
 ComplianceConfigurationBlock_jrecompliance_backwardcompatibility_warning=The system libraries from the selected release {0} will be used with ''--release'' compiler option using current JRE {1}. When using --release, it is recommended to use a JRE version 12 or greater.
 ComplianceConfigurationBlock_jrecompliance_backwardcompatibility_label=Use '--&release' option
+ComplianceConfigurationBlock_release_notWith_addExports_error=Option --release is incompatible with exporting a package from system module ''{0}''
 
 CodeStylePreferencePage_title=Code Style
 CodeTemplatesPreferencePage_title=Code Templates

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
@@ -548,6 +548,7 @@ public final class NewWizardMessages extends NLS {
 	public static String AddReadsBlock_targetModule_label;
 	//
 	public static String ModuleDependenciesPage_modules_label;
+	public static String ModuleDependenciesPage_addExport_notWith_release_info;
 	public static String ModuleDependenciesPage_addSystemModule_button;
 	public static String ModuleDependenciesPage_details_label;
 	public static String ModuleDependenciesPage_nonModularProject_dummy;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
@@ -585,6 +585,7 @@ AddReadsBlock_sourceModule_label=Source module
 AddReadsBlock_targetModule_label=Target module
 
 ModuleDependenciesPage_modules_label=All Modules
+ModuleDependenciesPage_addExport_notWith_release_info=Exporting packages from system module ''{0}'' is not allowed with --release
 ModuleDependenciesPage_addSystemModule_button=Add S&ystem Module...
 ModuleDependenciesPage_details_label=Details
 ModuleDependenciesPage_nonModularProject_dummy=Non-modular Project

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/LibrariesWorkbookPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/LibrariesWorkbookPage.java
@@ -357,7 +357,7 @@ public class LibrariesWorkbookPage extends BuildPathBasePage {
 
 	}
 
-	static boolean isJREContainer(IPath path) {
+	public static boolean isJREContainer(IPath path) {
 		if (path == null)
 			return false;
 		String[] segments= path.segments();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ModuleDependenciesPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ModuleDependenciesPage.java
@@ -63,6 +63,8 @@ import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
+import org.eclipse.jdt.ui.JavaUI;
+
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.dialogs.StatusInfo;
 import org.eclipse.jdt.internal.ui.wizards.IStatusChangeListener;
@@ -266,7 +268,7 @@ public class ModuleDependenciesPage extends BuildPathBasePage {
 			fAddSystemModuleButton.setEnabled(false);
 			fDetailsList.removeAllElements();
 			fDetailsList.refresh();
-			ModuleDependenciesAdapter.updateButtonEnablement(fDetailsList, false, false, false);
+			ModuleDependenciesAdapter.updateButtonEnablement(fDetailsList, false, false, false, false);
 			return;
 		}
 		fModuleList.setEnabled(true);
@@ -459,6 +461,7 @@ public class ModuleDependenciesPage extends BuildPathBasePage {
 
 	private void selectModule(List<CPListElement> elements, IModuleDescription module) {
 		fDetailsList.removeAllElements();
+		boolean enableAddExport= true;
 		if (elements.size() == 1) {
 			CPListElement element= elements.get(0);
 			fDetailsList.addElement(new ModuleDependenciesAdapter.DeclaredDetails(module, element));
@@ -466,8 +469,17 @@ public class ModuleDependenciesPage extends BuildPathBasePage {
 			ModuleDependenciesAdapter.ConfiguredDetails configured= new ModuleDependenciesAdapter.ConfiguredDetails(module, element, moduleKind, this);
 			fDetailsList.addElement(configured);
 			fDetailsList.expandElement(configured, 1);
+			if (moduleKind == ModuleKind.System) {
+				enableAddExport = JavaCore.DISABLED.equals(this.fCurrJProject.getOption(JavaCore.COMPILER_RELEASE, false));
+			}
 		}
-		ModuleDependenciesAdapter.updateButtonEnablement(fDetailsList, elements.size() == 1, !elements.isEmpty(), true);
+		if (!enableAddExport) {
+			setStatus(new Status(IStatus.INFO, JavaUI.ID_PLUGIN,
+					MessageFormat.format(NewWizardMessages.ModuleDependenciesPage_addExport_notWith_release_info, module.getElementName())));
+		} else {
+			setStatus(StatusInfo.OK_STATUS);
+		}
+		ModuleDependenciesAdapter.updateButtonEnablement(fDetailsList, elements.size() == 1, !elements.isEmpty(), true, enableAddExport);
 	}
 
 	@Override


### PR DESCRIPTION
This is a follow-up from issue [eclipse.jdt.core#114](https://github.com/eclipse-jdt/eclipse.jdt.core/issues/114), where a new buildpath error has been implemented.

In this current PR we try to signal the problem right while configuring a project:
* **Build Path**: When `--release` is set, the Module Dependencies tab will disable the "Expose Package" button for all system modules - providing an info message why this is not possible.
* **Compiler Options**: When `--add-exports` exists on a system module, let selection of `--release` raise an error, thus disabling "Apply".

I chose this slightly asymmetric design, because
* I didn't find a suitable why to explain the problem on the Compiler Options page short of raising an error when the illegal combination is selected.
* On the Module Dependencies tab I preferred to disable that button, so the user is spared the effort of selecting the details for --add-exports only to learn that this is illegal from the outset. Selecting a system module seemed a suitable trigger for showing the info about why "Expose Package" is not possible.

To test simply create a project with JRE > 9 and compliance less than the JRE version, thus auto-enabling `--release`: "Expose Package" will be disabled for system modules. Conversely, when `--release` is deselected, and an export is added to a system module, after apply, re-enabling `--release` will no longer be possible.

Two caveats: 
* When starting from disabled `--release`, going to compiler options to select `--release` then switching to Build Path without Apply, "Expose Package" will still be enabled, because `--release` is not yet effective. A build path error will be reported when the project is built on final Apply.
* JDT/Core doesn't yet fully understand when exactly classpath validation needs to be triggered, because at this point not real .classpath changes are relevant but also changes to the compiler option `--release`. I'll file a follow-up in JDT/Core about this.