### PR TITLE
When unused thrown exception is removed, check if import is needed

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -101,6 +101,7 @@ import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.InstanceofExpression;
 import org.eclipse.jdt.core.dom.LabeledStatement;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MemberValuePair;
@@ -120,6 +121,7 @@ import org.eclipse.jdt.core.dom.PrefixExpression;
 import org.eclipse.jdt.core.dom.PrimitiveType;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
@@ -4180,10 +4182,10 @@ public class ASTNodes {
 		List<Comment> comments= new ArrayList<>();
 		CompilationUnit cu= (CompilationUnit)node.getRoot();
 		List<Comment> commentList= cu.getCommentList();
-		for (Comment comment : commentList) {
-			if (comment.getStartPosition() >= cu.getExtendedStartPosition(node)
-					&& comment.getStartPosition() + comment.getLength() < node.getStartPosition()) {
-				comments.add(comment);
+		for (Comment commentFromList : commentList) {
+			if (commentFromList.getStartPosition() >= cu.getExtendedStartPosition(node)
+					&& commentFromList.getStartPosition() + commentFromList.getLength() < node.getStartPosition()) {
+				comments.add(commentFromList);
 			}
 		}
 		return comments;
@@ -4201,12 +4203,123 @@ public class ASTNodes {
 		List<Comment> commentList= cu.getCommentList();
 		int extendedStart= cu.getExtendedStartPosition(node);
 		int extendedLength= cu.getExtendedLength(node);
-		for (Comment comment : commentList) {
-			if (comment.getStartPosition() > node.getStartPosition()
-					&& comment.getStartPosition() < extendedStart + extendedLength) {
-				comments.add(comment);
+		for (Comment commentFromList : commentList) {
+			if (commentFromList.getStartPosition() > node.getStartPosition()
+					&& commentFromList.getStartPosition() < extendedStart + extendedLength) {
+				comments.add(commentFromList);
 			}
 		}
 		return comments;
+	}
+
+	/**
+	 * Get the number of Type references in a Compilation Unit - used for determining
+	 * if an import can be removed.
+	 *
+	 * @param typeBinding - binding of the type in question
+	 * @param cu - compilation unit
+	 * @return integer count of times type is referenced (may be 0 if bindings cannot be resolved)
+	 */
+	public static int getNumberOfTypeReferences(ITypeBinding typeBinding, CompilationUnit cu) {
+		class CounterVisitor extends ASTVisitor {
+			private int counter= 0;
+			private void checkType(Type type) {
+				if (type != null && !type.isParameterizedType()) {
+					ITypeBinding binding= type.resolveBinding();
+					if (binding != null) {
+						if (binding.isArray()) {
+							binding= binding.getElementType();
+						}
+						if (binding.isEqualTo(typeBinding)) {
+							++counter;
+						}
+					}
+				}
+			}
+			public int getCounter() {
+				return counter;
+			}
+			@Override
+			public boolean visit(ArrayCreation node) {
+				Type type= node.getType();
+				checkType(type);
+				return true;
+			}
+			@Override
+			public boolean visit(MethodDeclaration node) {
+				Type type= node.getReturnType2();
+				checkType(type);
+				List<Type> exceptions= node.thrownExceptionTypes();
+				for (Type t : exceptions) {
+					checkType(t);
+				}
+				return true;
+			}
+			@Override
+			public boolean visit(ClassInstanceCreation node) {
+				Type type= node.getType();
+				checkType(type);
+				return true;
+			}
+			@Override
+			public boolean visit(SingleVariableDeclaration node) {
+				Type type= node.getType();
+				checkType(type);
+				return true;
+			}
+			@Override
+			public boolean visit(CastExpression node) {
+				Type type= node.getType();
+				checkType(type);
+				return true;
+			}
+			@Override
+			public boolean visit(VariableDeclarationExpression node) {
+				Type type= node.getType();
+				checkType(type);
+				return true;
+			}
+			@Override
+			public boolean visit(InstanceofExpression node) {
+				Type type= node.getRightOperand();
+				checkType(type);
+				return true;
+			}
+			@Override
+			public boolean visit(FieldDeclaration node) {
+				Type type= node.getType();
+				checkType(type);
+				return true;
+			}
+			@Override
+			public boolean visit(ParameterizedType node) {
+				Type type= node.getType();
+				checkType(type);
+				List<Type> types= node.typeArguments();
+				for (Type t : types) {
+					checkType(t);
+				}
+				return true;
+			}
+			@Override
+			public boolean visit(TypeDeclaration node) {
+				List<Type> types= node.typeParameters();
+				for (Type t : types) {
+					checkType(t);
+				}
+				return true;
+			}
+			@Override
+			public boolean visit(RecordDeclaration node) {
+				List<Type> types= node.typeParameters();
+				for (Type t : types) {
+					checkType(t);
+				}
+				return true;
+			}
+		}
+		CounterVisitor visitor= new CounterVisitor();
+		cu.accept(visitor);
+		return visitor.getCounter();
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/PackageJavadocTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/PackageJavadocTests.java
@@ -331,7 +331,7 @@ public class PackageJavadocTests extends CoreTests {
 		IClasspathAttribute attribute=
 				JavaCore.newClasspathAttribute(
 						IClasspathAttribute.JAVADOC_LOCATION_ATTRIBUTE_NAME,
-						"https://docs.oracle.com/javase/6/docs/apii/");
+						"https://doc.oracle.com/javase/6/docs/apii/");
 		IClasspathEntry[] rawClasspath= fJProject1.getRawClasspath();
 		IClasspathEntry newEntry= JavaCore.newLibraryEntry(new Path(JavaTestPlugin.getDefault().getFileInPlugin(new Path("/testresources/rtstubs15.jar")).getAbsolutePath()), null, null, null,
 				new IClasspathAttribute[] { attribute }, false);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest.java
@@ -6842,7 +6842,7 @@ public class LocalCorrectionsQuickFixTest extends QuickFixTest {
 
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
-		buf.append("import java.io.IOException;\n");
+		buf.append("\n");
 		buf.append("public class E {\n");
 		buf.append("    public void foo(String b) {\n");
 		buf.append("        if  (b != null) {\n");
@@ -6903,7 +6903,6 @@ public class LocalCorrectionsQuickFixTest extends QuickFixTest {
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("import java.io.IOException;\n");
-		buf.append("import java.text.ParseException;\n");
 		buf.append("public class E {\n");
 		buf.append("    /**\n");
 		buf.append("     * @throws IOException\n");
@@ -6973,7 +6972,6 @@ public class LocalCorrectionsQuickFixTest extends QuickFixTest {
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("import java.io.IOException;\n");
-		buf.append("import java.text.ParseException;\n");
 		buf.append("public class E {\n");
 		buf.append("    /**\n");
 		buf.append("     * @param i\n");
@@ -6988,6 +6986,86 @@ public class LocalCorrectionsQuickFixTest extends QuickFixTest {
 		assertEqualString(preview, buf.toString());
 	}
 
+	@Test
+	public void testUnnecessaryThrownException4() throws Exception {
+		Hashtable<String, String> hashtable= JavaCore.getOptions();
+		hashtable.put(JavaCore.COMPILER_PB_UNUSED_DECLARED_THROWN_EXCEPTION, JavaCore.ERROR);
+		JavaCore.setOptions(hashtable);
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.io.IOException;\n");
+		buf.append("import java.text.ParseException;\n");
+		buf.append("public class E {\n");
+		buf.append("    /**\n");
+		buf.append("     * @throws IOException\n");
+		buf.append("     */\n");
+		buf.append("    public E(int i) throws IOException, ParseException {\n");
+		buf.append("        if  (i == 0) {\n");
+		buf.append("            throw new IOException();\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("    public void foo(int i) throws ParseException {\n");
+		buf.append("        if  (i == 0) {\n");
+		buf.append("            throw new ParseException(null, 4);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
+		assertNumberOfProposals(proposals, 3);
+		assertCorrectLabels(proposals);
+
+		String[] expected= new String[2];
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.io.IOException;\n");
+		buf.append("import java.text.ParseException;\n");
+		buf.append("public class E {\n");
+		buf.append("    /**\n");
+		buf.append("     * @throws IOException\n");
+		buf.append("     */\n");
+		buf.append("    public E(int i) throws IOException {\n");
+		buf.append("        if  (i == 0) {\n");
+		buf.append("            throw new IOException();\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("    public void foo(int i) throws ParseException {\n");
+		buf.append("        if  (i == 0) {\n");
+		buf.append("            throw new ParseException(null, 4);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		expected[0]= buf.toString();
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.io.IOException;\n");
+		buf.append("import java.text.ParseException;\n");
+		buf.append("public class E {\n");
+		buf.append("    /**\n");
+		buf.append("     * @throws IOException\n");
+		buf.append("     * @throws ParseException \n");
+		buf.append("     */\n");
+		buf.append("    public E(int i) throws IOException, ParseException {\n");
+		buf.append("        if  (i == 0) {\n");
+		buf.append("            throw new IOException();\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("    public void foo(int i) throws ParseException {\n");
+		buf.append("        if  (i == 0) {\n");
+		buf.append("            throw new ParseException(null, 4);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		expected[1]= buf.toString();
+
+		assertExpectedExistInProposals(proposals, expected);
+	}
 
 	@Test
 	public void testUnqualifiedFieldAccess1() throws Exception {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest.java
@@ -1423,7 +1423,6 @@ public class LocalCorrectionsQuickFixTest extends QuickFixTest {
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("import java.io.IOException;\n");
-		buf.append("import java.net.SocketException;\n");
 		buf.append("public class E {\n");
 		buf.append("    public void goo() throws IOException {\n");
 		buf.append("        return;\n");

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/TypeMismatchQuickFixTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/TypeMismatchQuickFixTests.java
@@ -1692,7 +1692,7 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
-		buf.append("import java.io.IOException;\n");
+		buf.append("\n");
 		buf.append("public class E implements IBase {\n");
 		buf.append("    public String[] getValues() {\n");
 		buf.append("        return null;\n");
@@ -1752,7 +1752,6 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("import java.io.EOFException;\n");
-		buf.append("import java.text.ParseException;\n");
 		buf.append("public class E extends Base {\n");
 		buf.append("    public String[] getValues() throws EOFException {\n");
 		buf.append("        return null;\n");
@@ -1834,7 +1833,6 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("import java.io.EOFException;\n");
-		buf.append("import java.text.ParseException;\n");
 		buf.append("public class E extends Base {\n");
 		buf.append("    /**\n");
 		buf.append("     * @param i The parameter\n");
@@ -1894,7 +1892,7 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
-		buf.append("import java.io.IOException;\n");
+		buf.append("\n");
 		buf.append("public class E implements IBase<String> {\n");
 		buf.append("    public String[] getValues() {\n");
 		buf.append("        return null;\n");

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/ChangeMethodSignatureProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/ChangeMethodSignatureProposal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -402,6 +402,15 @@ public class ChangeMethodSignatureProposal extends LinkedCorrectionProposal {
 			} else if (curr instanceof RemoveDescription) {
 				Type node= exceptions.get(k);
 
+				ITypeBinding binding= node.resolveBinding();
+
+				if (binding != null) {
+					int typeReferences= ASTNodes.getNumberOfTypeReferences(binding, (CompilationUnit)node.getRoot());
+					if (typeReferences == 1) {
+						String name= binding.getQualifiedName();
+						imports.removeImport(name);
+					}
+				}
 				listRewrite.remove(node, null);
 				k++;
 


### PR DESCRIPTION
- for quick fix when a method specifies a thrown exception that is not used, check if import of exception can be removed
- fixes #277
- add new function in ASTNodes to count type references in cu
- modify ChangeMethodSignatureProposal when removing an exception to check type reference count and remove if there is only 1
- modify existing tests in LocalCorrectionsQuickFixTest and add new one

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Adds logic to remove unnecessary import when correcting an unused throws exception for a method.

## How to test
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
