### PR TITLE
Javadocbug

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.hover;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -152,7 +154,7 @@ public class JavadocHoverTests extends CoreTests {
 			    " * <pre>{@code\n" +
 			    " *    for (String s : strings) {\n" +
 			    " *        if (s.equals(value)) {\n" +
-			    " * 	          return 0;\n" +
+			    " *            return 0;\n" +
 			    " *        }\n" +
 			    " *        if (s.startsWith(value)) {\n" +
 			    " *            return 1;\n" +
@@ -186,7 +188,7 @@ public class JavadocHoverTests extends CoreTests {
 			String expectedCodeSequence= "<pre><code>\n"
 					+ "    for (String s : strings) {\n"
 					+ "        if (s.equals(value)) {\n"
-					+ " 	          return 0;>\n"
+					+ "            return 0;\n"
 					+ "        }\n"
 					+ "        if (s.startsWith(value)) {\n"
 					+ "            return 1;\n"
@@ -196,7 +198,10 @@ public class JavadocHoverTests extends CoreTests {
 					+ " </code></pre>";
 
 			// value should be expanded:
-			assertTrue(actualHtmlContent, actualHtmlContent.contains(expectedCodeSequence));
+			int index= actualHtmlContent.indexOf("<pre><code>");
+			assertFalse(index == -1);
+			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
+			assertEquals("sequence doesn't match", actualSnippet, expectedCodeSequence);
 		}
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
@@ -1436,6 +1436,13 @@ public class JavadocContentAccess2 {
 					++fPreCounter;
 				} else if (text.equals("</pre>")) { //$NON-NLS-1$
 					--fPreCounter;
+				} else if (fPreCounter > 0 && text.matches("}\\s*</pre>")) { //$NON-NLS-1$
+					// this is a temporary workaround for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/316
+					// as the parser for @code is treating the first } it finds as the end of the code
+					// sequence but this is not the case for a <pre>{@code sequence which goes over
+					// multiple lines and may contain }'s that are part of the code
+					--fPreCounter;
+					text= "</pre>"; //$NON-NLS-1$
 				}
 				handleText(text);
 			} else if (child instanceof TagElement) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
@@ -471,6 +471,7 @@ public class JavadocContentAccess2 {
 	private StringBuffer[] fTypeParamDescriptions;
 	private StringBuffer[] fParamDescriptions;
 	private HashMap<String, StringBuffer> fExceptionDescriptions;
+	private int fPreCounter;
 
 	private JavadocContentAccess2(IJavaElement element, Javadoc javadoc, String source, JavadocLookup lookup) {
 		Assert.isNotNull(element);
@@ -1387,10 +1388,14 @@ public class JavadocContentAccess2 {
 
 
 	private void handleContentElements(List<? extends ASTNode> nodes) {
-		handleContentElements(nodes, false);
+		handleContentElements(nodes, false, null);
 	}
 
-	private void handleContentElements(List<? extends ASTNode> nodes, boolean skipLeadingWhitespace) {
+	private void handleContentElements(List<? extends ASTNode> nodes, boolean skipLeadingWhiteSpace) {
+		handleContentElements(nodes, skipLeadingWhiteSpace, null);
+	}
+
+	private void handleContentElements(List<? extends ASTNode> nodes, boolean skipLeadingWhitespace, TagElement tagElement) {
 		ASTNode previousNode= null;
 		for (ASTNode child : nodes) {
 			if (previousNode != null) {
@@ -1411,6 +1416,13 @@ public class JavadocContentAccess2 {
 					String text= removeDocLineIntros(textWithStars);
 					fBuf.append(text);
 				}
+			} else if (tagElement != null && fPreCounter >= 1) {
+				int childStart= child.getStartPosition();
+				int previousEnd= tagElement.getStartPosition() + tagElement.getTagName().length() + 1;
+				// Need to preserve whitespace before a node in a <pre> section
+				String textWithStars= fSource.substring(previousEnd, childStart);
+				String text= removeDocLineIntros(textWithStars);
+				fBuf.append(text);
 			}
 			previousNode= child;
 			if (child instanceof TextElement) {
@@ -1420,6 +1432,11 @@ public class JavadocContentAccess2 {
 				}
 				// workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=233481 :
 				text= text.replaceAll("(\r\n?|\n)([ \t]*\\*)", "$1"); //$NON-NLS-1$ //$NON-NLS-2$
+				if (text.equals("<pre>")) { //$NON-NLS-1$
+					++fPreCounter;
+				} else if (text.equals("</pre>")) { //$NON-NLS-1$
+					--fPreCounter;
+				}
 				handleText(text);
 			} else if (child instanceof TagElement) {
 				handleInlineTagElement((TagElement) child);
@@ -1502,7 +1519,7 @@ public class JavadocContentAccess2 {
 		else if (isIndex)
 			handleIndex(node.fragments());
 		else if (isCode || isLiteral)
-			handleContentElements(node.fragments(), true);
+			handleContentElements(node.fragments(), true, node);
 		else if (isSnippet) {
 			handleSnippet(node);
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
@@ -1432,11 +1432,11 @@ public class JavadocContentAccess2 {
 				}
 				// workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=233481 :
 				text= text.replaceAll("(\r\n?|\n)([ \t]*\\*)", "$1"); //$NON-NLS-1$ //$NON-NLS-2$
-				if (text.equals("<pre>")) { //$NON-NLS-1$
+				if (tagElement == null && text.equals("<pre>")) { //$NON-NLS-1$
 					++fPreCounter;
-				} else if (text.equals("</pre>")) { //$NON-NLS-1$
+				} else if (tagElement == null && text.equals("</pre>")) { //$NON-NLS-1$
 					--fPreCounter;
-				} else if (fPreCounter > 0 && text.matches("}\\s*</pre>")) { //$NON-NLS-1$
+				} else if (tagElement == null && fPreCounter > 0 && text.matches("}\\s*</pre>")) { //$NON-NLS-1$
 					// this is a temporary workaround for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/316
 					// as the parser for @code is treating the first } it finds as the end of the code
 					// sequence but this is not the case for a <pre>{@code sequence which goes over
@@ -1444,7 +1444,7 @@ public class JavadocContentAccess2 {
 					--fPreCounter;
 					text= "</code></pre>"; //$NON-NLS-1$
 					int lastCodeEnd= fBuf.lastIndexOf("</code>"); //$NON-NLS-1$
-					fBuf.replace(lastCodeEnd, lastCodeEnd + 6, ""); //$NON-NLS-1$
+					fBuf.replace(lastCodeEnd, lastCodeEnd + 7, ""); //$NON-NLS-1$
 				}
 				handleText(text);
 			} else if (child instanceof TagElement) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavadocContentAccess2.java
@@ -1442,7 +1442,9 @@ public class JavadocContentAccess2 {
 					// sequence but this is not the case for a <pre>{@code sequence which goes over
 					// multiple lines and may contain }'s that are part of the code
 					--fPreCounter;
-					text= "</pre>"; //$NON-NLS-1$
+					text= "</code></pre>"; //$NON-NLS-1$
+					int lastCodeEnd= fBuf.lastIndexOf("</code>"); //$NON-NLS-1$
+					fBuf.replace(lastCodeEnd, lastCodeEnd + 6, ""); //$NON-NLS-1$
 				}
 				handleText(text);
 			} else if (child instanceof TagElement) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Fixes Javadoc hover when <pre>{@code ... }</pre> is used for a code sequence.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
