### PR TITLE
Refactor rename wrongly reports shadowings#201

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringScopeFactory.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringScopeFactory.java
@@ -15,8 +15,10 @@
 package org.eclipse.jdt.internal.corext.refactoring;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -174,6 +176,26 @@ public class RefactoringScopeFactory {
 			}
 		}
 		return create(candidate, true, sourceReferencesOnly);
+	}
+
+	/**
+	 * Creates a new search scope comprising <code>members</code>.
+	 * Includes the scopes of all projects that elements in {@code members} belong to.
+	 *
+	 * @param members the members
+	 * @param sourceReferencesOnly consider references in source only (no references in binary)
+	 * @return the search scope
+	 * @throws JavaModelException if an error occurs
+	 */
+	public static IJavaSearchScope createProjectsScope(IMember[] members, boolean sourceReferencesOnly) throws JavaModelException {
+		Assert.isTrue(members != null && members.length > 0);
+		Set<IJavaElement> scopeElements = new LinkedHashSet<>();
+		for (IMember member : members) {
+			IJavaProject javaProject= member.getJavaProject();
+			IJavaElement[] projectScopeElements = getAllScopeElements(javaProject, sourceReferencesOnly);
+			scopeElements.addAll(Arrays.asList(projectScopeElements));
+		}
+		return SearchEngine.createJavaSearchScope(scopeElements.toArray(IJavaElement[]::new), false);
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
@@ -619,7 +619,7 @@ public abstract class RenameMethodProcessor extends JavaRenameProcessor implemen
 
 		SearchPattern refsPattern= RefactoringSearchEngine.createOrPattern(wcNewMethods, IJavaSearchConstants.REFERENCES);
 		SearchParticipant[] searchParticipants= SearchUtils.getDefaultSearchParticipants();
-		IJavaSearchScope scope= RefactoringScopeFactory.create(wcNewMethods);
+		IJavaSearchScope scope= RefactoringScopeFactory.createProjectsScope(wcNewMethods, true);
 
 		MethodOccurenceCollector requestor;
 		if (getDelegateUpdating()) {


### PR DESCRIPTION
During a refactor rename, its possible that new occurrences of the
renamed methods are not correctly detected by
RenameMethodProcessor.batchFindNewOccurrences().

This is due to batchFindNewOccurrences() creating a scope based on the
set of new (renamed) methods, using
RefactoringScopeFactory.create(IMember[]). This create() method
essentially picks the project of the first of the specified IMember
objects, at least for trivial refactor renames. However that project
might not be sufficient to search for all new renamed method
occurrences, it might instead be a project that is a leaf dependency and
not a root dependency.

This change adjusts the used scope to be that of the project scopes of
all new methods provided to batchFindNewOccurrences(), instead of just
using the first method.

Fixes: #201

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
