### PR TITLE
Sort build path container entries by label

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/CPListElementSorter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/CPListElementSorter.java
@@ -74,8 +74,8 @@ public class CPListElementSorter extends ViewerComparator {
         if (cat1 != cat2)
             return cat1 - cat2;
 
-        if (cat1 == ATTRIBUTE || cat1 == CONTAINER_ENTRY) {
-        	return 0; // do not sort attributes or container entries
+        if (cat1 == ATTRIBUTE) {
+            return 0; // do not sort attributes
         }
 
 		if (viewer instanceof ContentViewer) {


### PR DESCRIPTION
## What it does
Sorts the build path "Libraries" entries alphabetically by its label. When you have a project with a lot of library dependencies (say, OSGi plugin dependencies), having them not be ordered makes it very difficult to find anything. One of our plugins has 508 plugin dependencies, for example. 
It's nice to be able to find things reliably and not have them placed in a seemingly-random spot. As before, ordering is delegated to the label provider's `getText(Object)` method.

Example before:
![image](https://user-images.githubusercontent.com/9405706/182951028-30231147-41eb-4223-962d-d4dfce4c87a6.png)

Example after:
![image](https://user-images.githubusercontent.com/9405706/182951112-5644215f-5c65-43d4-9ee7-342a558f8d27.png)


## How to test
1. Have any project in the IDE that has some kind of build path "Library" dependency. JRE library included (i.e., any Java project can work).
2. Select Project Properties-->Java Build Path-->Libraries, expand one of the containers (such as "JRE System Library"), and see that its entries are in alphabetical order.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
