### PR TITLE
Build AST and Element views as part of the Maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,5 +70,9 @@
     <module>org.eclipse.jdt.junit5.runtime</module>
     <module>org.eclipse.jdt.ui.unittest.junit</module>
     <module>org.eclipse.jdt.ui.unittest.junit.feature</module>
+    <module>org.eclipse.jdt.astview</module>
+    <module>org.eclipse.jdt.astview.feature</module>
+    <module>org.eclipse.jdt.jeview</module>
+    <module>org.eclipse.jdt.jeview.feature</module>
   </modules>
 </project>


### PR DESCRIPTION
## What it does
Builds AST and Element views as part of the Maven build so they can be later added to SDK feature. Tracked in https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/387

## How to test
Check the console log that the respective bundles and features are build

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
