### PR TITLE
Fix code style cleanup to remove this from generic class field

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CodeStyleFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CodeStyleFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -360,8 +360,19 @@ public class CodeStyleFixCore extends CompilationUnitRewriteOperationsFixCore {
 		private boolean hasConflict(int startPosition, SimpleName name, int flag) {
 			ScopeAnalyzer analyzer= new ScopeAnalyzer(fCompilationUnit);
 			for (IBinding decl : analyzer.getDeclarationsInScope(startPosition, flag)) {
-				if (decl.getName().equals(name.getIdentifier()) && name.resolveBinding() != decl)
+				IBinding nameBinding= name.resolveBinding();
+				if (decl.getName().equals(name.getIdentifier()) && nameBinding != decl) {
+					if ((decl instanceof IVariableBinding) && (nameBinding instanceof IVariableBinding)) {
+						IVariableBinding declVarBinding= (IVariableBinding)decl;
+						IVariableBinding nameVarBinding= (IVariableBinding)nameBinding;
+						if (declVarBinding.isField() && nameVarBinding.isField()) {
+							if (declVarBinding.getVariableDeclaration().isEqualTo(nameVarBinding.getVariableDeclaration())) {
+								return false;
+							}
+						}
+					}
 					return true;
+				}
 			}
 			return false;
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2022 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -4329,5 +4329,42 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		assertEquals(expected1, cu1.getBuffer().getContents());
 
 	}
+
+	@Test
+	public void testRemoveThisBug536138() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class A<K> {\n" //
+				+ "    private int val;\n" //
+				+ "    public A(int val) {\n" //
+				+ "        this.val = val;\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        this.val = 7;\n" //
+				+ "    }\n" //
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("A.java", sample, false, null);
+
+		enable(CleanUpConstants.MEMBER_ACCESSES_NON_STATIC_FIELD_USE_THIS);
+		enable(CleanUpConstants.MEMBER_ACCESSES_NON_STATIC_FIELD_USE_THIS_IF_NECESSARY);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class A<K> {\n" //
+				+ "    private int val;\n" //
+				+ "    public A(int val) {\n" //
+				+ "        this.val = val;\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        val = 7;\n" //
+				+ "    }\n" //
+				+ "}\n";
+		String expected1= sample;
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+    }
 
 }


### PR DESCRIPTION
- fixes #411
- fix ThisQualifierVisitor.hasConflict() to not flag field accesses when field declaration is equal
- add new test

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the unnecessary this cleanup work for fields of generic classes.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
