### PR TITLE
WIP: Refactor for moving quickfixe logic into JDT

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/IInvocationContext.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/IInvocationContext.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from /org.eclipse.jdt.ui/src/org/eclipse/jdt/ui/text/java/IInvocationContext.java
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.corrections;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+/**
+ * Context information for quick fix and quick assist processors.
+ * <p>
+ * Note: this interface is not intended to be implemented.
+ * </p>
+ *
+ * @since 3.0
+ *
+ * @noimplement This interface is not intended to be implemented by clients.
+ * @noextend This interface is not intended to be extended by clients.
+ */
+public interface IInvocationContext {
+
+	/**
+	 * @return the current compilation unit
+	 */
+	ICompilationUnit getCompilationUnit();
+
+	/**
+	 * @return the offset of the current selection
+	 */
+	int getSelectionOffset();
+
+	/**
+	 * @return the length of the current selection
+	 */
+	int getSelectionLength();
+
+	/**
+	 * Returns an AST of the compilation unit, possibly only a partial AST
+	 * focused on the selection offset (see
+	 * {@link org.eclipse.jdt.core.dom.ASTParser#setFocalPosition(int)}). The
+	 * returned AST is shared and therefore protected and cannot be modified.
+	 * The client must check the AST API level and do nothing if they are given
+	 * an AST they can't handle.
+	 *
+	 * @see org.eclipse.jdt.core.dom.AST#apiLevel()
+	 * @return the root of the AST corresponding to the current compilation unit
+	 */
+	CompilationUnit getASTRoot();
+
+	/**
+	 * If the AST contains nodes whose range is equal to the selection, returns
+	 * the innermost of those nodes. Otherwise, returns the first node in a
+	 * preorder traversal of the AST, where the complete node range is covered
+	 * by the selection.
+	 *
+	 * @return the covered node, or <code>null</code> if the selection is empty
+	 *         or too short to cover an entire node
+	 */
+	ASTNode getCoveredNode();
+
+	/**
+	 * Returns the innermost node that fully contains the selection. A node also
+	 * contains the zero-length selection on either end.
+	 * <p>
+	 * If more than one node covers the selection, the returned node is the last
+	 * covering node found in a preorder traversal of the AST. This implies that
+	 * for a zero-length selection between two adjacent sibling nodes, the node
+	 * on the right is returned.
+	 * </p>
+	 *
+	 * @return the covering node
+	 */
+	ASTNode getCoveringNode();
+
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/ASTRewriteCorrectionProposal.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/ASTRewriteCorrectionProposal.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from /org.eclipse.jdt.ui/src/org/eclipse/jdt/ui/text/java/correction/ASTRewriteCorrectionProposal.java
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.corrections.proposals;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.manipulation.CodeStyleConfiguration;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.text.edits.TextEdit;
+
+/**
+ * A proposal for quick fixes and quick assists that works on an AST rewrite.
+ * Either a rewrite is
+ * directly passed in the constructor or the method {@link #getRewrite()} is
+ * overridden to provide
+ * the AST rewrite that is evaluated on the document when the proposal is
+ * applied.
+ */
+public class ASTRewriteCorrectionProposal extends CUCorrectionProposal {
+
+	private ASTRewrite fRewrite;
+	private ImportRewrite fImportRewrite;
+
+	/**
+	 * Constructs an AST rewrite correction proposal.
+	 *
+	 * @param name      the display name of the proposal
+	 * @param cu        the compilation unit that is modified
+	 * @param rewrite   the AST rewrite that is invoked when the proposal is applied
+	 *                  or
+	 *                  <code>null</code> if {@link #getRewrite()} is overridden
+	 * @param relevance the relevance of this proposal
+	 */
+	public ASTRewriteCorrectionProposal(String name, String kind, ICompilationUnit cu, ASTRewrite rewrite,
+			int relevance) {
+		super(name, kind, cu, null, relevance);
+		fRewrite = rewrite;
+	}
+
+	/**
+	 * Returns the import rewrite used for this compilation unit.
+	 *
+	 * @return the import rewrite or <code>null</code> if no import rewrite has been
+	 *         set
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 */
+	public ImportRewrite getImportRewrite() {
+		return fImportRewrite;
+	}
+
+	/**
+	 * Sets the import rewrite used for this compilation unit.
+	 *
+	 * @param rewrite the import rewrite
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 */
+	public void setImportRewrite(ImportRewrite rewrite) {
+		fImportRewrite = rewrite;
+	}
+
+	/**
+	 * Creates and sets the import rewrite used for this compilation unit.
+	 *
+	 * @param astRoot the AST for the current CU
+	 * @return the created import rewrite
+	 * @nooverride This method is not intended to be re-implemented or extended by
+	 *             clients.
+	 */
+	public ImportRewrite createImportRewrite(CompilationUnit astRoot) {
+		fImportRewrite = CodeStyleConfiguration.createImportRewrite(astRoot, true);
+		return fImportRewrite;
+	}
+
+	@Override
+	protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
+		super.addEdits(document, editRoot);
+		ASTRewrite rewrite = getRewrite();
+		if (rewrite != null) {
+			try {
+				TextEdit edit = rewrite.rewriteAST();
+				editRoot.addChild(edit);
+			} catch (IllegalArgumentException e) {
+				throw new CoreException(StatusFactory.newErrorStatus("Invalid AST rewriter", e));
+			}
+		}
+		if (fImportRewrite != null) {
+			editRoot.addChild(fImportRewrite.rewriteImports(new NullProgressMonitor()));
+		}
+	}
+
+	/**
+	 * Returns the rewrite that has been passed in the constructor. Implementors can
+	 * override this
+	 * method to create the rewrite lazily. This method will only be called once.
+	 *
+	 * @return the rewrite to be used
+	 * @throws CoreException when the rewrite could not be created
+	 */
+	protected ASTRewrite getRewrite() throws CoreException {
+		if (fRewrite == null) {
+			IStatus status = StatusFactory.newErrorStatus("Rewrite not initialized", null); //$NON-NLS-1$
+			throw new CoreException(status);
+		}
+		return fRewrite;
+	}
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/CUCorrectionProposal.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/CUCorrectionProposal.java
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from /org.eclipse.jdt.ui/src/org/eclipse/jdt/ui/text/java/correction/CUCorrectionProposal.java
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ls.core.internal.corrections.proposals;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.manipulation.CUCorrectionProposalCore;
+import org.eclipse.jdt.core.manipulation.ICUCorrectionProposal;
+import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.TextChange;
+import org.eclipse.text.edits.TextEdit;
+
+
+
+/**
+ * A proposal for quick fixes and quick assists that work on a single compilation unit. Either a
+ * {@link TextChange text change} is directly passed in the constructor or method
+ * {@link #addEdits(IDocument, TextEdit)} is overridden to provide the text edits that are applied
+ * to the document when the proposal is evaluated.
+ * <p>
+ * The proposal takes care of the preview of the changes as proposal information.
+ * </p>
+ */
+public class CUCorrectionProposal extends ChangeCorrectionProposal implements ICUCorrectionProposal {
+
+	private CUCorrectionProposalCore fProposalCore;
+
+	/**
+	 * Constructs a correction proposal working on a compilation unit with a given
+	 * text change.
+	 *
+	 * @param name
+	 *            the name that is displayed in the proposal selection dialog
+	 * @param kind
+	 *            the kind of the correction type that the proposal performs
+	 * @param cu
+	 *            the compilation unit to which the change can be applied
+	 * @param change
+	 *            the change that is executed when the proposal is applied or
+	 *            <code>null</code> if implementors override
+	 *            {@link #addEdits(IDocument, TextEdit)} to provide the text edits
+	 *            or {@link #createTextChange()} to provide a text change
+	 * @param relevance
+	 *            the relevance of this proposal
+	 */
+	public CUCorrectionProposal(String name, String kind, ICompilationUnit cu, TextChange change, int relevance) {
+		super(name, kind, change, relevance);
+		if (cu == null) {
+			throw new IllegalArgumentException("Compilation unit must not be null"); //$NON-NLS-1$
+		}
+		fProposalCore = new CUCorrectionProposalCore(name, cu, change, relevance);
+	}
+
+	/**
+	 * Called when the {@link CompilationUnitChange} is initialized. Subclasses can override to add
+	 * text edits to the root edit of the change. Implementors must not access the proposal, e.g.
+	 * not call {@link #getChange()}.
+	 * <p>
+	 * The default implementation does not add any edits
+	 * </p>
+	 *
+	 * @param document content of the underlying compilation unit. To be accessed read only.
+	 * @param editRoot The root edit to add all edits to
+	 * @throws CoreException can be thrown if adding the edits is failing.
+	 */
+	protected void addEdits(IDocument document, TextEdit editRoot) throws CoreException {
+		// empty default implementation
+	}
+
+	@Override
+	public Object getAdditionalProposalInfo(IProgressMonitor monitor) {
+		return fProposalCore.getAdditionalProposalInfo(monitor);
+	}
+
+	@Override
+	public void apply() throws CoreException {
+		performChange();
+	}
+
+	/**
+	 * Creates the text change for this proposal. This method is only called once
+	 * and only when no text change has been passed in
+	 * {@link #CUCorrectionProposal(String, ICompilationUnit, TextChange, int)}.
+	 *
+	 * @return the created text change
+	 * @throws CoreException
+	 *             if the creation of the text change failed
+	 */
+	protected TextChange createTextChange() throws CoreException {
+		TextChange change = fProposalCore.getNewChange();
+		// initialize text change
+		IDocument document= change.getCurrentDocument(new NullProgressMonitor());
+		addEdits(document, change.getEdit());
+		return change;
+	}
+
+	@Override
+	protected final Change createChange() throws CoreException {
+		return createTextChange(); // make sure that only text changes are allowed here
+	}
+
+	/**
+	 * Returns the text change that is invoked when the change is applied.
+	 *
+	 * @return the text change that is invoked when the change is applied
+	 * @throws CoreException if accessing the change failed
+	 */
+	@Override
+	public final TextChange getTextChange() throws CoreException {
+		return (TextChange) getChange();
+	}
+
+	/**
+	 * The compilation unit on which the change works.
+	 *
+	 * @return the compilation unit on which the change works
+	 */
+	public final ICompilationUnit getCompilationUnit() {
+		return fProposalCore.getCompilationUnit();
+	}
+
+	/**
+	 * Creates a preview of the content of the compilation unit after applying the change.
+	 *
+	 * @return the preview of the changed compilation unit
+	 * @throws CoreException if the creation of the change failed
+	 *
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public String getPreviewContent() throws CoreException {
+		return getTextChange().getPreviewContent(new NullProgressMonitor());
+	}
+
+	@Override
+	public String toString() {
+		try {
+			return getPreviewContent();
+		} catch (CoreException e) {
+			// didn't work out
+		}
+		return super.toString();
+	}
+
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/ChangeCorrectionProposal.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/ChangeCorrectionProposal.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from /org.eclipse.jdt.ui/src/org/eclipse/jdt/ui/text/java/correction/ChangeCorrectionProposal.java
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.corrections.proposals;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.manipulation.ChangeCorrectionProposalCore;
+import org.eclipse.jdt.core.manipulation.JavaManipulation;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.IUndoManager;
+import org.eclipse.ltk.core.refactoring.RefactoringCore;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+public class ChangeCorrectionProposal extends ChangeCorrectionProposalCore {
+	// LSP: Code Action Kind
+	private String fKind;
+
+	/**
+	 * Constructs a change correction proposal.
+	 *
+	 * @param name      the name that is displayed in the proposal selection dialog
+	 * @param change    the change that is executed when the proposal is applied or
+	 *                  <code>null</code>
+	 *                  if the change will be created by implementors of
+	 *                  {@link #createChange()}
+	 * @param relevance the relevance of this proposal
+	 */
+	public ChangeCorrectionProposal(String name, String kind, Change change, int relevance) {
+		super(name, change, relevance);
+		fKind = kind;
+	}
+
+	/**
+	 * Performs the change associated with this proposal.
+	 * <p>
+	 * Subclasses may extend, but must call the super implementation.
+	 *
+	 * @throws CoreException
+	 *                       when the invocation of the change failed
+	 */
+	@Override
+	protected void performChange() throws CoreException {
+
+		Change change = null;
+		try {
+			change = getChange();
+			if (change != null) {
+
+				change.initializeValidationData(new NullProgressMonitor());
+				RefactoringStatus valid = change.isValid(new NullProgressMonitor());
+				if (valid.hasFatalError()) {
+					IStatus status = new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, IStatus.ERROR,
+							valid.getMessageMatchingSeverity(RefactoringStatus.FATAL), null);
+					throw new CoreException(status);
+				} else {
+					IUndoManager manager = RefactoringCore.getUndoManager();
+					Change undoChange;
+					boolean successful = false;
+					try {
+						manager.aboutToPerformChange(change);
+						undoChange = change.perform(new NullProgressMonitor());
+						successful = true;
+					} finally {
+						manager.changePerformed(change, successful);
+					}
+					if (undoChange != null) {
+						undoChange.initializeValidationData(new NullProgressMonitor());
+						manager.addUndo(getName(), undoChange);
+					}
+				}
+			}
+		} finally {
+
+			if (change != null) {
+				change.dispose();
+			}
+		}
+	}
+
+	/**
+	 * Returns the kind of the proposal.
+	 *
+	 * @return the kind of the proposal
+	 */
+	public String getKind() {
+		return fKind;
+	}
+
+	/**
+	 * @param codeActionKind the Code Action Kind to set
+	 */
+	public void setKind(String codeActionKind) {
+		this.fKind = codeActionKind;
+	}
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/CodeActionKind.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/CodeActionKind.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Gayan Perera and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Gayan Perera - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.corrections.proposals;
+
+/**
+ * Code action kind constants used with {@link ASTRewriteCorrectionProposal}.
+ * Most of kinds are aligned with Language Server Protocol, but not limited to
+ * it.
+ */
+public final class CodeActionKind {
+    /**
+     * Base kind for refactoring rewrite actions: 'refactor.rewrite'
+     *
+     * Example rewrite actions:
+     *
+     * - Convert JavaScript function to class - Add or remove parameter -
+     * Encapsulate field - Make method static - Move method to base class - ...
+     */
+    public static final String RefactorRewrite = "refactor.rewrite";
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/IProposalRelevance.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/corrections/proposals/IProposalRelevance.java
@@ -1,0 +1,313 @@
+/*******************************************************************************
+ * Copyright (c) 2012, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from /org.eclipse.jdt.ui/src/org/eclipse/jdt/internal/ui/text/correction/IProposalRelevance.java
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Billy Huang <billyhuang31@gmail.com> - [quick assist] concatenate/merge string literals - https://bugs.eclipse.org/77632
+ *     Lukas Hanke <hanke@yatta.de> - Bug 241696 [quick fix] quickfix to iterate over a collection - https://bugs.eclipse.org/bugs/show_bug.cgi?id=241696
+ *     Sandra Lions <sandra.lions-piron@oracle.com> - [quick fix] for qualified enum constants in switch-case labels - https://bugs.eclipse.org/bugs/90140
+ *******************************************************************************/
+package org.eclipse.jdt.core.corrections.proposals;
+
+/**
+ * Interface defining relevance values for quick fixes/assists.
+ *
+ * @see org.eclipse.jdt.ui.text.java.IJavaCompletionProposal#getRelevance()
+ */
+public interface IProposalRelevance {
+	public static final int OVERRIDES_DEPRECATED = 15;
+	public static final int ADD_OVERRIDE_ANNOTATION = 15;
+	public static final int ADD_DEPRECATED_ANNOTATION = 15;
+
+	public static final int CREATE_NON_STATIC_ACCESS_USING_DECLARING_TYPE = 12;
+	public static final int CREATE_INDIRECT_ACCESS_TO_STATIC = 12;
+	public static final int CREATE_NON_STATIC_ACCESS_USING_INSTANCE_TYPE = 11;
+
+	public static final int REMOVE_UNUSED_CAST = 10;
+	public static final int ADD_UNIMPLEMENTED_METHODS = 10;
+	public static final int UNUSED_MEMBER = 10;
+	public static final int REMOVE_ELSE = 10;
+	public static final int ADD_MISSING_DEFAULT_CASE = 10;
+	public static final int ADD_MISSING_CASE_STATEMENTS = 10;
+	public static final int UNNECESSARY_INSTANCEOF = 10;
+	public static final int REPLACE_FIELD_ACCESS_WITH_METHOD = 10;
+	public static final int REMOVE_UNREACHABLE_CODE_INCLUDING_CONDITION = 10;
+	public static final int CHANGE_VISIBILITY = 10;
+	public static final int MARKER_RESOLUTION = 10;
+	public static final int CREATE_LOCAL_PREFIX_OR_SUFFIX_MATCH = 10;
+	public static final int CHANGE_NULLNESS_ANNOTATION = 10;
+
+	public static final int CHANGE_NULLNESS_ANNOTATION_IN_OVERRIDDEN_METHOD = 9;
+	public static final int REMOVE_FINAL_MODIFIER = 9;
+	public static final int GETTER_SETTER_NOT_VISIBLE_FIELD = 9;
+	public static final int ADD_MISSING_BODY = 9;
+	public static final int MISSING_SERIAL_VERSION = 9;
+	public static final int MISSING_SERIAL_VERSION_DEFAULT = 9;
+	public static final int CREATE_CONSTANT_PREFIX_OR_SUFFIX_MATCH = 9;
+	public static final int CREATE_FIELD_PREFIX_OR_SUFFIX_MATCH = 9;
+
+	public static final int ADD_ABSTRACT_MODIFIER = 8;
+	public static final int ADD_STATIC_MODIFIER = 8;
+	public static final int ADD_DEFAULT_MODIFIER = 8;
+	public static final int ADD_PARENTHESES_AROUND_CAST = 8;
+	public static final int REMOVE_ARGUMENTS = 8;
+	public static final int QUALIFY_WITH_ENCLOSING_TYPE = 8;
+	public static final int THROW_ALLOCATED_OBJECT = 8;
+	public static final int CHANGE_TO_METHOD = 8;
+	public static final int ADD_FIELD_QUALIFIER = 8;
+	public static final int ADD_THROWS_DECLARATION = 8;
+	public static final int CHANGE_OVERRIDDEN_MODIFIER_1 = 8;
+	public static final int REMOVE_EXCEPTIONS = 8;
+	public static final int SWAP_ARGUMENTS = 8;
+	public static final int GETTER_SETTER_UNUSED_PRIVATE_FIELD = 8;
+	public static final int RENAME_REFACTORING = 8;
+	public static final int LINKED_NAMES_ASSIST = 8;
+	public static final int ADD_ARGUMENTS = 8;
+	public static final int ADD_PROJECT_TO_BUILDPATH = 8;
+	public static final int CHANGE_VARIABLE = 8;
+	public static final int CHANGE_RETURN_TYPE = 8;
+	public static final int CREATE_PARAMETER_PREFIX_OR_SUFFIX_MATCH = 8;
+
+	public static final int CHANGE_OVERRIDDEN_MODIFIER_2 = 7;
+	public static final int ADD_EXCEPTIONS = 7;
+	public static final int CHANGE_METHOD_SIGNATURE = 7;
+	public static final int SURROUND_WITH_TRY_MULTICATCH = 7;
+	public static final int CAST_AND_ASSIGN = 7;
+	public static final int ADD_ADDITIONAL_MULTI_CATCH = 7;
+	public static final int ADD_EXCEPTIONS_TO_EXISTING_CATCH = 7;
+	public static final int ADD_ADDITIONAL_CATCH = 7;
+	public static final int ADD_NEW_KEYWORD_UPPERCASE = 7;
+	public static final int GETTER_SETTER_QUICK_ASSIST = 7;
+	public static final int RENAME_REFACTORING_QUICK_FIX = 7;
+	public static final int ADD_TO_BUILDPATH = 7;
+	public static final int CHANGE_RETURN_TYPE_OF_OVERRIDDEN = 7;
+	public static final int CREATE_CAST = 7;
+	public static final int ARRAY_CHANGE_TO_LENGTH = 7;
+	public static final int MISSING_PACKAGE_DECLARATION = 7;
+	public static final int INSERT_INFERRED_TYPE_ARGUMENTS = 7;
+	public static final int RETURN_ALLOCATED_OBJECT_MATCH = 7;
+	public static final int CREATE_LOCAL = 7;
+
+	public static final int MOVE_REFACTORING = 6;
+	public static final int REMOVE_SEMICOLON = 6;
+	public static final int CREATE_METHOD_IN_SUPER = 6;
+	public static final int QUALIFY_LHS = 6;
+	public static final int CHANGE_WORKSPACE_COMPLIANCE = 6;
+	public static final int ARRAY_CHANGE_TO_METHOD = 6;
+	public static final int CAST_ARGUMENT_1 = 6;
+	public static final int CHANGE_METHOD = 6;
+	public static final int VOID_METHOD_RETURNS = 6;
+	public static final int RENAME_CU = 6;
+	public static final int MOVE_CU_TO_PACKAGE = 6;
+	public static final int INITIALIZE_VARIABLE = 6;
+	public static final int MISSING_RETURN_TYPE = 6;
+	public static final int CHANGE_METHOD_RETURN_TYPE = 6;
+	public static final int UNNECESSARY_NLS_TAG = 6;
+	public static final int RAW_TYPE_REFERENCE = 6;
+	public static final int SURROUND_WITH_TRY_CATCH = 6;
+	public static final int REMOVE_REDUNDANT_TYPE_ARGUMENTS = 6;
+	public static final int REMOVE_REDUNDANT_SUPER_INTERFACE = 6;
+	public static final int CHANGE_EXTENDS_TO_IMPLEMENTS = 6;
+	public static final int REMOVE_OVERRIDE = 6;
+	public static final int MOVE_EXCEPTION_TO_SEPERATE_CATCH_BLOCK = 6;
+	public static final int REMOVE_ABSTRACT_MODIFIER = 6;
+	public static final int REMOVE_EXCEPTION = 6;
+	public static final int REPLACE_EXCEPTION_WITH_THROWS = 6;
+	public static final int REMOVE_TYPE_ARGUMENTS = 6;
+	public static final int CHANGE_IF_ELSE_TO_BLOCK = 6;
+	public static final int REMOVE_NATIVE = 6;
+	public static final int REMOVE_UNUSED_IMPORT = 6;
+	public static final int CHANGE_TYPE_OF_RECEIVER_NODE = 6;
+	public static final int EXTRACT_LOCAL_ALL = 6;
+	public static final int CHANGE_TO_ATTRIBUTE_SIMILAR_NAME = 6;
+	public static final int CREATE_FIELD = 6;
+	public static final int CONVERT_TO_LAMBDA_EXPRESSION = 6;
+	public static final int CONVERT_METHOD_REFERENCE_TO_LAMBDA = 6;
+	public static final int CONVERT_TO_METHOD_REFERENCE = 6;
+
+	public static final int ADD_ALL_MISSING_TAGS = 5;
+	public static final int QUALIFY_INNER_TYPE_NAME = 5;
+	public static final int REMOVE_TAG = 5;
+	public static final int INVALID_OPERATOR = 5;
+	public static final int REMOVE_METHOD_BODY = 5;
+	public static final int INSERT_BREAK_STATEMENT = 5;
+	public static final int REMOVE_CATCH_CLAUSE = 5;
+	public static final int CHANGE_TO_RETURN = 5;
+	public static final int INCOMPATIBLE_FOREACH_TYPE = 5;
+	public static final int CHANGE_RETURN_TYPE_TO_VOID = 5;
+	public static final int CHANGE_TO_CONSTRUCTOR = 5;
+	public static final int FIX_SUPPRESS_TOKEN = 5;
+	public static final int REMOVE_ANNOTATION = 5;
+	public static final int OVERRIDE_HASHCODE = 5;
+	public static final int ADD_BLOCK = 5;
+	public static final int MAKE_TYPE_ABSTRACT = 5;
+	public static final int ADD_MISSING_NLS_TAGS = 5;
+	public static final int MAKE_TYPE_ABSTRACT_FIX = 5;
+	public static final int CONVERT_LOCAL_TO_FIELD = 5;
+	public static final int CONVERT_ANONYMOUS_TO_NESTED = 5;
+	public static final int IMPORT_EXPLICIT = 5;
+	public static final int ADD_STATIC_IMPORT = 5;
+	public static final int REMOVE_SAFEVARARGS = 5;
+	public static final int INFER_GENERIC_TYPE_ARGUMENTS = 5;
+	public static final int ORGANIZE_IMPORTS = 5;
+	public static final int INLINE_LOCAL = 5;
+	public static final int CREATE_PARAMETER = 5;
+	public static final int UNNECESSARY_THROW = 5;
+	public static final int ADD_METHOD_MODIFIER = 5;
+	public static final int CHANGE_MODIFIER_TO_FINAL = 5;
+	public static final int CHANGE_MODIFIER_OF_VARIABLE_TO_FINAL = 5;
+	public static final int CONFIGURE_ACCESS_RULES = 5;
+	public static final int CONFIGURE_BUILD_PATH = 5;
+	public static final int CHANGE_METHOD_ADD_PARAMETER = 5;
+	public static final int CHANGE_METHOD_REMOVE_PARAMETER = 5;
+	public static final int CREATE_METHOD = 5;
+	public static final int CHANGE_METHOD_SWAP_PARAMETERS = 5;
+	public static final int CREATE_ATTRIBUTE = 5;
+	public static final int CREATE_CONSTRUCTOR = 5;
+	public static final int CAST_ARGUMENT_2 = 5;
+	public static final int CHANGE_TYPE_OF_NODE_TO_CAST = 5;
+	public static final int IMPORT_NOT_FOUND_NEW_TYPE = 5;
+	public static final int REMOVE_INVALID_MODIFIERS = 5;
+	public static final int CHANGE_VISIBILITY_TO_NON_PRIVATE = 5;
+	public static final int CHANGE_MODIFIER_TO_STATIC = 5;
+	public static final int VARIABLE_TYPE_PROPOSAL_1 = 5;
+	public static final int EXTRACT_LOCAL = 5;
+	public static final int QUALIFY_RHS = 5;
+	public static final int ADD_CONSTRUCTOR_FROM_SUPER_CLASS = 5;
+	public static final int GETTER_SETTER_UNQUALIFIED_FIELD_ACCESS = 5;
+	public static final int RENAME_TYPE = 5;
+	public static final int CHANGE_PROJECT_COMPLIANCE = 5;
+	public static final int CORRECT_PACKAGE_DECLARATION = 5;
+	public static final int TYPE_ARGUMENTS_FROM_CONTEXT = 5;
+	public static final int REMOVE_REDUNDANT_NULLNESS_ANNOTATION = 5;
+	public static final int REPLACE_WITH_UNQUALIFIED_ENUM_CONSTANT = 5;
+	public static final int OVERRIDE_DEFAULT_METHOD = 5;
+
+	public static final int ADD_MISSING_TAG = 4;
+	public static final int INSERT_FALL_THROUGH = 4;
+	public static final int REPLACE_CATCH_CLAUSE_WITH_THROWS = 4;
+	public static final int INSERT_CASES_OMITTED = 4;
+	public static final int REMOVE_ASSIGNMENT = 4;
+	public static final int EXTERNALIZE_STRINGS = 4;
+	public static final int ADD_NEW_KEYWORD = 4;
+	public static final int REMOVE_STATIC_MODIFIER = 4;
+	public static final int EXTRACT_METHOD = 4;
+	public static final int METHOD_RETURNS_VOID = 4;
+	public static final int EXTRACT_CONSTANT = 4;
+	public static final int CREATE_CONSTANT = 4;
+
+	public static final int CHANGE_CLASS_TO_INTERFACE = 3;
+	public static final int GENERATE_GETTER_AND_SETTER = 3;
+	public static final int GENERATE_HASHCODE_AND_EQUALS = 3;
+	public static final int SIMILAR_TYPE = 3;
+	public static final int EXTRACT_LOCAL_ALL_ERROR = 3;
+	public static final int ASSIGN_PARAM_TO_NEW_FIELD = 3;
+	public static final int ASSIGN_TO_LOCAL = 3;
+	public static final int CHANGE_CAST = 3;
+	public static final int CHANGE_TO_ATTRIBUTE = 3;
+	public static final int CHANGE_LAMBDA_BODY_TO_BLOCK = 3;
+	public static final int CHANGE_LAMBDA_BODY_TO_EXPRESSION = 3;
+	public static final int ADD_INFERRED_LAMBDA_PARAMETER_TYPES = 3;
+
+	public static final int ASSIGN_ALL_PARAMS_TO_NEW_FIELDS = 2;
+	public static final int CONVERT_TO_INDEXED_FOR_LOOP = 2;
+	public static final int GENERATE_ENHANCED_FOR_LOOP = 2;
+	public static final int USE_SEPARATE_CATCH_BLOCKS = 2;
+	public static final int INSERT_NULL_CHECK = 2;
+	public static final int COMBINE_CATCH_BLOCKS = 2;
+	public static final int EXTRACT_LOCAL_ERROR = 2;
+	public static final int ASSIGN_TO_FIELD = 2;
+	public static final int RETURN_ALLOCATED_OBJECT = 2;
+	public static final int REMOVE_BLOCK_FIX = 2;
+	public static final int CONVERT_TO_ANONYMOUS_CLASS_CREATION = 2;
+	public static final int CONVERT_TO_SWITCH_EXPRESSION = 2;
+	public static final int EXTRACT_LAMBDA_BODY_TO_METHOD = 3;
+
+	public static final int JOIN_VARIABLE_DECLARATION = 1;
+	public static final int INVERT_EQUALS = 1;
+	public static final int CONVERT_TO_ITERATOR_FOR_LOOP = 1;
+	public static final int GENERATE_FOR_LOOP = 1;
+	public static final int ADD_TYPE_TO_ARRAY_INITIALIZER = 1;
+	public static final int REMOVE_EXTRA_PARENTHESES = 1;
+	public static final int CONVERT_ITERABLE_LOOP_TO_ENHANCED = 1;
+	public static final int CONVERT_FOR_LOOP_TO_ENHANCED = 1;
+	public static final int SPLIT_OR_CONDITION = 1;
+	public static final int SPLIT_AND_CONDITION = 1;
+	public static final int REPLACE_IF_ELSE_WITH_CONDITIONAL = 1;
+	public static final int REPLACE_CONDITIONAL_WITH_IF_ELSE = 1;
+	public static final int PULL_NEGATION_DOWN = 1;
+	public static final int PULL_NEGATION_UP = 1;
+	public static final int JOIN_IF_STATEMENTS_WITH_OR = 1;
+	public static final int JOIN_IF_SEQUENCE = 1;
+	public static final int JOIN_IF_WITH_OUTER_IF = 1;
+	public static final int INVERSE_IF_STATEMENT = 1;
+	public static final int INVERT_IF_TO_CONTINUE = 1;
+	public static final int INVERSE_IF_CONTINUE = 1;
+	public static final int INVERSE_CONDITIONS = 1;
+	public static final int INVERSE_CONDITIONAL_EXPRESSION = 1;
+	public static final int CONVERT_TO_IF_ELSE = 1;
+	public static final int EXCHANGE_OPERANDS = 1;
+	public static final int EXCHANGE_INNER_AND_OUTER_IF_CONDITIONS = 1;
+	public static final int CONVERT_SWITCH_TO_IF_ELSE = 1;
+	public static final int CONVERT_IF_ELSE_TO_SWITCH = 1;
+	public static final int DOCUMENT_UNUSED_ITEM = 1;
+	public static final int PICK_SELECTED_STRING = 1;
+	public static final int COMBINE_STRINGS = 1;
+	public static final int INVERSE_BOOLEAN_VARIABLE = 1;
+	public static final int REMOVE_UNUSED_ALLOCATED_OBJECT = 1;
+	public static final int UNWRAP_STATEMENTS = 1;
+	public static final int SPLIT_VARIABLE_DECLARATION = 1;
+	public static final int ADD_FINALLY_BLOCK = 1;
+	public static final int ADD_ELSE_BLOCK = 1;
+	public static final int CONVERT_TO_STRING_BUFFER = 1;
+	public static final int JOIN_IF_WITH_INNER_IF = 1;
+	public static final int ADD_JAVADOC_ENUM = 1;
+	public static final int ADD_JAVADOC_FIELD = 1;
+	public static final int ADD_JAVADOC_TYPE = 1;
+	public static final int ADD_JAVADOC_METHOD = 1;
+	public static final int EXTRACT_METHOD_ERROR = 1;
+	public static final int EXTRACT_CONSTANT_ERROR = 1;
+	public static final int LINKED_NAMES_ASSIST_ERROR = 1;
+	public static final int RENAME_REFACTORING_ERROR = 1;
+	public static final int ASSIGN_PARAM_TO_EXISTING_FIELD = 1;
+	public static final int INSERT_INFERRED_TYPE_ARGUMENTS_ERROR = 1;
+	public static final int RETURN_ALLOCATED_OBJECT_VOID = 1;
+	public static final int CONVERT_TO_IF_RETURN = 1;
+
+	public static final int CONVERT_TO_MESSAGE_FORMAT = 0;
+	public static final int COPY_ANNOTATION_JAR = 0;
+	public static final int NO_SUGGESSTIONS_AVAILABLE = 0;
+	public static final int ADD_QUOTE = 0;
+	public static final int NEW_TYPE = 0;
+	public static final int SIMILAR_VARIABLE_PROPOSAL = 0;
+	public static final int EXTRACT_LOCAL_ALL_ZERO_SELECTION = 0;
+
+	public static final int EXTRACT_LOCAL_ZERO_SELECTION = -1;
+	public static final int MAKE_VARIABLE_DECLARATION_FINAL = -1;
+
+	public static final int ADD_SUPPRESSWARNINGS = -2;
+	public static final int VARIABLE_TYPE_PROPOSAL_2 = -2;
+	public static final int EXTRACT_CONSTANT_ZERO_SELECTION = -2;
+	public static final int ADD_SAFEVARARGS = -2;
+
+	public static final int ADD_PARANOIDAL_PARENTHESES = -9;
+
+	public static final int ADD_PARENTHESES_FOR_EXPRESSION = -10;
+
+	public static final int CONFIGURE_PROBLEM_SEVERITY = -11;
+
+	// Be careful while tweaking these values because WordCorrectionProposal uses
+	// -distance (between the words) as relevance.
+	public static final int DISABLE_SPELL_CHECKING = Integer.MIN_VALUE + 1;
+	public static final int WORD_IGNORE = Integer.MIN_VALUE + 1;
+	public static final int ADD_WORD = Integer.MIN_VALUE;
+
+}


### PR DESCRIPTION

## What it does
Move core components from jdt.ls into org.eclipse.jdt.core.manipulation so that quickfix and refactoring logic in jdt.ls can be moved back into jdt.ui

## How to test
N/A

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
