### PR TITLE
Don't do switch expression cleanup if there is an empty return statement

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
@@ -120,6 +120,9 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 					currentBlock= new ArrayList<>();
 					currentCase= switchCase;
 				} else if (statement instanceof ReturnStatement) {
+					if (((ReturnStatement)statement).getExpression() == null) {
+						return null;
+					}
 					returnList.add(currentCase);
 					if (currentBlock == null) {
 						return null;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
@@ -613,6 +613,51 @@ public class CleanUpTest14 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testConvertToSwitchExpressionIssue380() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    public void bar() {\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public int foo(int i) {\n" //
+				+ "        switch (i) {\n" //
+				+ "        case 0:\n" //
+				+ "            return 0;\n" //
+				+ "        default:\n" //
+				+ "            bar(); //\n" //
+				+ "            throw new AssertionError();\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    public void bar() {\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public int foo(int i) {\n" //
+				+ "        return switch (i) {\n" //
+				+ "            case 0 -> 0;\n" //
+				+ "            default -> {\n" //
+				+ "                bar(); //\n" //
+				+ "                throw new AssertionError();\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
 	public void testDoNotConvertToReturnSwitchExpressionIssue104_1() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= "" //
@@ -942,6 +987,30 @@ public class CleanUpTest14 extends CleanUpTestCase {
 			    + "        System.out.println(rulesOK);\n" //
 			    + "    }\n" //
 				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
+	}
+
+	@Test
+	public void testDoNotConvertToSwitchExpressionIssue381() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class E1 {\n" //
+				+ "    public void f(int i) {\n" //
+				+ "        switch (i) {\n" //
+				+ "        case 0:\n" //
+				+ "            return;\n" //
+				+ "        default:\n" //
+				+ "            throw new AssertionError();\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
 
 		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);


### PR DESCRIPTION
- fixes #381

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Stops the switch expression cleanup if any case has a return statement with no expression.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See test in issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
