### PR TITLE
Fix postfix templates regarding for loops to be consistent with index

### DIFF
--- a/org.eclipse.jdt.ui/templates/default-postfixtemplates.xml
+++ b/org.eclipse.jdt.ui/templates/default-postfixtemplates.xml
@@ -34,19 +34,19 @@
 	${cursor}&#13;
 }</template>
 
-	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.fori" context="postfix" deleted="false" description="%PostfixTemplates.fori" enabled="true" name="fori">for (int ${index} = 0; i &lt; ${i:inner_expression(array)}.length; ${index}++) {&#13;
+	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.fori" context="postfix" deleted="false" description="%PostfixTemplates.fori" enabled="true" name="fori">for (int ${index} = 0; ${index} &lt; ${i:inner_expression(array)}.length; ${index}++) {&#13;
 	${cursor}&#13;
 }</template>
 
-	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.foriub" context="postfix" deleted="false" description="%PostfixTemplates.foriub" enabled="true" name="foriub">for (int ${index} = 0; i &lt; ${i:inner_expression(int)}; ${index}++) {&#13;
+	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.foriub" context="postfix" deleted="false" description="%PostfixTemplates.foriub" enabled="true" name="foriub">for (int ${index} = 0; ${index} &lt; ${i:inner_expression(int)}; ${index}++) {&#13;
 	${cursor}&#13;
 }</template>
 
-	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.forrlb" context="postfix" deleted="false" description="%PostfixTemplates.forrlb" enabled="true" name="forrlb">for (int ${index} = ${i:inner_expression(int)} - 1; i &gt;= 0 ; ${index}--) {&#13;
+	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.forrlb" context="postfix" deleted="false" description="%PostfixTemplates.forrlb" enabled="true" name="forrlb">for (int ${index} = ${i:inner_expression(int)} - 1; ${index} &gt;= 0 ; ${index}--) {&#13;
 	${cursor}&#13;
 }</template>
 
-	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.forr" context="postfix" deleted="false" description="%PostfixTemplates.forr" enabled="true" name="forr">for (int ${index} = ${i:inner_expression(array)}.length - 1; i &gt;= 0; ${index}--) {&#13;
+	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.forr" context="postfix" deleted="false" description="%PostfixTemplates.forr" enabled="true" name="forr">for (int ${index} = ${i:inner_expression(array)}.length - 1; ${index} &gt;= 0; ${index}--) {&#13;
 	${cursor}&#13;
 }</template>
 


### PR DESCRIPTION
- use ${index} in templates everywhere the index is accessed
- fixes #299

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Makes the for, fori, forr postfix loops use just one variable name for the indexing instead of mixing generated name and i.

## How to test
Create a method that passes an array of String[] args
Type args.fori and do postfix completion.  The name used for the index should be the same as the variable used in the test of
the forloop.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
