### PR TITLE
Add Bytecode Outline feature

### DIFF
--- a/org.eclipse.jdt.bcoview.feature/.project
+++ b/org.eclipse.jdt.bcoview.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.jdt.bcoview.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.bcoview.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.bcoview.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.bcoview.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/org.eclipse.jdt.bcoview.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/org.eclipse.jdt.bcoview.feature/build.properties
+++ b/org.eclipse.jdt.bcoview.feature/build.properties
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) 2023 Andrey Loskutov (loskutov@gmx.de) and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+bin.includes = feature.xml,\
+               feature.properties
+src.includes = feature.xml,\
+               feature.properties

--- a/org.eclipse.jdt.bcoview.feature/feature.properties
+++ b/org.eclipse.jdt.bcoview.feature/feature.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) Andrey Loskutov (loskutov@gmx.de) and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+

--- a/org.eclipse.jdt.bcoview.feature/feature.xml
+++ b/org.eclipse.jdt.bcoview.feature/feature.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.jdt.bcoview.feature"
+      label="Bytecode Outline View"
+      version="1.1.0.qualifier"
+      provider-name="Eclipse.org"
+      license-feature="org.eclipse.license"
+      license-feature-version="0.0.0">
+
+   <description>
+      Bytecode Outline View
+   </description>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <requires>
+      <import plugin="org.eclipse.compare"/>
+      <import plugin="org.eclipse.core.filesystem"/>
+      <import plugin="org.eclipse.core.runtime"/>
+      <import plugin="org.eclipse.debug.ui"/>
+      <import plugin="org.eclipse.jdt.core" version="3.33.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.jdt.ui" version="3.28.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.jface.text"/>
+      <import plugin="org.eclipse.ui"/>
+      <import plugin="org.eclipse.ui.console"/>
+      <import plugin="org.eclipse.ui.editors"/>
+      <import plugin="org.eclipse.ui.ide"/>
+      <import plugin="org.eclipse.ui.workbench.texteditor"/>
+      <import plugin="org.objectweb.asm" version="9.4.0" match="greaterOrEqual"/>
+      <import plugin="org.objectweb.asm.tree" version="9.4.0" match="greaterOrEqual"/>
+      <import plugin="org.objectweb.asm.tree.analysis" version="9.4.0" match="greaterOrEqual"/>
+      <import plugin="org.objectweb.asm.util" version="9.4.0" match="greaterOrEqual"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.jdt.bcoview"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/org.eclipse.jdt.bcoview.feature/pom.xml
+++ b/org.eclipse.jdt.bcoview.feature/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) Andrey Loskutov (loskutov@gmx.de) and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Distribution License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/org/documents/edl-v10.php
+ 
+  Contributors:
+     Andrey Loskutov (loskutov@gmx.de) - initial implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>eclipse.jdt.ui</artifactId>
+    <groupId>eclipse.jdt.ui</groupId>
+    <version>4.27.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.eclipse.jdt.feature</groupId>
+  <artifactId>org.eclipse.jdt.bcoview.feature</artifactId>
+  <version>1.1.0-SNAPSHOT</version>
+  <packaging>eclipse-feature</packaging>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,5 +75,6 @@
     <module>org.eclipse.jdt.jeview</module>
     <module>org.eclipse.jdt.jeview.feature</module>
     <module>org.eclipse.jdt.bcoview</module>
+    <module>org.eclipse.jdt.bcoview.feature</module>
   </modules>
 </project>


### PR DESCRIPTION
Adds `org.eclipse.jdt.bcoview.feature` and integrates with maven build

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/364