### PR TITLE
Fix token for Javadoc tag in SpellCheckIterator

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/SpellCheckIterator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/SpellCheckIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -338,11 +338,11 @@ public class SpellCheckIterator implements ISpellCheckIterator {
 
 			if (fSuccessor != BreakIterator.DONE && fContent.charAt(fPrevious) == IJavaDocTagConstants.JAVADOC_TAG_PREFIX) {
 
-				int fOldNext= fNext;
+				int oldNextValue= fNext;
 				nextBreak();
 				if (Character.isLetter(fContent.charAt(fPrevious + 1))) {
 					update= true;
-					token= fContent.substring(fPrevious, fOldNext);
+					token= fContent.substring(fPrevious, oldNextValue);
 				} else
 					fPredecessor= fNext;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/SpellCheckIterator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/SpellCheckIterator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -338,10 +338,11 @@ public class SpellCheckIterator implements ISpellCheckIterator {
 
 			if (fSuccessor != BreakIterator.DONE && fContent.charAt(fPrevious) == IJavaDocTagConstants.JAVADOC_TAG_PREFIX) {
 
+				int fOldNext= fNext;
 				nextBreak();
 				if (Character.isLetter(fContent.charAt(fPrevious + 1))) {
 					update= true;
-					token= fContent.substring(fPrevious, fNext);
+					token= fContent.substring(fPrevious, fOldNext);
 				} else
 					fPredecessor= fNext;
 


### PR DESCRIPTION
- use the old next value to avoid adding whitespace to end of Javadoc tag token
- fixes #365

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes problem with spell checker flagging Javadoc tags.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Create a class with method that has at least one parameter.  Create Javadoc for the method by adding /** and hitting enter.
The Javadoc should be added and the param tag should not be flagged as a spelling error, nor should the parameter name.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
