### PR TITLE
Make new cleanup tab page buttons default to noops to help Xtend

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ModifyDialogTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ModifyDialogTabPage.java
@@ -928,19 +928,19 @@ public abstract class ModifyDialogTabPage implements IModifyDialogTabPage {
 	 * @param value true if set all, false if deselect all
 	 *
 	 */
-	public abstract void doSetAll(boolean value);
+	public void doSetAll(boolean value) {}
 
 	/**
 	 * This method is called when the reset button is pressed.
 	 *
 	 */
-	public abstract void resetValues();
+	public void resetValues() {}
 
 	/**
 	 * This method is called when the defaults buttons is pressed.
 	 *
 	 */
-	public abstract void setDefaults();
+	public void setDefaults() {}
 
 	/**
 	 * Create the left side of the modify dialog. This is meant to be implemented by subclasses.


### PR DESCRIPTION
## What it does
Change new cleanup tab page button functions to be public with noop default implementations to help the Xtend
project which is using the internal ModifyDialogTabPage.

## How to test
Build the Xtend plug-ins.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
