### PR TITLE
Show option to create a new java project in the project explorer

### DIFF
--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -6351,6 +6351,16 @@
 					</or>
 				</enablement>
 			</commonWizard>
+			<commonWizard
+	           menuGroupId="org.eclipse.jdt.ui.java"
+	           type="new"
+	           wizardId="org.eclipse.jdt.ui.wizards.JavaProjectWizard">
+		       <enablement>
+					<with variable="activeWorkbenchWindow.activePerspective">
+   						<equals value="org.eclipse.jdt.ui.JavaPerspective"/>
+   					</with>
+				</enablement>
+		    </commonWizard>
   			<dropAssistant
     			class="org.eclipse.jdt.internal.ui.navigator.JavaDropAdapterAssistant"
    				id="org.eclipse.jdt.ui.dropAssistant">


### PR DESCRIPTION
Currently if one opens the "Package Explorer" and rightclick an item the user is offered to create a new java project. On the other hand, in the "Project Explorer" this option is not offered what is confusing.

This adds a commonWizzard with a filter for the active perspective that shows this option in the "Project Explorer" as well.