### PR TITLE
Fix mixups in isStatic and isPrivate methods in StubUtility2Core

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
@@ -861,11 +861,11 @@ public final class StubUtility2Core {
 	}
 
 	private static boolean isStatic(IMethodBinding method) {
-		return Modifier.isPrivate(method.getModifiers());
+		return Modifier.isStatic(method.getModifiers());
 	}
 
 	private static boolean isPrivate(IMethodBinding method) {
-		return Modifier.isStatic(method.getModifiers());
+		return Modifier.isPrivate(method.getModifiers());
 	}
 
 	private static boolean isAbstract(IMethodBinding method) {


### PR DESCRIPTION
## What it does
Fixes isStatic() and isPrivate() methods in StubUtility2Core which have mixed up the flags to test.

## How to test
Examine the source.  It is an obvious fix.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
