### PR TITLE
Enable releng version comparison

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
 				wrap([$class: 'Xvnc', useXauthority: true]) {
 					sh """
 					mvn -f pom.xml -Dmaven.compiler.failOnWarning=true -DskipTests=false -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-						clean verify --batch-mode -Pbuild-individual-bundles -Pbree-libs -Papi-check
+						clean verify --batch-mode -Pbuild-individual-bundles -Pbree-libs -Papi-check -Dcompare-version-with-baselines.skip=false
 					"""
 				}
 			}


### PR DESCRIPTION
## What it does
Makes Jenkins build complain if version hasn't been bumped for the current stream.
That would safe a lot of churn on releng side having to request JDT committers to bump versions after looking at I-build reports.

## How to test
Current build should just work and when a version  bump is needed in some bundle the build will fail with message which bundle has to increase version

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
