### PR TITLE
Remove use of deprecated SubProgressMonitor from AddImportsOperation

### DIFF
--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddImportsOperation.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddImportsOperation.java
@@ -22,7 +22,6 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
@@ -164,37 +163,31 @@ public class AddImportsOperation implements IWorkspaceRunnable {
 	 */
 	@Override
 	public void run(IProgressMonitor monitor) throws CoreException, OperationCanceledException {
-		if (monitor == null) {
-			monitor= new NullProgressMonitor();
+		SubMonitor subMonitor= SubMonitor.convert(monitor, CodeGenerationMessages.AddImportsOperation_description, 4);
+
+		CompilationUnit astRoot= SharedASTProviderCore.getAST(fCompilationUnit, SharedASTProviderCore.WAIT_YES, subMonitor.split(1));
+		if (astRoot == null)
+			throw new OperationCanceledException();
+
+		ImportRewrite importRewrite= StubUtility.createImportRewrite(astRoot, true);
+
+		MultiTextEdit res= new MultiTextEdit();
+
+		TextEdit edit= evaluateEdits(astRoot, importRewrite, fSelectionOffset, fSelectionLength, subMonitor.split(1));
+		if (edit == null) {
+			return;
 		}
-		try {
-			monitor.beginTask(CodeGenerationMessages.AddImportsOperation_description, 4);
+		res.addChild(edit);
 
-			CompilationUnit astRoot= SharedASTProviderCore.getAST(fCompilationUnit, SharedASTProviderCore.WAIT_YES, SubMonitor.convert(monitor, 1));
-			if (astRoot == null)
-				throw new OperationCanceledException();
+		TextEdit importsEdit= importRewrite.rewriteImports(subMonitor.split(1));
+		res.addChild(importsEdit);
 
-			ImportRewrite importRewrite= StubUtility.createImportRewrite(astRoot, true);
+		fResultingEdit= res;
 
-			MultiTextEdit res= new MultiTextEdit();
-
-			TextEdit edit= evaluateEdits(astRoot, importRewrite, fSelectionOffset, fSelectionLength, SubMonitor.convert(monitor, 1));
-			if (edit == null) {
-				return;
-			}
-			res.addChild(edit);
-
-			TextEdit importsEdit= importRewrite.rewriteImports(SubMonitor.convert(monitor, 1));
-			res.addChild(importsEdit);
-
-			fResultingEdit= res;
-
-			if (fApply) {
-				JavaModelUtil.applyEdit(fCompilationUnit, res, fDoSave, SubMonitor.convert(monitor, 1));
-			}
-		} finally {
-			monitor.done();
+		if (fApply) {
+			JavaModelUtil.applyEdit(fCompilationUnit, res, fDoSave, subMonitor.split(1));
 		}
+		subMonitor.setWorkRemaining(0);
 	}
 
 	/**
@@ -207,6 +200,7 @@ public class AddImportsOperation implements IWorkspaceRunnable {
 	}
 
 	private TextEdit evaluateEdits(CompilationUnit root, ImportRewrite importRewrite, int offset, int length, IProgressMonitor monitor) throws JavaModelException {
+		SubMonitor subMonitor= SubMonitor.convert(monitor, 1);
 		SimpleName nameNode= null;
 		if (root != null) { // got an AST
 			ASTNode node= NodeFinder.perform(root, offset, length);
@@ -354,15 +348,12 @@ public class AddImportsOperation implements IWorkspaceRunnable {
 		}
 		IJavaSearchScope searchScope= SearchEngine.createJavaSearchScope(new IJavaElement[] { fCompilationUnit.getJavaProject() });
 
-		TypeNameMatch[] types= findAllTypes(simpleName, searchScope, nameNode, SubMonitor.convert(monitor, 1));
+		TypeNameMatch[] types= findAllTypes(simpleName, searchScope, nameNode, subMonitor.split(1));
 		if (types.length == 0) {
 			fStatus= JavaUIStatus.createError(IStatus.ERROR, Messages.format(CodeGenerationMessages.AddImportsOperation_error_notresolved_message, BasicElementLabels.getJavaElementName(simpleName)), null);
 			return null;
 		}
 
-		if (monitor.isCanceled()) {
-			throw new OperationCanceledException();
-		}
 		TypeNameMatch chosen;
 		if (types.length > 1 && fQuery != null) {
 			chosen= fQuery.chooseImport(types, containerName);

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddImportsOperation.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddImportsOperation.java
@@ -25,7 +25,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 import org.eclipse.core.resources.IWorkspaceRunnable;
@@ -170,7 +170,7 @@ public class AddImportsOperation implements IWorkspaceRunnable {
 		try {
 			monitor.beginTask(CodeGenerationMessages.AddImportsOperation_description, 4);
 
-			CompilationUnit astRoot= SharedASTProviderCore.getAST(fCompilationUnit, SharedASTProviderCore.WAIT_YES, new SubProgressMonitor(monitor, 1));
+			CompilationUnit astRoot= SharedASTProviderCore.getAST(fCompilationUnit, SharedASTProviderCore.WAIT_YES, SubMonitor.convert(monitor, 1));
 			if (astRoot == null)
 				throw new OperationCanceledException();
 
@@ -178,19 +178,19 @@ public class AddImportsOperation implements IWorkspaceRunnable {
 
 			MultiTextEdit res= new MultiTextEdit();
 
-			TextEdit edit= evaluateEdits(astRoot, importRewrite, fSelectionOffset, fSelectionLength, new SubProgressMonitor(monitor, 1));
+			TextEdit edit= evaluateEdits(astRoot, importRewrite, fSelectionOffset, fSelectionLength, SubMonitor.convert(monitor, 1));
 			if (edit == null) {
 				return;
 			}
 			res.addChild(edit);
 
-			TextEdit importsEdit= importRewrite.rewriteImports(new SubProgressMonitor(monitor, 1));
+			TextEdit importsEdit= importRewrite.rewriteImports(SubMonitor.convert(monitor, 1));
 			res.addChild(importsEdit);
 
 			fResultingEdit= res;
 
 			if (fApply) {
-				JavaModelUtil.applyEdit(fCompilationUnit, res, fDoSave, new SubProgressMonitor(monitor, 1));
+				JavaModelUtil.applyEdit(fCompilationUnit, res, fDoSave, SubMonitor.convert(monitor, 1));
 			}
 		} finally {
 			monitor.done();
@@ -354,7 +354,7 @@ public class AddImportsOperation implements IWorkspaceRunnable {
 		}
 		IJavaSearchScope searchScope= SearchEngine.createJavaSearchScope(new IJavaElement[] { fCompilationUnit.getJavaProject() });
 
-		TypeNameMatch[] types= findAllTypes(simpleName, searchScope, nameNode, new SubProgressMonitor(monitor, 1));
+		TypeNameMatch[] types= findAllTypes(simpleName, searchScope, nameNode, SubMonitor.convert(monitor, 1));
 		if (types.length == 0) {
 			fStatus= JavaUIStatus.createError(IStatus.ERROR, Messages.format(CodeGenerationMessages.AddImportsOperation_error_notresolved_message, BasicElementLabels.getJavaElementName(simpleName)), null);
 			return null;


### PR DESCRIPTION
Following the [boy scout rule](https://www.informit.com/articles/article.aspx?p=1235624&seqNum=6) I removed the warnings from AddImportsOperation, which I changed in https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/297.