### PR TITLE
Make quickfix that suggests importing a class smarter

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
@@ -888,9 +888,9 @@ public class UnresolvedElementsSubProcessor {
 			if ((elem.getKind() & TypeKinds.ALL_TYPES) != 0) {
 				String fullName= elem.getName();
 				if (!fullName.equals(resolvedTypeName)) {
-					if (simpleBinding != null && simpleBinding.isInterface()) {
-						// If we have an interface, we should verify that any classes we suggest to import
-						// inherit directly or implement the interface
+					if (simpleBinding != null) {
+						// If we have an expected type, we should verify that any classes we suggest to import
+						// inherit directly or indirectly from the type
 						ITypeBinding qualifiedTypeBinding= null;
 						try {
 							IJavaProject focus= simpleBinding.getJavaElement().getJavaProject();
@@ -922,16 +922,6 @@ public class UnresolvedElementsSubProcessor {
 		if (elements.length == 0) {
 			addRequiresModuleProposals(cu, node, IProposalRelevance.IMPORT_NOT_FOUND_ADD_REQUIRES_MODULE, proposals, true);
 		}
-	}
-
-	private static Type getQualifiedType(String qualifiedName, Name name) {
-		AST ast= name.getAST();
-		String[] qualifiers= qualifiedName.split("\\."); //$NON-NLS-1$
-		Type type= ast.newSimpleType(ast.newSimpleName(qualifiers[0]));
-		for (int i= 1; i < qualifiers.length; ++i) {
-			type= ast.newQualifiedType(type, ast.newSimpleName(qualifiers[i]));
-		}
-		return type;
 	}
 
 	private static boolean isInherited(ITypeBinding binding, ITypeBinding ancestorBinding) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 202 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -888,7 +888,7 @@ public class UnresolvedElementsSubProcessor {
 			if ((elem.getKind() & TypeKinds.ALL_TYPES) != 0) {
 				String fullName= elem.getName();
 				if (!fullName.equals(resolvedTypeName)) {
-					if (simpleBinding != null) {
+					if (simpleBinding != null && !simpleBinding.isPrimitive()) {
 						// If we have an expected type, we should verify that any classes we suggest to import
 						// inherit directly or indirectly from the type
 						ITypeBinding qualifiedTypeBinding= null;


### PR DESCRIPTION
- change UnresolvedElementsSubProcessor.addSimilarTypeProposals() to check if an interface is expected in which case make sure that each suggested class to import has the interface in its hierarchy
- fixes #349

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the quickfix for an undefined type that is used to initialize or return an interface so that any suggested import class has the given interface in its hierarchy.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Create the following:

```
package tests;

public class BundleInfo {
	
	public int getInt() {
		return 43;
	}

}

package tests2;

public interface ISomePath {
	
	public String getPath();

}

package tests2;

public class BundleInfo implements ISomePath {

	@Override
	public String getPath() {
		// TODO Auto-generated method stub
		return null;
	}

}

package tests3;

import tests2.ISomePath;

public class TestBundleInfo {
	
	public ISomePath getSomePath() {
		return new BundleInfo();
	}

}
```

Hover over the missing BundleInfo() creation in TestBundleInfo().  The quickfix should only suggest the version of BundleInfo that implements ISomePath.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
