### PR TITLE
HierarchicalASTVisitorTest fails due to RecordPattern ast node visit not being present

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -610,6 +614,16 @@ public abstract class HierarchicalASTVisitor extends ASTVisitor {
 	}
 
 	//---- End Name Hierarchy ------------------------------------
+
+	@Override
+	public boolean visit(RecordPattern node) {
+		return visit((Pattern)node);
+	}
+
+	@Override
+	public void endVisit(RecordPattern node) {
+		endVisit((Pattern)node);
+	}
 
 	@Override
 	public boolean visit(GuardedPattern node) {


### PR DESCRIPTION

## What it does
This fix adds the visit function for RecordPattern in  HierarchicalASTVisitor, so that HierarchicalASTVisitorTest does not fail.

## How to test
Run HierarchicalASTVisitorTest as a `junit plugin test` and it should not fail.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
