### PR TITLE
Adding Hiererarchical visitor nodes for AbstractTextElement. Fixes #231

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
@@ -1185,14 +1185,32 @@ public abstract class HierarchicalASTVisitor extends ASTVisitor {
 		endVisit((AbstractTagElement)node);
 	}
 
+	public boolean visit(AbstractTextElement node) {
+		return visit((ASTNode)node);
+	}
+
+	public void endVisit(AbstractTextElement node) {
+		endVisit((ASTNode)node);
+	}
+
 	@Override
 	public boolean visit(TextElement node) {
-		return visit((ASTNode)node);
+		return visit((AbstractTextElement)node);
 	}
 
 	@Override
 	public void endVisit(TextElement node) {
-		endVisit((ASTNode)node);
+		endVisit((AbstractTextElement)node);
+	}
+
+	@Override
+	public boolean visit(JavaDocTextElement node) {
+		return visit((AbstractTextElement)node);
+	}
+
+	@Override
+	public void endVisit(JavaDocTextElement node) {
+		endVisit((AbstractTextElement)node);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/HierarchicalASTVisitorTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/HierarchicalASTVisitorTest.java
@@ -30,6 +30,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTagElement;
+import org.eclipse.jdt.core.dom.AbstractTextElement;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnnotatableType;
 import org.eclipse.jdt.core.dom.Annotation;
@@ -146,6 +147,24 @@ public class HierarchicalASTVisitorTest {
 		}
 		@SuppressWarnings("unused") // called reflectively
 		public void superEndVisit(AbstractTagElement node) {
+			super.visit(node);
+		}
+
+		@Override
+		public boolean visit(AbstractTextElement node) {
+			registerCall(AbstractTextElement.class);
+			return false;
+		}
+		@SuppressWarnings("unused") // called reflectively
+		public void superVisit(AbstractTextElement node) {
+			super.visit(node);
+		}
+		@Override
+		public void endVisit(AbstractTextElement node) {
+			registerCall(AbstractTextElement.class);
+		}
+		@SuppressWarnings("unused") // called reflectively
+		public void superEndVisit(AbstractTextElement node) {
 			super.visit(node);
 		}
 


### PR DESCRIPTION
Signed-off-by: Kalyan Prasad Tatavarthi <kalyan_prasad@in.ibm.com>

## What it does
Fixes `HierarchicalASTVisitorTest` failure because of new DOM AST Node added `AbstractTextElement`

## How to test
Run `HierarchicalASTVisitorTest` locally. All tests should pass.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
