### PR TITLE
Allow JUnitLauncher to launch all tests in a Package including subpackages

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.11.500.qualifier
+Bundle-Version: 3.11.600.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/pom.xml
+++ b/org.eclipse.jdt.junit.core/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit.core</artifactId>
-  <version>3.11.500-SNAPSHOT</version>
+  <version>3.11.600-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitPropertyTester.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitPropertyTester.java
@@ -81,7 +81,7 @@ public class JUnitPropertyTester extends PropertyTester {
 				case IJavaElement.PACKAGE_FRAGMENT_ROOT:
 					return true; // can run, let test runner detect if there are tests
 				case IJavaElement.PACKAGE_FRAGMENT:
-					return ((IPackageFragment) element).hasChildren();
+					return ((IPackageFragment) element).hasChildren() || ((IPackageFragment) element).hasSubpackages();
 				case IJavaElement.COMPILATION_UNIT:
 					IType[] types= ((ICompilationUnit) element).getAllTypes();
 					for (IType type : types) {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -578,7 +578,7 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 
 			try (BufferedWriter bw= new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8))) {
 				if (testContainer instanceof IPackageFragment) {
-					pkgNames.add(getPackageName(testContainer.getElementName()));
+					addAllSubPackageFragments((IPackageFragment) testContainer, pkgNames);
 				} else if (testContainer instanceof IPackageFragmentRoot) {
 					addAllPackageFragments((IPackageFragmentRoot) testContainer, pkgNames);
 				} else if (testContainer instanceof IJavaProject) {
@@ -613,6 +613,16 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 			}
 		}
 		return pkgNames;
+	}
+
+	private void addAllSubPackageFragments(IPackageFragment pkgFragment, Set<String> pkgNames) throws JavaModelException {
+		String elementName= getPackageName(pkgFragment.getElementName());
+		IPackageFragmentRoot pkgFragmentRoot= (IPackageFragmentRoot) pkgFragment.getParent();
+		for (IJavaElement child : pkgFragmentRoot.getChildren()) {
+			if (child instanceof IPackageFragment && getPackageName(((IPackageFragment) child).getElementName()).startsWith(elementName) && ((IPackageFragment) child).hasChildren()) {
+				pkgNames.add(getPackageName(((IPackageFragment) child).getElementName()));
+			}
+		}
 	}
 
 	private String getPackageName(String elementName) {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -1153,20 +1153,21 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 		ViewerFilter filter= new TypedViewerFilter(acceptedClasses) {
 			@Override
 			public boolean select(Viewer viewer, Object parent, Object element) {
-			    if (element instanceof IPackageFragmentRoot && ((IPackageFragmentRoot)element).isArchive())
-			        return false;
-			    try {
-					if (element instanceof IPackageFragment && !((IPackageFragment) element).hasChildren()) {
-						return false;
-					}
-				} catch (JavaModelException e) {
+				if (element instanceof IPackageFragmentRoot && ((IPackageFragmentRoot) element).isArchive())
 					return false;
-				}
 				return super.select(viewer, parent, element);
 			}
 		};
 
-		StandardJavaElementContentProvider provider= new StandardJavaElementContentProvider();
+		StandardJavaElementContentProvider provider= new StandardJavaElementContentProvider() {
+			@Override
+			public boolean hasChildren(Object element) {
+				if(element instanceof IPackageFragment) {
+					return false;
+				}
+				return super.hasChildren(element);
+			}
+		};
 		ILabelProvider labelProvider= new JavaElementLabelProvider(JavaElementLabelProvider.SHOW_DEFAULT);
 		ElementTreeSelectionDialog dialog= new ElementTreeSelectionDialog(getShell(), labelProvider, provider);
 		dialog.setValidator(validator);


### PR DESCRIPTION
## What it does
Allow JUnitLauncher to launch all tests in a Package including subpackages.

Fix : https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/420

## How to test
Create a package "a" without test and add a "a.b" with test "C" and in Eclipse run test on "a".
Verify that "C" is run.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
