### PR TITLE
Whitespaceissue

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/SelectionConverter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/SelectionConverter.java
@@ -283,7 +283,7 @@ public class SelectionConverter {
 		String selectedString= selection.getText();
 		if (selectedString != null && !selectedString.isEmpty()) {
 			int i= 0;
-			while (Character.isWhitespace(selectedString.charAt(i))) {
+			while (i < selectedString.length() && Character.isWhitespace(selectedString.charAt(i))) {
 				++i;
 		    }
 			whiteSpaceOffset= i;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/SelectionConverter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/SelectionConverter.java
@@ -288,6 +288,9 @@ public class SelectionConverter {
 		    }
 			whiteSpaceOffset= i;
 		}
+		if (selectedString != null && whiteSpaceOffset == selectedString.length()) {
+			whiteSpaceOffset= 0; // leave offset alone if selection is all white-space
+		}
 		IJavaElement ref= input.getElementAt(selection.getOffset() + whiteSpaceOffset);
 		if (ref == null)
 			return input;


### PR DESCRIPTION
- for all white-space selection, don't set a white-space offset
  in SelectionConverter.getElementAtOffset() and don't cause IOBException

## What it does

Fixes problem with selecting all white-space characters

## How to test

Select area with only white-space characters and right-click

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
