### PR TITLE
Add JUnit5 support to New TestSuite Wizard

### DIFF
--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.15.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/pom.xml
+++ b/org.eclipse.jdt.junit/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit</artifactId>
-  <version>3.14.200-SNAPSHOT</version>
+  <version>3.15.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/SuiteClassesContentProvider.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/SuiteClassesContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Johannes Utzig <mail@jutzig.de> - [JUnit] Update test suite wizard for JUnit 4: @RunWith(Suite.class)... - https://bugs.eclipse.org/155828
+ *     Red Hat Inc. - Update test suite wizard for JUnit5 (@Suite support)
  *******************************************************************************/
 package org.eclipse.jdt.internal.junit.wizards;
 
@@ -31,18 +32,21 @@ import org.eclipse.jdt.core.IType;
 
 import org.eclipse.jdt.internal.junit.launcher.JUnit3TestFinder;
 import org.eclipse.jdt.internal.junit.launcher.JUnit4TestFinder;
+import org.eclipse.jdt.internal.junit.launcher.JUnit5TestFinder;
 import org.eclipse.jdt.internal.junit.ui.JUnitPlugin;
 
 public class SuiteClassesContentProvider implements IStructuredContentProvider {
 
 	private boolean fIncludeJunit4Tests;
+	private boolean fIncludeJunit5Tests;
 
 	public SuiteClassesContentProvider() {
-		this(false);
+		this(false, false);
 	}
 
-	public SuiteClassesContentProvider(boolean includeJunit4Tests) {
-		this.fIncludeJunit4Tests = includeJunit4Tests;
+	public SuiteClassesContentProvider(boolean includeJunit4Tests, boolean includeJunit5Tests) {
+		this.fIncludeJunit4Tests= includeJunit4Tests;
+		this.fIncludeJunit5Tests= includeJunit5Tests;
 	}
 
 	@Override
@@ -67,12 +71,13 @@ public class SuiteClassesContentProvider implements IStructuredContentProvider {
 	public Set<IType> getTests(IPackageFragment pack) {
 		try {
 			HashSet<IType> result= new HashSet<>();
-			if (isIncludeJunit4Tests()) {
+			if (isIncludeJunit5Tests()) {
+				new JUnit5TestFinder().findTestsInContainer(pack, result, null);
+			} else if (isIncludeJunit4Tests()) {
 				new JUnit4TestFinder().findTestsInContainer(pack, result, null);
 			} else {
 				new JUnit3TestFinder().findTestsInContainer(pack, result, null);
 			}
-
 			return result;
 		} catch (CoreException e) {
 			JUnitPlugin.log(e);
@@ -94,5 +99,13 @@ public class SuiteClassesContentProvider implements IStructuredContentProvider {
 
 	public boolean isIncludeJunit4Tests() {
 		return fIncludeJunit4Tests;
+	}
+
+	public void setIncludeJunit5Tests(boolean includeJunit5Tests) {
+		fIncludeJunit5Tests= includeJunit5Tests;
+	}
+
+	public boolean isIncludeJunit5Tests() {
+		return fIncludeJunit5Tests;
 	}
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/WizardMessages.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/WizardMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -95,11 +95,13 @@ public final class WizardMessages extends NLS {
 	public static String NewTestSuiteWizPage_typeName_error_name_name_discouraged;
 	public static String NewTestSuiteWizPage_typeName_warning_already_exists;
 	public static String NewTestSuiteWizPage_typeName_warning_already_exists_junit4;
+	public static String NewTestSuiteWizPage_typeName_warning_already_exists_junit5;
 	public static String NewTestSuiteWizPage_typeName_error_filtered;
 	public static String NewTestSuiteWizPage_cannotUpdateDialog_title;
 	public static String NewTestSuiteWizPage_cannotUpdateDialog_message;
 	public static String NewTestClassWizPage_junit3_radio_label;
 	public static String NewTestClassWizPage_junit4_radio_label;
+	public static String NewTestClassWizPage_junit5_radio_label;
 	public static String NewTestClassWizPage_treeCaption_classSelected;
 	public static String NewTestClassWizPage_treeCaption_classesSelected;
 	public static String NewTestSuiteCreationWizardPage_infinite_recursion;
@@ -112,6 +114,8 @@ public final class WizardMessages extends NLS {
 	public static String UpdateAllTests_cannotUpdate_errorDialog_message;
 	public static String UpdateAllTests_cannotFind_annotation_errorDialog_message;
 	public static String UpdateAllTests_cannotFind_annotation_errorDialog_title;
+	public static String UpdateAllTests_cannotFind_annotation5_errorDialog_message;
+	public static String UpdateAllTests_cannotFind_annotation5_errorDialog_title;
 	public static String UpdateAllTests_cannotFind_errorDialog_title;
 	public static String UpdateAllTests_cannotFind_errorDialog_message;
 	public static String NewJUnitWizard_op_error_title;

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/WizardMessages.properties
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/WizardMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2017 IBM Corporation and others.
+# Copyright (c) 2000, 2022 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,8 @@
 #
 # Contributors:
 #     IBM Corporation - initial API and implementation
-#     Johannes Utzig <mail@jutzig.de> - [JUnit] Update test suite wizard for JUnit 4: @RunWith(Suite.class)... - https://bugs.eclipse.org/155828
+#     Johannes Utzig <mail@jutzig.de> - [JUnit] Update test suite wizard for JUnit 4: @RunWith(Suite.class)... - https://bugs.eclipse.org/1558284
+#     Red Hat Inc. - update test suite wizard for JUnit 5: @Suite
 ###############################################################################
 #
 # Miscellaneous
@@ -105,12 +106,14 @@ NewTestSuiteWizPage_typeName_error_name_not_valid=Test suite name is not valid.
 NewTestSuiteWizPage_typeName_error_name_name_discouraged=Warning: Test suite name is discouraged.
 NewTestSuiteWizPage_typeName_warning_already_exists=Warning: Test suite already exists. suite() method will be replaced.
 NewTestSuiteWizPage_typeName_warning_already_exists_junit4=Warning: Test suite already exists. @SuiteClasses(...) will be overwritten.
+NewTestSuiteWizPage_typeName_warning_already_exists_junit5=Warning: Test suite already exists. @SelectClasses(...) will be overwritten.
 NewTestSuiteWizPage_typeName_error_filtered= This type is hidden in the workspace due to resource filters.
 NewTestSuiteWizPage_cannotUpdateDialog_title=Cannot update suite() method
 NewTestSuiteWizPage_cannotUpdateDialog_message=The code in suite() that the wizard replaces must start with {0} and end with {1}
 
 NewTestClassWizPage_junit3_radio_label=New JUnit &3 suite
 NewTestClassWizPage_junit4_radio_label=New JUnit &4 suite
+NewTestClassWizPage_junit5_radio_label=New JUnit &5 suite
 NewTestClassWizPage_treeCaption_classSelected={0} class selected
 NewTestClassWizPage_treeCaption_classesSelected={0} classes selected
 NewTestSuiteCreationWizardPage_infinite_recursion=Warning: Adding a test suite as a test case in itself will result in infinite recursion and StackOverflowError
@@ -127,6 +130,8 @@ UpdateAllTests_cannotUpdate_errorDialog_title=Cannot recreate suite() method.
 UpdateAllTests_cannotUpdate_errorDialog_message=The code in suite() that the wizard replaces must start with {0} and end with {1}
 UpdateAllTests_cannotFind_annotation_errorDialog_message=The SuiteClasses() annotation cannot be found.
 UpdateAllTests_cannotFind_annotation_errorDialog_title=Cannot find SuiteClasses() annotation.
+UpdateAllTests_cannotFind_annotation5_errorDialog_message=The SelectClasses() annotation cannot be found.
+UpdateAllTests_cannotFind_annotation5_errorDialog_title=Cannot find SelectClasses() annotation.
 UpdateAllTests_cannotFind_errorDialog_title=Cannot find suite() method.
 UpdateAllTests_cannotFind_errorDialog_message=The suite() method cannot be found.
 

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestSuiteWizardPage.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestSuiteWizardPage.java
@@ -197,11 +197,8 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 				isJunit4= true;
 			}
 			isJunit5= CoreTestSearchEngine.hasJUnit5TestAnnotation(project);
-			if (!isJunit5 && !CoreTestSearchEngine.hasTestCaseType(project) && JUnitStubUtility.is18OrHigher(project)) {
-				isJunit5= true;
-			}
 		}
-		setJUnit4or5(isJunit5, isJunit5, true);
+		setJUnit4or5(isJunit4, isJunit5, true);
 		doStatusUpdate();
 	}
 
@@ -216,7 +213,7 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			setAddComments(StubUtility.doAddComments(project), true); // from project or workspace
 		}
 
-		setTypeName(ALL_TESTS, true);
+		setTypeName(generateName(ALL_TESTS), true);
 		fTypeNameStatus= typeNameChanged(); //set status on initialization for this dialog - user must know that suite method will be overridden
 	}
 
@@ -476,6 +473,22 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 	}
 
 
+	private String generateName(String name) {
+		IPackageFragment pack= getPackageFragment();
+		String finalName= name;
+		if (pack != null) {
+			int counter= 2;
+			ICompilationUnit cu= pack.getCompilationUnit(finalName + ".java"); //$NON-NLS-1$
+			//if this cu already exists, we need to disable the
+			//junit 3 option if it is a junit 4 suite and vice versa
+			while (cu.exists()) {
+				finalName= name + counter++;
+				cu= pack.getCompilationUnit(finalName + ".java"); //$NON-NLS-1$
+			}
+		}
+		return finalName;
+	}
+
 	@Override
 	protected IStatus typeNameChanged() {
 		super.typeNameChanged();
@@ -681,13 +694,13 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 		fIsJunit5Enabled= isEnabled;
 		if (fJUnit5Toggle != null && !fJUnit5Toggle.isDisposed()) {
 			fJUnit3Toggle.setSelection(!isJUnit4 && !isJUnit5);
-			fJUnit4Toggle.setSelection(!isJUnit5);
+			fJUnit4Toggle.setSelection(isJUnit4 && !isJUnit5);
 			fJUnit5Toggle.setSelection(isJUnit5);
 			fJUnit4Toggle.setEnabled(isEnabled || !isJUnit5);
 			fJUnit3Toggle.setEnabled(isEnabled || !isJUnit5  && !isJUnit4);
 		}
 		if (isJUnit5) {
-			internalSetJUnit5(isJUnit5);
+			internalSetJUnit5(true);
 			internalSetJUnit4(false);
 		} else {
 			internalSetJUnit5(false);

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestSuiteWizardPage.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestSuiteWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Johannes Utzig <mail@jutzig.de> - [JUnit] Update test suite wizard for JUnit 4: @RunWith(Suite.class)... - https://bugs.eclipse.org/155828
+ *     Red Hat Inc. - Update test suite wizard for Junit 5 (@Suite suport)
  *******************************************************************************/
 package org.eclipse.jdt.junit.wizards;
 
@@ -113,6 +114,12 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 	 */
 	public final static String JUNIT4TOGGLE= PAGE_NAME + ".junit4toggle"; //$NON-NLS-1$
 
+	/**
+	 * Field ID of the junit5 toggle field.
+	 *
+	 */
+	private final static String JUNIT5TOGGLE= PAGE_NAME + ".junit5toggle"; //$NON-NLS-1$
+
 	private CheckboxTableViewer fClassesInSuiteTable;
 	private IStatus fClassesInSuiteStatus;
 
@@ -120,10 +127,13 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 
 	private boolean fUpdatedExistingClassButton;
 
+	private Button fJUnit5Toggle;
 	private Button fJUnit4Toggle;
 	private Button fJUnit3Toggle;
 	private boolean fIsJunit4;
 	private boolean fIsJunit4Enabled;
+	private boolean fIsJunit5;
+	private boolean fIsJunit5Enabled;
 
 	/**
 	 * Creates a new <code>NewTestSuiteWizardPage</code>.
@@ -179,14 +189,19 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 		initContainerPage(jelem, true);
 		initSuitePage(jelem);
 		boolean isJunit4= false;
+		boolean isJunit5= false;
 		if (jelem != null && jelem.getElementType() != IJavaElement.JAVA_MODEL) {
 			IJavaProject project= jelem.getJavaProject();
 			isJunit4= CoreTestSearchEngine.hasJUnit4TestAnnotation(project);
 			if (!isJunit4 && !CoreTestSearchEngine.hasTestCaseType(project) && JUnitStubUtility.is50OrHigher(project)) {
 				isJunit4= true;
 			}
+			isJunit5= CoreTestSearchEngine.hasJUnit5TestAnnotation(project);
+			if (!isJunit5 && !CoreTestSearchEngine.hasTestCaseType(project) && JUnitStubUtility.is18OrHigher(project)) {
+				isJunit5= true;
+			}
 		}
-		setJUnit4(isJunit4, true);
+		setJUnit4or5(isJunit5, isJunit5, true);
 		doStatusUpdate();
 	}
 
@@ -208,7 +223,7 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 	@Override
 	protected void handleFieldChanged(String fieldName) {
 		super.handleFieldChanged(fieldName);
-		if (PACKAGE.equals(fieldName) || CONTAINER.equals(fieldName) || JUNIT4TOGGLE.equals(fieldName)) {
+		if (PACKAGE.equals(fieldName) || CONTAINER.equals(fieldName) || JUNIT4TOGGLE.equals(fieldName) || JUNIT5TOGGLE.equals(fieldName)) {
 			updateClassesInSuiteTable();
 		} else if (CLASSES_IN_SUITE.equals(fieldName)) {
 			fClassesInSuiteStatus= classesInSuiteChanged();
@@ -294,7 +309,8 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			gd.horizontalSpan= nColumns-1;
 
 			fClassesInSuiteTable.getTable().setLayoutData(gd);
-			fClassesInSuiteTable.setContentProvider(new SuiteClassesContentProvider(isJUnit4()));
+			System.out.println("is junit4 " + isJUnit4() + " is junit5 " + isJUnit5()); //$NON-NLS-1$ //$NON-NLS-2$
+			fClassesInSuiteTable.setContentProvider(new SuiteClassesContentProvider(isJUnit4(), isJUnit5()));
 			fClassesInSuiteTable.setLabelProvider(new JavaElementLabelProvider());
 			fClassesInSuiteTable.addCheckStateListener(event -> handleFieldChanged(CLASSES_IN_SUITE));
 
@@ -346,7 +362,7 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 	@Override
 	protected void createTypeMembers(IType type, ImportsManager imports, IProgressMonitor monitor) throws CoreException {
 		writeImports(imports);
-		if(!isJUnit4())
+		if(!isJUnit4() && !isJUnit5())
 			type.createMethod(getSuiteMethodString(type), null, false, null);
 	}
 
@@ -389,6 +405,14 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			IAnnotation suiteClasses= suiteType.getAnnotation("SuiteClasses"); //$NON-NLS-1$
 			if (suiteClasses.exists()) {
 				UpdateTestSuite.updateTestCasesInJunit4Suite(new SubProgressMonitor(monitor, 5), cu, suiteClasses, fClassesInSuiteTable.getCheckedElements());
+			} else {
+				cannotUpdateSuiteError();
+			}
+		} else if (isJUnit5()) {
+			/* find TestClasses already in Test Suite */
+			IAnnotation selectClasses= suiteType.getAnnotation("SelectClasses"); //$NON-NLS-1$
+			if (selectClasses.exists()) {
+				UpdateTestSuite.updateTestCasesInJunit5Suite(new SubProgressMonitor(monitor, 5), cu, selectClasses, fClassesInSuiteTable.getCheckedElements());
 			} else {
 				cannotUpdateSuiteError();
 			}
@@ -477,10 +501,10 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			if (cu.exists()) {
 				IType type= cu.findPrimaryType();
 				if (type != null) {
-					setJUnit4(type.getAnnotation("RunWith").exists(), false); //$NON-NLS-1$
+					setJUnit4or5(type.getAnnotation("RunWith").exists(), type.getAnnotation("Suite").exists(), false); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			} else {
-				setJUnit4(isJUnit4(), true);
+				setJUnit4or5(isJUnit4(), isJUnit5(), true);
 			}
 		}
 
@@ -502,7 +526,9 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			if (cu.exists()) {
 				status.setWarning(isJUnit4()
 						? WizardMessages.NewTestSuiteWizPage_typeName_warning_already_exists_junit4
-						: WizardMessages.NewTestSuiteWizPage_typeName_warning_already_exists);
+						: isJUnit5()
+							? WizardMessages.NewTestSuiteWizPage_typeName_warning_already_exists_junit5
+							: WizardMessages.NewTestSuiteWizPage_typeName_warning_already_exists);
 				return status;
 			}
 			IResource resource= cu.getResource();
@@ -541,6 +567,9 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			imports.addImport("org.junit.runner.RunWith"); //$NON-NLS-1$
 			imports.addImport("org.junit.runners.Suite"); //$NON-NLS-1$
 			imports.addImport("org.junit.runners.Suite.SuiteClasses"); //$NON-NLS-1$
+		} else if (isJUnit5()) {
+			imports.addImport("org.junit.platform.suite.api.Suite"); //$NON-NLS-1$
+			imports.addImport("org.junit.platform.suite.api.SelectClasses"); //$NON-NLS-1$
 		} else {
 			imports.addImport("junit.framework.Test"); //$NON-NLS-1$
 			imports.addImport("junit.framework.TestSuite"); //$NON-NLS-1$
@@ -575,7 +604,7 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 	protected void createJUnit4Controls(Composite composite, int nColumns) {
 		Composite inner= new Composite(composite, SWT.NONE);
 		inner.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, nColumns, 1));
-		GridLayout layout= new GridLayout(2, false);
+		GridLayout layout= new GridLayout(3, false);
 		layout.marginHeight= 0;
 		layout.marginWidth= 0;
 		inner.setLayout(layout);
@@ -585,6 +614,14 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			public void widgetSelected(SelectionEvent e) {
 				boolean isSelected= ((Button) e.widget).getSelection();
 				internalSetJUnit4(isSelected);
+			}
+		};
+
+		SelectionAdapter listener2= new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				boolean isSelected= ((Button) e.widget).getSelection();
+				internalSetJUnit5(isSelected);
 			}
 		};
 
@@ -600,6 +637,13 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 		fJUnit4Toggle.setEnabled(fIsJunit4Enabled);
 		fJUnit4Toggle.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, false, false, 1, 1));
 		fJUnit4Toggle.addSelectionListener(listener);
+
+		fJUnit5Toggle= new Button(inner, SWT.RADIO);
+		fJUnit5Toggle.setText(WizardMessages.NewTestClassWizPage_junit5_radio_label);
+		fJUnit5Toggle.setSelection(fIsJunit5);
+		fJUnit5Toggle.setEnabled(fIsJunit5Enabled);
+		fJUnit5Toggle.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, false, false, 1, 1));
+		fJUnit5Toggle.addSelectionListener(listener2);
 	}
 
 	/**
@@ -610,16 +654,67 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 	 * editable; otherwise they are read-only
 	 *
 	 * @since 3.7
+	 * @deprecated Use setJUnit4or5 instead
 	 */
+	@Deprecated
 	public void setJUnit4(boolean isJUnit4, boolean isEnabled) {
 		fIsJunit4Enabled= isEnabled;
 		if (fJUnit4Toggle != null && !fJUnit4Toggle.isDisposed()) {
 			fJUnit4Toggle.setSelection(isJUnit4);
 			fJUnit3Toggle.setSelection(!isJUnit4);
+			fJUnit5Toggle.setSelection(false);
 			fJUnit4Toggle.setEnabled(isEnabled || isJUnit4);
 			fJUnit3Toggle.setEnabled(isEnabled || !isJUnit4);
 		}
 		internalSetJUnit4(isJUnit4);
+	}
+
+	/**
+	 * Specifies if the test should be created as JUnit 5 test.
+	 * @param isJUnit4 If set, a JUnit 4 test will be created
+	 * @param isJUnit5 If set, a JUnit 5 test will be created
+	 * @param isEnabled if <code>true</code> the modifier fields are
+	 * editable; otherwise they are read-only
+	 *
+	 * @since 3.15
+	 */
+	public void setJUnit4or5(boolean isJUnit4, boolean isJUnit5, boolean isEnabled) {
+		fIsJunit5Enabled= isEnabled;
+		if (fJUnit5Toggle != null && !fJUnit5Toggle.isDisposed()) {
+			fJUnit3Toggle.setSelection(!isJUnit4 && !isJUnit5);
+			fJUnit4Toggle.setSelection(isJUnit4);
+			fJUnit5Toggle.setSelection(isJUnit5 && !isJUnit4);
+			fJUnit4Toggle.setEnabled(isEnabled || !isJUnit5);
+			fJUnit3Toggle.setEnabled(isEnabled || !isJUnit5  && !isJUnit4);
+		}
+		internalSetJUnit5(isJUnit5);
+		internalSetJUnit4(isJUnit4);
+	}
+
+	/**
+	 * Returns <code>true</code> if the test suite should be created as Junit 5 suite
+	 * @return returns <code>true</code> if the test suite should be created as Junit 5 test
+	 *
+	 * @since 3.15
+	 */
+	public boolean isJUnit5() {
+		return fIsJunit5;
+	}
+
+	private void internalSetJUnit5(boolean isJUnit5) {
+		if (fIsJunit5 == isJUnit5)
+			return;
+		fIsJunit5= isJUnit5;
+		if (fClassesInSuiteTable != null && fClassesInSuiteTable.getContentProvider() instanceof SuiteClassesContentProvider) {
+			SuiteClassesContentProvider provider= (SuiteClassesContentProvider)fClassesInSuiteTable.getContentProvider();
+			provider.setIncludeJunit5Tests(isJUnit5);
+		}
+		if (fIsJunit5) {
+			setSuperClass("java.lang.Object", false); //$NON-NLS-1$
+		} else {
+			setSuperClass(JUnitCorePlugin.TEST_SUPERCLASS_NAME, true);
+		}
+		handleFieldChanged(JUNIT5TOGGLE);
 	}
 
 	/**
@@ -652,6 +747,8 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 	protected String constructCUContent(ICompilationUnit cu, String typeContent, String lineDelimiter) throws CoreException {
 		if (isJUnit4()) {
 			typeContent= appendAnnotations(typeContent, lineDelimiter);
+		} else if (isJUnit5()) {
+			typeContent= appendAnnotations5(typeContent, lineDelimiter);
 		}
 
 		return super.constructCUContent(cu, typeContent, lineDelimiter);
@@ -677,4 +774,26 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 		buffer.append(typeContent);
 		return buffer.toString();
 	}
+
+	private String appendAnnotations5(String typeContent, String lineDelimiter) {
+		Object[] checkedElements= fClassesInSuiteTable.getCheckedElements();
+		StringBuilder buffer = new StringBuilder("@Suite"); //$NON-NLS-1$
+		buffer.append(lineDelimiter);
+		buffer.append("@SelectClasses({"); //$NON-NLS-1$
+		for (int i= 0; i < checkedElements.length; i++) {
+			if (checkedElements[i] instanceof IType) {
+				IType testType= (IType) checkedElements[i];
+				buffer.append(testType.getElementName());
+				buffer.append(".class"); //$NON-NLS-1$
+				if(i<checkedElements.length-1)
+					buffer.append(',');
+
+			}
+		}
+		buffer.append("})"); //$NON-NLS-1$
+		buffer.append(lineDelimiter);
+		buffer.append(typeContent);
+		return buffer.toString();
+	}
 }
+

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestSuiteWizardPage.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestSuiteWizardPage.java
@@ -309,7 +309,6 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 			gd.horizontalSpan= nColumns-1;
 
 			fClassesInSuiteTable.getTable().setLayoutData(gd);
-			System.out.println("is junit4 " + isJUnit4() + " is junit5 " + isJUnit5()); //$NON-NLS-1$ //$NON-NLS-2$
 			fClassesInSuiteTable.setContentProvider(new SuiteClassesContentProvider(isJUnit4(), isJUnit5()));
 			fClassesInSuiteTable.setLabelProvider(new JavaElementLabelProvider());
 			fClassesInSuiteTable.addCheckStateListener(event -> handleFieldChanged(CLASSES_IN_SUITE));
@@ -682,13 +681,18 @@ public class NewTestSuiteWizardPage extends NewTypeWizardPage {
 		fIsJunit5Enabled= isEnabled;
 		if (fJUnit5Toggle != null && !fJUnit5Toggle.isDisposed()) {
 			fJUnit3Toggle.setSelection(!isJUnit4 && !isJUnit5);
-			fJUnit4Toggle.setSelection(isJUnit4);
-			fJUnit5Toggle.setSelection(isJUnit5 && !isJUnit4);
+			fJUnit4Toggle.setSelection(!isJUnit5);
+			fJUnit5Toggle.setSelection(isJUnit5);
 			fJUnit4Toggle.setEnabled(isEnabled || !isJUnit5);
 			fJUnit3Toggle.setEnabled(isEnabled || !isJUnit5  && !isJUnit4);
 		}
-		internalSetJUnit5(isJUnit5);
-		internalSetJUnit4(isJUnit4);
+		if (isJUnit5) {
+			internalSetJUnit5(isJUnit5);
+			internalSetJUnit4(false);
+		} else {
+			internalSetJUnit5(false);
+			internalSetJUnit4(isJUnit4);
+		}
 	}
 
 	/**


### PR DESCRIPTION
- fixes #142
- modify NewTestSuiteWizardPage, SuiteClassesContentProvider, and UpdateTestSuite classes

## What it does
Add JUnit 5 support to the NewTestSuiteWizard

## How to test
Invoke the NewTestSuiteWizard via the New -> Other -> Java -> JUnit -> JUnit Test Suite

Select JUnit 5 Test Suite from the radio buttons

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
