### PR TITLE
More fixes for new method creation proposal

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest1d8.java
@@ -555,6 +555,141 @@ public class UnresolvedMethodsQuickFixTest1d8 extends QuickFixTest {
 	}
 
 	@Test
+	public void testCreateMethodIssue330_1() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    private static class Class1<T> {\n");
+		buf.append("        T t;\n");
+		buf.append("        Class2<T> c2;\n");
+		buf.append("        \n");
+		buf.append("        T method() {\n");
+		buf.append("            return c2.useT(t);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static class Class2<U> {\n");
+		buf.append("\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 2);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    private static class Class1<T> {\n");
+		buf.append("        T t;\n");
+		buf.append("        Class2<T> c2;\n");
+		buf.append("        \n");
+		buf.append("        T method() {\n");
+		buf.append("            return c2.useT(t);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static class Class2<U> {\n");
+		buf.append("\n");
+		buf.append("        public U useT(U t) {\n");
+		buf.append("            return null;\n");
+		buf.append("        }\n");
+		buf.append("\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
+	@Test
+	public void testCreateMethodIssue330_2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <K> void test(K t) {\n");
+		buf.append("        Class2<K> c2 = new Class2<>();\n");
+		buf.append("        c2.useT(t);\n");
+		buf.append("       \n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static class Class2<U> {\n");
+		buf.append("\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 2);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static <K> void test(K t) {\n");
+		buf.append("        Class2<K> c2 = new Class2<>();\n");
+		buf.append("        c2.useT(t);\n");
+		buf.append("       \n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static class Class2<U> {\n");
+		buf.append("\n");
+		buf.append("        public void useT(U t) {\n");
+		buf.append("        }\n");
+		buf.append("\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
+	@Test
+	public void testCreateMethodIssue330_3() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    private static class Class1<T> {\n");
+		buf.append("        <K> void test(T t) {\n");
+		buf.append("            Class2<K> c2 = new Class2<>();\n");
+		buf.append("            c2.useT(t);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static class Class2<U> {\n");
+		buf.append("\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+		assertNumberOfProposals(proposals, 2);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    private static class Class1<T> {\n");
+		buf.append("        <K> void test(T t) {\n");
+		buf.append("            Class2<K> c2 = new Class2<>();\n");
+		buf.append("            c2.useT(t);\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private static class Class2<U> {\n");
+		buf.append("\n");
+		buf.append("        public <T> void useT(T t) {\n");
+		buf.append("        }\n");
+		buf.append("\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertExpectedExistInProposals(proposals, new String[] { buf.toString() });
+	}
+
+	@Test
 	public void testBug514213_avoidRedundantNonNullWhenCreatingMissingMethodForOverride() throws Exception {
 		Hashtable<String, String> options= JavaCore.getOptions();
 		options.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, JavaCore.ENABLED);


### PR DESCRIPTION
- refine type parameter logic to handle substitution of class type parameters when appropriate
- also handle adding type parameters when needed that may come from either the enclosing method or from a type
- add new tests to UnresolvedMethodsQuickFixTest1d8
- fixes #330

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the new method creation quick fix for a missing method so it handles the case where type parameters are needed
in the new method.  It also handles the case where the type parameter names need to be changed to match existing
type parameters for the class that the new method is being created.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue #330 

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
