### PR TITLE
Bug #237: No comparison dialog for subclasses of ComparisonFailure in JUnit5

### DIFF
--- a/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestListener.java
+++ b/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestListener.java
@@ -117,14 +117,15 @@ public class JUnit5TestListener implements TestExecutionListener {
 		}
 
 		// Avoid reference to ComparisonFailure initially to avoid NoClassDefFoundError for ComparisonFailure when junit.jar is not on the build path
-		String classname= exception.getClass().getName();
-		if ("junit.framework.ComparisonFailure".equals(classname)) { //$NON-NLS-1$
-			junit.framework.ComparisonFailure comparisonFailure= (junit.framework.ComparisonFailure) exception;
-			return new FailedComparison(comparisonFailure.getExpected(), comparisonFailure.getActual());
-		}
-		if ("org.junit.ComparisonFailure".equals(classname)) { //$NON-NLS-1$
-			org.junit.ComparisonFailure comparisonFailure= (org.junit.ComparisonFailure) exception;
-			return new FailedComparison(comparisonFailure.getExpected(), comparisonFailure.getActual());
+		for(Class<?> it= exception.getClass(); !Object.class.equals(it); it= it.getSuperclass()) {
+			if ("junit.framework.ComparisonFailure".equals(it.getName())) { //$NON-NLS-1$
+				junit.framework.ComparisonFailure comparisonFailure= (junit.framework.ComparisonFailure) exception;
+				return new FailedComparison(comparisonFailure.getExpected(), comparisonFailure.getActual());
+			}
+			if ("org.junit.ComparisonFailure".equals(it.getName())) { //$NON-NLS-1$
+				org.junit.ComparisonFailure comparisonFailure= (org.junit.ComparisonFailure) exception;
+				return new FailedComparison(comparisonFailure.getExpected(), comparisonFailure.getActual());
+			}
 		}
 
 		return null;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Fixes #237 

## How to test
Throw a __subclass__ of `ComparisonFailure` from a JUnit5 test and see that the compare dialog works for it.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
