### PR TITLE
Fix scope calculation for surround with try/catch and resources

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryWithResourcesRefactoringCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryWithResourcesRefactoringCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -216,7 +216,10 @@ public class SurroundWithTryWithResourcesRefactoringCore extends Refactoring {
 
 			fLinkedProposalModel= createLinkedProposalModel();
 
-			fScope= CodeScopeBuilder.perform(fAnalyzer.getEnclosingBodyDeclaration(), fSelection).
+			BodyDeclaration enclosingBodyDeclaration= fAnalyzer.getEnclosingBodyDeclaration();
+			Selection ignoreSelection= Selection.createFromStartEnd(fSelection.getOffset(),
+					enclosingBodyDeclaration.getStartPosition() + enclosingBodyDeclaration.getLength());
+			fScope= CodeScopeBuilder.perform(enclosingBodyDeclaration, ignoreSelection).
 				findScope(fSelection.getOffset(), fSelection.getLength());
 			fScope.setCursor(fSelection.getOffset());
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/trycatch_in/TestIssue353.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/trycatch_in/TestIssue353.java
@@ -1,0 +1,12 @@
+package trycatch_in;
+
+public class TestIssue353 {
+	public void foo() {
+		/*[*/throw new Exception();/*]*/
+		try {
+			
+		} catch (Exception e) {
+			// do nothing
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/trycatch_out/TestIssue353.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/trycatch_out/TestIssue353.java
@@ -1,0 +1,15 @@
+package trycatch_in;
+
+public class TestIssue353 {
+	public void foo() {
+		try {
+			/*[*/throw new Exception();/*]*/
+		} catch (Exception e) {
+		}
+		try {
+			
+		} catch (Exception e) {
+			// do nothing
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/tryresources18_in/TestIssue353.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/tryresources18_in/TestIssue353.java
@@ -1,0 +1,14 @@
+package trycatch18_in;
+
+import java.net.Socket;
+
+class TestIssue353 {
+	void foo(int a) {
+		/*[*/Socket s=new Socket();
+		s.getInetAddress();/*]*/
+		
+		try {
+		} catch (Exception e) {
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/tryresources18_out/TestIssue353.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/tryresources18_out/TestIssue353.java
@@ -1,0 +1,16 @@
+package trycatch18_out;
+
+import java.io.IOException;
+import java.net.Socket;
+
+class TestIssue353 {
+	void foo(int a) {
+		try (/*[*/ Socket s = new Socket()) {
+			s.getInetAddress();/*]*/
+		} catch (IOException e) {
+		}
+		try {
+		} catch (Exception e) {
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithResourcesTests1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithResourcesTests1d8.java
@@ -204,4 +204,8 @@ public class SurroundWithResourcesTests1d8 extends AbstractJunit4SelectionTestCa
 		tryResourcesTest();
 	}
 
+	@Test
+	public void testIssue353() throws Exception {
+		tryResourcesTest();
+	}
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -242,6 +242,11 @@ public class SurroundWithTests extends AbstractJunit4SelectionTestCase {
 
 	@Test
 	public void testMethodThrowsException1() throws Exception {
+		tryCatchTest();
+	}
+
+	@Test
+	public void testIssue353() throws Exception {
 		tryCatchTest();
 	}
 }

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,7 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -221,7 +222,10 @@ public class SurroundWithTryCatchRefactoring extends Refactoring {
 
 			fLinkedProposalModel= new LinkedProposalModel();
 
-			fScope= CodeScopeBuilder.perform(fAnalyzer.getEnclosingBodyDeclaration(), fSelection).
+			BodyDeclaration enclosingBodyDeclaration= fAnalyzer.getEnclosingBodyDeclaration();
+			Selection ignoreSelection= Selection.createFromStartEnd(fSelection.getOffset(),
+					enclosingBodyDeclaration.getStartPosition() + enclosingBodyDeclaration.getLength());
+			fScope= CodeScopeBuilder.perform(enclosingBodyDeclaration, ignoreSelection).
 				findScope(fSelection.getOffset(), fSelection.getLength());
 			fScope.setCursor(fSelection.getOffset());
 


### PR DESCRIPTION
- fixes #353

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the code that generates a catch clause for surround with try/catch and try-with-resources so it doesn't
unnecessarily rename the exception local variable.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See test in issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
