### PR TITLE
Fix Javadoc warnings and errors.

### DIFF
--- a/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/RefactoringStatusContext.java
+++ b/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/core/refactoring/RefactoringStatusContext.java
@@ -35,7 +35,7 @@ public abstract class RefactoringStatusContext {
 	 * <p>
 	 * For example, the corresponding element of a context for a problem
 	 * detected in an <code>IResource</code> would be the resource itself.
-	 * <p>
+	 * </p>
 	 *
 	 * @return the corresponding element
 	 */


### PR DESCRIPTION
As found by Java 17 javadoc tool.
Needed by
eclipse-platform/eclipse.platform.releng.aggregator#482

