### PR TITLE
Make Text Block indentation consistent

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/IndentActionTest15.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/IndentActionTest15.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2022 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -171,6 +171,58 @@ public class IndentActionTest15 {
 
 	@Test
 	public void testIssue30_4() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_PRESERVE));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+
+	@Test
+	public void testIssue414_1() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_BY_ONE));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+
+	@Test
+	public void testIssue414_2() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_DEFAULT));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+
+	@Test
+	public void testIssue414_3() throws Exception {
+		IJavaProject project= indentTestSetup.getProject();
+		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
+		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_ON_COLUMN));
+		try {
+			selectAll();
+			assertIndentResult();
+		} finally {
+			project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, value);
+		}
+	}
+
+	@Test
+	public void testIssue414_4() throws Exception {
 		IJavaProject project= indentTestSetup.getProject();
 		String value= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, true);
 		project.setOption(DefaultCodeFormatterConstants.FORMATTER_TEXT_BLOCK_INDENTATION, Integer.toString(DefaultCodeFormatterConstants.INDENT_PRESERVE));

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_1/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_1/Before.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = 
+				"""
+				This is a text block
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_1/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_1/Modified.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = 
+			"""
+			This is a text block
+			   with an indent
+			""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_2/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_2/Before.java
@@ -1,0 +1,12 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = 
+				"""
+				This is a text block
+				
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_2/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_2/Modified.java
@@ -1,0 +1,12 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = 
+				"""
+				This is a text block
+
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_3/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_3/Before.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = 
+				"""
+				This is a text block
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_3/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_3/Modified.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = 
+					"""
+					This is a text block
+					   with an indent
+					""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_4/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_4/Before.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x = 
+				"""
+				This is a text block
+				   with an indent
+				""";
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_4/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_4/Modified.java
@@ -1,0 +1,11 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x = 
+"""
+This is a text block
+   with an indent
+""";
+	}
+}


### PR DESCRIPTION
- make text block indentation the same whether the open quotes occur on a separate line or at the end of another line
- fixes #414

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #414

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
