### PR TITLE
Fix ClassCastException in SwitchExpressionFixCore

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -400,13 +400,16 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 							newBlock.statements().add(rewrite.createCopyTarget(oldSwitchCaseStatement));
 						}
 						Statement lastStatement= oldStatements.get(statementsLen - 1);
-						YieldStatement newYield= null;
-						if (lastStatement instanceof ReturnStatement) {
-							newYield= getNewYieldStatementFromReturn(cuRewrite, rewrite, (ReturnStatement)oldStatements.get(statementsLen-1));
+						Statement newStatement= null;
+						if (lastStatement instanceof ThrowStatement) {
+							ThrowStatement throwStatement= (ThrowStatement)lastStatement;
+							newStatement= (Statement)rewrite.createCopyTarget(throwStatement);
+						} else if (lastStatement instanceof ReturnStatement) {
+							newStatement= getNewYieldStatementFromReturn(cuRewrite, rewrite, (ReturnStatement)oldStatements.get(statementsLen-1));
 						} else {
-							newYield= getNewYieldStatement(cuRewrite, rewrite, (ExpressionStatement)oldStatements.get(statementsLen-1));
+							newStatement= getNewYieldStatement(cuRewrite, rewrite, (ExpressionStatement)oldStatements.get(statementsLen-1));
 						}
-						newBlock.statements().add(newYield);
+						newBlock.statements().add(newStatement);
 						newSwitchExpression.statements().add(newBlock);
 					}
 					if (needDuplicateDefault) {


### PR DESCRIPTION
- modify code that generates yield statement to be prepared for throw being last statement
- fixes #380

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes a ClassCastException that occurs when there is more than one statement in a case that ends in a throw statement.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue test case.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
