### PR TITLE
NPE in OrganizeImportsOperation.addStaticImports() (#209)

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
@@ -675,6 +675,9 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 				}
 				if (unresolvableImports.isEmpty()) {
 					String pref= JavaManipulation.getPreference(JavaManipulationPlugin.CODEASSIST_FAVORITE_STATIC_MEMBERS, importRewrite.getCompilationUnit().getJavaProject());
+					if (pref == null  || pref.isBlank()) {
+						return;
+					}
 					String[] favourites= pref.split(";"); //$NON-NLS-1$
 					if (favourites.length == 0) {
 						return;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
@@ -1324,6 +1324,9 @@ public class UnresolvedElementsSubProcessor {
 		IJavaProject project= context.getCompilationUnit().getJavaProject();
 		if (JavaModelUtil.is50OrHigher(project)) {
 			String pref= PreferenceConstants.getPreference(PreferenceConstants.CODEASSIST_FAVORITE_STATIC_MEMBERS, project);
+			if (pref == null  || pref.isBlank()) {
+				return;
+			}
 			String[] favourites= pref.split(";"); //$NON-NLS-1$
 			if (favourites.length == 0) {
 				return;


### PR DESCRIPTION
Don't assume the "CODEASSIST_FAVORITE_STATIC_MEMBERS" preference is
always set and check for NPE.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/209