### PR TITLE
Support Inlining within switch expression. Fixes #197

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression1.java
@@ -1,0 +1,16 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		return "";
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 -> /*]*/format("")/*[*/;
+			default -> "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression2.java
@@ -1,0 +1,16 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		return "";
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 : yield /*]*/format("")/*[*/;
+			default : yield "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression3.java
@@ -1,0 +1,22 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		if (input == null) {
+			return "null";
+		} else if (input.length > 1) {
+			return "multiple";
+		} else {
+			return "single";
+		}
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 -> /*]*/format("")/*[*/;
+			default -> "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression4.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression4.java
@@ -1,0 +1,22 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		if (input == null) {
+			return "null";
+		} else if (input.length > 1) {
+			return "multiple";
+		} else {
+			return "single";
+		}
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 : yield /*]*/format("")/*[*/;
+			default : yield "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression1.java
@@ -1,0 +1,19 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		return "";
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 -> {
+	String[] input = {""};
+	yield "";
+}
+			default -> "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression2.java
@@ -1,0 +1,19 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		return "";
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 : {
+					String[] input = {""};
+					yield "";
+				}
+			default : yield "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression3.java
@@ -1,0 +1,31 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		if (input == null) {
+			return "null";
+		} else if (input.length > 1) {
+			return "multiple";
+		} else {
+			return "single";
+		}
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 -> {
+	String[] input = {""};
+	if (input == null) {
+		yield "null";
+	} else if (input.length > 1) {
+		yield "multiple";
+	} else {
+		yield "single";
+	}
+}
+			default -> "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression4.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression4.java
@@ -1,0 +1,31 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format (String... input) {
+		if (input == null) {
+			return "null";
+		} else if (input.length > 1) {
+			return "multiple";
+		} else {
+			return "single";
+		}
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 : {
+					String[] input = {""};
+					if (input == null) {
+						yield "null";
+					} else if (input.length > 1) {
+						yield "multiple";
+					} else {
+						yield "single";
+					}
+				}
+			default : yield "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests16.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests16.java
@@ -64,4 +64,24 @@ public class InlineMethodTests16 extends InlineMethodTests {
 	public void testInlineProblem2() throws Exception {
 		performDefaultTest();
 	}
+
+	@Test
+	public void testSwitchExpression1() throws Exception {
+		performSimpleTest();
+	}
+
+	@Test
+	public void testSwitchExpression2() throws Exception {
+		performSimpleTest();
+	}
+
+	@Test
+	public void testSwitchExpression3() throws Exception {
+		performSimpleTest();
+	}
+
+	@Test
+	public void testSwitchExpression4() throws Exception {
+		performSimpleTest();
+	}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
This patch fixes the NPE reported by #197 as well as support inlining of yield statement within a switch expression

## How to test
Please use the steps reported in #197

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
