### PR TITLE
Fix NPE in getTextBlockHoverInfo. Fixes #200

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaSourceHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaSourceHover.java
@@ -443,6 +443,9 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 				return null;
 			}
 			CompilationUnit ast= SharedASTProviderCore.getAST(input, SharedASTProviderCore.WAIT_NO, null);
+			if (ast == null) {
+				return null;
+			}
 			ASTNode textBlockNode= NodeFinder.perform(ast, partition.getOffset(),
 					partition.getLength());
 			if (!(textBlockNode instanceof TextBlock)) {


### PR DESCRIPTION
## What it does
Fix NPE in getTextBlockHoverInfo

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
