### PR TITLE
Fix ClassCastException in CompositeChange

### DIFF
--- a/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/CompositeChange.java
+++ b/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/CompositeChange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -510,9 +510,13 @@ public class CompositeChange extends Change {
 	 */
 	public int getFilenumber() {
 		if(fChanges.size()>0) {
-			CompositeChange obj= (CompositeChange) fChanges.get(0);
-			return obj.getAmount();
-		} else return 0;
+			if (fChanges.get(0) instanceof CompositeChange) {
+				CompositeChange obj= (CompositeChange) fChanges.get(0);
+				return obj.getAmount();
+			}
+			return 1;
+		}
+		return 0;
 	}
 
 	private int getAmount() {


### PR DESCRIPTION
- fixes #169

## What it does
Adds check to CompositeChange that change is already a CompositeChange before casting

## How to test
Run test from specified issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
