### PR TITLE
[19] Add AST levels 18 and 19 in AST view

### DIFF
--- a/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTView.java
+++ b/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -138,6 +142,8 @@ import org.eclipse.jdt.internal.ui.util.ASTHelper;
 public class ASTView extends ViewPart implements IShowInSource, IShowInTargetList {
 
 	static final int JLS_LATEST= AST.getJLSLatest();
+	private static final int JLS19= ASTHelper.JLS19;
+	private static final int JLS18= ASTHelper.JLS18;
 	private static final int JLS17= ASTHelper.JLS17;
 	private static final int JLS16= ASTHelper.JLS16;
 	private static final int JLS15= ASTHelper.JLS15;
@@ -511,6 +517,8 @@ public class ASTView extends ViewPart implements IShowInSource, IShowInTargetLis
 				case JLS15:
 				case JLS16:
 				case JLS17:
+				case JLS18:
+				case JLS19:
 					fCurrentASTLevel= level;
 			}
 		} catch (NumberFormatException e) {
@@ -1134,6 +1142,8 @@ public class ASTView extends ViewPart implements IShowInSource, IShowInTargetLis
 				new ASTLevelToggle("AST Level 1&5 (15)", JLS15), //$NON-NLS-1$
 				new ASTLevelToggle("AST Level 1&6 (16)", JLS16), //$NON-NLS-1$
 				new ASTLevelToggle("AST Level 1&7 (17)", JLS17), //$NON-NLS-1$
+				new ASTLevelToggle("AST Level 1&8 (18)", JLS18), //$NON-NLS-1$
+				new ASTLevelToggle("AST Level 1&9 (19)", JLS19), //$NON-NLS-1$
 		};
 
 		fAddToTrayAction= new Action() {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/ASTHelper.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/ASTHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -33,6 +37,8 @@ public class ASTHelper {
 	public static final int JLS15 = AST.JLS15;
 	public static final int JLS16 = AST.JLS16;
 	public static final int JLS17 = AST.JLS17;
+	public static final int JLS18 = AST.JLS18;
+	public static final int JLS19 = AST.JLS19;
 
 	private static boolean isNodeTypeSupportedInAST(AST ast, int nodeType) {
 		switch (nodeType) {


### PR DESCRIPTION
Fixes #159

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Adds AST levels 18 and 19 in AST view's menu

## How to test
Open AST view and use the view menu to select the AST 18 and 19 levels

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
