### PR TITLE
Use tree selection for picking the nested test classes

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.11.400.qualifier
+Bundle-Version: 3.11.500.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/pom.xml
+++ b/org.eclipse.jdt.junit.core/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit.core</artifactId>
-  <version>3.11.400-SNAPSHOT</version>
+  <version>3.11.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnit5TestFinder.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnit5TestFinder.java
@@ -18,8 +18,7 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IRegion;
@@ -65,11 +64,11 @@ public class JUnit5TestFinder implements ITestFinder {
 			fName= name;
 		}
 
-		public String getName() {
+		String getName() {
 			return fName;
 		}
 
-		public boolean annotatesAtLeastOneInnerClass(ITypeBinding type) {
+		boolean annotatesAtLeastOneInnerClass(ITypeBinding type) {
 			if (type == null) {
 				return false;
 			}
@@ -110,7 +109,7 @@ public class JUnit5TestFinder implements ITestFinder {
 			return false;
 		}
 
-		public boolean annotatesTypeOrSuperTypes(ITypeBinding type) {
+		boolean annotatesTypeOrSuperTypes(ITypeBinding type) {
 			while (type != null) {
 				if (annotates(type.getAnnotations())) {
 					return true;
@@ -120,7 +119,7 @@ public class JUnit5TestFinder implements ITestFinder {
 			return false;
 		}
 
-		public boolean annotatesAtLeastOneMethod(ITypeBinding type) {
+		boolean annotatesAtLeastOneMethod(ITypeBinding type) {
 			if (type == null) {
 				return false;
 			}
@@ -211,34 +210,27 @@ public class JUnit5TestFinder implements ITestFinder {
 			}
 		}
 
-		if (pm == null)
-			pm= new NullProgressMonitor();
+		var subMonitor = SubMonitor.convert(pm, JUnitMessages.JUnit5TestFinder_searching_description, 4);
 
-		try {
-			pm.beginTask(JUnitMessages.JUnit5TestFinder_searching_description, 4);
+		IRegion region= CoreTestSearchEngine.getRegion(element);
+		ITypeHierarchy hierarchy= JavaCore.newTypeHierarchy(region, null, subMonitor.split(1));
+		IType[] allClasses= hierarchy.getAllClasses();
 
-			IRegion region= CoreTestSearchEngine.getRegion(element);
-			ITypeHierarchy hierarchy= JavaCore.newTypeHierarchy(region, null, new SubProgressMonitor(pm, 1));
-			IType[] allClasses= hierarchy.getAllClasses();
-
-			// search for all types with references to RunWith and Test and all subclasses
-			for (IType type : allClasses) {
-				if (internalIsTest(type, pm) && region.contains(type)) {
-					addTypeAndSubtypes(type, result, hierarchy);
-				}
+		// search for all types with references to RunWith and Test and all subclasses
+		for (IType type : allClasses) {
+			if (internalIsTest(type, pm) && region.contains(type)) {
+				addTypeAndSubtypes(type, result, hierarchy);
 			}
-
-			// add all classes implementing JUnit 3.8's Test interface in the region
-			IType testInterface= element.getJavaProject().findType(JUnitCorePlugin.TEST_INTERFACE_NAME);
-			if (testInterface != null) {
-				CoreTestSearchEngine.findTestImplementorClasses(hierarchy, testInterface, region, result);
-			}
-
-			//JUnit 4.3 can also run JUnit-3.8-style public static Test suite() methods:
-			CoreTestSearchEngine.findSuiteMethods(element, result, new SubProgressMonitor(pm, 1));
-		} finally {
-			pm.done();
 		}
+
+		// add all classes implementing JUnit 3.8's Test interface in the region
+		IType testInterface= element.getJavaProject().findType(JUnitCorePlugin.TEST_INTERFACE_NAME);
+		if (testInterface != null) {
+			CoreTestSearchEngine.findTestImplementorClasses(hierarchy, testInterface, region, result);
+		}
+
+		//JUnit 4.3 can also run JUnit-3.8-style public static Test suite() methods:
+		CoreTestSearchEngine.findSuiteMethods(element, result, subMonitor.split(1));
 	}
 
 	private void addTypeAndSubtypes(IType type, Set<IType> result, ITypeHierarchy hierarchy) {

--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/pom.xml
+++ b/org.eclipse.jdt.junit/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit</artifactId>
-  <version>3.15.0-SNAPSHOT</version>
+  <version>3.15.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.internal.junit.launcher.ITestKind;
  */
 public class TestSearchEngine extends CoreTestSearchEngine {
 
-	public static IType[] findTests(IRunnableContext context, final IJavaElement element, final ITestKind testKind) throws InvocationTargetException, InterruptedException {
+	public static Set<IType> findTests(IRunnableContext context, final IJavaElement element, final ITestKind testKind) throws InvocationTargetException, InterruptedException {
 		final Set<IType> result= new HashSet<>();
 
 		IRunnableWithProgress runnable= progressMonitor -> {
@@ -45,7 +45,7 @@ public class TestSearchEngine extends CoreTestSearchEngine {
 			}
 		};
 		context.run(true, true, runnable);
-		return result.toArray(new IType[result.size()]);
+		return result;
 	}
 
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -592,7 +592,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 
 		IJavaProject javaProject = getJavaProject();
 
-		IType[] types= new IType[0];
+		final Set<IType> types;
 		boolean[] radioSetting= new boolean[2];
 		try {
 			// fix for 66922 Wrong radio behaviour when switching
@@ -1115,12 +1115,12 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 				ITestKind testKind= TestKindRegistry.getContainerTestKind(javaElement);
 				testKindId= testKind.getId();
 
-				IType[] types = TestSearchEngine.findTests(getLaunchConfigurationDialog(), javaElement, testKind);
-				if ((types == null) || (types.length < 1)) {
+				var types = TestSearchEngine.findTests(getLaunchConfigurationDialog(), javaElement, testKind);
+				if ((types == null) || (types.isEmpty())) {
 					return;
 				}
 				// Simply grab the first main type found in the searched element
-				name= types[0].getFullyQualifiedName('.');
+				name= types.iterator().next().getFullyQualifiedName('.');
 
 			}
 		} catch (InterruptedException | InvocationTargetException ite) {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchShortcut.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchShortcut.java
@@ -16,14 +16,15 @@ package org.eclipse.jdt.junit.launcher;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
@@ -37,6 +38,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.window.Window;
 
 import org.eclipse.jface.text.ITextSelection;
@@ -44,6 +47,7 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.dialogs.ElementTreeSelectionDialog;
 
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -55,7 +59,6 @@ import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.IDebugModelPresentation;
 import org.eclipse.debug.ui.ILaunchShortcut2;
 
-import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
@@ -212,27 +215,18 @@ public class JUnitLaunchShortcut implements ILaunchShortcut2 {
 	}
 
 	private IType findTypeToLaunch(ICompilationUnit cu, String mode) throws InterruptedException, InvocationTargetException, JavaModelException {
-		IType[] types= findTypesToLaunch(cu);
-		if (types.length == 0) {
+		var types= findTypesToLaunch(cu);
+		if (types.isEmpty()) {
 			return null;
-		} else if (types.length > 1) {
+		} else if (types.size() > 1) {
 			return chooseType(types, mode);
 		}
-		return types[0];
+		return types.iterator().next();
 	}
 
-	private IType[] findTypesToLaunch(ICompilationUnit cu) throws InterruptedException, InvocationTargetException, JavaModelException {
+	private Set<IType> findTypesToLaunch(ICompilationUnit cu) throws InterruptedException, InvocationTargetException, JavaModelException {
 		ITestKind testKind= TestKindRegistry.getContainerTestKind(cu);
-		IType[] foundTests= TestSearchEngine.findTests(PlatformUI.getWorkbench().getActiveWorkbenchWindow(), cu, testKind);
-
-		Set<IType> tests= new LinkedHashSet<>(Arrays.asList(foundTests));
-		for (IType type : foundTests) {
-			if (!Flags.isStatic(type.getFlags()) && tests.contains(type.getDeclaringType())) {
-				tests.remove(type);
-			}
-		}
-
-		return tests.toArray(new IType[0]);
+		return TestSearchEngine.findTests(PlatformUI.getWorkbench().getActiveWorkbenchWindow(), cu, testKind);
 	}
 
 	private void performLaunch(IJavaElement element, String mode) throws InterruptedException, CoreException {
@@ -245,16 +239,63 @@ public class JUnitLaunchShortcut implements ILaunchShortcut2 {
 		DebugUITools.launch(config, mode);
 	}
 
-	private IType chooseType(IType[] types, String mode) throws InterruptedException {
-		ElementListSelectionDialog dialog= new ElementListSelectionDialog(getShell(), new JavaElementLabelProvider(JavaElementLabelProvider.SHOW_POST_QUALIFIED));
-		dialog.setElements(types);
+	static class TreeProvider implements ITreeContentProvider {
+		private final static Object ROOT= new Object();
+
+		private final Map<Object, List<IType>> tree= new HashMap<>();
+
+		public TreeProvider(Set<IType> types) {
+			for (var type : types) {
+				var parent= type.getParent();
+				var parentInTree= types.contains(parent) ? parent : ROOT;
+				tree.compute(parentInTree, (key, value) -> {
+					var list= value != null ? value : new ArrayList<IType>();
+					list.add(type);
+					return list;
+				});
+			}
+		}
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			return tree.get(ROOT).toArray();
+		}
+
+		@Override
+		public Object[] getChildren(Object parentElement) {
+			var children= tree.get(parentElement);
+			return children != null ? children.toArray() : new Object[0];
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			return null;
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			var children= tree.get(element);
+			return children != null && !children.isEmpty();
+		}
+	}
+
+	private IType chooseType(Set<IType> types, String mode) throws InterruptedException {
+		var dialog = new ElementTreeSelectionDialog(getShell(), new JavaElementLabelProvider(JavaElementLabelProvider.SHOW_POST_QUALIFIED), new TreeProvider(types)) {
+			@Override
+			protected TreeViewer createTreeViewer(Composite parent) {
+				var tree = super.createTreeViewer(parent);
+				tree.expandAll();
+				return tree;
+			}
+		};
 		dialog.setTitle(JUnitMessages.JUnitLaunchShortcut_dialog_title2);
+		dialog.setAllowMultiple(false);
+		dialog.setInput(TreeProvider.ROOT);
 		if (ILaunchManager.DEBUG_MODE.equals(mode)) {
 			dialog.setMessage(JUnitMessages.JUnitLaunchShortcut_message_selectTestToDebug);
 		} else {
 			dialog.setMessage(JUnitMessages.JUnitLaunchShortcut_message_selectTestToRun);
 		}
-		dialog.setMultipleSelection(false);
 		if (dialog.open() == Window.OK) {
 			return (IType) dialog.getFirstResult();
 		}

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.14.400.qualifier
+Bundle-Version: 3.14.500.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.14.400-SNAPSHOT</version>
+  <version>3.14.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestTestSearchEngine.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestTestSearchEngine.java
@@ -16,8 +16,9 @@ package org.eclipse.jdt.junit.tests;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
@@ -68,10 +69,10 @@ public class TestTestSearchEngine {
 		ICompilationUnit test1= createCompilationUnit(p, 1);
 		ICompilationUnit test2= createCompilationUnit(p, 2);
 
-		IType[] result= findTests(p);
-		assertEqualTypes("Test case not found", new IType[] {
+		var result= findTests(p);
+		assertEqualTypes("Test case not found", List.of(
 				test1.getType("Test1"), test2.getType("Test2")
-			}, result);
+			), result);
 	}
 
 	@Test
@@ -83,10 +84,10 @@ public class TestTestSearchEngine {
 		IPackageFragment q= fRoot.createPackageFragment("q", true, null);
 		ICompilationUnit test3= createCompilationUnit(q, 3);
 
-		IType[] result= findTests(new IJavaElement[] {p, q});
-		assertEqualTypes("Test case not found", new IType[] {
+		var result= findTests(new IJavaElement[] {p, q});
+		assertEqualTypes("Test case not found", List.of(
 				test1.getType("Test1"), test2.getType("Test2"), test3.getType("Test3")
-			}, result);
+			), result);
 	}
 
 	@Test
@@ -98,10 +99,10 @@ public class TestTestSearchEngine {
 		IPackageFragment q= fRoot.createPackageFragment("q", true, null);
 		createCompilationUnit(q, 3);
 
-		IType[] result= findTests(p);
-		assertEqualTypes("Test case not found", new IType[] {
+		var result= findTests(p);
+		assertEqualTypes("Test case not found", List.of(
 				test1.getType("Test1"), test2.getType("Test2")
-			}, result);
+			), result);
 	}
 
 	@Test
@@ -113,10 +114,10 @@ public class TestTestSearchEngine {
 		IPackageFragment q= fRoot.createPackageFragment("q", true, null);
 		ICompilationUnit test3= createCompilationUnit(q, 3);
 
-		IType[] result= findTests(fRoot);
-		assertEqualTypes("Test case not found", new IType[] {
+		var result= findTests(fRoot);
+		assertEqualTypes("Test case not found", List.of(
 				test1.getType("Test1"), test2.getType("Test2"), test3.getType("Test3")
-			}, result);
+			), result);
 	}
 
 	@Test
@@ -134,11 +135,11 @@ public class TestTestSearchEngine {
 		ICompilationUnit test4= createCompilationUnit(r, 4);
 		ICompilationUnit test5= createCompilationUnit(r, 5);
 
-		IType[] result= findTests(new IJavaElement[] {fRoot, root2});
-		assertEqualTypes("Test case not found", new IType[] {
+		var result= findTests(new IJavaElement[] {fRoot, root2});
+		assertEqualTypes("Test case not found", List.of(
 				test1.getType("Test1"), test2.getType("Test2"), test3.getType("Test3"),
 				test4.getType("Test4"), test5.getType("Test5")
-			}, result);
+			), result);
 	}
 
 	@Test
@@ -156,10 +157,10 @@ public class TestTestSearchEngine {
 		ICompilationUnit test4= createCompilationUnit(r, 4);
 		ICompilationUnit test5= createCompilationUnit(r, 5);
 
-		IType[] result= findTests(root2);
-		assertEqualTypes("Test case not found", new IType[] {
+		var result= findTests(root2);
+		assertEqualTypes("Test case not found", List.of(
 				test4.getType("Test4"), test5.getType("Test5")
-			}, result);
+			), result);
 	}
 
 	@Test
@@ -176,8 +177,8 @@ public class TestTestSearchEngine {
 				true,
 				null);
 
-		IType[] result= findTests(root2);
-		assertEqualTypes("Test case not found", new IType[] { testSub.getType("TestSub") }, result);
+		var result= findTests(root2);
+		assertEqualTypes("Test case not found", List.of(testSub.getType("TestSub")), result);
 	}
 
 	@Test
@@ -195,11 +196,11 @@ public class TestTestSearchEngine {
 		ICompilationUnit test4= createCompilationUnit(r, 4);
 		ICompilationUnit test5= createCompilationUnit(r, 5);
 
-		IType[] result= findTests(fProject);
-		assertEqualTypes("Test case not found", new IType[] {
+		var result= findTests(fProject);
+		assertEqualTypes("Test case not found", List.of(
 				test1.getType("Test1"), test2.getType("Test2"), test3.getType("Test3"),
 				test4.getType("Test4"), test5.getType("Test5")
-			}, result);
+			), result);
 	}
 
 	@Test
@@ -210,26 +211,23 @@ public class TestTestSearchEngine {
 		IPackageFragment q= fRoot.createPackageFragment("p.q", true, null);
 		createCompilationUnit(q, 2);
 
-		IType[] result= findTests(p);
-		assertEqualTypes("Test case not found", new IType[] {
-				test1.getType("Test1")
-			}, result);
+		var result= findTests(p);
+		assertEqualTypes("Test case not found", List.of(test1.getType("Test1")), result);
 	}
 
-	private IType[] findTests(IJavaElement element) throws InvocationTargetException, InterruptedException {
+	private List<IType> findTests(IJavaElement element) throws InvocationTargetException, InterruptedException {
 		ITestKind testKind= TestKindRegistry.getContainerTestKind(fProject);
-		return TestSearchEngine.findTests(new BusyIndicatorRunnableContext(), element, testKind);
+		return new ArrayList<>(TestSearchEngine.findTests(new BusyIndicatorRunnableContext(), element, testKind));
 	}
 
-	private IType[] findTests(IJavaElement[] elements) throws InvocationTargetException, InterruptedException {
+	private List<IType> findTests(IJavaElement[] elements) throws InvocationTargetException, InterruptedException {
 		HashSet<IType> res= new HashSet<>();
 		for (IJavaElement element : elements) {
-			IType[] types= findTests(element);
-			res.addAll(Arrays.asList(types));
+			var types= findTests(element);
+			res.addAll(types);
 		}
-		return res.toArray(new IType[res.size()]);
+		return new ArrayList<>(res);
 	}
-
 
 	@Test
 	public void testJUnit4NoSrc() throws Exception {
@@ -245,11 +243,10 @@ public class TestTestSearchEngine {
 			true, null);
 	}
 
-	private void assertEqualTypes(String message, IType[] expected, IType[] actual) {
-		assertEquals("Wrong number of found tests", expected.length, actual.length);
-		List<IType> list= Arrays.asList(expected);
-		for (int i= 0; i < actual.length; i++) {
-			assertTrue(message + expected[i].getFullyQualifiedName(), list.contains(expected[i]));
+	private void assertEqualTypes(String message, List<IType> expected, List<IType> actual) {
+		assertEquals("Wrong number of found tests", expected.size(), actual.size());
+		for (int i= 0; i < actual.size(); i++) {
+			assertTrue(message + expected.get(i).getFullyQualifiedName(), expected.contains(actual.get(i)));
 		}
 	}
 }

--- a/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
+++ b/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.ui.unittest.junit.feature"
       label="%featureName"
-      version="1.0.300.qualifier"
+      version="1.0.400.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.ui.unittest.junit.feature/pom.xml
+++ b/org.eclipse.jdt.ui.unittest.junit.feature/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt.feature</groupId>
   <artifactId>org.eclipse.jdt.ui.unittest.junit.feature</artifactId>
-  <version>1.0.300-SNAPSHOT</version>
+  <version>1.0.400-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <build>
      <plugins>

--- a/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.unittest.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui.unittest.junit;singleton:=true
-Bundle-Version: 1.0.400.qualifier
+Bundle-Version: 1.0.500.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.unittest.junit.JUnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui.unittest.junit/pom.xml
+++ b/org.eclipse.jdt.ui.unittest.junit/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.unittest.junit</artifactId>
-  <version>1.0.400-SNAPSHOT</version>
+  <version>1.0.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
       <skipAPIAnalysis>true</skipAPIAnalysis>

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -596,7 +596,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 
 		IJavaProject javaProject = getJavaProject();
 
-		IType[] types = new IType[0];
+		final Set<IType> types;
 		boolean[] radioSetting = new boolean[2];
 		try {
 			// fix for 66922 Wrong radio behaviour when switching
@@ -1125,12 +1125,12 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 				ITestKind testKind = JUnitTestPlugin.getJUnitVersion(javaElement).getJUnitTestKind();
 				testKindId = testKind.getId();
 
-				IType[] types = TestSearchEngine.findTests(getLaunchConfigurationDialog(), javaElement, testKind);
-				if ((types == null) || (types.length < 1)) {
+				var types = TestSearchEngine.findTests(getLaunchConfigurationDialog(), javaElement, testKind);
+				if ((types == null) || (types.isEmpty())) {
 					return;
 				}
 				// Simply grab the first main type found in the searched element
-				name = types[0].getFullyQualifiedName('.');
+				name = types.iterator().next().getFullyQualifiedName('.');
 
 			}
 		} catch (InterruptedException | InvocationTargetException ie) {

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchShortcut.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchShortcut.java
@@ -16,13 +16,17 @@ package org.eclipse.jdt.ui.unittest.junit.launcher;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.unittest.ui.ConfigureViewerSupport;
 
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 
@@ -36,6 +40,8 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.window.Window;
 
 import org.eclipse.jface.text.ITextSelection;
@@ -43,6 +49,7 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
+import org.eclipse.ui.dialogs.ElementTreeSelectionDialog;
 
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -207,16 +214,16 @@ public class JUnitLaunchShortcut implements ILaunchShortcut2 {
 
 	private IType findTypeToLaunch(ICompilationUnit cu, String mode)
 			throws InterruptedException, InvocationTargetException {
-		IType[] types = findTypesToLaunch(cu);
-		if (types.length == 0) {
+		var types= findTypesToLaunch(cu);
+		if (types.isEmpty()) {
 			return null;
-		} else if (types.length > 1) {
+		} else if (types.size() > 1) {
 			return chooseType(types, mode);
 		}
-		return types[0];
+		return types.iterator().next();
 	}
 
-	private IType[] findTypesToLaunch(ICompilationUnit cu) throws InterruptedException, InvocationTargetException {
+	private Set<IType> findTypesToLaunch(ICompilationUnit cu) throws InterruptedException, InvocationTargetException {
 		return TestSearchEngine.findTests(PlatformUI.getWorkbench().getActiveWorkbenchWindow(), cu,
 				JUnitTestPlugin.getJUnitVersion(cu).getJUnitTestKind());
 	}
@@ -231,17 +238,63 @@ public class JUnitLaunchShortcut implements ILaunchShortcut2 {
 		DebugUITools.launch(config, mode);
 	}
 
-	private IType chooseType(IType[] types, String mode) throws InterruptedException {
-		ElementListSelectionDialog dialog = new ElementListSelectionDialog(getShell(),
-				new JavaElementLabelProvider(JavaElementLabelProvider.SHOW_POST_QUALIFIED));
-		dialog.setElements(types);
+	static class TreeProvider implements ITreeContentProvider {
+		private final static Object ROOT= new Object();
+
+		private final Map<Object, List<IType>> tree= new HashMap<>();
+
+		public TreeProvider(Set<IType> types) {
+			for (var type : types) {
+				var parent= type.getParent();
+				var parentInTree= types.contains(parent) ? parent : ROOT;
+				tree.compute(parentInTree, (key, value) -> {
+					var list= value != null ? value : new ArrayList<IType>();
+					list.add(type);
+					return list;
+				});
+			}
+		}
+
+		@Override
+		public Object[] getElements(Object inputElement) {
+			return tree.get(ROOT).toArray();
+		}
+
+		@Override
+		public Object[] getChildren(Object parentElement) {
+			var children= tree.get(parentElement);
+			return children != null ? children.toArray() : new Object[0];
+		}
+
+		@Override
+		public Object getParent(Object element) {
+			return null;
+		}
+
+		@Override
+		public boolean hasChildren(Object element) {
+			var children= tree.get(element);
+			return children != null && !children.isEmpty();
+		}
+	}
+
+	private IType chooseType(Set<IType> types, String mode) throws InterruptedException {
+		var dialog = new ElementTreeSelectionDialog(getShell(), new JavaElementLabelProvider(JavaElementLabelProvider.SHOW_POST_QUALIFIED), new TreeProvider(types)) {
+			@Override
+			protected TreeViewer createTreeViewer(Composite parent) {
+				var tree = super.createTreeViewer(parent);
+				tree.expandAll();
+				return tree;
+			}
+		};
 		dialog.setTitle(Messages.UnitTestLaunchShortcut_dialog_title2);
-		if (mode.equals(ILaunchManager.DEBUG_MODE)) {
+		dialog.setAllowMultiple(false);
+		dialog.setInput(TreeProvider.ROOT);
+		if (ILaunchManager.DEBUG_MODE.equals(mode)) {
 			dialog.setMessage(Messages.UnitTestLaunchShortcut_message_selectTestToDebug);
 		} else {
 			dialog.setMessage(Messages.UnitTestLaunchShortcut_message_selectTestToRun);
 		}
-		dialog.setMultipleSelection(false);
 		if (dialog.open() == Window.OK) {
 			return (IType) dialog.getFirstResult();
 		}


### PR DESCRIPTION
instead of a list, which makes picking test cases easier.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
It changes the dialog which is shown when "Run As/Debug As" -> "JUnit Test" action is executed in a file, which has multiple test 
classes. Previously, only a simple listing of the found types are shown, which is not the most optimal solution, if there are multiple nested classes, the original structure of the classes are lost. Specially, finding the root class is not trivial. 
 Changing the dialog to show the tree structure of the classes, helps tremendously.


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
 Create a **JUnit** test class with multiple inner classes, with **Nested** annotations and test methods in it. Try to start them...

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
