### PR TITLE
Improve names of new views

### DIFF
--- a/org.eclipse.jdt.astview/plugin.xml
+++ b/org.eclipse.jdt.astview/plugin.xml
@@ -5,7 +5,7 @@
      <extension
          point="org.eclipse.ui.views">
       <view
-            name="ASTView"
+            name="Abstract Syntax Tree"
             icon="$nl$/icons/view.png"
             category="org.eclipse.jdt.ui.java"
             class="org.eclipse.jdt.astview.views.ASTView"

--- a/org.eclipse.jdt.jeview/plugin.properties
+++ b/org.eclipse.jdt.jeview/plugin.properties
@@ -1,15 +1,15 @@
 ###############################################################################
 # Copyright (c) 2000, 2005 IBM Corporation and others.
 #
-# This program and the accompanying materials 
+# This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
 # which accompanies this distribution, and is available at
 # https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
-# 
+#
 # Contributors:
 #     IBM Corporation - initial API and implementation
 ###############################################################################
-pluginName= JavaElement View Plug-in
+pluginName= Java Element View Plug-in
 providerName= Eclipse.org

--- a/org.eclipse.jdt.jeview/plugin.xml
+++ b/org.eclipse.jdt.jeview/plugin.xml
@@ -5,7 +5,7 @@
    <extension
          point="org.eclipse.ui.views">
       <view
-            name="JavaElement View"
+            name="Java Element"
             icon="icons/view.png"
             category="org.eclipse.jdt.ui.java"
             class="org.eclipse.jdt.jeview.views.JavaElementView"

--- a/org.eclipse.jdt.jeview/src/org/eclipse/jdt/jeview/views/JavaElementView.java
+++ b/org.eclipse.jdt.jeview/src/org/eclipse/jdt/jeview/views/JavaElementView.java
@@ -907,19 +907,19 @@ public class JavaElementView extends ViewPart implements IShowInSource, IShowInT
 
 	void showAndLogError(String message, CoreException e) {
 		JEViewPlugin.log(message, e);
-		ErrorDialog.openError(getSite().getShell(), "JavaElement View", message, e.getStatus()); //$NON-NLS-1$
+		ErrorDialog.openError(getSite().getShell(), "Java Element View", message, e.getStatus()); //$NON-NLS-1$
 	}
 
 	void showAndLogError(String message, Exception e) {
 		IStatus status= new Status(IStatus.ERROR, JEViewPlugin.getPluginId(), 0, message, e);
 		JEViewPlugin.log(status);
-		ErrorDialog.openError(getSite().getShell(), "JavaElement View", null, status); //$NON-NLS-1$
+		ErrorDialog.openError(getSite().getShell(), "Java Element View", null, status); //$NON-NLS-1$
 	}
 
 	void showMessage(String message) {
 		MessageDialog.openInformation(
 			fViewer.getControl().getShell(),
-			"JavaElement View",
+			"Java Element View",
 			message);
 	}
 


### PR DESCRIPTION
* Never use the _type_ of a UI element in its name (view, wizard, dialog, ...).
* Also use a blank for "Java Element", even though that is related to the JavaElement class. People not knowing that class will assume a typo otherwise.

![grafik](https://user-images.githubusercontent.com/406876/213864954-fe55fac3-2af3-4f92-a25e-a341fb9e1acc.png)

The new names will still work with Ctrl-3 and typing the old name, so committers don't have to re-learn muscle memory.