### PR TITLE
Fixes #426 [20] Allow JDT to target Java 20 in compiler preferences

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -80,7 +84,7 @@ public final class JavaModelUtil {
 	 */
 	public static final String VERSION_LATEST;
 	static {
-		VERSION_LATEST= JavaCore.VERSION_19; // make sure it is not inlined
+		VERSION_LATEST= JavaCore.VERSION_20; // make sure it is not inlined
 	}
 
 	public static final int VALIDATE_EDIT_CHANGED_CONTENT= 10003;
@@ -789,7 +793,7 @@ public final class JavaModelUtil {
 	}
 
 
-	public static boolean is20OrHigher(String compliance) {
+	public static boolean is1d2OrHigher(String compliance) {
 		return !isVersionLessThan(compliance, JavaCore.VERSION_1_2);
 	}
 
@@ -857,6 +861,10 @@ public final class JavaModelUtil {
 		return !isVersionLessThan(compliance, JavaCore.VERSION_19);
 	}
 
+	public static boolean is20OrHigher(String compliance) {
+		return !isVersionLessThan(compliance, JavaCore.VERSION_20);
+	}
+
 	/**
 	 * Checks if the given project or workspace has source compliance 1.2 or greater.
 	 *
@@ -864,7 +872,7 @@ public final class JavaModelUtil {
 	 * @return <code>true</code> if the given project or workspace has source compliance 1.2 or greater.
 	 */
 	public static boolean is1d2OrHigher(IJavaProject project) {
-		return is20OrHigher(getSourceCompliance(project));
+		return is1d2OrHigher(getSourceCompliance(project));
 	}
 
 	/**
@@ -1019,6 +1027,17 @@ public final class JavaModelUtil {
 		return is19OrHigher(getSourceCompliance(project));
 	}
 
+	/**
+	 * Checks if the given project or workspace has source compliance 20 or greater.
+	 *
+	 * @param project the project to test or <code>null</code> to test the workspace settings
+	 * @return <code>true</code> if the given project or workspace has source compliance 20 or
+	 *         greater.
+	 */
+	public static boolean is20OrHigher(IJavaProject project) {
+		return is20OrHigher(getSourceCompliance(project));
+	}
+
 	public static String getSourceCompliance(IJavaProject project) {
 		return project != null ? project.getOption(JavaCore.COMPILER_SOURCE, true) : JavaCore.getOption(JavaCore.COMPILER_SOURCE);
 	}
@@ -1069,6 +1088,10 @@ public final class JavaModelUtil {
 		String version= vMInstall.getJavaVersion();
 		if (version == null) {
 			return defaultCompliance;
+		} else if (version.startsWith(JavaCore.VERSION_20)) {
+			return JavaCore.VERSION_20;
+		} else if (version.startsWith(JavaCore.VERSION_19)) {
+			return JavaCore.VERSION_19;
 		} else if (version.startsWith(JavaCore.VERSION_18)) {
 			return JavaCore.VERSION_18;
 		} else if (version.startsWith(JavaCore.VERSION_17)) {
@@ -1117,7 +1140,9 @@ public final class JavaModelUtil {
 
 		// fallback:
 		String desc= executionEnvironment.getId();
-		if (desc.indexOf(JavaCore.VERSION_19) != -1) {
+		if (desc.indexOf(JavaCore.VERSION_20) != -1) {
+			return JavaCore.VERSION_20;
+		} else if (desc.indexOf(JavaCore.VERSION_19) != -1) {
 			return JavaCore.VERSION_19;
 		} else if (desc.indexOf(JavaCore.VERSION_18) != -1) {
 			return JavaCore.VERSION_18;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -155,6 +159,7 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 	private static final String VERSION_17 = JavaCore.VERSION_17;
 	private static final String VERSION_18 = JavaCore.VERSION_18;
 	private static final String VERSION_19 = JavaCore.VERSION_19;
+	private static final String VERSION_20 = JavaCore.VERSION_20;
 	private static final String VERSION_LATEST = JavaCore.latestSupportedJavaVersion();
 	private static final String VERSION_JSR14= "jsr14"; //$NON-NLS-1$
 
@@ -312,7 +317,7 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 	private Composite createComplianceTabContent(Composite folder) {
 
 		final String[] complianceVersions= new String[] { VERSION_1_3, VERSION_1_4,
-				VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_9, VERSION_10, VERSION_11, VERSION_12, VERSION_13, VERSION_14, VERSION_15, VERSION_16, VERSION_17, VERSION_18, VERSION_19 };
+				VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_9, VERSION_10, VERSION_11, VERSION_12, VERSION_13, VERSION_14, VERSION_15, VERSION_16, VERSION_17, VERSION_18, VERSION_19, VERSION_20 };
 		final String[] complianceLabels= new String[] {
 			PreferencesMessages.ComplianceConfigurationBlock_version13,
 			PreferencesMessages.ComplianceConfigurationBlock_version14,
@@ -330,11 +335,12 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 			PreferencesMessages.ComplianceConfigurationBlock_version_16,
 			PreferencesMessages.ComplianceConfigurationBlock_version_17,
 			PreferencesMessages.ComplianceConfigurationBlock_version_18,
-			PreferencesMessages.ComplianceConfigurationBlock_version_19
+			PreferencesMessages.ComplianceConfigurationBlock_version_19,
+			PreferencesMessages.ComplianceConfigurationBlock_version_20
 		};
 
 		String[] targetVersions= new String[] { VERSION_CLDC_1_1, VERSION_1_1, VERSION_1_2, VERSION_1_3, VERSION_1_4,
-				VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_9, VERSION_10, VERSION_11, VERSION_12, VERSION_13, VERSION_14, VERSION_15, VERSION_16, VERSION_17, VERSION_18, VERSION_19 };
+				VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_9, VERSION_10, VERSION_11, VERSION_12, VERSION_13, VERSION_14, VERSION_15, VERSION_16, VERSION_17, VERSION_18, VERSION_19, VERSION_20 };
 		String[] targetLabels= new String[] {
 				PreferencesMessages.ComplianceConfigurationBlock_versionCLDC11,
 				PreferencesMessages.ComplianceConfigurationBlock_version11,
@@ -355,7 +361,8 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 				PreferencesMessages.ComplianceConfigurationBlock_version_16,
 				PreferencesMessages.ComplianceConfigurationBlock_version_17,
 				PreferencesMessages.ComplianceConfigurationBlock_version_18,
-				PreferencesMessages.ComplianceConfigurationBlock_version_19
+				PreferencesMessages.ComplianceConfigurationBlock_version_19,
+				PreferencesMessages.ComplianceConfigurationBlock_version_20
 		};
 		if (ComplianceConfigurationBlock.VERSION_JSR14.equals(getValue(PREF_CODEGEN_TARGET_PLATFORM))) {
 			targetVersions= append(targetVersions, ComplianceConfigurationBlock.VERSION_JSR14);
@@ -363,7 +370,7 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 		}
 
 		String[] sourceVersions= new String[] { VERSION_1_3, VERSION_1_4,
-				VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_9, VERSION_10, VERSION_11, VERSION_12, VERSION_13, VERSION_14, VERSION_15, VERSION_16, VERSION_17, VERSION_18, VERSION_19 };
+				VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_9, VERSION_10, VERSION_11, VERSION_12, VERSION_13, VERSION_14, VERSION_15, VERSION_16, VERSION_17, VERSION_18, VERSION_19, VERSION_20 };
 		String[] sourceLabels= new String[] {
 				PreferencesMessages.ComplianceConfigurationBlock_version13,
 				PreferencesMessages.ComplianceConfigurationBlock_version14,
@@ -381,7 +388,8 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 				PreferencesMessages.ComplianceConfigurationBlock_version_16,
 				PreferencesMessages.ComplianceConfigurationBlock_version_17,
 				PreferencesMessages.ComplianceConfigurationBlock_version_18,
-				PreferencesMessages.ComplianceConfigurationBlock_version_19
+				PreferencesMessages.ComplianceConfigurationBlock_version_19,
+				PreferencesMessages.ComplianceConfigurationBlock_version_20
 		};
 
 		final ScrolledPageContent sc1 = new ScrolledPageContent(folder);
@@ -841,13 +849,13 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 				}
 			}
 
-//			//TODO: Comment once Java SE 19 has been shipped:
-//			String selectedCompliance= getValue(PREF_COMPLIANCE);
-//			if (VERSION_19.equals(selectedCompliance)) {
-//				fJRE50InfoText.setText(
-//						"This is an implementation of an early-draft specification developed under the Java Community Process (JCP) and is made available for testing and evaluation purposes only. The code is not compatible with any specification of the JCP."); //$NON-NLS-1$
-//				isVisible= true;
-//			}
+			//TODO: Comment once Java SE 20 has been shipped:
+			String selectedCompliance= getValue(PREF_COMPLIANCE);
+			if (VERSION_20.equals(selectedCompliance)) {
+				fJRE50InfoText.setText(
+						"This is an implementation of an early-draft specification developed under the Java Community Process (JCP) and is made available for testing and evaluation purposes only. The code is not compatible with any specification of the JCP."); //$NON-NLS-1$
+				isVisible= true;
+			}
 
 			fJRE50InfoText.setVisible(isVisible);
 			fJRE50InfoImage.setImage(isVisible ? image : null);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     John Kaplan, johnkaplantech@gmail.com - 108071 [code templates] template for body of newly created class
@@ -845,6 +849,7 @@ public final class PreferencesMessages extends NLS {
 	public static String ComplianceConfigurationBlock_version_17;
 	public static String ComplianceConfigurationBlock_version_18;
 	public static String ComplianceConfigurationBlock_version_19;
+	public static String ComplianceConfigurationBlock_version_20;
 	public static String ComplianceConfigurationBlock_versionCLDC11;
 	public static String ComplianceConfigurationBlock_src_greater_compliance;
 	public static String ComplianceConfigurationBlock_classfile_greater_compliance;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -7,6 +7,10 @@
 # https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
+# 
+# This is an implementation of an early-draft specification developed under the Java
+# Community Process (JCP) and is made available for testing and evaluation purposes
+# only. The code is not compatible with any specification of the JCP.
 #
 # Contributors:
 #     IBM Corporation - initial API and implementation
@@ -599,6 +603,7 @@ ComplianceConfigurationBlock_version_16=16
 ComplianceConfigurationBlock_version_17=17
 ComplianceConfigurationBlock_version_18=18
 ComplianceConfigurationBlock_version_19=19
+ComplianceConfigurationBlock_version_20=20 (BETA)
 ComplianceConfigurationBlock_versionCLDC11=CLDC 1.1
 
 ComplianceConfigurationBlock_needsbuild_title=Compiler Settings Changed

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
   <profiles>
     <profile>
       <id>build-individual-bundles</id>
+      <properties>
+      	<eclipse-p2-repo.url>http://download.eclipse.org/eclipse/updates/Y-builds</eclipse-p2-repo.url>
+      	<skipAPIAnalysis>true</skipAPIAnalysis>
+      </properties>
       <repositories>
         <repository>
           <releases>


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/426

Signed-off-by: Noopur Gupta [noopur_gupta@in.ibm.com](mailto:noopur_gupta@in.ibm.com)

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
