### PR TITLE
Change com.ibm.icu.text.UTF16.isSurrogate() -> Character.isSurrogate()

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestCaseWizardPageOne.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestCaseWizardPageOne.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
-import com.ibm.icu.text.UTF16;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -1132,7 +1130,7 @@ public class NewTestCaseWizardPageOne extends NewTypeWizardPage {
 				buffer.replace(index, index + 1, QUESTION_MARK_TAG);
 			else if (!Character.isJavaIdentifierPart(character)) {
 				// Check for surrogates
-				if (!UTF16.isSurrogate(character)) {
+				if (!Character.isSurrogate(character)) {
 					/*
 					 * XXX: Here we should create the code point and test whether
 					 * it is a Java identifier part. Currently this is not possible

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaWordFinder.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaWordFinder.java
@@ -14,8 +14,6 @@
 package org.eclipse.jdt.internal.ui.text;
 
 
-import com.ibm.icu.text.UTF16;
-
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
@@ -36,7 +34,7 @@ public class JavaWordFinder {
 				c= document.getChar(pos);
 				if (!Character.isJavaIdentifierPart(c)) {
 					// Check for surrogates
-					if (UTF16.isSurrogate(c)) {
+					if (Character.isSurrogate(c)) {
 						/*
 						 * XXX: Here we should create the code point and test whether
 						 * it is a Java identifier part. Currently this is not possible
@@ -58,7 +56,7 @@ public class JavaWordFinder {
 			while (pos < length) {
 				c= document.getChar(pos);
 				if (!Character.isJavaIdentifierPart(c)) {
-					if (UTF16.isSurrogate(c)) {
+					if (Character.isSurrogate(c)) {
 						/*
 						 * XXX: Here we should create the code point and test whether
 						 * it is a Java identifier part. Currently this is not possible


### PR DESCRIPTION
This should avoid issues with incompatible ICU4J change in 70, see
details in https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/476

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/217