### PR TITLE
Fix the Java editor not saving HTML to Clipboard (#89)

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
@@ -30,6 +30,7 @@ import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.dnd.ByteArrayTransfer;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.HTMLTransfer;
 import org.eclipse.swt.dnd.RTFTransfer;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
@@ -425,8 +426,8 @@ public final class ClipboardOperationAction extends TextEditorAction {
 				if (textData == null)
 					return;
 
-				ArrayList<Object> datas= new ArrayList<>(3);
-				ArrayList<ByteArrayTransfer> transfers= new ArrayList<>(3);
+				ArrayList<Object> datas= new ArrayList<>(4);
+				ArrayList<ByteArrayTransfer> transfers= new ArrayList<>(4);
 				datas.add(textData);
 				transfers.add(TextTransfer.getInstance());
 
@@ -434,6 +435,12 @@ public final class ClipboardOperationAction extends TextEditorAction {
 				if (rtfData != null) {
 					datas.add(rtfData);
 					transfers.add(RTFTransfer.getInstance());
+				}
+
+				Object htmlData= clipboard.getContents(HTMLTransfer.getInstance());
+				if (htmlData != null) {
+					datas.add(htmlData);
+					transfers.add(HTMLTransfer.getInstance());
 				}
 
 				datas.add(clipboardData);


### PR DESCRIPTION
## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

---

The original bug was filed here:
https://github.com/eclipse-platform/eclipse.platform.text/issues/101

Very likely that is the wrong place, but at the time I didn't know where the fix will end up.
Let me know if you want me to file an equivalent bug here (or close than one and open it here)

Thank you,
Mihai