### PR TITLE
Cleanup preview: Cover zero hit case

### DIFF
--- a/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
+++ b/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
@@ -305,7 +305,7 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 	 */
 	public PreviewWizardPage(boolean wizard) {
 		super(PAGE_NAME, wizard);
-		setDescription(RefactoringUIMessages.PreviewWizardPage_description_s);
+		setDescription(RefactoringUIMessages.PreviewWizardPage_description_z);
 	}
 
 	/**
@@ -562,8 +562,10 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 		if (fTreeViewerInputChange != null) {
 			input= AbstractChangeNode.createNode(null, fTreeViewerInputChange);
 			int filenumber= fTreeViewerInputChange.getFilenumber();
-			String fullDescription= RefactoringUIMessages.PreviewWizardPage_description_s;
-			if (filenumber > 1) {
+			String fullDescription= RefactoringUIMessages.PreviewWizardPage_description_z;
+			if (filenumber == 1) {
+				fullDescription= RefactoringUIMessages.PreviewWizardPage_description_s;
+			} else if (filenumber > 1) {
 				fullDescription= MessageFormat.format(RefactoringUIMessages.PreviewWizardPage_description_m, String.valueOf(filenumber));
 			}
 			setDescription(fullDescription);

--- a/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringUIMessages.java
+++ b/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringUIMessages.java
@@ -124,6 +124,8 @@ public final class RefactoringUIMessages extends NLS {
 
 	public static String PreviewWizardPage_changes_filtered2;
 
+	public static String PreviewWizardPage_description_z;
+
 	public static String PreviewWizardPage_description_s;
 
 	public static String PreviewWizardPage_description_m;

--- a/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringUIMessages.properties
+++ b/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringUIMessages.properties
@@ -63,6 +63,7 @@ PreviewWizardPage_changes_filter_derived=derived resources hidden
 PreviewWizardPage_hideDerived_text=&Hide derived resources
 PreviewWizardPage_refactoring= Refactoring
 PreviewWizardPage_Internal_error=An unexpected exception while creating a preview. See the error log for more details.
+PreviewWizardPage_description_z= No changes to perform.
 PreviewWizardPage_description_s= The following change to 1 file is necessary to perform the refactoring.
 PreviewWizardPage_description_m= The following changes to {0} files are necessary to perform the refactoring.
 PreviewWizardPage_changeElementLabelProvider_textFormat= {0} - {1}


### PR DESCRIPTION
With the addition of the number of files that are affected by a cleanup in the preview the zero hit case has been left out.

## What it does
This patch checks for no hits and adds a third variant of text as title in the preview "No changes to perform".

## How to test
Run a cleanup on a file where you have no hit. In the preview you see the new title that differs from the 1 hit and >1 hit case.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
