### PR TITLE
Version bump for 4.27 stream

### DIFF
--- a/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.runtime
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.runtime;singleton:=true
-Bundle-Version: 3.7.0.qualifier
+Bundle-Version: 3.7.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit.runner;

--- a/org.eclipse.jdt.junit.runtime/pom.xml
+++ b/org.eclipse.jdt.junit.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit.runtime</artifactId>
-  <version>3.7.0-SNAPSHOT</version>
+  <version>3.7.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>


### PR DESCRIPTION
As it can be seen at https://download.eclipse.org/eclipse/downloads/drops4/I20230114-1800/buildlogs/reporeports/reports/versionChecks.html only qualifier changed in this stream:


org.eclipse.jdt.junit.runtime | 3.7.0.v20220609-1843 | 3.7.0.v20230112-1828
-- | -- | --
org.eclipse.jdt.junit.runtime.source | 3.7.0.v20220609-1843 | 3.7.0.v20230112-1828


