### PR TITLE
Don't select all/deselect all for radio button cleanup options

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpTabPage.java
@@ -126,7 +126,9 @@ public abstract class CleanUpTabPage extends ModifyDialogTabPage implements ICle
 	@Override
 	public void doSetAll(boolean value) {
 		for (ButtonPreference pref : fCheckboxes) {
-			pref.setChecked(value);
+			if (!(pref instanceof RadioPreference)) {
+				pref.setChecked(value);
+			}
 		}
 	}
 


### PR DESCRIPTION
- fixes #253

## What it does
Has the new code to select all/deselect all on a cleanup tab page ignore radio button preferences which are meant to choose
one sub-option and only one sub-option.

## How to test
Go to Source -> Clean Up ... -> Configure...
Go to the Code Style tab
Push Select All button
The radio buttons under Use blocks in if/while/for/do statements should not change

Press Deselect All button
The radio buttons above should not change

Press Select All again
This time change the radio button above

Press Reset Profile button
The radio button should return to its initial value

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
