### PR TITLE
Adopt new IProblem.IsClassPathCorrectWithReferencingType from jdt.core

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -113,7 +113,7 @@ Require-Bundle:
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.core.resources;bundle-version="[3.14.0,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.2.200,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.28.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.32.0,4.0.0)",
  org.eclipse.search;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.debug.ui;bundle-version="[3.11.0,4.0.0)",

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -234,6 +234,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.MethodMustOverride:
 			case IProblem.MethodMustOverrideOrImplement:
 			case IProblem.IsClassPathCorrect:
+			case IProblem.IsClassPathCorrectWithReferencingType:
 			case IProblem.MethodReturnsVoid:
 			case IProblem.ForbiddenReference:
 			case IProblem.DiscouragedReference:
@@ -743,6 +744,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 				ModifierCorrectionSubProcessor.addOverridingDeprecatedMethodProposal(context, problem, proposals);
 				break;
 			case IProblem.IsClassPathCorrect:
+			case IProblem.IsClassPathCorrectWithReferencingType:
 				ReorgCorrectionsSubProcessor.getIncorrectBuildPathProposals(context, problem, proposals);
 				break;
 			case IProblem.ForbiddenReference:


### PR DESCRIPTION
## What it does
Adopt the new constant `IProblem.IsClassPathCorrectWithReferencingType` from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/327 and treat it identically to `IProblem.IsClassPathCorrect`
