### PR TITLE
Add new preference to ignore inexact refs for Code Minings

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaReferenceCodeMining.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaReferenceCodeMining.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Angelo Zerr and others.
+ * Copyright (c) 2018, 2023 Angelo Zerr and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -36,8 +36,6 @@ import org.eclipse.ui.IEditorPart;
 
 import org.eclipse.ui.texteditor.ITextEditor;
 
-import org.eclipse.search.ui.NewSearchUI;
-
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -50,10 +48,12 @@ import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.SearchRequestor;
 
+import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.actions.FindReferencesAction;
 
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
+import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesPropertyTester;
 import org.eclipse.jdt.internal.ui.search.JavaSearchScopeFactory;
 
 /**
@@ -144,7 +144,7 @@ public class JavaReferenceCodeMining extends AbstractJavaElementLineHeaderCodeMi
 			return 0;
 		}
 		SearchEngine engine= new SearchEngine();
-		final boolean ignoreInaccurate= NewSearchUI.arePotentialMatchesIgnored();
+		final boolean ignoreInaccurate= JavaPreferencesPropertyTester.isEnabled(PreferenceConstants.EDITOR_JAVA_CODEMINING_IGNORE_INEXACT_MATCHES);
 		engine.search(pattern, new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
 				createSearchScope(element), new SearchRequestor() {
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorCodeMiningConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorCodeMiningConfigurationBlock.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2018, 2020 Angelo ZERR.
+ *  Copyright (c) 2018, 2023 Angelo ZERR.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -54,6 +54,9 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 	private static final Key PREF_SHOW_CODEMINING_AT_LEAST_ONE= getJDTUIKey(
 			PreferenceConstants.EDITOR_JAVA_CODEMINING_SHOW_CODEMINING_AT_LEAST_ONE);
 
+	private static final Key PREF_IGNORE_INEXACT_MATCHES= getJDTUIKey(
+			PreferenceConstants.EDITOR_JAVA_CODEMINING_IGNORE_INEXACT_MATCHES);
+
 	private static final Key PREF_SHOW_REFERENCES= getJDTUIKey(
 			PreferenceConstants.EDITOR_JAVA_CODEMINING_SHOW_REFERENCES);
 
@@ -80,6 +83,8 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 
 	private Button atLeastOneCheckBox;
 
+	private Button ignoreInexactReferenceMatches;
+
 	private PreferenceTree fFilteredPrefTree;
 
 	public JavaEditorCodeMiningConfigurationBlock(IStatusChangeListener context,
@@ -90,7 +95,7 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 	public static Key[] getAllKeys() {
 		return new Key[] { PREF_CODEMINING_ENABLED, PREF_SHOW_CODEMINING_AT_LEAST_ONE, PREF_SHOW_REFERENCES, PREF_SHOW_REFERENCES_ON_TYPES, PREF_SHOW_REFERENCES_ON_FIELDS,
 				PREF_SHOW_REFERENCES_ON_METHODS,
-				PREF_SHOW_IMPLEMENTATIONS, PREF_SHOW_PARAMETER_NAMES };
+				PREF_SHOW_IMPLEMENTATIONS, PREF_SHOW_PARAMETER_NAMES, PREF_IGNORE_INEXACT_MATCHES };
 	}
 
 	@Override
@@ -122,6 +127,11 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 				PreferencesMessages.JavaEditorCodeMiningConfigurationBlock_showCodeMining_atLeastOne_label,
 				PREF_SHOW_CODEMINING_AT_LEAST_ONE, TRUE_FALSE, LayoutUtil.getIndent());
 
+		ignoreInexactReferenceMatches= addCheckBox(mainComp,
+				PreferencesMessages.JavaEditorCodeMiningConfigurationBlock_ignoreInexactMatches_label,
+				PREF_IGNORE_INEXACT_MATCHES, TRUE_FALSE, LayoutUtil.getIndent());
+
+
 		Composite commonComposite= createCodeMiningContent(mainComp);
 		GridData gridData= new GridData(GridData.FILL, GridData.FILL, true, true);
 		gridData.heightHint= fPixelConverter.convertHeightInCharsToPixels(20);
@@ -135,6 +145,7 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 		});
 		atLeastOneCheckBox.setEnabled(codeMiningEnabledCheckBox.getSelection());
 		fFilteredPrefTree.setEnabled(codeMiningEnabledCheckBox.getSelection());
+		ignoreInexactReferenceMatches.setEnabled(codeMiningEnabledCheckBox.getSelection());
 		validateSettings(null, null, null);
 		return mainComp;
 	}
@@ -206,6 +217,7 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 		if (enabledCodeMining) {
 			// Show references checkboxes
 			atLeastOneCheckBox.setEnabled(true);
+			ignoreInexactReferenceMatches.setEnabled(true);
 			fFilteredPrefTree.setEnabled(true);
 
 			boolean showReferences= getCheckBox(PREF_SHOW_REFERENCES).getSelection();
@@ -217,6 +229,7 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 			getCheckBox(PREF_SHOW_PARAMETER_NAMES).getSelection();
 		} else {
 			atLeastOneCheckBox.setEnabled(false);
+			ignoreInexactReferenceMatches.setEnabled(false);
 			fFilteredPrefTree.setEnabled(false);
 		}
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -905,6 +905,7 @@ public final class PreferencesMessages extends NLS {
 
 	public static String JavaEditorCodeMiningConfigurationBlock_common_description;
 	public static String JavaEditorCodeMiningConfigurationBlock_enableCodeMining_label;
+	public static String JavaEditorCodeMiningConfigurationBlock_ignoreInexactMatches_label;
 	public static String JavaEditorCodeMiningConfigurationBlock_showCodeMining_atLeastOne_label;
 	public static String JavaEditorCodeMiningConfigurationBlock_section_general;
 	public static String JavaEditorCodeMiningConfigurationBlock_showReferences_label;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -1031,6 +1031,7 @@ JavaCompilerPropertyPage_invalid_element_selection=Java Compiler settings cannot
 
 # Code minings
 JavaEditorCodeMiningConfigurationBlock_enableCodeMining_label=&Enable code minings (also controls code minings of <a href=\"org.eclipse.ui.preferencePages.GeneralTextEditor\">'Text Editors'</a>)
+JavaEditorCodeMiningConfigurationBlock_ignoreInexactMatches_label=I&gnore inexact reference matches
 JavaEditorCodeMiningConfigurationBlock_showCodeMining_atLeastOne_label=Only if there is at &least one result
 JavaEditorCodeMiningConfigurationBlock_common_description=&Select the code minings that you wish to enable/disable:
 JavaEditorCodeMiningConfigurationBlock_section_general=General

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3829,6 +3829,16 @@ public class PreferenceConstants {
 	public static final String EDITOR_JAVA_CODEMINING_SHOW_CODEMINING_AT_LEAST_ONE = "java.codemining.atLeastOne"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that stores the value for "Ignore inexact matches".
+	 * <p>
+	 * Value is of type <code>Boolean</code>.
+	 * </p>
+	 *
+	 * @since 3.28
+	 */
+	public static final String EDITOR_JAVA_CODEMINING_IGNORE_INEXACT_MATCHES = "java.codemining.ignoreInexactMatches"; //$NON-NLS-1$
+
+	/**
 	 * A named preference that stores the value for "Show references" codemining.
 	 * <p>
 	 * Value is of type <code>Boolean</code>.
@@ -4297,6 +4307,8 @@ public class PreferenceConstants {
 		// Code minings preferences
 		store.setDefault(PreferenceConstants.EDITOR_CODEMINING_ENABLED, true);
 		store.setDefault(EDITOR_JAVA_CODEMINING_SHOW_CODEMINING_AT_LEAST_ONE,
+				true);
+		store.setDefault(EDITOR_JAVA_CODEMINING_IGNORE_INEXACT_MATCHES,
 				true);
 		store.setDefault(EDITOR_JAVA_CODEMINING_SHOW_REFERENCES, false);
 		store.setDefault(EDITOR_JAVA_CODEMINING_SHOW_REFERENCES_ON_TYPES, false);


### PR DESCRIPTION
- add a new preference to ignore inexact results for Code Mining references and have this used instead of the Search preference
- fixes #370

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds a Code Mining preference to ignore inexact references which will be used instead of reading the similar preference
in the Search preferences which is not intuitive to the end-user.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Perform Code Mining and specify to show method references.  The new option will match the results of setting the Search preference regarding ignore potential matches.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
