### PR TITLE
UI for configuring annotation path relative to a classpath container

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaPrecomputedNamesAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaPrecomputedNamesAssistProcessor.java
@@ -52,6 +52,10 @@ public class JavaPrecomputedNamesAssistProcessor implements ISubjectControlConte
 		fProposalAutoActivationSet= triggers.toCharArray();
 	}
 
+	public void setNames(Iterable<String> names) {
+		fNames= names;
+	}
+
 	@Override
 	public ICompletionProposal[] computeCompletionProposals(ITextViewer viewer, int offset) {
 		Assert.isTrue(false, "ITextViewer not supported"); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
@@ -457,6 +457,12 @@ public final class NewWizardMessages extends NLS {
 	public static String ExternalAnnotationsDialog_title;
 
 	public static String AnnotationsAttachmentBlock_message;
+	public static String AnnotationsAttachmentBlock_artifact_label;
+	public static String AnnotationsAttachmentBlock_artifactNotFound_error;
+	public static String AnnotationsAttachmentBlock_container_label;
+	public static String AnnotationsAttachmentBlock_containerRelative_radio;
+	public static String AnnotationsAttachmentBlock_missingArtifact_error;
+	public static String AnnotationsAttachmentBlock_missingContainer_error;
 	public static String AnnotationsAttachmentBlock_filename_externalfile_button;
 	public static String AnnotationsAttachmentBlock_filename_externalfolder_button;
 	public static String AnnotationsAttachmentBlock_filename_external_label;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
@@ -508,6 +508,12 @@ AnnotationsAttachmentBlock_extjardialog_text=JAR/ZIP File Selection
 AnnotationsAttachmentBlock_extfolderdialog_text=External Annotations Folder Selection
 AnnotationsAttachmentBlock_extfolderdialog_message=Choose a directory containing external annotations:
 AnnotationsAttachmentBlock_workspace_radiolabel=Wor&kspace location
+AnnotationsAttachmentBlock_artifact_label=Artifact:
+AnnotationsAttachmentBlock_artifactNotFound_error=Artifact ''{0}'' cannot be found in container ''{1}''.
+AnnotationsAttachmentBlock_container_label=Container:
+AnnotationsAttachmentBlock_containerRelative_radio=Container relative
+AnnotationsAttachmentBlock_missingArtifact_error=Missing artifact name
+AnnotationsAttachmentBlock_missingContainer_error=Container must be selected
 ExternalAnnotationsDialog_title=External Annotations Attachment Configuration
 
 # ------- ModuleDialog ---------

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttachmentBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttachmentBlock.java
@@ -16,13 +16,21 @@ package org.eclipse.jdt.internal.ui.wizards.buildpaths;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.ibm.icu.text.MessageFormat;
 
 import org.eclipse.equinox.bidi.StructuredTextTypeHandlerFactory;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.DirectoryDialog;
@@ -56,23 +64,31 @@ import org.eclipse.ui.model.WorkbenchContentProvider;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 
 import org.eclipse.jdt.core.IClasspathAttribute;
+import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.dialogs.StatusInfo;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
+import org.eclipse.jdt.internal.ui.refactoring.contentassist.ControlContentAssistHelper;
+import org.eclipse.jdt.internal.ui.refactoring.contentassist.JavaPrecomputedNamesAssistProcessor;
 import org.eclipse.jdt.internal.ui.wizards.IStatusChangeListener;
 import org.eclipse.jdt.internal.ui.wizards.NewWizardMessages;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.ComboDialogField;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.DialogField;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.IDialogFieldListener;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.IStringButtonAdapter;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.LayoutUtil;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.SelectionButtonDialogField;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.StringButtonDialogField;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.StringDialogField;
 
 
 /**
@@ -86,10 +102,17 @@ public class ExternalAnnotationsAttachmentBlock {
 	private StringButtonDialogField fWorkspaceFileNameField;
 	private StringButtonDialogField fExternalFileNameField;
 	private SelectionButtonDialogField fExternalFolderButton;
-	private SelectionButtonDialogField fExternalRadio, fWorkspaceRadio;
+	private SelectionButtonDialogField fExternalRadio, fWorkspaceRadio, fContainerRelativeRadio;
+	private ComboDialogField fContainerSelection;
+	private StringDialogField fContainerRelative;
+
+	private Map<String,String> fContainerDesc2ID;
+	private Map<String,IClasspathContainer> fID2Container;
+	private JavaPrecomputedNamesAssistProcessor fArtifactAssistprocessor;
 
 	private IStatus fWorkspaceNameStatus;
 	private IStatus fExternalNameStatus;
+	private IStatus fContainerRelativeStatus;
 
 	private final IWorkspaceRoot fWorkspaceRoot;
 
@@ -100,8 +123,9 @@ public class ExternalAnnotationsAttachmentBlock {
 	/**
 	 * @param context listeners for status updates
 	 * @param entry The entry to edit
+	 * @param javaProject The enclosing java project
 	 */
-	public ExternalAnnotationsAttachmentBlock(IStatusChangeListener context, IPath entry) {
+	public ExternalAnnotationsAttachmentBlock(IStatusChangeListener context, IPath entry, IJavaProject javaProject) {
 		fContext= context;
 		fEntry= entry == null ? Path.EMPTY : entry;
 
@@ -135,7 +159,46 @@ public class ExternalAnnotationsAttachmentBlock {
 		fExternalFolderButton.setDialogFieldListener(adapter);
 		fExternalFolderButton.setLabelText(NewWizardMessages.AnnotationsAttachmentBlock_filename_externalfolder_button);
 
+		fContainerRelativeRadio= new SelectionButtonDialogField(SWT.RADIO);
+		fContainerRelativeRadio.setDialogFieldListener(adapter);
+		fContainerRelativeRadio.setLabelText(NewWizardMessages.AnnotationsAttachmentBlock_containerRelative_radio);
+
+		createContainerMaps(javaProject);
+		fContainerSelection= new ComboDialogField(SWT.READ_ONLY);
+		fContainerSelection.setDialogFieldListener(adapter);
+		fContainerSelection.setItems(fContainerDesc2ID.keySet().toArray(String[]::new));
+		fContainerSelection.setLabelText(NewWizardMessages.AnnotationsAttachmentBlock_container_label);
+
+		fContainerRelative= new StringDialogField();
+		fContainerRelative.setDialogFieldListener(adapter);
+		fContainerRelative.setLabelText(NewWizardMessages.AnnotationsAttachmentBlock_artifact_label);
+
 		setDefaults();
+	}
+
+	private void createContainerMaps(IJavaProject javaProject) {
+		fContainerDesc2ID= new HashMap<>();
+		fID2Container= new HashMap<>();
+		if (javaProject != null) {
+			try {
+				for (IClasspathEntry entry : javaProject.getRawClasspath()) {
+					if (entry.getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
+						IPath path= entry.getPath();
+						IClasspathContainer container= JavaCore.getClasspathContainer(path, javaProject);
+						fContainerDesc2ID.put(container.getDescription(), path.toString());
+						fID2Container.put(path.toString(), container);
+					}
+				}
+			} catch (JavaModelException e) {
+				JavaPlugin.log(e.getStatus());
+			}
+		} else {
+			// workaround for missing java project:
+			// fetch all registered containers and use ID also instead of readable description
+			for (String containerId : IClasspathContainer.getRegisteredContainerIds()) {
+				fContainerDesc2ID.put(containerId, containerId);
+			}
+		}
 	}
 
 	public void setDefaults() {
@@ -146,12 +209,29 @@ public class ExternalAnnotationsAttachmentBlock {
 			fWorkspaceRadio.setSelection(true);
 			fWorkspaceFileNameField.setText(path);
 		} else if (path != null && path.length() != 0) {
-			fExternalRadio.setSelection(true);
-			fExternalFileNameField.setText(path);
+			Entry<String, String> container= getContainerPrefix(path);
+			if (container != null) {
+				fContainerRelativeRadio.setSelection(true);
+				fContainerSelection.selectItem(container.getKey());
+				fContainerRelative.setText(path.substring(container.getValue().length()+1));
+			} else {
+				fExternalRadio.setSelection(true);
+				fExternalFileNameField.setText(path);
+			}
 		} else {
 			fWorkspaceRadio.setSelection(true);
 			fExternalRadio.setSelection(false);
 		}
+	}
+
+	/* Answer description and ID of a container that is the prefix of path. */
+	private Entry<String,String> getContainerPrefix(String path) {
+		for (Entry<String, String> entry : fContainerDesc2ID.entrySet()) {
+			if (path.startsWith(entry.getValue()+'/')) {
+				return entry;
+			}
+		}
+		return null;
 	}
 
 	private boolean isWorkspacePath(IPath path) {
@@ -223,10 +303,30 @@ public class ExternalAnnotationsAttachmentBlock {
 
 		fExternalFolderButton.doFillIntoGrid(composite, 1);
 
+		fContainerRelativeRadio.doFillIntoGrid(composite, 3);
+
+		fContainerSelection.doFillIntoGrid(composite, 3);
+		LayoutUtil.setHorizontalIndent(fContainerSelection.getLabelControl(null));
+		Combo containerSelection= fContainerSelection.getComboControl(null);
+		LayoutUtil.setWidthHint(containerSelection, widthHint);
+		LayoutUtil.setHorizontalGrabbing(containerSelection);
+
+		fContainerRelative.doFillIntoGrid(composite, 3);
+		LayoutUtil.setHorizontalIndent(fContainerRelative.getLabelControl(null));
+		Text containerRelative= fContainerRelative.getTextControl(null);
+		LayoutUtil.setWidthHint(containerRelative, widthHint);
+		LayoutUtil.setHorizontalGrabbing(containerRelative);
+
 		fWorkspaceRadio.attachDialogField(fWorkspaceFileNameField);
 		fExternalRadio.attachDialogFields(new DialogField[] { fExternalFileNameField, fExternalFolderButton });
+		fContainerRelativeRadio.attachDialogFields(new DialogField[] { fContainerSelection, fContainerRelative });
 
 		Dialog.applyDialogFont(composite);
+
+		if (fContainerRelativeRadio.isSelected()) {
+			// continue initialization that started during setDefaults, but didn't have a textControl at that time
+			configureArtifactAssist();
+		}
 
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, IJavaHelpContextIds.EXTERNAL_ANNOTATIONS_ATTACHMENT_DIALOG);
 		return composite;
@@ -275,6 +375,37 @@ public class ExternalAnnotationsAttachmentBlock {
 				fExternalFileNameField.setText(folderPath.toString());
 			}
 			return;
+		} else if (field == fContainerRelative || field == fContainerRelativeRadio || field == fContainerSelection) {
+			if (field == fContainerSelection && fSWTWidget != null) {
+				configureArtifactAssist();
+			}
+			StatusInfo status= new StatusInfo();
+			if (fContainerSelection.getText().isEmpty()) {
+				status.setError(NewWizardMessages.AnnotationsAttachmentBlock_missingContainer_error);
+			} else if (fContainerRelative.getText().isEmpty()) {
+				status.setError(NewWizardMessages.AnnotationsAttachmentBlock_missingArtifact_error);
+			} else {
+				String containerID= fContainerDesc2ID.get(fContainerSelection.getText());
+				if (fID2Container.containsKey(containerID)) {
+					IClasspathContainer container= fID2Container.get(containerID);
+					boolean found= false;
+					String relative= fContainerRelative.getText();
+					for (IClasspathEntry classpathEntry : container.getClasspathEntries()) {
+						String entryPath= classpathEntry.getPath().lastSegment().toString();
+						// relative must be equal to entryPath (a) entirely, or (b) up-to a boundary char
+						if (entryPath.equals(relative) ||
+								(entryPath.startsWith(relative) && !Character.isLetterOrDigit(entryPath.charAt(relative.length())))) {
+							found= true;
+							break;
+						}
+					}
+					if (!found) {
+						status.setError(MessageFormat.format(NewWizardMessages.AnnotationsAttachmentBlock_artifactNotFound_error,
+								fContainerRelative.getText(), fContainerSelection.getText()));
+					}
+				}
+			}
+			fContainerRelativeStatus= status;
 		}
 		doStatusLineUpdate();
 	}
@@ -285,11 +416,54 @@ public class ExternalAnnotationsAttachmentBlock {
 		if (isWorkSpace) {
 			fWorkspaceFileNameField.enableButton(canBrowseFileName());
 			status= fWorkspaceNameStatus;
-		} else {
+		} else if (fExternalRadio.isSelected()) {
 			fExternalFileNameField.enableButton(canBrowseFileName());
 			status= fExternalNameStatus;
+		} else {
+			status= fContainerRelativeStatus;
 		}
 		fContext.statusChanged(status);
+	}
+
+	private void configureArtifactAssist() {
+		String id= fContainerDesc2ID.get(fContainerSelection.getText());
+		if (id == null) return;
+		IClasspathContainer container= fID2Container.get(id);
+		if (container == null) return;
+		List<String> names= new ArrayList<>();
+		for (IClasspathEntry entry : container.getClasspathEntries()) {
+			String path= guessArtifactName(entry.getPath().toString());
+			names.add(path);
+		}
+		Text textControl= fContainerRelative.getTextControl(null);
+		getArtifactAssistprocessor(textControl).setNames(names);
+		if (names.size() == 1) {
+			textControl.setText(names.iterator().next());
+		}
+	}
+
+	private JavaPrecomputedNamesAssistProcessor getArtifactAssistprocessor(Text textControl) {
+		if (fArtifactAssistprocessor == null) {
+			fArtifactAssistprocessor= new JavaPrecomputedNamesAssistProcessor(Collections.emptyList(),
+					JavaPlugin.getImageDescriptorRegistry().get(JavaPluginImages.DESC_OBJS_JAR));
+			ControlContentAssistHelper.createTextContentAssistant(textControl, fArtifactAssistprocessor);
+		}
+		return fArtifactAssistprocessor;
+	}
+
+	private String guessArtifactName(String path) {
+		int s= path.lastIndexOf('/')+1;
+		for (int i=s; i<path.length(); i++) {
+			if (!Character.isLetterOrDigit(path.charAt(i))) {
+				if (i+1 < path.length()) {
+					char next= path.charAt(i+1);
+					if (Character.isLetter(next))
+						continue;
+				}
+				return path.substring(s, i);
+			}
+		}
+		return path.substring(s);
 	}
 
 	private boolean canBrowseFileName() { // FIXME remove
@@ -342,6 +516,10 @@ public class ExternalAnnotationsAttachmentBlock {
 	}
 
 	private IPath getFilePath() {
+		if (fContainerRelativeRadio.isSelected()) {
+			String container= fContainerSelection.getText();
+			return new Path(fContainerDesc2ID.get(container)).append(fContainerRelative.getText());
+		}
 		String filePath= fWorkspaceRadio.isSelected() ? fWorkspaceFileNameField.getText() : fExternalFileNameField.getText();
 		return Path.fromOSString(filePath).makeAbsolute();
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttachmentDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttachmentDialog.java
@@ -21,6 +21,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.jface.dialogs.StatusDialog;
+import org.eclipse.jface.window.Window;
 
 import org.eclipse.ui.PlatformUI;
 
@@ -31,11 +32,29 @@ import org.eclipse.jdt.internal.ui.wizards.IStatusChangeListener;
 import org.eclipse.jdt.internal.ui.wizards.NewWizardMessages;
 
 /**
- * A dialog to configure the external annotations attachment of a library (class folder, archives
- * and variable entries).
+ * A dialog to configure the external annotations attachment of any classpath entry.
  *
  */
 public class ExternalAnnotationsAttachmentDialog extends StatusDialog {
+
+	/**
+	 * Shows the UI for configuring an external annotations attachment. <code>null</code> is
+	 * returned when the user cancels the dialog. The dialog does not apply any changes.
+	 *
+	 * @param shell The parent shell for the dialog
+	 * @param initialEntry The entry to edit.
+	 * @param javaProject The enclosing java project, or {@code null} in which case a container
+	 * 	relative annotation path cannot be validated and has no content assist.
+	 * @return Returns the selected path, possibly different from the initialEntry,
+	 * or <code>null</code> if the dialog has been cancelled.
+	 */
+	public static IPath configureExternalAnnotationsAttachment(Shell shell, IPath initialEntry, IJavaProject javaProject) {
+		ExternalAnnotationsAttachmentDialog dialog= new ExternalAnnotationsAttachmentDialog(shell, initialEntry, javaProject);
+		if (dialog.open() == Window.OK) {
+			return dialog.getResult();
+		}
+		return null;
+	}
 
 	private ExternalAnnotationsAttachmentBlock fAnnotationsAttachmentBlock;
 
@@ -45,9 +64,10 @@ public class ExternalAnnotationsAttachmentDialog extends StatusDialog {
 	 *
 	 * @param parent Parent shell for the dialog
 	 * @param entry The entry to edit.
-	 * @param javaProject
+	 * @param javaProject The enclosing java project, or {@code null} in which case a container
+	 * 	relative annotation path cannot be validated and has no content assist.
 	 */
-	public ExternalAnnotationsAttachmentDialog(Shell parent, IPath entry, IJavaProject javaProject) {
+	protected ExternalAnnotationsAttachmentDialog(Shell parent, IPath entry, IJavaProject javaProject) {
 		super(parent);
 
 		IStatusChangeListener listener= this::updateStatus;
@@ -95,7 +115,7 @@ public class ExternalAnnotationsAttachmentDialog extends StatusDialog {
 	 *
 	 * @return the configured class path entry, or Path.EMPTY if no path was selected.
 	 */
-	public IPath getResult() {
+	protected IPath getResult() {
 		return fAnnotationsAttachmentBlock.getAnnotationsPath();
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttachmentDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttachmentDialog.java
@@ -24,6 +24,8 @@ import org.eclipse.jface.dialogs.StatusDialog;
 
 import org.eclipse.ui.PlatformUI;
 
+import org.eclipse.jdt.core.IJavaProject;
+
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.wizards.IStatusChangeListener;
 import org.eclipse.jdt.internal.ui.wizards.NewWizardMessages;
@@ -43,12 +45,13 @@ public class ExternalAnnotationsAttachmentDialog extends StatusDialog {
 	 *
 	 * @param parent Parent shell for the dialog
 	 * @param entry The entry to edit.
+	 * @param javaProject
 	 */
-	public ExternalAnnotationsAttachmentDialog(Shell parent, IPath entry) {
+	public ExternalAnnotationsAttachmentDialog(Shell parent, IPath entry, IJavaProject javaProject) {
 		super(parent);
 
 		IStatusChangeListener listener= this::updateStatus;
-		fAnnotationsAttachmentBlock= new ExternalAnnotationsAttachmentBlock(listener, entry);
+		fAnnotationsAttachmentBlock= new ExternalAnnotationsAttachmentBlock(listener, entry, javaProject);
 
 		setTitle(NewWizardMessages.ExternalAnnotationsDialog_title);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttributeConfiguration.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttributeConfiguration.java
@@ -27,7 +27,6 @@ import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.javadoc.JavaDocLocations;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
-import org.eclipse.jdt.ui.wizards.BuildPathDialogAccess;
 import org.eclipse.jdt.ui.wizards.ClasspathAttributeConfiguration;
 
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
@@ -90,7 +89,7 @@ public class ExternalAnnotationsAttributeConfiguration extends ClasspathAttribut
 	public IClasspathAttribute performEdit(Shell shell, ClasspathAttributeAccess attribute) {
 		String initialLocation= attribute.getClasspathAttribute().getValue();
 		IPath locationPath= initialLocation == null ? null : new Path(initialLocation);
-		IPath newPath= BuildPathDialogAccess.configureExternalAnnotationsAttachment(shell, locationPath, attribute.getJavaProject());
+		IPath newPath= ExternalAnnotationsAttachmentDialog.configureExternalAnnotationsAttachment(shell, locationPath, attribute.getJavaProject());
 		if(null == newPath)	// Was the dialog cancelled?
 			return null;
 		return JavaCore.newClasspathAttribute(IClasspathAttribute.EXTERNAL_ANNOTATION_PATH, newPath.segmentCount() == 0 ? null : newPath.toPortableString());

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttributeConfiguration.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ExternalAnnotationsAttributeConfiguration.java
@@ -23,6 +23,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.JavaCore;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.javadoc.JavaDocLocations;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
@@ -30,7 +31,6 @@ import org.eclipse.jdt.ui.wizards.BuildPathDialogAccess;
 import org.eclipse.jdt.ui.wizards.ClasspathAttributeConfiguration;
 
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.ui.wizards.NewWizardMessages;
 
 public class ExternalAnnotationsAttributeConfiguration extends ClasspathAttributeConfiguration {
@@ -90,7 +90,7 @@ public class ExternalAnnotationsAttributeConfiguration extends ClasspathAttribut
 	public IClasspathAttribute performEdit(Shell shell, ClasspathAttributeAccess attribute) {
 		String initialLocation= attribute.getClasspathAttribute().getValue();
 		IPath locationPath= initialLocation == null ? null : new Path(initialLocation);
-		IPath newPath= BuildPathDialogAccess.configureExternalAnnotationsAttachment(shell, locationPath);
+		IPath newPath= BuildPathDialogAccess.configureExternalAnnotationsAttachment(shell, locationPath, attribute.getJavaProject());
 		if(null == newPath)	// Was the dialog cancelled?
 			return null;
 		return JavaCore.newClasspathAttribute(IClasspathAttribute.EXTERNAL_ANNOTATION_PATH, newPath.segmentCount() == 0 ? null : newPath.toPortableString());

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/BuildPathDialogAccess.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/BuildPathDialogAccess.java
@@ -155,26 +155,7 @@ public final class BuildPathDialogAccess {
 	 * @since 3.11
 	 */
 	public static IPath configureExternalAnnotationsAttachment(Shell shell, IPath initialEntry) {
-		return configureExternalAnnotationsAttachment(shell, initialEntry,  null);
-	}
-
-	/**
-	 * Shows the UI for configuring an external annotations attachment. <code>null</code> is
-	 * returned when the user cancels the dialog. The dialog does not apply any changes.
-	 *
-	 * @param shell The parent shell for the dialog
-	 * @param initialEntry The entry to edit.
-	 * @param javaProject The enclosing java project
-	 * @return Returns the selected path, possibly different from the initialEntry,
-	 * or <code>null</code> if the dialog has been cancelled.
-	 * @since 3.27
-	 */
-	public static IPath configureExternalAnnotationsAttachment(Shell shell, IPath initialEntry, IJavaProject javaProject) {
-		ExternalAnnotationsAttachmentDialog dialog= new ExternalAnnotationsAttachmentDialog(shell, initialEntry, javaProject);
-		if (dialog.open() == Window.OK) {
-			return dialog.getResult();
-		}
-		return null;
+		return ExternalAnnotationsAttachmentDialog.configureExternalAnnotationsAttachment(shell, initialEntry, null);
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/BuildPathDialogAccess.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/BuildPathDialogAccess.java
@@ -44,13 +44,13 @@ import org.eclipse.ui.views.navigator.ResourceComparator;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.javadoc.JavaDocLocations;
 
 import org.eclipse.jdt.ui.JavaUI;
 
 import org.eclipse.jdt.internal.ui.IUIConstants;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.ui.viewsupport.FilteredElementTreeSelectionDialog;
 import org.eclipse.jdt.internal.ui.wizards.NewWizardMessages;
 import org.eclipse.jdt.internal.ui.wizards.TypedElementSelectionValidator;
@@ -155,7 +155,22 @@ public final class BuildPathDialogAccess {
 	 * @since 3.11
 	 */
 	public static IPath configureExternalAnnotationsAttachment(Shell shell, IPath initialEntry) {
-		ExternalAnnotationsAttachmentDialog dialog= new ExternalAnnotationsAttachmentDialog(shell, initialEntry);
+		return configureExternalAnnotationsAttachment(shell, initialEntry,  null);
+	}
+
+	/**
+	 * Shows the UI for configuring an external annotations attachment. <code>null</code> is
+	 * returned when the user cancels the dialog. The dialog does not apply any changes.
+	 *
+	 * @param shell The parent shell for the dialog
+	 * @param initialEntry The entry to edit.
+	 * @param javaProject The enclosing java project
+	 * @return Returns the selected path, possibly different from the initialEntry,
+	 * or <code>null</code> if the dialog has been cancelled.
+	 * @since 3.27
+	 */
+	public static IPath configureExternalAnnotationsAttachment(Shell shell, IPath initialEntry, IJavaProject javaProject) {
+		ExternalAnnotationsAttachmentDialog dialog= new ExternalAnnotationsAttachmentDialog(shell, initialEntry, javaProject);
 		if (dialog.open() == Window.OK) {
 			return dialog.getResult();
 		}


### PR DESCRIPTION
Fixes #315


## What it does
Adds a 3rd option to the dialog by which "annotationpath" details are edited in the Java Build Path page. This option consists of two fields:
* Selection among the classpath containers used in the current Java project
* Name of a resolved element within the selected classpath container. Here "name" is loosely used as any prefix of the element names, which ends at some word "boundary" (a char other than letter or digit). This interpretation should support ignoring customary suffixes like version, classifier, file extension...

The 1st field is a drop down with available container names (which internally will be mapped to the actual container ID).

The 2nd field offers content assist and is also validated against the actual resolved elements of the container.

Open OK, the dialog creates a proper "annotationpath" attribute according to eclipse-jdt/eclipse.jdt.core#23.

## How to test
* Configure a project to use annotation based null analysis.
* Add a dependency on a project / artifact containing .eea files
* Open the projects **Java Build Path** page, select any classpath entry, and edit its **External annotations** attribute.
* Select **Container relative** and edit the details to point to the .eea artifact from step (2)
* After **Apply** the corresponding "annotationpath" attribute should be seen in `.classpath`