### PR TITLE
Reduce warnings

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTSemanticMatcher.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTSemanticMatcher.java
@@ -101,7 +101,7 @@ public class ASTSemanticMatcher extends ASTMatcher {
 	 */
 	public static final ASTSemanticMatcher INSTANCE= new ASTSemanticMatcher();
 
-	private static final Map<PrefixExpression.Operator, InfixExpression.Operator> PREFIX_TO_INFIX_OPERATOR= new HashMap<PrefixExpression.Operator, InfixExpression.Operator>() {
+	private static final Map<PrefixExpression.Operator, InfixExpression.Operator> PREFIX_TO_INFIX_OPERATOR= new HashMap<>() {
 		private static final long serialVersionUID= -8949107654517355855L;
 
 		{
@@ -110,7 +110,7 @@ public class ASTSemanticMatcher extends ASTMatcher {
 		}
 	};
 
-	private static final Map<PrefixExpression.Operator, Assignment.Operator> PREFIX_TO_ASSIGN_OPERATOR= new HashMap<PrefixExpression.Operator, Assignment.Operator>() {
+	private static final Map<PrefixExpression.Operator, Assignment.Operator> PREFIX_TO_ASSIGN_OPERATOR= new HashMap<>() {
 		private static final long serialVersionUID= -8949107654517355856L;
 
 		{
@@ -119,7 +119,7 @@ public class ASTSemanticMatcher extends ASTMatcher {
 		}
 	};
 
-	private static final Map<PostfixExpression.Operator, InfixExpression.Operator> POSTFIX_TO_INFIX_OPERATOR= new HashMap<PostfixExpression.Operator, InfixExpression.Operator>() {
+	private static final Map<PostfixExpression.Operator, InfixExpression.Operator> POSTFIX_TO_INFIX_OPERATOR= new HashMap<>() {
 		private static final long serialVersionUID= -8949107654517355857L;
 
 		{
@@ -128,7 +128,7 @@ public class ASTSemanticMatcher extends ASTMatcher {
 		}
 	};
 
-	private static final Map<PostfixExpression.Operator, Assignment.Operator> POSTFIX_TO_ASSIGN_OPERATOR= new HashMap<PostfixExpression.Operator, Assignment.Operator>() {
+	private static final Map<PostfixExpression.Operator, Assignment.Operator> POSTFIX_TO_ASSIGN_OPERATOR= new HashMap<>() {
 		private static final long serialVersionUID= -8949107654517355858L;
 
 		{
@@ -137,7 +137,7 @@ public class ASTSemanticMatcher extends ASTMatcher {
 		}
 	};
 
-	private static final Map<PrefixExpression.Operator, PostfixExpression.Operator> PREFIX_TO_POSTFIX_OPERATOR= new HashMap<PrefixExpression.Operator, PostfixExpression.Operator>() {
+	private static final Map<PrefixExpression.Operator, PostfixExpression.Operator> PREFIX_TO_POSTFIX_OPERATOR= new HashMap<>() {
 		private static final long serialVersionUID= -8949107654517355859L;
 
 		{
@@ -146,7 +146,7 @@ public class ASTSemanticMatcher extends ASTMatcher {
 		}
 	};
 
-	private static final Map<Assignment.Operator, InfixExpression.Operator> ASSIGN_TO_INFIX_OPERATOR= new HashMap<Assignment.Operator, InfixExpression.Operator>() {
+	private static final Map<Assignment.Operator, InfixExpression.Operator> ASSIGN_TO_INFIX_OPERATOR= new HashMap<>() {
 		private static final long serialVersionUID= -8949107654517355859L;
 
 		{
@@ -164,7 +164,7 @@ public class ASTSemanticMatcher extends ASTMatcher {
 		}
 	};
 
-	private static final Map<InfixExpression.Operator, InfixExpression.Operator> INFIX_TO_MIRROR_OPERATOR= new HashMap<InfixExpression.Operator, InfixExpression.Operator>() {
+	private static final Map<InfixExpression.Operator, InfixExpression.Operator> INFIX_TO_MIRROR_OPERATOR= new HashMap<>() {
 		private static final long serialVersionUID= -8949107654517355857L;
 
 		{

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LinkedProposalModelCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LinkedProposalModelCore.java
@@ -54,7 +54,7 @@ public class LinkedProposalModelCore {
 
 	public Iterator<LinkedProposalPositionGroupCore> getPositionGroupCoreIterator() {
 		if (fPositionGroups == null) {
-			return new Iterator<LinkedProposalPositionGroupCore>() {
+			return new Iterator<>() {
 				@Override
 				public boolean hasNext() {return false;}
 				@Override

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsConstraintsSolver.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsConstraintsSolver.java
@@ -320,7 +320,7 @@ public class InferTypeArgumentsConstraintsSolver {
 	}
 
 	private static final int MAX_CACHE= 1024;
-	private Map<TType, Boolean> fInterfaceTaggingCache= new LinkedHashMap<TType, Boolean>(MAX_CACHE, 0.75f, true) {
+	private Map<TType, Boolean> fInterfaceTaggingCache= new LinkedHashMap<>(MAX_CACHE, 0.75f, true) {
 		private static final long serialVersionUID= 1L;
 		@Override
 		protected boolean removeEldestEntry(Map.Entry<TType, Boolean> eldest) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsTCModel.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsTCModel.java
@@ -85,7 +85,7 @@ public class InferTypeArgumentsTCModel {
 	private TypeEnvironment fTypeEnvironment;
 
 	private static final int MAX_TTYPE_CACHE= 1024;
-	private Map<String, TType> fTTypeCache= new LinkedHashMap<String, TType>(MAX_TTYPE_CACHE, 0.75f, true) {
+	private Map<String, TType> fTTypeCache= new LinkedHashMap<>(MAX_TTYPE_CACHE, 0.75f, true) {
 		private static final long serialVersionUID= 1L;
 		@Override
 		protected boolean removeEldestEntry(Map.Entry<String, TType> eldest) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsModel.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsModel.java
@@ -212,7 +212,7 @@ public final class SuperTypeConstraintsModel {
 	private final TType fSuperType;
 
 	/** The TType cache */
-	private Map<String, TType> fTTypeCache= new LinkedHashMap<String, TType>(MAX_CACHE, 0.75f, true) {
+	private Map<String, TType> fTTypeCache= new LinkedHashMap<>(MAX_CACHE, 0.75f, true) {
 
 		private static final long serialVersionUID= 1L;
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/types/TypeEnvironment.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/types/TypeEnvironment.java
@@ -118,7 +118,7 @@ public class TypeEnvironment {
 	private UnboundWildcardType fUnboundWildcardType= null;
 
 	private static final int MAX_ENTRIES= 1024;
-	private Map<TypeTuple, Boolean> fSubTypeCache= new LinkedHashMap<TypeTuple, Boolean>(50, 0.75f, true) {
+	private Map<TypeTuple, Boolean> fSubTypeCache= new LinkedHashMap<>(50, 0.75f, true) {
 		private static final long serialVersionUID= 1L;
 		@Override
 		protected boolean removeEldestEntry(Map.Entry<TypeTuple, Boolean> eldest) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/typesets/ArrayTypeSet.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/typesets/ArrayTypeSet.java
@@ -114,7 +114,7 @@ public class ArrayTypeSet extends TypeSet {
 	public Iterator<TType> iterator() {
 		if (fEnumCache != null) return fEnumCache.iterator();
 
-		return new Iterator<TType>() {
+		return new Iterator<>() {
 			Iterator<TType> fElemIter= fElemTypeSet.iterator();
 			@Override
 			public boolean hasNext() {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/typesets/EmptyTypeSet.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/typesets/EmptyTypeSet.java
@@ -85,7 +85,7 @@ public class EmptyTypeSet extends TypeSet {
 
 	@Override
 	public Iterator<TType> iterator() {
-		return new Iterator<TType>() {
+		return new Iterator<>() {
 			@Override
 			public void remove() {
 				//do nothing

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/typesets/SingletonTypeSet.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/typesets/SingletonTypeSet.java
@@ -99,7 +99,7 @@ public class SingletonTypeSet extends TypeSet {
 
 	@Override
 	public Iterator<TType> iterator() {
-		return new Iterator<TType>() {
+		return new Iterator<>() {
 			private boolean done= false;
 			@Override
 			public void remove() {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/NodeMatcher.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/NodeMatcher.java
@@ -36,7 +36,7 @@ public abstract class NodeMatcher<N extends ASTNode> {
 	 */
 	public NodeMatcher<N> negate() {
 		final NodeMatcher<N> thisNodeMatcher= this;
-		return new NodeMatcher<N>() {
+		return new NodeMatcher<>() {
 			@Override
 			public Boolean isMatching(final N node) {
 				Boolean isMatching= thisNodeMatcher.isMatching(node);

--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/pom.xml
+++ b/org.eclipse.jdt.junit/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit</artifactId>
-  <version>3.15.100-SNAPSHOT</version>
+  <version>3.15.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -522,7 +522,7 @@ public class TestViewer {
 				comparator= null;
 				break;
 			case SORT_BY_EXECUTION_TIME:
-				comparator= new Comparator<ITestElement>() {
+				comparator= new Comparator<>() {
 					@Override
 					public int compare(ITestElement o1, ITestElement o2) {
 						return compareElapsedTime(o1, o2);
@@ -530,7 +530,7 @@ public class TestViewer {
 				};
 				break;
 			case SORT_BY_NAME:
-				comparator= new Comparator<ITestElement>() {
+				comparator= new Comparator<>() {
 					@Override
 					public int compare(ITestElement o1, ITestElement o2) {
 						return compareName(o1, o2);

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/util/History.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/util/History.java
@@ -50,12 +50,12 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.CorextMessages;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaUIException;
 import org.eclipse.jdt.internal.ui.JavaUIStatus;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 /**
  * History stores a list of key, object pairs. The list is bounded at size
@@ -84,7 +84,7 @@ public abstract class History<K, V> {
 	private final String fInfoNodeName;
 
 	public History(String fileName, String rootNodeName, String infoNodeName) {
-		fHistory= new LinkedHashMap<K, V>(80, 0.75f, true) {
+		fHistory= new LinkedHashMap<>(80, 0.75f, true) {
 			private static final long serialVersionUID= 1L;
 			@Override
 			protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/CUPositionCompletionProcessor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/CUPositionCompletionProcessor.java
@@ -53,7 +53,7 @@ import org.eclipse.jdt.internal.ui.text.java.JavaTypeCompletionProposal;
 import org.eclipse.jdt.internal.ui.viewsupport.ImageDescriptorRegistry;
 
 
-public class CUPositionCompletionProcessor implements IContentAssistProcessor, ISubjectControlContentAssistProcessor {
+public class CUPositionCompletionProcessor implements ISubjectControlContentAssistProcessor {
 
 	private static final ImageDescriptorRegistry IMAGE_DESC_REGISTRY= JavaPlugin.getImageDescriptorRegistry();
 

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/FieldNameProcessor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/FieldNameProcessor.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 
@@ -39,7 +38,7 @@ import org.eclipse.jdt.internal.ui.text.java.JavaCompletionProposal;
 import org.eclipse.jdt.internal.ui.viewsupport.ImageDescriptorRegistry;
 import org.eclipse.jdt.internal.ui.viewsupport.JavaElementImageProvider;
 
-public class FieldNameProcessor implements IContentAssistProcessor, ISubjectControlContentAssistProcessor {
+public class FieldNameProcessor implements ISubjectControlContentAssistProcessor {
 
 	private String[] fFieldNameProposals;
 	private String fErrorMessage;

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaPackageCompletionProcessor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaPackageCompletionProcessor.java
@@ -30,7 +30,6 @@ import org.eclipse.jface.viewers.ILabelProvider;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 
@@ -46,7 +45,7 @@ import org.eclipse.jdt.ui.text.java.CompletionProposalComparator;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.text.java.JavaCompletionProposal;
 
-public class JavaPackageCompletionProcessor implements IContentAssistProcessor, ISubjectControlContentAssistProcessor {
+public class JavaPackageCompletionProcessor implements ISubjectControlContentAssistProcessor {
 
 	private IPackageFragmentRoot[] fPackageFragmentRoots;
 	private CompletionProposalComparator fComparator;

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaPackageFragmentRootCompletionProcessor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaPackageFragmentRootCompletionProcessor.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 
@@ -48,7 +47,7 @@ import org.eclipse.jdt.internal.ui.viewsupport.ImageDescriptorRegistry;
  * TODO: this class is not used anywhere yet.
  * (ContentAssist should be added to all source folder dialog fields.)
  */
-public class JavaPackageFragmentRootCompletionProcessor implements IContentAssistProcessor, ISubjectControlContentAssistProcessor {
+public class JavaPackageFragmentRootCompletionProcessor implements ISubjectControlContentAssistProcessor {
 	private static final ImageDescriptorRegistry IMAGE_DESC_REGISTRY= JavaPlugin.getImageDescriptorRegistry();
 
 	private IPackageFragmentRoot fPackageFragmentRoot;

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaSourcePackageFragmentRootCompletionProcessor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/JavaSourcePackageFragmentRootCompletionProcessor.java
@@ -29,7 +29,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 
@@ -50,7 +49,7 @@ import org.eclipse.jdt.internal.ui.text.java.JavaCompletionProposal;
  * Simple completion processor that completes package fragment roots that are source
  * folders.
  */
-public class JavaSourcePackageFragmentRootCompletionProcessor implements IContentAssistProcessor, ISubjectControlContentAssistProcessor {
+public class JavaSourcePackageFragmentRootCompletionProcessor implements ISubjectControlContentAssistProcessor {
 
 	private char[] fProposalAutoActivationSet;
 	private IJavaModel fRoot;

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/VariableNamesProcessor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/contentassist/VariableNamesProcessor.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.resource.ImageDescriptor;
 
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
-import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 
@@ -37,7 +36,7 @@ import org.eclipse.jdt.internal.ui.JavaUIMessages;
 import org.eclipse.jdt.internal.ui.text.java.JavaCompletionProposal;
 import org.eclipse.jdt.internal.ui.viewsupport.ImageDescriptorRegistry;
 
-public class VariableNamesProcessor implements IContentAssistProcessor, ISubjectControlContentAssistProcessor {
+public class VariableNamesProcessor implements ISubjectControlContentAssistProcessor {
 
 	private String fErrorMessage;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
@@ -167,7 +167,7 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 
 	private static JavaPlugin fgJavaPlugin;
 
-	private static LinkedHashMap<String, Long> fgRepeatedMessages= new LinkedHashMap<String, Long>(20, 0.75f, true) {
+	private static LinkedHashMap<String, Long> fgRepeatedMessages= new LinkedHashMap<>(20, 0.75f, true) {
 		private static final long serialVersionUID= 1L;
 		@Override
 		protected boolean removeEldestEntry(java.util.Map.Entry<String, Long> eldest) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/CategoryFilterActionGroup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/CategoryFilterActionGroup.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.ui.actions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -22,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.ibm.icu.text.Collator;
-import java.util.Arrays;
 
 import org.eclipse.swt.custom.BusyIndicator;
 import org.eclipse.swt.graphics.Image;
@@ -266,7 +266,7 @@ public class CategoryFilterActionGroup extends ActionGroup {
 		Assert.isLegal(viewerId != null);
 		Assert.isLegal(input != null);
 
-		fLRUList= new LinkedHashMap<String, String>(MAX_NUMBER_OF_CATEGORIES_IN_MENU * 2, 0.75f, true) {
+		fLRUList= new LinkedHashMap<>(MAX_NUMBER_OF_CATEGORIES_IN_MENU * 2, 0.75f, true) {
 			private static final long serialVersionUID= 1L;
 			@Override
 			protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/HistoryListAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/HistoryListAction.java
@@ -66,7 +66,7 @@ public class HistoryListAction extends Action {
 				CallHierarchyMessages.HistoryListDialog_remove_button,
 			};
 
-			IListAdapter<IMember[]> adapter= new IListAdapter<IMember[]>() {
+			IListAdapter<IMember[]> adapter= new IListAdapter<>() {
 				@Override
 				public void customButtonPressed(ListDialogField<IMember[]> field, int index) {
 					doCustomButtonPressed();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/GenerateToStringDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/GenerateToStringDialog.java
@@ -201,7 +201,7 @@ public class GenerateToStringDialog extends SourceActionDialog {
 		}
 
 		public void sort() {
-			Comparator<IBinding> comparator= new Comparator<IBinding>() {
+			Comparator<IBinding> comparator= new Comparator<>() {
 				Collator collator= Collator.getInstance();
 				@Override
 				public int compare(IBinding b1, IBinding b2) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/CleanUpRefactoringWizard.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/CleanUpRefactoringWizard.java
@@ -288,7 +288,7 @@ public class CleanUpRefactoringWizard extends RefactoringWizard {
 			String[] buttons= new String[] {
 				MultiFixMessages.CleanUpRefactoringWizard_Configure_Button
 			};
-			final ListDialogField<IJavaProject> settingsField= new ListDialogField<IJavaProject>(listAdapter, buttons, tableLabelProvider) {
+			final ListDialogField<IJavaProject> settingsField= new ListDialogField<>(listAdapter, buttons, tableLabelProvider) {
 				@Override
 				protected int getListStyle() {
 					return super.getListStyle() | SWT.SINGLE;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
@@ -254,7 +254,7 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 				AtomicReference<Expression> criteria= new AtomicReference<>();
 				AtomicBoolean isForward= new AtomicBoolean(true);
 
-				NodeMatcher<Expression> compareToMatcher= new NodeMatcher<Expression>() {
+				NodeMatcher<Expression> compareToMatcher= new NodeMatcher<>() {
 					@Override
 					public Boolean isMatching(final Expression node) {
 						if (isReturnedExpressionToRefactor(node, criteria, isForward, name1, name2)) {
@@ -265,7 +265,7 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 					}
 				};
 
-				NodeMatcher<Expression> zeroMatcher= new NodeMatcher<Expression>() {
+				NodeMatcher<Expression> zeroMatcher= new NodeMatcher<>() {
 					@Override
 					public Boolean isMatching(final Expression node) {
 						if (Long.valueOf(0L).equals(ASTNodes.getIntegerLiteral(node))) {
@@ -276,7 +276,7 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 					}
 				};
 
-				NodeMatcher<Expression> positiveMatcher= new NodeMatcher<Expression>() {
+				NodeMatcher<Expression> positiveMatcher= new NodeMatcher<>() {
 					@Override
 					public Boolean isMatching(final Expression node) {
 						Long value= ASTNodes.getIntegerLiteral(node);
@@ -289,7 +289,7 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 					}
 				};
 
-				NodeMatcher<Expression> negativeMatcher= new NodeMatcher<Expression>() {
+				NodeMatcher<Expression> negativeMatcher= new NodeMatcher<>() {
 					@Override
 					public Boolean isMatching(final Expression node) {
 						Long value= ASTNodes.getIntegerLiteral(node);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/CodeAssistAdvancedConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/CodeAssistAdvancedConfigurationBlock.java
@@ -168,7 +168,7 @@ final class CodeAssistAdvancedConfigurationBlock extends OptionsConfigurationBlo
 		}
 	}
 
-	private final Comparator<ModelElement> fCategoryComparator= new Comparator<ModelElement>() {
+	private final Comparator<ModelElement> fCategoryComparator= new Comparator<>() {
 		private int getRank(ModelElement o) {
 			return o.getRank();
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/NameConventionConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/NameConventionConfigurationBlock.java
@@ -46,8 +46,8 @@ import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
 import org.eclipse.jdt.core.JavaConventions;
 import org.eclipse.jdt.core.JavaCore;
 
-import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.core.manipulation.util.Strings;
+import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementImageDescriptor;
 import org.eclipse.jdt.ui.PreferenceConstants;
@@ -314,7 +314,7 @@ public class NameConventionConfigurationBlock extends OptionsConfigurationBlock 
 		String[] buttons= new String[] {
 			PreferencesMessages.NameConventionConfigurationBlock_list_edit_button
 		};
-		fNameConventionList= new ListDialogField<NameConventionEntry>(adapter, buttons, new NameConventionLabelProvider()) {
+		fNameConventionList= new ListDialogField<>(adapter, buttons, new NameConventionLabelProvider()) {
 			@Override
 			protected int getListStyle() {
 				return super.getListStyle() & ~SWT.MULTI | SWT.SINGLE;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ModifyDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ModifyDialog.java
@@ -426,7 +426,7 @@ public abstract class ModifyDialog extends StatusDialog implements IModification
 		}
 
 		public static ModifyAll<Button> addModifyAll(Section section, Images images) {
-			return new ModifyAll<Button>(section, images) {
+			return new ModifyAll<>(section, images) {
 				@Override
 				protected Button createControl(Composite parent) {
 					Button checkBox= new Button(parent, SWT.CHECK);
@@ -520,7 +520,7 @@ public abstract class ModifyDialog extends StatusDialog implements IModification
 		}
 
 		public static ModifyAll<Combo> addModifyAll(Section section, Images images) {
-			return new ModifyAll<Combo>(section, images) {
+			return new ModifyAll<>(section, images) {
 				ArrayList<String> fItems= new ArrayList<>();
 
 				@Override
@@ -648,7 +648,7 @@ public abstract class ModifyDialog extends StatusDialog implements IModification
 		}
 
 		public static ModifyAll<Spinner> addModifyAll(final int minValue, final int maxValue, Section section, Images images) {
-			return new ModifyAll<Spinner>(section, images) {
+			return new ModifyAll<>(section, images) {
 				private Label fLabel;
 
 				@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/AnonymousTypeCompletionProposal.java
@@ -34,7 +34,6 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.TextUtilities;
-import org.eclipse.jface.text.contentassist.ICompletionProposalExtension4;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.link.LinkedModeModel;
 
@@ -81,7 +80,7 @@ import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
 import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileManager;
 
 
-public class AnonymousTypeCompletionProposal extends JavaTypeCompletionProposal implements ICompletionProposalExtension4 {
+public class AnonymousTypeCompletionProposal extends JavaTypeCompletionProposal {
 
 	private final String fDeclarationSignature;
 	private final IType fSuperType;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/GetterSetterCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/GetterSetterCompletionProposal.java
@@ -25,7 +25,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.TextUtilities;
-import org.eclipse.jface.text.contentassist.ICompletionProposalExtension4;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IField;
@@ -50,7 +49,7 @@ import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
 import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileManager;
 
-public class GetterSetterCompletionProposal extends JavaTypeCompletionProposal implements ICompletionProposalExtension4 {
+public class GetterSetterCompletionProposal extends JavaTypeCompletionProposal {
 
 	public static void evaluateProposals(IType type, String prefix, int offset, int length, int relevance, Set<String> suggestedMethods, Collection<IJavaCompletionProposal> result) throws CoreException {
 		if (prefix.length() == 0) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/MethodDeclarationCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/MethodDeclarationCompletionProposal.java
@@ -27,7 +27,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.TextUtilities;
-import org.eclipse.jface.text.contentassist.ICompletionProposalExtension4;
 
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
@@ -54,7 +53,7 @@ import org.eclipse.jdt.internal.ui.viewsupport.JavaElementImageProvider;
 /**
  * Method declaration proposal.
  */
-public class MethodDeclarationCompletionProposal extends JavaTypeCompletionProposal implements ICompletionProposalExtension4 {
+public class MethodDeclarationCompletionProposal extends JavaTypeCompletionProposal {
 
 
 	public static void evaluateProposals(IType type, String prefix, int offset, int length, int relevance, Set<String> suggestedMethods, Collection<IJavaCompletionProposal> result) throws CoreException {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/OverrideCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/OverrideCompletionProposal.java
@@ -28,7 +28,6 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.TextUtilities;
-import org.eclipse.jface.text.contentassist.ICompletionProposalExtension4;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -61,7 +60,7 @@ import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
 
-public class OverrideCompletionProposal extends JavaTypeCompletionProposal implements ICompletionProposalExtension4 {
+public class OverrideCompletionProposal extends JavaTypeCompletionProposal {
 
 	private String fMethodName;
 	private String[] fParamTypes;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HistoryListAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HistoryListAction.java
@@ -62,7 +62,7 @@ public class HistoryListAction extends Action {
 				TypeHierarchyMessages.HistoryListDialog_remove_button,
 			};
 
-			IListAdapter<IJavaElement[]> adapter= new IListAdapter<IJavaElement[]>() {
+			IListAdapter<IJavaElement[]> adapter= new IListAdapter<>() {
 				@Override
 				public void customButtonPressed(ListDialogField<IJavaElement[]> field, int index) {
 					doCustomButtonPressed();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/HistoryListAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/HistoryListAction.java
@@ -74,7 +74,7 @@ import org.eclipse.jdt.internal.ui.wizards.dialogfields.StringDialogField;
 		}
 
 		private void createHistoryList() {
-			IListAdapter<E> adapter= new IListAdapter<E>() {
+			IListAdapter<E> adapter= new IListAdapter<>() {
 				@Override
 				public void customButtonPressed(ListDialogField<E> field, int index) {
 					doCustomButtonPressed(index);

--- a/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.ltk.core.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.core.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.core.refactoring; singleton:=true
-Bundle-Version: 3.13.0.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Activator: org.eclipse.ltk.internal.core.refactoring.RefactoringCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.ltk.core.refactoring/pom.xml
+++ b/org.eclipse.ltk.core.refactoring/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.ltk</groupId>
   <artifactId>org.eclipse.ltk.core.refactoring</artifactId>
-  <version>3.13.0-SNAPSHOT</version>
+  <version>3.13.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/internal/core/refactoring/history/RefactoringHistoryService.java
+++ b/org.eclipse.ltk.core.refactoring/src/org/eclipse/ltk/internal/core/refactoring/history/RefactoringHistoryService.java
@@ -307,7 +307,7 @@ public final class RefactoringHistoryService implements IRefactoringHistoryServi
 	private static final int MAX_MANAGERS= 2;
 
 	/** The refactoring history manager cache */
-	private final Map<IFileStore, RefactoringHistoryManager> fManagerCache= new LinkedHashMap<IFileStore, RefactoringHistoryManager>(MAX_MANAGERS, 0.75f, true) {
+	private final Map<IFileStore, RefactoringHistoryManager> fManagerCache= new LinkedHashMap<>(MAX_MANAGERS, 0.75f, true) {
 
 		private static final long serialVersionUID= 1L;
 


### PR DESCRIPTION
## What it does
Reduce warnings in jdt.ui workspace. Namely redundant type declarations and redundant super interfaces.

## How to test


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
