### PR TITLE
Do not run concurrent jenkins builds for same branch/pr

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
 	options {
 		timeout(time: 40, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
+		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()
 	}
 	agent {


### PR DESCRIPTION
## What it does
Ensures only one build is ongoing for branch or PR. Currently there are multiple concurrent builds in the current setup if new commits are pushed to branch/PR before the previous one finished. This patch configures Jenkins to stop the running one and start the new one.

## How to test


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
