### PR TITLE
Remove Eclipse-SourceReferences properties

### DIFF
--- a/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
@@ -3,8 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.astview
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.astview; singleton:=true
-Bundle-Version: 1.5.0.qualifier
-Eclipse-SourceReferences: scm:git:https://git.eclipse.org/r/jdt/eclipse.jdt.ui.git;path="org.eclipse.jdt.astview";tag=R4_4
+Bundle-Version: 1.5.100.qualifier
 Bundle-Activator: org.eclipse.jdt.astview.ASTViewPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.astview/pom.xml
+++ b/org.eclipse.jdt.astview/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.astview</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.5.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.jeview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.jeview/META-INF/MANIFEST.MF
@@ -3,8 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.jeview
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.jeview; singleton:=true
-Bundle-Version: 1.4.0.qualifier
-Eclipse-SourceReferences: scm:git:https://git.eclipse.org/r/jdt/eclipse.jdt.ui.git;path="org.eclipse.jdt.jeview";tag=R4_4
+Bundle-Version: 1.4.100.qualifier
 Bundle-Activator: org.eclipse.jdt.jeview.JEViewPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.jeview/pom.xml
+++ b/org.eclipse.jdt.jeview/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.jeview</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Tycho generates these properties automatically such that they don't become stale over time.

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/256

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does

<!-- Include relevant issues and describe how they are addressed. -->
Ensure that there are not stale SCM URLs in the Tycho-built bundle.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check the MANIFEST of the Tych-built bundle.  E.g., the bundle https://download.eclipse.org/eclipse/updates/4.25/R-4.25-202208311800/plugins/org.eclipse.jdt.ui_3.27.0.v20220824-0714.jar  has this property:
```
Eclipse-SourceReferences: scm:git:https://github.com/eclipse-jdt/eclipse
 .jdt.ui.git;path="org.eclipse.jdt.ui";tag="I20220824-0600";commitId=054
 cfef225a81a6958a61deb10484577d8de9ef0
```

I don't think these bundles are published to the build result so probably that's why no one notices.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
