### PR TITLE
Update ICU4J to version 71.1

### DIFF
--- a/org.eclipse.jdt.junit/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit/forceQualifierUpdate.txt
@@ -9,3 +9,4 @@ Bug 564399 - [Comparator] Comparator Errors in Y-build Y20200617-2350
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Comparator errors in jdt.ui bundles in I20210317-0330
 Bug 574522 - 4.21 I-Build: I20210628-1800 - Comparator Errors Found
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/439 - Update ICU4J to version 71.1

--- a/org.eclipse.jdt.ui/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.ui/forceQualifierUpdate.txt
@@ -11,3 +11,4 @@ Bug 574012 - Comparator errors in I20210604-0350
 Bug 574522 - 4.21 I-Build: I20210628-1800 - Comparator Errors Found
 Bug 577483 - Comparator errors in I20211126-0230
 Bug 579126 - 4.24 I-Build: I20220307-0340 - Comparator Errors Found
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/439 - Update ICU4J to version 71.1


### PR DESCRIPTION
Signature of com.ibm.icu.text.UTF16.isSurrogate(char) changed to
com.ibm.icu.text.UTF16.isSurrogate(int). The affected code need to be
touched to avoid comparator errors

Comparator differences from current build
	/home/jenkins/agent/workspace/I-build-4.25/eclipse.platform.releng.aggregator/eclipse.platform.releng.aggregator/cje-production/siteDir/eclipse/downloads/drops4/I20220814-0600
compared to reference repo at
	https://download.eclipse.org/eclipse/updates/4.25-I-builds

1.  eclipse.jdt.ui/org.eclipse.jdt.ui
   no-classifier: different
      org/eclipse/jdt/internal/ui/text/JavaWordFinder.class: different
    The main artifact has been replaced with the baseline version.
    The following attached artifacts have been replaced with the
baseline version: [sources]

2.  eclipse.jdt.ui/org.eclipse.jdt.junit
   no-classifier: different
      org/eclipse/jdt/junit/wizards/NewTestCaseWizardPageOne.class:
different
    The main artifact has been replaced with the baseline version.
    The following attached artifacts have been replaced with the
baseline version: [sources]

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/439