### PR TITLE
Support Junit5 parallel test execution through RemoteTestRunner (#378)

### DIFF
--- a/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/FirstRunExecutionListener.java
+++ b/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/FirstRunExecutionListener.java
@@ -35,7 +35,7 @@ public class FirstRunExecutionListener implements IListensToTestExecutions {
 	}
 
 	@Override
-	public void notifyTestFailed(TestReferenceFailure failure) {
+	public synchronized void notifyTestFailed(TestReferenceFailure failure) {
 		sendMessage(failure.getTest(), failure.getStatus());
 		sendFailure(failure, MessageIds.TRACE_START, MessageIds.TRACE_END);
 		// fSender.flush(); // flush is implicitly done by sendFailure()

--- a/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/IListensToTestExecutions.java
+++ b/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/IListensToTestExecutions.java
@@ -16,7 +16,10 @@
 
 package org.eclipse.jdt.internal.junit.runner;
 
-
+/**
+ * Note that tests may be executed in parallel, so be aware of concurrency issues when implementing
+ * this interface.
+ */
 public interface IListensToTestExecutions {
 	void notifyTestFailed(TestReferenceFailure failure);
 

--- a/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RerunExecutionListener.java
+++ b/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RerunExecutionListener.java
@@ -27,7 +27,7 @@ public class RerunExecutionListener extends FirstRunExecutionListener {
 	private String fStatus = RemoteTestRunner.RERAN_OK;
 
 	@Override
-	public void notifyTestFailed(TestReferenceFailure failure) {
+	public synchronized void notifyTestFailed(TestReferenceFailure failure) {
 		sendFailure(failure, MessageIds.RTRACE_START, MessageIds.RTRACE_END);
 
 		String status = failure.getStatus();


### PR DESCRIPTION
## What it does

synchronized test failure notifications with multiple socket writes to prevent mixed-up output caused by calls from concurrent threads (resolves https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/378)

## How to test

(hopefully) by running parallel tests, e.g. in console mode

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
