### PR TITLE
Use right statements list (#184)

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -6086,6 +6086,64 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertEqualStringsIgnoreOrder(new String[] { preview1 }, new String[] { expected1 });
 		assertCorrectLabels(proposals);
 	}
+
+	@Test
+	public void testSurroundWithTryWithResource_05() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
+		StringBuilder bufOrg= new StringBuilder();
+		bufOrg.append("package p;\n");
+		bufOrg.append("\n");
+		bufOrg.append("import java.io.File;\n"
+				+ "import java.util.stream.Stream;\n"
+				+ "\n"
+				+ "public class X {\n"
+				+ "	public static void main(String[] args) throws Exception {\n"
+				+ "		try {\n"
+				+ "			try {\n"
+				+ "				Stream<File> stream = Stream.of(new File(\"\"));\n"
+				+ "				System.out.println(stream);\n"
+				+ "			} catch (Exception e) {\n"
+				+ "			}\n"
+				+ "		} catch (Exception e) {\n"
+				+ "		}\n"
+				+ "	}\n"
+				+ "}");
+
+		ICompilationUnit cu= pack1.createCompilationUnit("X.java", bufOrg.toString(), false, null);
+
+		int cursor = bufOrg.toString().indexOf("Stream<File>");
+		AssistContext context= getCorrectionContext(cu, cursor + 1, 0);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+
+		assertCorrectLabels(proposals);
+
+		CUCorrectionProposal proposal= (CUCorrectionProposal) findProposalByName("Surround with try-with-resources", proposals);
+		String preview1= getPreviewContent(proposal);
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("package p;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n"
+				+ "import java.util.stream.Stream;\n"
+				+ "\n"
+				+ "public class X {\n"
+				+ "	public static void main(String[] args) throws Exception {\n"
+				+ "		try {\n"
+				+ "			try (Stream<File> stream = Stream.of(new File(\"\"))) {\n"
+				+ "				System.out.println(stream);\n"
+				+ "			} catch (Exception e) {\n"
+				+ "			}\n"
+				+ "		} catch (Exception e) {\n"
+				+ "		}\n"
+				+ "	}\n"
+				+ "}");
+		String expected1= buf.toString();
+
+		assertEqualStringsIgnoreOrder(new String[] { preview1 }, new String[] { expected1 });
+		assertCorrectLabels(proposals);
+	}
+
+
 	@Test
 	public void testWrapInOptional_01() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -3165,7 +3165,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		TryStatement enclosingTry= (TryStatement)ASTResolving.findAncestor(node, ASTNode.TRY_STATEMENT);
 		ListRewrite resourcesRewriter= null;
 		ListRewrite clausesRewriter= null;
-		if (enclosingTry == null || enclosingTry.getBody() == null || enclosingTry.getBody().statements().get(0) != coveredNodes.get(0)) {
+		if (needNewTryBlock(coveredStatements, enclosingTry)) {
 			newTryStatement= ast.newTryStatement();
 			newTryBody= ast.newBlock();
 			newTryStatement.setBody(newTryBody);
@@ -3304,7 +3304,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 			catchClause.setException(decl);
 			linkedProposalModel.getPositionGroup(GROUP_EXC_NAME + 0, true).addPosition(rewrite.track(decl.getName()), false);
 			Statement st= null;
-			String s= StubUtility.getCatchBodyContent(icu, "Exception", name, coveredNodes.get(0), icu.findRecommendedLineSeparator()); //$NON-NLS-1$
+			String s= StubUtility.getCatchBodyContent(icu, "Exception", name, coveredStatements.get(0), icu.findRecommendedLineSeparator()); //$NON-NLS-1$
 			if (s != null) {
 				st= (Statement)rewrite.createStringPlaceholder(s, ASTNode.RETURN_STATEMENT);
 			}
@@ -3340,6 +3340,14 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 
 		resultingCollections.add(proposal);
 		return true;
+	}
+
+	private static boolean needNewTryBlock(List<ASTNode> coveredStatements, TryStatement enclosingTry) {
+		if(enclosingTry == null || enclosingTry.getBody() == null) {
+			return true;
+		}
+		List<?> statements= enclosingTry.getBody().statements();
+		return statements.size() > 0 && coveredStatements.size() > 0 && statements.get(0) != coveredStatements.get(0);
 	}
 
 	private static boolean getAddBlockProposals(IInvocationContext context, ASTNode node, Collection<ICommandAccess> resultingCollections) {


### PR DESCRIPTION
QuickAssistProcessor.getTryWithResourceProposals() used wrong variable
to process proposals: coveredNodes was used instead of
coveredStatements, and beside this, the check for the collections size
was missing. Fixed both and added regression test case.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/184