### PR TITLE
Add additional checks for encapsulate field

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -2295,6 +2295,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String SelfEncapsulateField_setter_pattern;
 
+	public static String SelfEncapsulateField_subtype_method_exists;
+
 	public static String SelfEncapsulateField_type_not_resolveable;
 
 	public static String SelfEncapsulateField_use_accessors;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -229,6 +229,7 @@ SelfEncapsulateFieldRefactoring_methoddoesnotexist_status_fatalError=Method {0}(
 
 SelfEncapsulateField_name=Encapsulate Field
 SelfEncapsulateField_method_exists=A method ''{0}'' already exists in type ''{1}''.
+SelfEncapsulateField_subtype_method_exists=A method ''{0}'' already exists in sub-type ''{1}''.
 SelfEncapsulateField_use_accessors=Use getter and setter methods in declaring type
 SelfEncapsulateField_compiler_errors_field=Cannot analyze field ''{0}'' due to the following compile error: {1}
 SelfEncapsulateField_compiler_errors_update={0} contains compile errors. This may affect field access update.

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/sef/SelfEncapsulateFieldRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/sef/SelfEncapsulateFieldRefactoring.java
@@ -478,7 +478,7 @@ public class SelfEncapsulateFieldRefactoring extends Refactoring {
 				root.accept(visitor);
 			}
 		} catch (AbortSearchException e) {
-			result.addWarning(Messages.format(RefactoringCoreMessages.SelfEncapsulateField_subtype_method_exists, new String[] { visitor.isGetterConflict() ? getGetterName() : getSetterName(), visitor.getTypeName() }));
+			result.addError(Messages.format(RefactoringCoreMessages.SelfEncapsulateField_subtype_method_exists, new String[] { visitor.isGetterConflict() ? getGetterName() : getSetterName(), visitor.getTypeName() }));
 		}
 	}
 


### PR DESCRIPTION
- check affected CUs and their super types for pre-existing getter/setter of chosen name
- fixes Bug 209316

## What it does
Fixes: [Bug 209316](https://bugs.eclipse.org/bugs/show_bug.cgi?id=209316) - [encapsulate field] should check for overriding methods

## How to test
See bug report.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
