### PR TITLE
Fix failures in AssistQuickFixTests1d8#testSurroundWithTryWithResource_*

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -5769,7 +5769,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertNumberOfProposals(proposals, 4);
 		assertCorrectLabels(proposals);
 
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+		CUCorrectionProposal proposal= (CUCorrectionProposal) findProposalByName("Surround with try-with-resources", proposals);
 		String preview1= getPreviewContent(proposal);
 
 		StringBuilder buf= new StringBuilder();
@@ -5802,7 +5802,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertNumberOfProposals(proposals, 4);
 		assertCorrectLabels(proposals);
 
-		proposal= (CUCorrectionProposal) proposals.get(0);
+		proposal= (CUCorrectionProposal) findProposalByName("Surround with try-with-resources", proposals);
 		String preview2= getPreviewContent(proposal);
 
 		buf= new StringBuilder();
@@ -5867,7 +5867,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertNumberOfProposals(proposals, 4);
 		assertCorrectLabels(proposals);
 
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+		CUCorrectionProposal proposal= (CUCorrectionProposal) findProposalByName("Surround with try-with-resources", proposals);
 		String preview1= getPreviewContent(proposal);
 
 		StringBuilder buf= new StringBuilder();
@@ -5908,7 +5908,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertNumberOfProposals(proposals, 4);
 		assertCorrectLabels(proposals);
 
-		proposal= (CUCorrectionProposal) proposals.get(0);
+		proposal= (CUCorrectionProposal) findProposalByName("Surround with try-with-resources", proposals);
 		String preview2= getPreviewContent(proposal);
 
 		buf= new StringBuilder();
@@ -5983,7 +5983,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		assertCorrectLabels(proposals);
 
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+		CUCorrectionProposal proposal= (CUCorrectionProposal) findProposalByName("Surround with try-with-resources", proposals);
 		String preview1= getPreviewContent(proposal);
 
 		StringBuilder buf= new StringBuilder();
@@ -6052,7 +6052,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		assertCorrectLabels(proposals);
 
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+		CUCorrectionProposal proposal= (CUCorrectionProposal) findProposalByName("Surround with try-with-resources", proposals);
 		String preview1= getPreviewContent(proposal);
 
 		StringBuilder buf= new StringBuilder();


### PR DESCRIPTION
- Test cases assumed target proposal was the first element in list
  returned by collectAssists(..)
- Use findProposalByName(..) to improve resilience of the test cases

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

See : 
- https://ci.eclipse.org/jdt/job/eclipse.jdt.ui-github/job/master/1/
- https://ci.eclipse.org/jdt/job/eclipse.jdt.ui-github/view/change-requests/job/PR-168/2/
- https://ci.eclipse.org/jdt/job/eclipse.jdt.ui-github/view/change-requests/job/PR-149/9/
- https://ci.eclipse.org/jdt/job/eclipse.jdt.ui-github/view/change-requests/job/PR-124/4/

The same 4 tests have been broken for the past while. They fail locally when run in `mvn` but pass when run in Eclipse.