### PR TITLE
Fix rename regression with renaming overridden interface method

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.14.300.qualifier
+Bundle-Version: 3.14.400.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.14.300-SNAPSHOT</version>
+  <version>3.14.400-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/RenameVirtualMethodInClass/test49/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/RenameVirtualMethodInClass/test49/in/A.java
@@ -1,0 +1,12 @@
+//can rename A.m() to k
+package p;
+
+interface ITest {
+	public void m();
+}
+class A implements ITest {
+    public void m() {}
+    public static void main(String[] args) {
+		new A().m();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/RenameVirtualMethodInClass/test49/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/RenameVirtualMethodInClass/test49/out/A.java
@@ -1,0 +1,12 @@
+//can rename A.m() to k
+package p;
+
+interface ITest {
+	public void k();
+}
+class A implements ITest {
+    public void k() {}
+    public static void main(String[] args) {
+		new A().k();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenameVirtualMethodInClassTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenameVirtualMethodInClassTests.java
@@ -496,36 +496,49 @@ public class RenameVirtualMethodInClassTests extends GenericRefactoringTest {
 		helper2();
 	}
 
+	@Test
 	public void test41() throws Exception {
 		helper2_0("m", "k", new String[] { "QI;" });
 	}
 
+	@Test
 	public void test42() throws Exception {
 		helper2_0("m", "k", new String[] { "QT;" });
 	}
 
+	@Test
 	public void test43() throws Exception {
 		helper2_0("m", "k", new String[] { "QObject;" });
 	}
 
+	@Test
 	public void test44() throws Exception {
 		helper2_0("m", "k", new String[] { "QE;" });
 	}
 
+	@Test
 	public void test45() throws Exception {
 		helper2_0("m", "k", new String[] { "QT;" });
 	}
 
+	@Test
 	public void test46() throws Exception {
 		helper2_0("m", "k", new String[] { "[QE;" });
 	}
 
+	@Test
 	public void test47() throws Exception {
 		helper2_0("m", "k", new String[] { "[QString;" });
 	}
 
+	@Test
 	public void test48() throws Exception {
 		helper2_0("m", "k", new String[] { "[QString;" });
+	}
+
+	@Test
+	public void test49() throws Exception {
+		helper2();
 	}
 
 	//anonymous inner class

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RippleMethodFinder2.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RippleMethodFinder2.java
@@ -208,8 +208,13 @@ public class RippleMethodFinder2 {
 
 		//TODO: report assertion as error status and fall back to only return fMethod
 		//check for bug 81058:
-		if (! fDeclarations.contains(fMethod))
-			Assert.isTrue(false, "Search for method declaration did not find original element: " + fMethod.toString()); //$NON-NLS-1$
+		if (! fDeclarations.contains(fMethod)) {
+			if (fSearchOnlyInCompilationUnit) {
+				return new IMethod[0];
+			} else {
+				Assert.isTrue(false, "Search for method declaration did not find original element: " + fMethod.toString()); //$NON-NLS-1$
+			}
+		}
 
 		createHierarchyOfDeclarations(new SubProgressMonitor(pm, 1), owner);
 		addMissedSuperTypes();

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/RenameLinkedMode.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/RenameLinkedMode.java
@@ -17,6 +17,7 @@ package org.eclipse.jdt.internal.ui.refactoring.reorg;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -273,7 +274,8 @@ public class RenameLinkedMode {
 						return relativeRank;
 				}
 			});
-			sameNodes.add(nameNode);
+			List<ASTNode> nodes= new ArrayList<>();
+			nodes.add(nameNode);
 			IBinding resolvedNameNode= nameNode.resolveBinding();
 			if (resolvedNameNode != null && resolvedNameNode instanceof IMethodBinding) {
 				IJavaElement javaElement= resolvedNameNode.getJavaElement();
@@ -282,12 +284,12 @@ public class RenameLinkedMode {
 					for (IMethod iMethod : relatedMethods) {
 						ASTNode n= NodeFinder.perform(root, iMethod.getNameRange());
 						if (n != null) {
-							sameNodes.add(n);
+							nodes.add(n);
 						}
 					}
 				}
 			}
-			for (ASTNode astNode : new ArrayList<>(sameNodes)) {
+			for (ASTNode astNode : nodes) {
 				if (astNode instanceof SimpleName) {
 					for (SimpleName sameNode : LinkedNodeFinder.findByNode(root, (SimpleName) astNode)) {
 						sameNodes.add(sameNode);


### PR DESCRIPTION
## What it does

- fixes #158
- add check in RippleMethodFinder2.findAllRippleMethods() to bypass
  an issue where search cannot find the original method in the
  compilation unit
- fix logic in RenameLinkedMode.start() so that the name node isn't
  added twice and the additional methods found by RippleMethodFinder2
  are processed correctly
- add new test to RenameVirtualMethodInClassTests and enable some
  tests that weren't being run

## How to test

Run test49 in RenameVirtualMethodInClassTests.java or see original issue

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
