### PR TITLE
Protect against import of local class when inferring type arguments

### DIFF
--- a/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit5.runtime;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.1.100.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit5.runner;x-internal:=true
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.jdt.junit5.runtime/pom.xml
+++ b/org.eclipse.jdt.junit5.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit5.runtime</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.14.400.qualifier
+Bundle-Version: 3.14.500.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.14.400-SNAPSHOT</version>
+  <version>3.14.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass1/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass1/in/A.java
@@ -1,0 +1,12 @@
+package p;
+
+import java.util.ArrayList;
+
+public class A {
+    void m() {
+        class Local {
+        	Local fSelf;
+        }
+        new ArrayList().add(new Local().fSelf);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass1/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass1/out/A.java
@@ -1,0 +1,12 @@
+package p;
+
+import java.util.ArrayList;
+
+public class A {
+    void m() {
+        class Local {
+        	Local fSelf;
+        }
+        new ArrayList<Local>().add(new Local().fSelf);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass2/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass2/in/A.java
@@ -1,0 +1,12 @@
+package p;
+
+import java.util.ArrayList;
+
+public class A {
+    void m() {
+        class Local<T> {
+        	Local<T> fSelf;
+        }
+        new ArrayList().add(new Local<String>().fSelf);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass2/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuWithLocalClass2/out/A.java
@@ -1,0 +1,12 @@
+package p;
+
+import java.util.ArrayList;
+
+public class A {
+    void m() {
+        class Local<T> {
+        	Local<T> fSelf;
+        }
+        new ArrayList<Local<String>>().add(new Local<String>().fSelf);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InferTypeArgumentsTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InferTypeArgumentsTests.java
@@ -514,4 +514,16 @@ public class InferTypeArgumentsTests extends GenericRefactoringTest {
 		performCuOK();
 	}
 
+	@Test
+	public void testCuWithLocalClass1() throws Exception {
+		// test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/224
+		performCuOK();
+	}
+
+	@Test
+	public void testCuWithLocalClass2() throws Exception {
+		// test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/224
+		performCuOK();
+	}
+
 }

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsRefactoring.java
@@ -46,6 +46,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTRequestor;
@@ -419,7 +420,14 @@ public class InferTypeArgumentsRefactoring extends Refactoring {
 				if (chosenType.isParameterizedType()) // workaround for bug 99124
 					chosenType= chosenType.getTypeDeclaration();
 				BindingKey bindingKey= new BindingKey(chosenType.getBindingKey());
-				typeArgument= rewrite.getImportRewrite().addImportFromSignature(bindingKey.toSignature(), rewrite.getAST());
+				if (chosenType.isLocal()) { // fix for issue #224
+					String typeName= chosenType.getName();
+					AST ast= rewrite.getAST();
+					// need type but do not obtain it via an extraneous import
+					typeArgument= ast.newSimpleType(ast.newSimpleName(typeName));
+				} else {
+					typeArgument= rewrite.getImportRewrite().addImportFromSignature(bindingKey.toSignature(), rewrite.getAST());
+				}
 				ArrayList<CollectionElementVariable2> nestedTypeArgumentCvs= getTypeArgumentCvs(elementCv, tCModel);
 				Type[] nestedTypeArguments= getTypeArguments(typeArgument, nestedTypeArgumentCvs, rewrite, tCModel, leaveUnconstraindRaw); //recursion
 				if (nestedTypeArguments != null) {


### PR DESCRIPTION
- fixes #224

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Fixes an issue where an import of a local class is added and ends up adding new in the import which is invalid.

## How to test
See the issue or run the new tests added to InferTypeArgumentsTests.java

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
