### PR TITLE
Allow OrganizeImportsOperation keeping existing imports

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.16.250.qualifier
+Bundle-Version: 1.17.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
@@ -499,6 +499,7 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 	private boolean fDoSave;
 
 	private boolean fIgnoreLowerCaseNames;
+	private boolean fRestoreExistingImports;
 
 	private IChooseImportQuery fChooseImportQuery;
 
@@ -528,6 +529,7 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 
 		fDoSave= save;
 		fIgnoreLowerCaseNames= ignoreLowerCaseNames;
+		fRestoreExistingImports= false;
 		fAllowSyntaxErrors= allowSyntaxErrors;
 		fChooseImportQuery= chooseImportQuery;
 
@@ -535,6 +537,23 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 		fNumberOfImportsRemoved= 0;
 
 		fParsingError= null;
+	}
+
+	/**
+	 * Creates a new OrganizeImportsOperation operation.
+	 *
+	 * @param cu The compilation unit
+	 * @param astRoot the compilation unit AST node
+	 * @param ignoreLowerCaseNames when true, type names starting with a lower case are ignored
+	 * @param save If set, the result will be saved
+	 * @param allowSyntaxErrors If set, the operation will only proceed when the compilation unit has no syntax errors
+	 * @param chooseImportQuery Query element to be used for UI interaction or <code>null</code> to not select anything
+	 * @param restoreExistingImports when true, the operation will restore existing imports
+	 * @since 1.17
+	 */
+	public OrganizeImportsOperation(ICompilationUnit cu, CompilationUnit astRoot, boolean ignoreLowerCaseNames, boolean save, boolean allowSyntaxErrors, IChooseImportQuery chooseImportQuery, boolean restoreExistingImports) {
+		this(cu, astRoot, ignoreLowerCaseNames, save, allowSyntaxErrors, chooseImportQuery);
+		fRestoreExistingImports= restoreExistingImports;
 	}
 
 	/**
@@ -564,7 +583,7 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 		}
 		subMonitor.setWorkRemaining(7);
 
-		ImportRewrite importsRewrite= CodeStyleConfiguration.createImportRewrite(astRoot, false);
+		ImportRewrite importsRewrite= CodeStyleConfiguration.createImportRewrite(astRoot, fRestoreExistingImports);
 		if (astRoot.getAST().hasResolvedBindings()) {
 			importsRewrite.setUseContextToFilterImplicitImports(true);
 		}

--- a/org.eclipse.jdt.core.manipulation/pom.xml
+++ b/org.eclipse.jdt.core.manipulation/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.manipulation</artifactId>
-  <version>1.16.250-SNAPSHOT</version>
+  <version>1.17.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
@@ -495,6 +495,44 @@ public class ImportOrganizeTest extends CoreTests {
 	}
 
 	@Test
+	public void testRestoreExistingImports() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("import java.io.FileInputStream;\n");
+		buf.append("\n");
+		buf.append("import java.util.Properties;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query, true);
+		op.run(null);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("import java.io.File;\n");
+		buf.append("import java.io.FileInputStream;\n");
+		buf.append("\n");
+		buf.append("import java.util.Properties;\n");
+		buf.append("import java.util.Vector;\n");
+		buf.append("\n");
+		buf.append("public class C extends Vector {\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
 	public void testClearImportsNoPackage() throws Exception {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
@@ -3624,6 +3662,11 @@ public class ImportOrganizeTest extends CoreTests {
 	protected OrganizeImportsOperation createOperation(ICompilationUnit cu, String[] order, int threshold, boolean ignoreLowerCaseNames, boolean save, boolean allowSyntaxErrors, IChooseImportQuery chooseImportQuery) {
 		setOrganizeImportSettings(order, threshold, threshold, cu.getJavaProject());
 		return new OrganizeImportsOperation(cu, null, ignoreLowerCaseNames, save, allowSyntaxErrors, chooseImportQuery);
+	}
+
+	protected OrganizeImportsOperation createOperation(ICompilationUnit cu, String[] order, int threshold, boolean ignoreLowerCaseNames, boolean save, boolean allowSyntaxErrors, IChooseImportQuery chooseImportQuery, boolean restoreExistingImports) {
+		setOrganizeImportSettings(order, threshold, threshold, cu.getJavaProject());
+		return new OrganizeImportsOperation(cu, null, ignoreLowerCaseNames, save, allowSyntaxErrors, chooseImportQuery, restoreExistingImports);
 	}
 
 	protected void setOrganizeImportSettings(String[] order, int threshold, int staticThreshold, IJavaProject project) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
@@ -502,10 +502,9 @@ public class ImportOrganizeTest extends CoreTests {
 		StringBuilder buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("\n");
+		buf.append("import java.util.Properties;\n");
 		buf.append("import java.io.File;\n");
 		buf.append("import java.io.FileInputStream;\n");
-		buf.append("\n");
-		buf.append("import java.util.Properties;\n");
 		buf.append("\n");
 		buf.append("public class C extends Vector {\n");
 		buf.append("}\n");
@@ -521,11 +520,10 @@ public class ImportOrganizeTest extends CoreTests {
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("\n");
-		buf.append("import java.io.File;\n");
-		buf.append("import java.io.FileInputStream;\n");
-		buf.append("\n");
 		buf.append("import java.util.Properties;\n");
 		buf.append("import java.util.Vector;\n");
+		buf.append("import java.io.File;\n");
+		buf.append("import java.io.FileInputStream;\n");
 		buf.append("\n");
 		buf.append("public class C extends Vector {\n");
 		buf.append("}\n");


### PR DESCRIPTION
Signed-off-by: Shi Chen <chenshi@microsoft.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Allow `OrganizeImportsOperation` to have a change to restore existing imports. Currently it directly call ` CodeStyleConfiguration.createImportRewrite(astRoot, false)` to create corresponding `ImportRewrite`. If we do not want to change the current import statements but only want to add all missing imports, there is no easy way to achieve this. 

There is a scenario in JDT.LS to support "Add all missing imports" quick fix without changing the current import statements, see the related enhancement issue https://github.com/redhat-developer/vscode-java/issues/2748. With this change the implementation can make use of `OrganizeImportsOperation` directly, see the draft PR https://github.com/eclipse/eclipse.jdt.ls/pull/2292.
## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
With this change, we can use the new constructor to create a `OrganizeImportsOperation` instance with `restoreExistingImports` is true. The operation will not remove or sort the current imports, but only add missing imports.
## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

cc: @rgrunber 