### PR TITLE
fix ClassCastException in some PropertyDialogAction #78

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PropertyAndPreferencePage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PropertyAndPreferencePage.java
@@ -324,7 +324,8 @@ public abstract class PropertyAndPreferencePage extends PreferencePage implement
 
 	@Override
 	public void setElement(IAdaptable element) {
-		fProject= (IProject) element.getAdapter(IResource.class);
+		IResource resource= element.getAdapter(IResource.class);
+		fProject= resource == null ? null : resource.getProject();
 	}
 
 


### PR DESCRIPTION
If element is PackageFragmentRoot then resource is Folder.
If resource is already IProject then getProject() returns this - as
before.

This solution was already suggested in bug 467761 and 579428.

To test: show Properties of "src" folder. Then Select "Java Compiler".