### PR TITLE
Don't allow while to forEach if iterator used in multiple while stmts

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -4564,6 +4564,56 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
 	}
 
+	/**
+	 * https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/190
+	 *
+	 * @throws CoreException
+	 */
+	@Test
+	public void testWhileIssue190_MultipleWhileLoops() throws CoreException {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "public class Test {\n"
+				+ "    void m(List<String> strings) {\n"
+				+ "        Iterator<String> it = strings.iterator();\n"
+				+ "        while (it.hasNext()) {\n"
+				+ "            String s = (String) it.next();\n"
+				+ "            System.out.println(s);\n"
+				+ "            System.err.println(s);\n"
+				+ "        }\n"
+				+ "        Iterator<String> it2 = strings.iterator();\n"
+				+ "        while (it2.hasNext()) {\n"
+				+ "            String s = (String) it2.next();\n"
+				+ "            System.out.println(s);\n"
+				+ "            System.err.println(s);\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		String expected= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "public class Test {\n"
+				+ "    void m(List<String> strings) {\n"
+				+ "        for (String s : strings) {\n"
+				+ "            System.out.println(s);\n"
+				+ "            System.err.println(s);\n"
+				+ "        }\n"
+				+ "        for (String s : strings) {\n"
+				+ "            System.out.println(s);\n"
+				+ "            System.err.println(s);\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
+				new HashSet<>(Arrays.asList(FixMessages.Java50Fix_ConvertToEnhancedForLoop_description)));
+	}
+
 	@Test
 	public void testWhileSelf() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
@@ -5039,6 +5089,65 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
 
 		assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
+	}
+
+	@Test
+	public void testDoNotWhileIssue190_1() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				        + "import java.util.*;\n"
+				        + "public class Test {\n"
+				        + "    void m(List<String> strings) {\n"
+				        + "        Iterator<String> it = strings.iterator();\n"
+				        + "        while (it.hasNext()) {\n"
+				        + "            String s = (String) it.next();\n"
+				        + "            System.out.println(s);\n"
+				        + "            System.err.println(s);\n"
+				        + "        }\n"
+				        + "        it = strings.iterator();\n"
+				        + "        while (it.hasNext()) {\n"
+				        + "            String s = (String) it.next();\n"
+				        + "            System.out.println(s);\n"
+				        + "            System.err.println(s);\n"
+				        + "        }\n"
+			        + "    }\n"
+				        + "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
+
+	}
+
+	@Test
+	public void testDoNotWhileIssue190_2() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				+ "import java.util.*;\n"
+				+ "public class Test {\n"
+				+ "    void m(List<String> strings) {\n"
+				+ "        Iterator<String> it = strings.iterator();\n"
+				+ "        while (it.hasNext()) {\n"
+				+ "            String s = (String) it.next();\n"
+				+ "            System.out.println(s);\n"
+				+ "            System.err.println(s);\n"
+				+ "        }\n"
+				+ "        while (it.hasNext()) {\n"
+				+ "            String s = (String) it.next();\n"
+				+ "            System.out.println(s);\n"
+				+ "            System.err.println(s);\n"
+				+ "        }\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
+
 	}
 
 	@Test


### PR DESCRIPTION
- fixes #190

## What it does
Prevents a while iterator loop to enhanced for loop cleanup to occur if an iterator is used by multiple while loops.  This is
necessary because the iterator declaration gets removed.

## How to test
See #190.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
