### PR TITLE
Moving a package shows many JRT as possible target

### DIFF
--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 20230 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *     IBM Corporation - initial API and implementation
  *     Carsten Pfeiffer <carsten.pfeiffer@gebit.de> - [ccp] ReorgPolicies' canEnable() methods return true too often - https://bugs.eclipse.org/bugs/show_bug.cgi?id=303698
  *     Yves Joan <yves.joan@oracle.com> - [reorg] Copy action should NOT add 'copy of' prefix - https://bugs.eclipse.org/bugs/show_bug.cgi?id=151668
+ *     Red Hat Inc. - [reorg] Move of package should not show binary roots and package roots should not expand - https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/430
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.refactoring.reorg;
 
@@ -3097,7 +3098,6 @@ public final class ReorgPolicyFactory {
 			switch (javaElement.getElementType()) {
 				case IJavaElement.JAVA_MODEL:
 				case IJavaElement.JAVA_PROJECT:
-				case IJavaElement.PACKAGE_FRAGMENT_ROOT:
 					// can be nested
 					// (with exclusion
 					// filters)
@@ -3116,8 +3116,13 @@ public final class ReorgPolicyFactory {
 		public boolean canElementBeDestination(IJavaElement javaElement) {
 			switch (javaElement.getElementType()) {
 				case IJavaElement.JAVA_PROJECT:
-				case IJavaElement.PACKAGE_FRAGMENT_ROOT:
 					return true;
+				case IJavaElement.PACKAGE_FRAGMENT_ROOT:
+					try {
+						return ((IPackageFragmentRoot)javaElement).getKind() != IPackageFragmentRoot.K_BINARY;
+					} catch (JavaModelException e) {
+						return false;
+					}
 				default:
 					return false;
 			}

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 20230 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
- fixes #430
- fix PackagesReorgPolicy to not show binary IPackageRoots such as jar files as destinations
- also mark IPackageRoots as not having children as destinations

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the reorg policy for packages so that binary source roots are not offered as destinations.  Also don't mark a
root as having children that can be destinations.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Select a package and right-click to bring up the Refactor->Move... menu.  No jars should be shown.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
