### PR TITLE
Fix new method creation to add required type parameters

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
@@ -403,7 +403,7 @@ public class UnresolvedMethodsQuickFixTest1d8 extends QuickFixTest {
 	}
 
 	@Test
-	public void testCreateMethodQuickFix8() throws Exception {
+	public void testCreateMethodIssue322_1() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		StringBuilder buf= new StringBuilder();
 		buf.append("package test1;\n");
@@ -427,6 +427,128 @@ public class UnresolvedMethodsQuickFixTest1d8 extends QuickFixTest {
 		buf.append("    }\n");
 		buf.append("\n");
 		buf.append("    private static <T> void test(T a, T a2) {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
+	@Test
+	public void testCreateMethodIssue322_2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T, U> void test(T a, U b) {\n");
+		buf.append("        test(a);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 3);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T, U> void test(T a, U b) {\n");
+		buf.append("        test(a);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static <T> void test(T a) {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
+	@Test
+	public void testCreateMethodIssue322_3() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T extends U, U> void test(T a, U b) {\n");
+		buf.append("        test(a);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 3);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T extends U, U> void test(T a, U b) {\n");
+		buf.append("        test(a);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static <T extends U, U> void test(T a) {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
+	@Test
+	public void testCreateMethodIssue322_4() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T extends U, U> U test(T a, U b) {\n");
+		buf.append("        return test(a);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 3);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T extends U, U> U test(T a, U b) {\n");
+		buf.append("        return test(a);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static <U, T extends U> U test(T a) {\n");
+		buf.append("        return null;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
+	@Test
+	public void testCreateMethodIssue322_5() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T extends U, U> U test(T a) {\n");
+		buf.append("        return test(a, a);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 3);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T extends U, U> U test(T a) {\n");
+		buf.append("        return test(a, a);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static <U, T extends U> U test(T a, T a2) {\n");
+		buf.append("        return null;\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -401,6 +401,37 @@ public class UnresolvedMethodsQuickFixTest1d8 extends QuickFixTest {
 		buf.append("}\n");
 		assertEqualStringsIgnoreOrder(new String[] { getPreviewContent(proposal) }, new String[] { buf.toString() });
 	}
+
+	@Test
+	public void testCreateMethodQuickFix8() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T> void test(T a) {\n");
+		buf.append("        test(a, a);      // error here\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 3);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <T> void test(T a) {\n");
+		buf.append("        test(a, a);      // error here\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static <T> void test(T a, T a2) {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
 	@Test
 	public void testBug514213_avoidRedundantNonNullWhenCreatingMissingMethodForOverride() throws Exception {
 		Hashtable<String, String> options= JavaCore.getOptions();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewMethodCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewMethodCorrectionProposal.java
@@ -328,26 +328,28 @@ public class NewMethodCorrectionProposal extends AbstractMethodCorrectionProposa
 
 		ITypeBinding returnTypeBinding= null;
 
-		if (node.getParent() instanceof MethodInvocation) {
-			MethodInvocation parent= (MethodInvocation) node.getParent();
-			if (parent.getExpression() == node) {
-				ITypeBinding[] bindings= ASTResolving.getQualifierGuess(node.getRoot(), parent.getName().getIdentifier(), parent.arguments(), getSenderBinding());
-				if (bindings.length > 0) {
-					returnTypeBinding= bindings[0];
+		if (!isConstructor()) {
+			if (node.getParent() instanceof MethodInvocation) {
+				MethodInvocation parent= (MethodInvocation) node.getParent();
+				if (parent.getExpression() == node) {
+					ITypeBinding[] bindings= ASTResolving.getQualifierGuess(node.getRoot(), parent.getName().getIdentifier(), parent.arguments(), getSenderBinding());
+					if (bindings.length > 0) {
+						returnTypeBinding= bindings[0];
+					}
 				}
 			}
-		}
-		if (returnTypeBinding == null) {
-			ITypeBinding binding= ASTResolving.guessBindingForReference(node);
-			if (binding != null && binding.isWildcardType()) {
-				binding= ASTResolving.normalizeWildcardType(binding, false, ast);
+			if (returnTypeBinding == null) {
+				ITypeBinding binding= ASTResolving.guessBindingForReference(node);
+				if (binding != null && binding.isWildcardType()) {
+					binding= ASTResolving.normalizeWildcardType(binding, false, ast);
+				}
+				returnTypeBinding= binding;
 			}
-			returnTypeBinding= binding;
-		}
 
-		if (returnTypeBinding != null) {
-			IMethodBinding mbinding= returnTypeBinding.getDeclaringMethod();
-			getTypeParameters(returnTypeBinding, mbinding, typeParametersFound);
+			if (returnTypeBinding != null) {
+				IMethodBinding mbinding= returnTypeBinding.getDeclaringMethod();
+				getTypeParameters(returnTypeBinding, mbinding, typeParametersFound);
+			}
 		}
 
 		List<Expression> arguments= fArguments;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewMethodCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewMethodCorrectionProposal.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.text.correction.proposals;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -304,13 +304,53 @@ public class NewMethodCorrectionProposal extends AbstractMethodCorrectionProposa
 	protected void addNewExceptions(ASTRewrite rewrite, List<Type> exceptions, ImportRewriteContext context) throws CoreException {
 	}
 
+	private void getTypeParameters(ITypeBinding binding, IMethodBinding methodBinding, Set<ITypeBinding> typeParametersFound) {
+		if (methodBinding != null) {
+			ITypeBinding[] typeParameters= methodBinding.getTypeParameters();
+			for (ITypeBinding typeParameter : typeParameters) {
+				if (typeParameter.isEqualTo(binding)) {
+					typeParametersFound.add(typeParameter);
+					ITypeBinding[] typeBounds= typeParameter.getTypeBounds();
+					for (ITypeBinding typeBound : typeBounds) {
+						getTypeParameters(typeBound, methodBinding, typeParametersFound);
+					}
+				}
+			}
+		}
+	}
+
 	@Override
-	protected void addNewTypeParameters(ASTRewrite rewrite, List<String> takenNames, List<TypeParameter> params, ImportRewriteContext context) throws CoreException {
+	protected void addNewTypeParameters(ASTRewrite rewrite, List<String> takenNames, List<TypeParameter> params,
+			ImportRewriteContext context) throws CoreException {
 		AST ast= rewrite.getAST();
+		ASTNode node= getInvocationNode();
+		Set<ITypeBinding> typeParametersFound= new LinkedHashSet<>();
+
+		ITypeBinding returnTypeBinding= null;
+
+		if (node.getParent() instanceof MethodInvocation) {
+			MethodInvocation parent= (MethodInvocation) node.getParent();
+			if (parent.getExpression() == node) {
+				ITypeBinding[] bindings= ASTResolving.getQualifierGuess(node.getRoot(), parent.getName().getIdentifier(), parent.arguments(), getSenderBinding());
+				if (bindings.length > 0) {
+					returnTypeBinding= bindings[0];
+				}
+			}
+		}
+		if (returnTypeBinding == null) {
+			ITypeBinding binding= ASTResolving.guessBindingForReference(node);
+			if (binding != null && binding.isWildcardType()) {
+				binding= ASTResolving.normalizeWildcardType(binding, false, ast);
+			}
+			returnTypeBinding= binding;
+		}
+
+		if (returnTypeBinding != null) {
+			IMethodBinding mbinding= returnTypeBinding.getDeclaringMethod();
+			getTypeParameters(returnTypeBinding, mbinding, typeParametersFound);
+		}
 
 		List<Expression> arguments= fArguments;
-
-		Set<ITypeBinding> typeParametersFound= new HashSet<>();
 
 		for (int i= 0; i < arguments.size(); i++) {
 			Expression elem= arguments.get(i);
@@ -319,18 +359,19 @@ public class NewMethodCorrectionProposal extends AbstractMethodCorrectionProposa
 				binding= ASTResolving.normalizeWildcardType(binding, true, ast);
 			}
 			if (binding != null) {
-				IMethodBinding mbinding= binding.getDeclaringMethod();
-				if (mbinding != null) {
-					ITypeBinding[] bindings= mbinding.getTypeParameters();
-					for (ITypeBinding m : bindings) {
-						if (m.isEqualTo(binding) && !typeParametersFound.contains(binding)) {
-							typeParametersFound.add(m);
-							TypeParameter newTypeParameter= ast.newTypeParameter();
-							newTypeParameter.setName(ast.newSimpleName(m.getName()));
-							params.add(newTypeParameter);
-						}
-					}
-				}
+				getTypeParameters(binding, binding.getDeclaringMethod(), typeParametersFound);
+			}
+		}
+
+		for (ITypeBinding m : typeParametersFound) {
+			TypeParameter newTypeParameter= ast.newTypeParameter();
+			newTypeParameter.setName(ast.newSimpleName(m.getName()));
+			params.add(newTypeParameter);
+			ITypeBinding[] bounds= m.getTypeBounds();
+			List<Type> newTypeBounds= newTypeParameter.typeBounds();
+			for (ITypeBinding bound : bounds) {
+				Type t= getImportRewrite().addImport(bound, ast, context, TypeLocation.TYPE_PARAMETER);
+				newTypeBounds.add(t);
 			}
 		}
 	}


### PR DESCRIPTION

## What it does
Fixes the case where a new method is created and requires its own type parameters.

## How to test
See: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/322

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
