### PR TITLE
Fix move to top refactoring when var variable is used

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.17.0.qualifier
+Bundle-Version: 1.17.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
@@ -663,7 +663,7 @@ public final class MoveInnerToTopRefactoring extends Refactoring {
 		Assert.isNotNull(type);
 		Assert.isNotNull(targetRewrite);
 		final ITypeBinding binding= type.resolveBinding();
-		if (binding != null) {
+		if (!type.isVar() && binding != null) {
 			final ITypeBinding declaring= binding.getDeclaringClass();
 			if (declaring != null) {
 				if (type instanceof SimpleType) {

--- a/org.eclipse.jdt.core.manipulation/pom.xml
+++ b/org.eclipse.jdt.core.manipulation/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.manipulation</artifactId>
-  <version>1.17.0-SNAPSHOT</version>
+  <version>1.17.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.14.500.qualifier
+Bundle-Version: 3.14.600.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.14.500-SNAPSHOT</version>
+  <version>3.14.600-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew10/test_Bug567020_Issue338_0/in/p1/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew10/test_Bug567020_Issue338_0/in/p1/Foo.java
@@ -1,0 +1,12 @@
+package p1;
+
+public class Foo {
+	class Bar {
+		static class X {
+			static void method() {
+				var x = new X();
+				System.out.println(x);
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew10/test_Bug567020_Issue338_0/out/p1/Bar.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew10/test_Bug567020_Issue338_0/out/p1/Bar.java
@@ -1,0 +1,13 @@
+/**
+ * 
+ */
+package p1;
+
+class Bar {
+	static class X {
+		static void method() {
+			var x = new X();
+			System.out.println(x);
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew10/test_Bug567020_Issue338_0/out/p1/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew10/test_Bug567020_Issue338_0/out/p1/Foo.java
@@ -1,0 +1,4 @@
+package p1;
+
+public class Foo {
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AllRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AllRefactoringTests.java
@@ -65,6 +65,7 @@ import org.junit.runners.Suite;
 	ExtractSupertypeTests.class,
 	MoveInnerToTopLevelTests.class,
 	MoveInnerToTopLevelTests16.class,
+	MoveInnerToNewTests10.class,
 	MoveInnerToNewTests16.class,
 	UseSupertypeWherePossibleTests.class,
 	UseSupertypeWherePossibleTests16.class,

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInnerToNewTests10.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInnerToNewTests10.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc. - created based on MoveMembersTests
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.refactoring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IType;
+
+import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTester;
+import org.eclipse.jdt.internal.corext.refactoring.structure.MoveInnerToTopRefactoring;
+
+import org.eclipse.jdt.ui.tests.refactoring.rules.Java10Setup;
+
+import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
+
+public class MoveInnerToNewTests10 extends GenericRefactoringTest {
+	private static final String REFACTORING_PATH= "MoveInnerToNew10/";
+
+	public MoveInnerToNewTests10() {
+		rts= new Java10Setup();
+	}
+
+	@Override
+	public void genericbefore() throws Exception {
+		super.genericbefore();
+		fIsPreDeltaTest= true;
+	}
+
+	@Override
+	protected String getRefactoringPath() {
+		return REFACTORING_PATH;
+	}
+
+	//---
+	private IPackageFragment createPackage(String name) throws Exception{
+		return getRoot().createPackageFragment(name, true, null);
+	}
+
+	private ICompilationUnit createCu(IPackageFragment pack, String cuPath, String cuName) throws Exception{
+		return createCU(pack, cuName, getFileContents(getRefactoringPath() + cuPath));
+	}
+
+	@Test
+	public void test_Bug567020_Issue338_0() throws Exception{
+		ParticipantTesting.reset();
+		final String p1Name= "p1";
+		final String inDir= "/in/";
+		final String outDir= "/out/";
+
+		IPackageFragment packP1= createPackage(p1Name);
+		ICompilationUnit p1Foo= createCu(packP1, getName() + inDir + p1Name + "/Foo.java", "Foo.java");
+		IType fooType= p1Foo.getTypes()[0];
+		IType barType= fooType.getTypes()[0];
+
+		assertTrue("should be enabled", RefactoringAvailabilityTester.isMoveInnerAvailable(barType));
+		MoveInnerToTopRefactoring ref= ((RefactoringAvailabilityTester.isMoveInnerAvailable(barType)) ? new MoveInnerToTopRefactoring(barType, JavaPreferencesSettings.getCodeGenerationSettings(barType.getJavaProject())) : null);
+		assertNotNull("MoveInnerToTopRefactoring should not be null", ref);
+		RefactoringStatus preconditionResult= ref.checkInitialConditions(new NullProgressMonitor());
+		assertTrue("activation was supposed to be successful" + preconditionResult.toString(), preconditionResult.isOK());
+
+
+		RefactoringStatus checkInputResult= ref.checkFinalConditions(new NullProgressMonitor());
+		assertFalse("precondition was supposed to pass", checkInputResult.hasError());
+		performChange(ref, false);
+
+		assertEquals("p1 files", 2, packP1.getChildren().length);
+
+		String expectedSource= getFileContents(getRefactoringPath() + getName() + outDir + p1Name + "/Foo.java");
+		assertEqualLines("incorrect update of Foo", expectedSource, packP1.getCompilationUnit("Foo.java").getSource());
+
+		expectedSource= getFileContents(getRefactoringPath() + getName() + outDir + p1Name + "/Bar.java");
+		assertEqualLines("incorrect creation of Bar", expectedSource, packP1.getCompilationUnit("Bar.java").getSource());
+
+	}
+
+}


### PR DESCRIPTION
- fixes #338
- don't try to qualify a var type descriptor in MoveInnerToTopRefactoring class
- add new MoveInnerToNewTests10 test

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes Bug 567020 which has an inner class moved to its own file and causes invalid code.  This is also discussed
in the issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Try the scenario described in the issue or run the new test case.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
