### PR TITLE
Rework searching for unimplemented methods. Fix #161, #182

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnimplementedCodeFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnimplementedCodeFixCore.java
@@ -78,7 +78,7 @@ public class UnimplementedCodeFixCore extends CompilationUnitRewriteOperationsFi
 			if (addMissingMethod) {
 				ASTNode typeNode= getSelectedTypeNode(root, problem);
 				if (typeNode != null && !isTypeBindingNull(typeNode)) {
-					operations.add(new AddUnimplementedMethodsOperation(typeNode));
+					operations.add(new AddUnimplementedMethodsOperation(typeNode, null));
 				}
 			} else {
 				ASTNode typeNode= getSelectedTypeNode(root, problem);
@@ -108,7 +108,7 @@ public class UnimplementedCodeFixCore extends CompilationUnitRewriteOperationsFi
 		if (isTypeBindingNull(typeNode))
 			return null;
 
-		AddUnimplementedMethodsOperation operation= new AddUnimplementedMethodsOperation(typeNode);
+		AddUnimplementedMethodsOperation operation= new AddUnimplementedMethodsOperation(typeNode, null);
 		if (operation.getMethodsToImplement().length > 0) {
 			return new UnimplementedCodeFixCore(CorrectionMessages.UnimplementedMethodsCorrectionProposal_description, root, new CompilationUnitRewriteOperation[] { operation });
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTestSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTestSuite.java
@@ -30,6 +30,7 @@ import org.junit.runners.Suite;
 	UnresolvedVariablesQuickFixTest.class,
 	UnresolvedMethodsQuickFixTest.class,
 	UnresolvedMethodsQuickFixTest1d8.class,
+	UnresolvedMethodsQuickFixTest16.class,
 	ReturnTypeQuickFixTest.class,
 	LocalCorrectionsQuickFixTest.class,
 	LocalCorrectionsQuickFixTest1d7.class,

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest16.java
@@ -38,17 +38,17 @@ import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
-import org.eclipse.jdt.ui.tests.core.rules.Java17ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.Java16ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 import org.eclipse.jdt.ui.text.java.correction.CUCorrectionProposal;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
-public class UnresolvedMethodsQuickFixTest17 extends QuickFixTest {
+public class UnresolvedMethodsQuickFixTest16 extends QuickFixTest {
 
 	@Rule
-    public ProjectTestSetup projectSetup = new Java17ProjectTestSetup(false);
+    public ProjectTestSetup projectSetup = new Java16ProjectTestSetup(false);
 
 	private IJavaProject fJProject1;
 	private IPackageFragmentRoot fSourceFolder;
@@ -118,56 +118,4 @@ public class UnresolvedMethodsQuickFixTest17 extends QuickFixTest {
 		assertEqualStringsIgnoreOrder(new String[] { getPreviewContent(proposal) }, new String[] { buf.toString() });
 	}
 
-	/*
-	 * Test that a default method that is overridden with an abstract method is
-	 * adde when invoking "Add unimplemented methods"
-	 */
-	@Test
-	public void testOverrideDefaultMethod() throws Exception {
-		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		StringBuilder buf= new StringBuilder();
-
-		buf.append("package test1;\n");
-		buf.append("interface I1 {\n");
-		buf.append("    default int gogo() {\n");
-		buf.append("        return 24;\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		buf.append("\n");
-		buf.append("interface I2 extends I1 {\n");
-		buf.append("    int gogo();\n");
-		buf.append("}\n");
-		buf.append("\n");
-		buf.append("public class XX implements I1, I2 {\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("XX.java", buf.toString(), false, null);
-
-		CompilationUnit astRoot= getASTRoot(cu);
-		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
-		assertNumberOfProposals(proposals, 2);
-		assertCorrectLabels(proposals);
-
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
-
-		buf= new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("interface I1 {\n");
-		buf.append("    default int gogo() {\n");
-		buf.append("        return 24;\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		buf.append("\n");
-		buf.append("interface I2 extends I1 {\n");
-		buf.append("    int gogo();\n");
-		buf.append("}\n");
-		buf.append("\n");
-		buf.append("public class XX implements I1, I2 {\n");
-		buf.append("\n");
-		buf.append("    @Override\n");
-		buf.append("    public int gogo() {\n");
-		buf.append("        return 0;\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		assertEqualStringsIgnoreOrder(new String[] { getPreviewContent(proposal) }, new String[] { buf.toString() });
-	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest17.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest17.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.testplugin.TestOptions;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+
+import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.core.rules.Java17ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+import org.eclipse.jdt.ui.text.java.correction.CUCorrectionProposal;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+public class UnresolvedMethodsQuickFixTest17 extends QuickFixTest {
+
+	@Rule
+    public ProjectTestSetup projectSetup = new Java17ProjectTestSetup(false);
+
+	private IJavaProject fJProject1;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setUp() throws Exception {
+		Hashtable<String, String> options= TestOptions.getDefaultOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, "4");
+		options.put(JavaCore.COMPILER_PB_NO_EFFECT_ASSIGNMENT, JavaCore.IGNORE);
+		options.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
+		options.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "fg");
+		JavaCore.setOptions(options);
+
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.CODEGEN_ADD_COMMENTS, false);
+
+		fJProject1= projectSetup.getProject();
+
+		StubUtility.setCodeTemplate(CodeTemplateContextType.CATCHBLOCK_ID, "", null);
+		StubUtility.setCodeTemplate(CodeTemplateContextType.CONSTRUCTORSTUB_ID, "", null);
+		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "", null);
+
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		JavaProjectHelper.clear(fJProject1, projectSetup.getDefaultClasspath());
+	}
+
+	/*
+	 * Test that compiler-generated methods like toString() are not added when
+	 * invoking "Add unimplemented methods".
+	 */
+	@Test
+	public void testMethodInRecord() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("interface Snippet {\n");
+		buf.append("    String name();\n");
+		buf.append("}\n\n");
+		buf.append("public record XX(String bla) implements Snippet {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("XX.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 1);
+		assertCorrectLabels(proposals);
+
+		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("interface Snippet {\n");
+		buf.append("    String name();\n");
+		buf.append("}\n\n");
+		buf.append("public record XX(String bla) implements Snippet {\n");
+		buf.append("\n");
+		buf.append("    @Override\n");
+		buf.append("    public String name() {\n");
+		buf.append("        return null;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualStringsIgnoreOrder(new String[] { getPreviewContent(proposal) }, new String[] { buf.toString() });
+	}
+
+	/*
+	 * Test that a default method that is overridden with an abstract method is
+	 * adde when invoking "Add unimplemented methods"
+	 */
+	@Test
+	public void testOverrideDefaultMethod() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+
+		buf.append("package test1;\n");
+		buf.append("interface I1 {\n");
+		buf.append("    default int gogo() {\n");
+		buf.append("        return 24;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("interface I2 extends I1 {\n");
+		buf.append("    int gogo();\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("public class XX implements I1, I2 {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("XX.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 2);
+		assertCorrectLabels(proposals);
+
+		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("interface I1 {\n");
+		buf.append("    default int gogo() {\n");
+		buf.append("        return 24;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("interface I2 extends I1 {\n");
+		buf.append("    int gogo();\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("public class XX implements I1, I2 {\n");
+		buf.append("\n");
+		buf.append("    @Override\n");
+		buf.append("    public int gogo() {\n");
+		buf.append("        return 0;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualStringsIgnoreOrder(new String[] { getPreviewContent(proposal) }, new String[] { buf.toString() });
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
@@ -659,4 +659,57 @@ public class UnresolvedMethodsQuickFixTest1d8 extends QuickFixTest {
 		}
 	}
 
+	/*
+	 * Test that a default method that is overridden with an abstract method is
+	 * added when invoking "Add unimplemented methods"
+	 */
+	@Test
+	public void testOverrideDefaultMethod() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+
+		buf.append("package test1;\n");
+		buf.append("interface I1 {\n");
+		buf.append("    default int gogo() {\n");
+		buf.append("        return 24;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("interface I2 extends I1 {\n");
+		buf.append("    int gogo();\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("public class XX implements I1, I2 {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("XX.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 2);
+		assertCorrectLabels(proposals);
+
+		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("interface I1 {\n");
+		buf.append("    default int gogo() {\n");
+		buf.append("        return 24;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("interface I2 extends I1 {\n");
+		buf.append("    int gogo();\n");
+		buf.append("}\n");
+		buf.append("\n");
+		buf.append("public class XX implements I1, I2 {\n");
+		buf.append("\n");
+		buf.append("    @Override\n");
+		buf.append("    public int gogo() {\n");
+		buf.append("        return 0;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualStringsIgnoreOrder(new String[] { getPreviewContent(proposal) }, new String[] { buf.toString() });
+	}
+
 }

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddUnimplementedMethodsOperation.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddUnimplementedMethodsOperation.java
@@ -201,7 +201,7 @@ public final class AddUnimplementedMethodsOperation implements IWorkspaceRunnabl
 
 			IMethodBinding[] methodsToImplement= fMethodsToImplement;
 			if (methodsToImplement == null) {
-				methodsToImplement= StubUtility2Core.getUnimplementedMethods(currTypeBinding);
+				methodsToImplement= StubUtility2Core.getUnimplementedMethods(currTypeBinding, StubUtility2Core.IMPLEMENT_RECORD_SYNTHETICS);
 			}
 
 			Arrays.sort(methodsToImplement, new MethodsSourcePositionComparator(fType));

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceFactoryRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceFactoryRefactoring.java
@@ -663,7 +663,7 @@ public class IntroduceFactoryRefactoring extends Refactoring {
 	}
 
 	private IMethodBinding[] getUnimplementedMethods(ITypeBinding binding) {
-		IMethodBinding[] unimplementedMethods= StubUtility2Core.getUnimplementedMethods(binding, true);
+		IMethodBinding[] unimplementedMethods= StubUtility2Core.getUnimplementedMethods(binding, null);
 		Arrays.sort(unimplementedMethods, new MethodsSourcePositionComparator(binding));
 		return unimplementedMethods;
 	}


### PR DESCRIPTION
## What it does
Rework the search for unimplemented methods to be closer to JLS 17
8.4.8. etc. Also replaced feature flags with a method filter for clarity
and extensibility of the algorithm.

Fixes #161 and #182 

## How to test
* creating types via wizards and checking "create unimplemented method" 
* Cleaning up "unimplemented methods"
* "Add unimplemented methods" quickfixes for weird cases

A lot of the cases should be covered by tests, though.

