### PR TITLE
Improve the Safety of Extract Local Variable Refactorings concering ClassCasts #331

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test126_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test126_in.java
@@ -1,0 +1,12 @@
+package p; //6, 32, 6, 58
+
+class A {
+	void foo(Object obj) {
+		if (obj instanceof Integer && ((Integer) obj).intValue() > 0) {
+			System.out.println(((Integer) obj).intValue());
+		} else if (obj instanceof Float && ((Float) obj).floatValue() > 0.0) {
+			System.out.println(((Float) obj).floatValue());
+		}
+
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test126_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test126_out.java
@@ -1,0 +1,13 @@
+package p; //6, 32, 6, 58
+
+class A {
+	void foo(Object obj) {
+		if (obj instanceof Integer && ((Integer) obj).intValue() > 0) {
+			int intValue= ((Integer) obj).intValue();
+			System.out.println(intValue);
+		} else if (obj instanceof Float && ((Float) obj).floatValue() > 0.0) {
+			System.out.println(((Float) obj).floatValue());
+		}
+
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test127_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test127_in.java
@@ -1,0 +1,53 @@
+package p; //6, 32, 6, 47
+
+class A {
+	void method(B b) {
+		if (b instanceof D) {
+			System.out.println(((C) b).getV2());
+		}
+		if (b instanceof C) {
+			System.out.println(((C) b).getV2());
+		}
+
+	}
+}
+
+
+class B {
+	int v1;
+
+	public B(int v1) {
+		super();
+		this.v1 = v1;
+	}
+
+	public int getV1() {
+		return v1;
+	}
+}
+
+class C extends B {
+	int v2;
+
+	public C(int v2) {
+		super(v2 * 10);
+		this.v2 = v2;
+	}
+
+	public int getV2() {
+		return v2;
+	}
+}
+
+class D extends C {
+	int v3;
+
+	public D(int v3) {
+		super(v3 * 10);
+		this.v3 = v3;
+	}
+
+	public int getV3() {
+		return v3;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test127_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test127_out.java
@@ -1,0 +1,55 @@
+package p; //6, 32, 6, 47
+
+class A {
+	void method(B b) {
+		if (b instanceof D) {
+			int v2= ((C) b).getV2();
+			System.out.println(v2);
+		}
+		if (b instanceof C) {
+			int v22= ((C) b).getV2();
+			System.out.println(v22);
+		}
+
+	}
+}
+
+
+class B {
+	int v1;
+
+	public B(int v1) {
+		super();
+		this.v1 = v1;
+	}
+
+	public int getV1() {
+		return v1;
+	}
+}
+
+class C extends B {
+	int v2;
+
+	public C(int v2) {
+		super(v2 * 10);
+		this.v2 = v2;
+	}
+
+	public int getV2() {
+		return v2;
+	}
+}
+
+class D extends C {
+	int v3;
+
+	public D(int v3) {
+		super(v3 * 10);
+		this.v3 = v3;
+	}
+
+	public int getV3() {
+		return v3;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test128_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test128_in.java
@@ -1,0 +1,17 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		if (obj instanceof CC && ((I6) obj).hashCode() > 0) {
+			System.out.println(((I6) obj).hashCode());
+		} 
+	}
+}
+class CP implements I2,I5{}
+class CR extends CP {}
+class CC extends CR {}
+interface I2 extends I3{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test128_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test128_out.java
@@ -1,0 +1,18 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		if (obj instanceof CC && ((I6) obj).hashCode() > 0) {
+			int hashCode= ((I6) obj).hashCode();
+			System.out.println(hashCode);
+		} 
+	}
+}
+class CP implements I2,I5{}
+class CR extends CP {}
+class CC extends CR {}
+interface I2 extends I3{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test129_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test129_in.java
@@ -1,0 +1,18 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		if (obj instanceof CC && ((I7) obj).hashCode() > 0) {
+			System.out.println(((I7) obj).hashCode());
+		} 
+	}
+}
+class CP implements I2,I5{}
+class CR extends CP {}
+class CC extends CR {}
+interface I2 extends I3{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}
+interface I7 extends I6{}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test129_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test129_out.java
@@ -1,0 +1,19 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		int hashCode= ((I7) obj).hashCode();
+		if (obj instanceof CC && hashCode > 0) {
+			System.out.println(hashCode);
+		} 
+	}
+}
+class CP implements I2,I5{}
+class CR extends CP {}
+class CC extends CR {}
+interface I2 extends I3{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}
+interface I7 extends I6{}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test130_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test130_in.java
@@ -1,0 +1,15 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		if (obj instanceof I2 && ((I6) obj).hashCode() > 0) {
+			System.out.println(((I6) obj).hashCode());
+		} 
+	}
+}
+interface I2 extends I3,I4{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}
+interface I7 extends I6{}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test130_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test130_out.java
@@ -1,0 +1,16 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		if (obj instanceof I2 && ((I6) obj).hashCode() > 0) {
+			int hashCode= ((I6) obj).hashCode();
+			System.out.println(hashCode);
+		} 
+	}
+}
+interface I2 extends I3,I4{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}
+interface I7 extends I6{}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test131_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test131_in.java
@@ -1,0 +1,15 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		if (obj instanceof I3 && ((I7) obj).hashCode() > 0) {
+			System.out.println(((I7) obj).hashCode());
+		} 
+	}
+}
+interface I2 extends I3,I4{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}
+interface I7 extends I6{}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test131_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test131_out.java
@@ -1,0 +1,16 @@
+package p; //5, 34, 5, 55
+
+public class A {
+	void foo(Object obj) {
+		int hashCode= ((I7) obj).hashCode();
+		if (obj instanceof I3 && hashCode > 0) {
+			System.out.println(hashCode);
+		} 
+	}
+}
+interface I2 extends I3,I4{}
+interface I3 {}
+interface I4 extends I5{}
+interface I5 extends I6{}
+interface I6 {}
+interface I7 extends I6{}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
@@ -878,14 +878,38 @@ public class ExtractTempTests extends GenericRefactoringTest {
 
 	@Test
 	public void test126() throws Exception {
-		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/39
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/331
 		helper1(6, 32, 6, 58, true, false, "intValue", "intValue");
 	}
 
 	@Test
 	public void test127() throws Exception {
-		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/39
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/331
 		helper1(6, 32, 6, 47, true, false, "v2", "v2");
+	}
+
+	@Test
+	public void test128() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/331
+		helper1(5, 34, 5, 55, true, false, "hashCode", "hashCode");
+	}
+
+	@Test
+	public void test129() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/331
+		helper1(5, 34, 5, 55, true, false, "hashCode", "hashCode");
+	}
+
+	@Test
+	public void test130() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/331
+		helper1(5, 34, 5, 55, true, false, "hashCode", "hashCode");
+	}
+
+	@Test
+	public void test131() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/331
+		helper1(5, 34, 5, 55, true, false, "hashCode", "hashCode");
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
@@ -877,6 +877,18 @@ public class ExtractTempTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void test126() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/39
+		helper1(6, 32, 6, 58, true, false, "intValue", "intValue");
+	}
+
+	@Test
+	public void test127() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/39
+		helper1(6, 32, 6, 47, true, false, "v2", "v2");
+	}
+
+	@Test
 	public void testZeroLengthSelection0() throws Exception {
 //		printTestDisabledMessage("test for bug 30146");
 		helper1(4, 18, 4, 18, true, false, "temp", "j");

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -135,9 +135,9 @@ import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
 import org.eclipse.jdt.internal.corext.refactoring.base.RefactoringStatusCodes;
 import org.eclipse.jdt.internal.corext.refactoring.rename.RefactoringAnalyzeUtil;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.refactoring.util.Checker;
 import org.eclipse.jdt.internal.corext.refactoring.util.JavaStatusContext;
 import org.eclipse.jdt.internal.corext.refactoring.util.NoCommentSourceRangeComputer;
-import org.eclipse.jdt.internal.corext.refactoring.util.NullChecker;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 import org.eclipse.jdt.internal.corext.refactoring.util.ResourceUtil;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -302,6 +302,7 @@ public class ExtractTempRefactoring extends Refactoring {
 	private static boolean isReferringToLocalVariableFromFor(Expression expression) {
 		ASTNode current= expression;
 		ASTNode parent= current.getParent();
+
 		while (parent != null && !(parent instanceof BodyDeclaration)) {
 			if (parent instanceof ForStatement) {
 				ForStatement forStmt= (ForStatement) parent;
@@ -676,6 +677,7 @@ public class ExtractTempRefactoring extends Refactoring {
 
 	/**
 	 * Retrieves used names for the block containing a node.
+	 *
 	 * @param selected the selected node
 	 *
 	 * @return an array of used variable names to avoid
@@ -844,10 +846,10 @@ public class ExtractTempRefactoring extends Refactoring {
 			if (insertAtSelection) {
 				ASTNode realCommonASTNode= null;
 				realCommonASTNode= evalStartAndEnd(reSortRetainOnlyReplacableMatches, selectNumber);
-				if (realCommonASTNode == null && selectNumber >=0 ) {
+				if (realCommonASTNode == null && selectNumber >= 0) {
 					fSeen.add(reSortRetainOnlyReplacableMatches[selectNumber]);
 				}
-				if (realCommonASTNode != null || reSortRetainOnlyReplacableMatches.length ==0) {
+				if (realCommonASTNode != null || reSortRetainOnlyReplacableMatches.length == 0) {
 					insertAt(getSelectedExpression().getAssociatedNode(), vds);
 				}
 				return;
@@ -891,8 +893,8 @@ public class ExtractTempRefactoring extends Refactoring {
 			}
 			commonASTNode= convertToExtractNode(commonASTNode);
 			startOffset= commonASTNode.getStartPosition() - 1;
-			NullChecker nullChecker= new NullChecker(fCompilationUnitNode, fCu, commonASTNode, expression, startOffset, endOffset);
-			if (!nullChecker.hasNullCheck()) {//at least one be extracted
+			Checker checker= new Checker(fCompilationUnitNode, fCu, commonASTNode, expression, startOffset, endOffset);
+			if (!checker.hasCheck()) {//at least one be extracted
 				fStartPoint= start;
 				fEndPoint= end;
 				realCommonASTNode= commonASTNode;
@@ -1180,6 +1182,7 @@ public class ExtractTempRefactoring extends Refactoring {
 		return fSelectedExpression;
 	}
 
+
 	private Type createTempType() throws CoreException {
 		Expression expression= getSelectedExpression().getAssociatedExpression();
 
@@ -1256,6 +1259,7 @@ public class ExtractTempRefactoring extends Refactoring {
 		Expression expression= fragment.getAssociatedExpression();
 		if (expression == null)
 			return false;
+
 		switch (expression.getNodeType()) {
 			case ASTNode.BOOLEAN_LITERAL:
 			case ASTNode.CHARACTER_LITERAL:

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -135,11 +135,11 @@ import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
 import org.eclipse.jdt.internal.corext.refactoring.base.RefactoringStatusCodes;
 import org.eclipse.jdt.internal.corext.refactoring.rename.RefactoringAnalyzeUtil;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.refactoring.util.Checker;
 import org.eclipse.jdt.internal.corext.refactoring.util.JavaStatusContext;
 import org.eclipse.jdt.internal.corext.refactoring.util.NoCommentSourceRangeComputer;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 import org.eclipse.jdt.internal.corext.refactoring.util.ResourceUtil;
+import org.eclipse.jdt.internal.corext.refactoring.util.UnsafeCheckTester;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
@@ -402,7 +402,6 @@ public class ExtractTempRefactoring extends Refactoring {
 		fSelectionLength= selectionLength;
 		fCu= unit;
 		fCompilationUnitNode= null;
-
 		fReplaceAllOccurrences= true; // default
 		fDeclareFinal= false; // default
 		fDeclareVarType= false; // default
@@ -893,8 +892,8 @@ public class ExtractTempRefactoring extends Refactoring {
 			}
 			commonASTNode= convertToExtractNode(commonASTNode);
 			startOffset= commonASTNode.getStartPosition() - 1;
-			Checker checker= new Checker(fCompilationUnitNode, fCu, commonASTNode, expression, startOffset, endOffset);
-			if (!checker.hasCheck()) {//at least one be extracted
+			UnsafeCheckTester checker= new UnsafeCheckTester(fCompilationUnitNode, fCu, commonASTNode, expression, startOffset, endOffset);
+			if (!checker.hasUnsafeCheck()) {//at least one be extracted
 				fStartPoint= start;
 				fEndPoint= end;
 				realCommonASTNode= commonASTNode;

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/util/Checker.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/util/Checker.java
@@ -215,8 +215,10 @@ public class Checker {
 			if (el < startPosition || sl > endPosition || this.nullFlag == true || this.castFlag == true) {
 				return false;
 			}
-
-			if (sl >= startPosition && el <= endPosition && node instanceof InstanceofExpression) {
+			if (!(sl >= startPosition && el <= endPosition)) {
+				return super.preVisit2(node);
+			}
+			if (node instanceof InstanceofExpression) {
 				InstanceofExpression instanceofExpression= (InstanceofExpression) node;
 				Expression leftOperand= getOriginalExpression(instanceofExpression.getLeftOperand());
 				Type rightOperand= instanceofExpression.getRightOperand();
@@ -232,26 +234,8 @@ public class Checker {
 					return false;
 				}
 			}
-
-			if (sl >= startPosition && el <= endPosition && node instanceof InstanceofExpression) {
-				InstanceofExpression instanceofExpression= (InstanceofExpression) node;
-				Expression leftOperand= getOriginalExpression(instanceofExpression.getLeftOperand());
-				Type rightOperand= instanceofExpression.getRightOperand();
-				ITypeBinding resolveBinding= rightOperand.resolveBinding();
-				IBinding targetBinding= null;
-				if (leftOperand instanceof Name &&
-						(targetBinding= ((Name) leftOperand).resolveBinding()) != null &&
-						hasInheritanceRelationship(fInvocationHashMap.get(targetBinding), resolveBinding)) {
-					this.castFlag= true;
-					return false;
-				} else if (hasInheritanceRelationship(fMatchNodePosHashMap.get(leftOperand.getStartPosition()), resolveBinding)) {
-					this.castFlag= true;
-					return false;
-				}
-			}
-
 			Expression target= null;
-			if (sl >= startPosition && el <= endPosition && node instanceof InfixExpression) {
+			if (node instanceof InfixExpression) {
 				InfixExpression infixExpression= (InfixExpression) node;
 				Operator op= infixExpression.getOperator();
 				if (Operator.toOperator(op.toString()) == Operator.EQUALS || Operator.toOperator(op.toString()) == Operator.NOT_EQUALS) {

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/util/UnsafeCheckTester.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/util/UnsafeCheckTester.java
@@ -264,17 +264,19 @@ public class UnsafeCheckTester {
 		}
 
 		private boolean hasInheritanceRelationship(ITypeBinding itb1, ITypeBinding itb2) {
-			if (itb2 == null) {
+			if (itb2 == null || itb1 == null) {
 				return false;
 			} else if (itb1 == itb2) {
 				return true;
 			}
 			ITypeBinding superclass= itb2.getSuperclass();
-			while (superclass != null) {
-				if (superclass == itb1) {
+			ITypeBinding[] interfaces= itb2.getInterfaces();
+			for (int i= 0; i < interfaces.length; ++i) {
+				if (hasInheritanceRelationship(itb1, interfaces[i]))
 					return true;
-				}
-				superclass= superclass.getSuperclass();
+			}
+			if (superclass != null && hasInheritanceRelationship(itb1, superclass)) {
+				return true;
 			}
 			return false;
 

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/util/UnsafeCheckTester.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/util/UnsafeCheckTester.java
@@ -206,7 +206,7 @@ public class UnsafeCheckTester {
 					for (IASTFragment match : allMatches) {
 						ASTNode associatedNode= match.getAssociatedNode();
 						if (associatedNode != null) {
-							fMatchNodePosSet.add(new Position(associatedNode.getStartPosition(),associatedNode.getLength()));
+							fMatchNodePosSet.add(new Position(associatedNode.getStartPosition(), associatedNode.getLength()));
 						}
 					}
 				} catch (JavaModelException e) {
@@ -269,7 +269,7 @@ public class UnsafeCheckTester {
 						hasInheritanceRelationship(fInvocationHashMap.get(targetBinding), resolveBinding)) {
 					this.castFlag= true;
 					return false;
-				} else if (hasInheritanceRelationship(fMatchNodePosHashMap.get(leftOperand.getStartPosition()), resolveBinding)) {
+				} else if (hasInheritanceRelationship(fMatchNodePosHashMap.get(new Position(leftOperand.getStartPosition(), leftOperand.getLength())), resolveBinding)) {
 					this.castFlag= true;
 					return false;
 				}
@@ -297,7 +297,7 @@ public class UnsafeCheckTester {
 				if (target instanceof Name && (targetBinding= ((Name) target).resolveBinding()) != null && fInvocationSet.contains(targetBinding)) {
 					this.nullFlag= true;
 					return false;
-				} else if (fMatchNodePosSet.contains(target.getStartPosition())) {
+				} else if (fMatchNodePosSet.contains(new Position(target.getStartPosition(), target.getLength()))) {
 					this.nullFlag= true;
 					return false;
 				}


### PR DESCRIPTION
**This is a patch based on the solution explained in the bug report.**
The main changed file is `Checker.java`, the description of the modification of this file is as follows:

## 1. Implement Void ClassCasts Exception
Compared with the solution proposed in the original issue, we apply a more generalized solution. First, we traverse the selected expression and create a mapping from expression to type for each `CastExpression`. Second, we validate the code snippet between the variable declaration and the first expression matching the selected expression. If we detect the `InstanceofExpression` and value corresponding to the key value, `leftOperand` of  `InstanceofExpression`, is equal to the `rightOperand` of  `InstanceofExpression` or its supertype, we would assert that such extracting is unsafe.

## 2. Refactoring
Considering this class not only aims at avoiding NullPointerException but also ClassCastExecption, we renamed it to `Check` and renamed the inner class `NullMiddleCodeVisitor` to `MiddleCodeVisitor`. Besides, we removed some private fields of the inner classes to make the code more concise.