### PR TITLE
Use ToolFactory.createScanner() with source compliance set if possible

### DIFF
--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RefactoringScanner.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RefactoringScanner.java
@@ -19,6 +19,8 @@ import java.util.Set;
 import org.eclipse.core.runtime.Assert;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.compiler.IScanner;
@@ -71,7 +73,14 @@ public class RefactoringScanner {
 	public void scan(ICompilationUnit cu)	throws JavaModelException {
 		char[] chars= cu.getBuffer().getCharacters();
 		fMatches= new HashSet<>();
-		fScanner= ToolFactory.createScanner(true, true, false, true);
+		IJavaProject javaProject= cu.getJavaProject();
+        if (javaProject != null) {
+            String sourceLevel = javaProject.getOption(JavaCore.COMPILER_SOURCE, true);
+            String complianceLevel = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+            fScanner = ToolFactory.createScanner(true, true, true, sourceLevel, complianceLevel);
+        } else {
+        	fScanner= ToolFactory.createScanner(true, true, false, true);
+        }
 		fScanner.setSource(chars);
 
 //		IImportContainer importContainer= cu.getImportContainer();

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/MoveCuUpdateCreator.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/MoveCuUpdateCreator.java
@@ -39,8 +39,10 @@ import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IImportDeclaration;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.compiler.IScanner;
@@ -54,6 +56,8 @@ import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.TypeReferenceMatch;
 
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.refactoring.CollectingSearchRequestor;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringScopeFactory;
@@ -68,9 +72,6 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-
-import org.eclipse.jdt.internal.core.manipulation.StubUtility;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 public class MoveCuUpdateCreator {
 
@@ -318,7 +319,14 @@ public class MoveCuUpdateCreator {
 		public Collector(IPackageFragment source, ReferencesInBinaryContext binaryRefs) {
 			super(binaryRefs);
 			fSource= source;
-			fScanner= ToolFactory.createScanner(false, false, false, false);
+			IJavaProject javaProject= source.getJavaProject();
+	        if (javaProject != null) {
+	            String sourceLevel = javaProject.getOption(JavaCore.COMPILER_SOURCE, true);
+	            String complianceLevel = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+	            fScanner = ToolFactory.createScanner(false, false, false, sourceLevel, complianceLevel);
+	        } else {
+	        	fScanner= ToolFactory.createScanner(false, false, false, false);
+	        }
 		}
 
 		@Override

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/PasteAction.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/PasteAction.java
@@ -1039,7 +1039,14 @@ public class PasteAction extends SelectionDispatchAction{
 		}
 
 		private void parseCUs(IJavaProject javaProject, String text) {
-			IScanner scanner= ToolFactory.createScanner(false, false, false, false);
+			IScanner scanner;
+	        if (javaProject != null) {
+	            String sourceLevel = javaProject.getOption(JavaCore.COMPILER_SOURCE, true);
+	            String complianceLevel = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+	            scanner = ToolFactory.createScanner(false, false, false, sourceLevel, complianceLevel);
+	        } else {
+	        	scanner= ToolFactory.createScanner(false, false, false, false);
+	        }
 			scanner.setSource(text.toCharArray());
 
 			ArrayList<ParsedCu> cus= new ArrayList<>();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/selectionactions/GoToNextPreviousMemberAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/selectionactions/GoToNextPreviousMemberAction.java
@@ -31,11 +31,13 @@ import org.eclipse.ui.texteditor.IUpdate;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IInitializer;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IOrdinaryClassFile;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.SourceRange;
 import org.eclipse.jdt.core.ToolFactory;
@@ -230,7 +232,15 @@ public class GoToNextPreviousMemberAction extends Action implements IUpdate {
 
 	private static int firstOpeningBraceOffset(IInitializer iInitializer) throws JavaModelException {
 		try {
-			IScanner scanner= ToolFactory.createScanner(false, false, false, false);
+			IScanner scanner;
+			IJavaProject project = iInitializer.getJavaProject();
+	        if (project != null) {
+	            String sourceLevel = project.getOption(JavaCore.COMPILER_SOURCE, true);
+	            String complianceLevel = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+	            scanner = ToolFactory.createScanner(false, false, false, sourceLevel, complianceLevel);
+	        } else {
+	        	scanner= ToolFactory.createScanner(false, false, false, false);
+	        }
 			scanner.setSource(iInitializer.getSource().toCharArray());
 			int token= scanner.getNextToken();
 			while (token != ITerminalSymbols.TokenNameEOF && token != ITerminalSymbols.TokenNameLBRACE)

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/TaskMarkerProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/TaskMarkerProposal.java
@@ -25,6 +25,8 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.compiler.ITerminalSymbols;
@@ -68,7 +70,15 @@ public class TaskMarkerProposal extends CUCorrectionProposal {
 	}
 
 	private Position getUpdatedPosition(IDocument document) throws BadLocationException {
-		IScanner scanner= ToolFactory.createScanner(true, false, false, false);
+		IScanner scanner;
+		IJavaProject project = this.getCompilationUnit().getJavaProject();
+        if (project != null) {
+            String sourceLevel = project.getOption(JavaCore.COMPILER_SOURCE, true);
+            String complianceLevel = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+            scanner = ToolFactory.createScanner(true, false, false, sourceLevel, complianceLevel);
+        } else {
+        	scanner= ToolFactory.createScanner(true, false, false, false);
+        }
 		scanner.setSource(document.get().toCharArray());
 
 		int token= getSurroundingComment(scanner);


### PR DESCRIPTION
To avoid InvalidInputException if the source code contains elements not
covered by Java 1.3 JLS, specify proper source/target arguments while
creating scanner.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/203