### PR TITLE
Add support for inline return tags

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocMessages.java
@@ -45,6 +45,8 @@ final class JavaDocMessages extends NLS {
 	public static String JavaDoc2HTMLTextReader_provides;
 	public static String JavadocContentAccess2_getproperty_message;
 	public static String JavadocContentAccess2_setproperty_message;
+	public static String JavadocContentAccess2_returns_pre;
+	public static String JavadocContentAccess2_returns_post;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, JavaDocMessages.class);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocMessages.properties
@@ -31,3 +31,5 @@ JavaDoc2HTMLTextReader_uses=Uses:
 JavaDoc2HTMLTextReader_provides=Provides:
 JavadocContentAccess2_getproperty_message=<p>Gets the value of the property {0}.</p><dl><dt>Property Description:</dt><dd>{1}</dd></dl>
 JavadocContentAccess2_setproperty_message=<p>Sets the value of the property {0}.</p><dl><dt>Property Description:</dt><dd>{1}</dd></dl>
+JavadocContentAccess2_returns_pre=Returns 
+JavadocContentAccess2_returns_post=

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocMessages.properties
@@ -32,4 +32,4 @@ JavaDoc2HTMLTextReader_provides=Provides:
 JavadocContentAccess2_getproperty_message=<p>Gets the value of the property {0}.</p><dl><dt>Property Description:</dt><dd>{1}</dd></dl>
 JavadocContentAccess2_setproperty_message=<p>Sets the value of the property {0}.</p><dl><dt>Property Description:</dt><dd>{1}</dd></dl>
 JavadocContentAccess2_returns_pre=Returns 
-JavadocContentAccess2_returns_post=
+JavadocContentAccess2_returns_post=.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
This adds support for inline return tags which were introduced in java 16.
Inline return tags along with being added with the normal tags like the normal return tag they also get inserted into the main text where the inline return tag is but prepended with "Returns " when using English.
The spec for the inline return tag is: https://docs.oracle.com/en/java/javase/19/docs/specs/javadoc/doc-comment-spec.html#return

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Add a Javadoc to a method containing an inline return tag and either hover over the method or open the Javadoc view.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
