### PR TITLE
Support StringBuffer/StringBuilder concat to Text Block

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -204,6 +204,7 @@ public class MultiFixMessages extends NLS {
 	public static String ConstantsCleanUp_description;
 	public static String StringBufferToStringBuilderCleanUp_description;
 	public static String StringConcatToTextBlockCleanUp_description;
+	public static String StringConcatToTextBlockStringBuffer_description;
 	public static String StringBuilderForLocalVarsOnlyCleanUp_description;
 
 	static {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2005, 2022 IBM Corporation and others.
+# Copyright (c) 2005, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -186,4 +186,5 @@ MultiCatchCleanUp_description=Multi-catch
 ConstantsCleanUp_description=Use Java method instead of system property ''{0}''
 StringBufferToStringBuilderCleanUp_description=Convert StringBuffer to StringBuilder
 StringConcatToTextBlockCleanUp_description=Convert String concatenation to Text Block
+StringConcatToTextBlockStringBuffer_description=Convert String/StringBuffer/StringBuilder concatenation to Text Block
 StringBuilderForLocalVarsOnlyCleanUp_description=Convert StringBuffer to StringBuilder for local variables

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/StringConcatToTextBlockCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/StringConcatToTextBlockCleanUpCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -51,12 +51,15 @@ public class StringConcatToTextBlockCleanUpCore extends AbstractCleanUpCore {
 			return null;
 		}
 
-		return StringConcatToTextBlockFixCore.createCleanUp(compilationUnit);
+		return StringConcatToTextBlockFixCore.createCleanUp(compilationUnit, isEnabled(CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER));
 	}
 
 	@Override
 	public String[] getStepDescriptions() {
 		if (isEnabled(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK)) {
+			if (isEnabled(CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER)) {
+				return new String[] {MultiFixMessages.StringConcatToTextBlockStringBuffer_description};
+			}
 			return new String[] {MultiFixMessages.StringConcatToTextBlockCleanUp_description};
 		}
 		return new String[0];
@@ -79,6 +82,20 @@ public class StringConcatToTextBlockCleanUpCore extends AbstractCleanUpCore {
 			bld.append("    \"    public void foo() {\" +\n"); //$NON-NLS-1$
 			bld.append("    \"    }\" + \n"); //$NON-NLS-1$
 			bld.append("    \"}\";\n"); //$NON-NLS-1$
+		}
+		bld.append("\n"); //$NON-NLS-1$
+		if (isEnabled(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK) && isEnabled(CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER)) {
+			bld.append("String k = \"\"\"\n"); //$NON-NLS-1$
+			bld.append("    public void foo() {\n"); //$NON-NLS-1$
+			bld.append("        return null;\n"); //$NON-NLS-1$
+			bld.append("    }\n"); //$NON-NLS-1$
+			bld.append("    \"\"\";\n"); //$NON-NLS-1$
+		} else {
+			bld.append("StringBuffer buf= new StringBuffer();\n"); //$NON-NLS-1$
+			bld.append("buf.append(\"public void foo() {\\n\");\n"); //$NON-NLS-1$
+			bld.append("buf.append(\"    return null;\\n\");\n"); //$NON-NLS-1$
+			bld.append("buf.append(\"}\\n\");\n"); //$NON-NLS-1$
+			bld.append("String k = buf.toString();\n"); //$NON-NLS-1$
 		}
 
 		return bld.toString();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1236,6 +1236,32 @@ public class CleanUpConstants {
 	 */
 
 	public static final String STRINGCONCAT_TO_TEXTBLOCK= "cleanup.stringconcat_to_textblock"; //$NON-NLS-1$
+
+	/**
+	 * Replaces String concatenation via StringBuffer or StringBuilder to Text Block for Java 15 and higher.
+	 * Only applies if StringBuffer/StringBuilder append() method is used and immediately followed by toString().
+	 * Will not convert if subsequent code uses variable without an assignment to a new StringBuffer/StringBuilder.
+	 * <p>
+	 * Example:
+	 *
+	 * <pre>
+	 *			StringBuffer buf = new StringBuffer();
+	 *			buf.append("abc\n");
+	 *			buf.append("def\n");
+	 *			String s = buf.toString();
+	 * </pre>
+	 *
+	 * Only has an effect if {@link #STRINGCONCAT_TO_TEXTBLOCK} is TRUE <br>
+	 * <br>
+	 * Possible values: {TRUE, FALSE}<br>
+	 *
+	 * <br>
+	 *
+	 * @see CleanUpOptionsCore#TRUE
+	 * @see CleanUpOptionsCore#FALSE
+	 * @since 4.28
+	 */
+	public static String STRINGCONCAT_STRINGBUFFER_STRINGBUILDER= "cleanup.stringconcat_stringbuffer_stringbuilder"; //$NON-NLS-1$
 
 	/**
 	 * Only replace local var StringBuffer uses with StringBuilder.

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,11 @@
 package org.eclipse.jdt.internal.corext.fix;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -22,24 +26,40 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.text.edits.TextEditGroup;
 
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.Assignment;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.Comment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.LineComment;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.NullLiteral;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.TextBlock;
 import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
@@ -48,6 +68,9 @@ import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperationsFixCore {
 
 	private final static String JAVA_STRING= "java.lang.String"; //$NON-NLS-1$
+	private final static String JAVA_STRINGBUFFER= "java.lang.StringBuffer"; //$NON-NLS-1$
+	private final static String JAVA_STRINGBUILDER= "java.lang.StringBuilder"; //$NON-NLS-1$
+	private final static String NLSComment= "$NON-NLS-1$"; //$NON-NLS-1$
 
 	public static final class StringConcatFinder extends ASTVisitor {
 
@@ -206,98 +229,494 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			rewrite.replace(fInfix, textBlock, group);
 		}
 
-		/*
-		 * Split a given string into parts of a text block. Transformations undertaken will be:
-		 *
-		 * 1. Split the text at newline boundaries. The newline will be replaced at the end
-		 * of the first line being split with System.lineTerminator()
-		 * 2. Transform any sequence of three or more double quotes in such that it's not interpreted as "end of text block"
-		 * 3. Transform any trailing spaces into \s escapes
-		 * 4. Transform any non-trailing \t characters into tab characters
-		 */
-		private List<String> unescapeBlock(String escapedText) {
-			StringBuilder transformed= new StringBuilder();
-			int readIndex= 0;
-			int bsIndex= 0;
+	}
 
-			List<String> parts= new ArrayList<>();
+	/*
+	 * Split a given string into parts of a text block. Transformations undertaken will be:
+	 *
+	 * 1. Split the text at newline boundaries. The newline will be replaced at the end
+	 * of the first line being split with System.lineTerminator()
+	 * 2. Transform any sequence of three or more double quotes in such that it's not interpreted as "end of text block"
+	 * 3. Transform any trailing spaces into \s escapes
+	 * 4. Transform any non-trailing \t characters into tab characters
+	 */
+	private static List<String> unescapeBlock(String escapedText) {
+		StringBuilder transformed= new StringBuilder();
+		int readIndex= 0;
+		int bsIndex= 0;
 
-			while ((bsIndex= escapedText.indexOf("\\", readIndex)) >= 0) { //$NON-NLS-1$ "\"
-				if (escapedText.startsWith("\\n", bsIndex)) { //$NON-NLS-1$ "\n"
-					transformed.append(escapedText.substring(readIndex, bsIndex));
-					parts.add(escapeTrailingWhitespace(transformed.toString())+ System.lineSeparator());
-					transformed= new StringBuilder();
-					readIndex= bsIndex + 2;
-				} else if (escapedText.startsWith("\\\"", bsIndex)) { //$NON-NLS-1$ "\""
-					// if there are more than three quotes in a row, escape the first quote of every triplet to
-					// avoid it being interpreted as a text block terminator. This code would be much simpler if
-					// we could escape the third quote of each triplet, but the text block spec recommends this way.
+		List<String> parts= new ArrayList<>();
 
-					transformed.append(escapedText.substring(readIndex, bsIndex));
-					int quoteCount= 1;
-					while (escapedText.startsWith("\\\"", bsIndex + 2 * quoteCount)) { //$NON-NLS-1$
-						quoteCount++;
-					}
-					int i= 0;
-					while (i < quoteCount / 3) {
-						transformed.append("\\\"\"\""); //$NON-NLS-1$
-						i++;
-					}
+		while ((bsIndex= escapedText.indexOf("\\", readIndex)) >= 0) { //$NON-NLS-1$ "\"
+			if (escapedText.startsWith("\\n", bsIndex)) { //$NON-NLS-1$ "\n"
+				transformed.append(escapedText.substring(readIndex, bsIndex));
+				parts.add(escapeTrailingWhitespace(transformed.toString())+ System.lineSeparator());
+				transformed= new StringBuilder();
+				readIndex= bsIndex + 2;
+			} else if (escapedText.startsWith("\\\"", bsIndex)) { //$NON-NLS-1$ "\""
+				// if there are more than three quotes in a row, escape the first quote of every triplet to
+				// avoid it being interpreted as a text block terminator. This code would be much simpler if
+				// we could escape the third quote of each triplet, but the text block spec recommends this way.
 
-					if (i > 0 && quoteCount % 3 != 0) {
-						transformed.append("\\"); //$NON-NLS-1$
-					}
-					for (int j = 0; j < quoteCount % 3; j++) {
-						transformed.append("\""); //$NON-NLS-1$
-					}
-
-					readIndex= bsIndex + 2 * quoteCount;
-				} else if (escapedText.startsWith("\\t", bsIndex)) { //$NON-NLS-1$ "\t"
-					transformed.append(escapedText.substring(readIndex, bsIndex));
-					transformed.append("\t"); //$NON-NLS-1$
-					readIndex= bsIndex+2;
-				} else {
-					transformed.append(escapedText.substring(readIndex, bsIndex));
-					transformed.append("\\").append(escapedText.charAt(bsIndex + 1)); //$NON-NLS-1$
-					readIndex= bsIndex + 2;
+				transformed.append(escapedText.substring(readIndex, bsIndex));
+				int quoteCount= 1;
+				while (escapedText.startsWith("\\\"", bsIndex + 2 * quoteCount)) { //$NON-NLS-1$
+					quoteCount++;
 				}
+				int i= 0;
+				while (i < quoteCount / 3) {
+					transformed.append("\\\"\"\""); //$NON-NLS-1$
+					i++;
+				}
+
+				if (i > 0 && quoteCount % 3 != 0) {
+					transformed.append("\\"); //$NON-NLS-1$
+				}
+				for (int j = 0; j < quoteCount % 3; j++) {
+					transformed.append("\""); //$NON-NLS-1$
+				}
+
+				readIndex= bsIndex + 2 * quoteCount;
+			} else if (escapedText.startsWith("\\t", bsIndex)) { //$NON-NLS-1$ "\t"
+				transformed.append(escapedText.substring(readIndex, bsIndex));
+				transformed.append("\t"); //$NON-NLS-1$
+				readIndex= bsIndex+2;
+			} else {
+				transformed.append(escapedText.substring(readIndex, bsIndex));
+				transformed.append("\\").append(escapedText.charAt(bsIndex + 1)); //$NON-NLS-1$
+				readIndex= bsIndex + 2;
 			}
-			if (readIndex < escapedText.length()) {
-				// there is text at the end of the string that is not followed by a newline
-				transformed.append(escapeTrailingWhitespace(escapedText.substring(readIndex)));
+		}
+		if (readIndex < escapedText.length()) {
+			// there is text at the end of the string that is not followed by a newline
+			transformed.append(escapeTrailingWhitespace(escapedText.substring(readIndex)));
+		}
+		if (transformed.length() > 0) {
+			parts.add(transformed.toString());
+		}
+		return parts;
+	}
+
+	/*
+	 * Escape spaces and tabs at the end of a line, because they would be trimmed from a text block
+	 */
+	private static String escapeTrailingWhitespace(String unescaped) {
+		if (unescaped.length() == 0) {
+			return ""; //$NON-NLS-1$
+		}
+		int whitespaceStart= unescaped.length()-1;
+		StringBuilder trailingWhitespace= new StringBuilder();
+		while (whitespaceStart > 0) {
+			if (unescaped.charAt(whitespaceStart) == ' ') {
+				whitespaceStart--;
+				trailingWhitespace.append("\\s"); //$NON-NLS-1$
+			} else if (unescaped.charAt(whitespaceStart) == '\t') {
+				whitespaceStart--;
+				trailingWhitespace.append("\\t"); //$NON-NLS-1$
+			} else {
+				break;
 			}
-			if (transformed.length() > 0) {
-				parts.add(transformed.toString());
-			}
-			return parts;
 		}
 
-		/*
-		 * Escape spaces and tabs at the end of a line, because they would be trimmed from a text block
-		 */
-		private static String escapeTrailingWhitespace(String unescaped) {
-			if (unescaped.length() == 0) {
-				return ""; //$NON-NLS-1$
+		return unescaped.substring(0, whitespaceStart + 1) + trailingWhitespace;
+	}
+
+	public static final class StringBufferFinder extends ASTVisitor {
+
+		private final List<CompilationUnitRewriteOperation> fOperations;
+		private List<StringLiteral> fLiterals= new ArrayList<>();
+		private List<Statement> statementList= new ArrayList<>();
+		private SimpleName originalVarName;
+		private Map<ExpressionStatement, ChangeStringBufferToTextBlock> conversions= new HashMap<>();
+		private final String APPEND= "append"; //$NON-NLS-1$
+		private final String TO_STRING= "toString"; //$NON-NLS-1$
+		private final Set<String> fExcludedNames;
+
+		public StringBufferFinder(List<CompilationUnitRewriteOperation> operations, Set<String> excludedNames) {
+			super(true);
+			fOperations= operations;
+			fExcludedNames= excludedNames;
+		}
+
+		private class CheckValidityVisitor extends ASTVisitor {
+			private boolean valid= true;
+			private ExpressionStatement nextAssignment= null;
+			private int lastStatementEnd;
+			private IBinding varBinding;
+			private List<MethodInvocation> toStringList= new ArrayList<>();
+
+			public CheckValidityVisitor(int lastStatementEnd, IBinding varBinding) {
+				this.lastStatementEnd= lastStatementEnd;
+				this.varBinding= varBinding;
 			}
-			int whitespaceStart= unescaped.length()-1;
-			StringBuilder trailingWhitespace= new StringBuilder();
-			while (whitespaceStart > 0) {
-				if (unescaped.charAt(whitespaceStart) == ' ') {
-					whitespaceStart--;
-					trailingWhitespace.append("\\s"); //$NON-NLS-1$
-				} else if (unescaped.charAt(whitespaceStart) == '\t') {
-					whitespaceStart--;
-					trailingWhitespace.append("\\t"); //$NON-NLS-1$
+
+			public boolean isValid() {
+				return valid;
+			}
+
+			public ExpressionStatement getNextAssignment() {
+				return nextAssignment;
+			}
+
+			public List<MethodInvocation> getToStringList() {
+				return toStringList;
+			}
+
+			@Override
+			public boolean visit(SimpleName name) {
+				if (name.getStartPosition() > lastStatementEnd) {
+					IBinding binding= name.resolveBinding();
+					if (varBinding.isEqualTo(binding)) {
+						valid= false;
+						if (name.getLocationInParent() == Assignment.LEFT_HAND_SIDE_PROPERTY) {
+							Assignment assignment= (Assignment) name.getParent();
+							ASTNode parent= assignment.getParent();
+							if (parent instanceof ExpressionStatement &&
+									(assignment.getRightHandSide() instanceof ClassInstanceCreation ||
+											assignment.getRightHandSide() instanceof NullLiteral)) {
+								valid=true;
+								nextAssignment= (ExpressionStatement)parent;
+							}
+						} else if (name.getLocationInParent() == MethodInvocation.EXPRESSION_PROPERTY) {
+							MethodInvocation invocation= (MethodInvocation) name.getParent();
+							if (invocation.getName().getFullyQualifiedName().equals(TO_STRING)) {
+								valid= true;
+								toStringList.add(invocation);
+								return true;
+							} else {
+								valid= false;
+							}
+						} else {
+							valid= false;
+						}
+						throw new AbortSearchException();
+					}
+				}
+				return true;
+			}
+		}
+
+		public Map<ExpressionStatement, ChangeStringBufferToTextBlock> getConversionMap() {
+			return conversions;
+		}
+
+		private boolean isStringBufferType(Type type) {
+			if (type instanceof ArrayType) {
+				return false;
+			}
+			ITypeBinding typeBinding= type.resolveBinding();
+			if (typeBinding == null || (!typeBinding.getQualifiedName().equals(JAVA_STRINGBUFFER) && !typeBinding.getQualifiedName().equals(JAVA_STRINGBUILDER))) {
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		public boolean visit(ClassInstanceCreation node) {
+			if (!isStringBufferType(node.getType())) {
+				return false;
+			}
+			List<Expression> args= node.arguments();
+			Statement statement= ASTNodes.getFirstAncestorOrNull(node, Statement.class);
+			if (statement.getLocationInParent() != Block.STATEMENTS_PROPERTY ||
+					!(statement instanceof VariableDeclarationStatement) &&
+					!(statement instanceof ExpressionStatement)) {
+				return false;
+			}
+			boolean nonNLS= false;
+			CompilationUnit cu= (CompilationUnit) node.getRoot();
+			ICompilationUnit icu= (ICompilationUnit) cu.getJavaElement();
+			if (args.size() == 1 && args.get(0) instanceof StringLiteral) {
+				fLiterals.add((StringLiteral)args.get(0));
+				nonNLS= hasNLSMarker(statement, icu);
+			}
+			Block block= (Block) statement.getParent();
+			List<Statement> stmtList= block.statements();
+			int startIndex= stmtList.indexOf(statement);
+			int i= startIndex;
+			while (++i < stmtList.size()) {
+				Statement s= stmtList.get(i);
+				if (s instanceof ExpressionStatement) {
+					Expression exp= ((ExpressionStatement)s).getExpression();
+					if (exp instanceof MethodInvocation) {
+						MethodInvocation method= (MethodInvocation)exp;
+						Expression invocationExp= method.getExpression();
+						if (invocationExp instanceof SimpleName &&
+								((SimpleName)invocationExp).getFullyQualifiedName().equals(originalVarName.getFullyQualifiedName()) &&
+								method.getName().getFullyQualifiedName().equals(APPEND)) {
+							Expression arg= (Expression) method.arguments().get(0);
+							if (arg instanceof StringLiteral) {
+								if (nonNLS != hasNLSMarker(s, icu)) {
+									nonNLS= !nonNLS;
+									if (i - startIndex > 1 || args.size() == 1) {
+										return false;
+									}
+								}
+								fLiterals.add((StringLiteral)arg);
+								statementList.add(s);
+							} else {
+								return false;
+							}
+						} else {
+							break;
+						}
+					} else {
+						break;
+					}
 				} else {
 					break;
 				}
 			}
-
-			return unescaped.substring(0, whitespaceStart + 1) + trailingWhitespace;
+			Statement endStatement= stmtList.get(i - 1);
+			int lastStatementEnd= endStatement.getStartPosition() + endStatement.getLength();
+			IBinding varBinding= originalVarName.resolveBinding();
+			if (varBinding == null) {
+				return false;
+			}
+			CheckValidityVisitor checkValidityVisitor= new CheckValidityVisitor(lastStatementEnd, varBinding);
+			try {
+				block.accept(checkValidityVisitor);
+			} catch (AbortSearchException e) {
+				// do nothing
+			}
+			if (!checkValidityVisitor.isValid() || checkValidityVisitor.getToStringList().size() == 0) {
+				statementList.clear();
+				fLiterals.clear();
+				return false;
+			}
+			ExpressionStatement assignmentToConvert= checkValidityVisitor.getNextAssignment();
+			List<Statement> statements= new ArrayList<>(statementList);
+			List<StringLiteral> literals= new ArrayList<>(fLiterals);
+			List<MethodInvocation> toStringList= new ArrayList<>(checkValidityVisitor.getToStringList());
+			ChangeStringBufferToTextBlock operation= new ChangeStringBufferToTextBlock(toStringList, statements, literals, assignmentToConvert, fExcludedNames, nonNLS);
+			fOperations.add(operation);
+			conversions.put(assignmentToConvert, operation);
+			statementList.clear();
+			fLiterals.clear();
+			return true;
 		}
+
+		@Override
+		public boolean visit(final VariableDeclarationStatement visited) {
+			Type type= visited.getType();
+			if (!isStringBufferType(type) || visited.fragments().size() != 1) {
+				return false;
+			}
+			return true;
+		}
+
+		@Override
+		public boolean visit(VariableDeclarationFragment node) {
+			// TODO Auto-generated method stub
+			VariableDeclarationStatement varDeclStmt= ASTNodes.getFirstAncestorOrNull(node, VariableDeclarationStatement.class);
+			if (varDeclStmt == null || varDeclStmt.fragments().size() != 1) {
+				return false;
+			}
+			originalVarName= node.getName();
+			statementList.add(varDeclStmt);
+			return true;
+		}
+
+		@Override
+		public boolean visit(final Assignment visited) {
+			ITypeBinding typeBinding= visited.resolveTypeBinding();
+			if (typeBinding == null || (!typeBinding.getQualifiedName().equals(JAVA_STRINGBUFFER) && !typeBinding.getQualifiedName().equals(JAVA_STRINGBUILDER))) {
+				return false;
+			}
+			if (!(visited.getLeftHandSide() instanceof SimpleName)) {
+				return false;
+			}
+			ExpressionStatement statement= ASTNodes.getFirstAncestorOrNull(visited, ExpressionStatement.class);
+			if (statement == null) {
+				return false;
+			}
+			originalVarName= ((SimpleName)visited.getLeftHandSide());
+			statementList.add(statement);
+			return true;
+		}
+
 	}
 
-	public static ICleanUpFixCore createCleanUp(final CompilationUnit compilationUnit) {
+	private static boolean hasNLSMarker(Statement statement, ICompilationUnit cu) {
+		boolean hasNLS= false;
+		List<Comment> commentList= ASTNodes.getTrailingComments(statement);
+		if (commentList.size() > 0) {
+			if (commentList.get(0) instanceof LineComment) {
+				LineComment lineComment= (LineComment) commentList.get(0);
+				try {
+					String comment= cu.getBuffer().getText(lineComment.getStartPosition() + 2, lineComment.getLength() - 2).trim();
+					hasNLS= comment.equals(NLSComment);
+				} catch (IndexOutOfBoundsException | JavaModelException e) {
+					return false;
+				}
+			}
+		}
+		return hasNLS;
+	}
+
+	public static class ChangeStringBufferToTextBlock extends CompilationUnitRewriteOperation {
+
+		private final List<MethodInvocation> fToStringList;
+		private final List<Statement> fStatements;
+		private final List<StringLiteral> fLiterals;
+		private final String fIndent;
+		private final Set<String> fExcludedNames;
+		private final boolean fNonNLS;
+		private ExpressionStatement fAssignmentToConvert;
+
+		public ChangeStringBufferToTextBlock(final List<MethodInvocation> toStringList, List<Statement> statements,
+				List<StringLiteral> literals, ExpressionStatement assignmentToConvert, Set<String> excludedNames, boolean nonNLS) {
+			this.fToStringList= toStringList;
+			this.fStatements= statements;
+			this.fLiterals= literals;
+			this.fAssignmentToConvert= assignmentToConvert;
+			this.fIndent= "\t"; //$NON-NLS-1$
+			this.fExcludedNames= excludedNames;
+			this.fNonNLS= nonNLS;
+		}
+
+		public List<Statement> getStatements() {
+			return fStatements;
+		}
+
+		public void resetAssignmentToConvert() {
+			fAssignmentToConvert= null;
+		}
+
+		@Override
+		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+			String DEFAULT_NAME= "str"; //$NON-NLS-1$
+			ASTRewrite rewrite= cuRewrite.getASTRewrite();
+			TextEditGroup group= createTextEditGroup(MultiFixMessages.StringConcatToTextBlockCleanUp_description, cuRewrite);
+			rewrite.setTargetSourceRangeComputer(new TargetSourceRangeComputer() {
+				@Override
+				public SourceRange computeSourceRange(final ASTNode nodeWithComment) {
+					if (Boolean.TRUE.equals(nodeWithComment.getProperty(ASTNodes.UNTOUCH_COMMENT))) {
+						return new SourceRange(nodeWithComment.getStartPosition(), nodeWithComment.getLength());
+					}
+
+					return super.computeSourceRange(nodeWithComment);
+				}
+			});
+
+			StringBuilder buf= new StringBuilder();
+
+			List<String> parts= new ArrayList<>();
+			fLiterals.stream().forEach((t) -> { String value= t.getEscapedValue(); parts.addAll(unescapeBlock(value.substring(1, value.length() - 1))); });
+
+
+			buf.append("\"\"\"\n"); //$NON-NLS-1$
+			boolean newLine= false;
+			for (String part : parts) {
+				if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
+					if (!newLine) {
+						// no line terminator in this part: merge the line by emitting a line continuation escape
+						buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
+					}
+				}
+				newLine= part.endsWith(System.lineSeparator());
+				buf.append(fIndent).append(part);
+			}
+
+			if (newLine) {
+				buf.append(fIndent);
+			}
+			buf.append("\"\"\""); //$NON-NLS-1$
+			MethodInvocation firstToStringCall= fToStringList.get(0);
+			AST ast= firstToStringCall.getAST();
+			if (fToStringList.size() == 1 &&
+					ASTNodes.getLeadingComments(fStatements.get(0)).size() == 0 &&
+					(firstToStringCall.getLocationInParent() == Assignment.RIGHT_HAND_SIDE_PROPERTY ||
+					firstToStringCall.getLocationInParent() == VariableDeclarationFragment.INITIALIZER_PROPERTY)) {
+				// if we only have one use of buffer.toString() and it is assigned to another string variable,
+				// put the text block in place of the buffer.toString() call and delete the whole StringBuffer/StringBuilder
+				if (fNonNLS) {
+					Statement firstStatement= ASTNodes.getFirstAncestorOrNull(firstToStringCall, Statement.class);
+					ICompilationUnit cu= cuRewrite.getCu();
+					String newStmtText= cu.getBuffer().getText(firstStatement.getStartPosition(), firstToStringCall.getStartPosition() - firstStatement.getStartPosition());
+					newStmtText= newStmtText + buf.toString() + (fNonNLS ? "; //$NON-NLS-1$" : ";"); //$NON-NLS-1$ //$NON-NLS-2$
+					Statement newStmt= (Statement)rewrite.createStringPlaceholder(newStmtText, firstStatement.getNodeType());
+					ASTNodes.replaceButKeepComment(rewrite, firstStatement, newStmt, group);
+				} else {
+					TextBlock textBlock= (TextBlock) rewrite.createStringPlaceholder(buf.toString(), ASTNode.TEXT_BLOCK);
+					rewrite.replace(firstToStringCall, textBlock, group);
+				}
+				for (Statement statement : fStatements) {
+					rewrite.remove(statement, group);
+				}
+			} else {
+				// otherwise, create a new text block variable and use the variable name in every place the buffer.toString()
+				// call is found before the variable is reused to form a new StringBuilder/StringBuffer
+				ImportRewrite importRewriter= cuRewrite.getImportRewrite();
+				ITypeBinding binding= firstToStringCall.resolveTypeBinding();
+				if (binding != null) {
+					Set<String> excludedNames= new HashSet<>(ASTNodes.getVisibleLocalVariablesInScope(fToStringList.get(fToStringList.size() - 1)));
+					excludedNames.addAll(fExcludedNames);
+					String newVarName= DEFAULT_NAME;
+					if (excludedNames.contains(DEFAULT_NAME)) {
+						newVarName= createName(DEFAULT_NAME, excludedNames);
+					}
+					fExcludedNames.add(newVarName);
+					Type t= importRewriter.addImport(binding, ast);
+					if (!fNonNLS || hasNLSMarker(fStatements.get(0), cuRewrite.getCu())) {
+						TextBlock textBlock= (TextBlock) rewrite.createStringPlaceholder(buf.toString(), ASTNode.TEXT_BLOCK);
+						VariableDeclarationFragment newFragment= ast.newVariableDeclarationFragment();
+						newFragment.setName(ast.newSimpleName(newVarName));
+						newFragment.setInitializer(textBlock);
+						VariableDeclarationStatement newStmt= ast.newVariableDeclarationStatement(newFragment);
+						newStmt.setType(t);
+						ASTNodes.replaceButKeepComment(rewrite, fStatements.get(0), newStmt, group);
+					} else {
+						StringBuilder builder= new StringBuilder();
+						builder.append("String "); //$NON-NLS-1$
+						builder.append(newVarName);
+						builder.append(" = "); //$NON-NLS-1$
+						builder.append(buf.toString());
+						builder.append("; //$NON-NLS-1$"); //$NON-NLS-1$
+						VariableDeclarationStatement newStmt= (VariableDeclarationStatement) rewrite.createStringPlaceholder(builder.toString(), ASTNode.VARIABLE_DECLARATION_STATEMENT);
+						ASTNodes.replaceButKeepComment(rewrite, fStatements.get(0), newStmt, group);
+					}
+					for (int i= 1; i < fStatements.size(); ++i) {
+						rewrite.remove(fStatements.get(i), group);
+					}
+					for (MethodInvocation toStringCall : fToStringList) {
+						SimpleName name= ast.newSimpleName(newVarName);
+						rewrite.replace(toStringCall, name, group);
+					}
+				}
+			}
+			// convert any reuse of the StringBuffer/StringBuilder variable that assigns a new StringBuffer/StringBuilder so
+			// it will now declare the variable as the original declaration will be deleted
+			if (fAssignmentToConvert != null) {
+				ImportRewrite importRewriter= cuRewrite.getImportRewrite();
+				Assignment assignment= (Assignment) fAssignmentToConvert.getExpression();
+				ITypeBinding binding= assignment.resolveTypeBinding();
+				if (binding != null) {
+					Type t= importRewriter.addImport(binding, ast);
+					VariableDeclarationFragment newFragment= ast.newVariableDeclarationFragment();
+					newFragment.setName(ast.newSimpleName(((SimpleName)assignment.getLeftHandSide()).getFullyQualifiedName()));
+					newFragment.setInitializer((Expression)rewrite.createCopyTarget(assignment.getRightHandSide()));
+					VariableDeclarationStatement newStmt= ast.newVariableDeclarationStatement(newFragment);
+					newStmt.setType(t);
+					ASTNodes.replaceButKeepComment(rewrite, fAssignmentToConvert, newStmt, group);
+				}
+			}
+		}
+
+		private static String createName(final String nameRoot, final Set<String> excludedNames) {
+			int i= 1;
+			String candidate;
+
+			do {
+				candidate= nameRoot + i++;
+			} while (excludedNames.remove(candidate));
+
+			return candidate;
+		}
+
+	}
+
+	public static ICleanUpFixCore createCleanUp(final CompilationUnit compilationUnit, boolean includeStringBufferBuilder) {
 		if (!JavaModelUtil.is15OrHigher(compilationUnit.getJavaElement().getJavaProject()))
 			return null;
 
@@ -305,6 +724,23 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 
 		StringConcatFinder finder= new StringConcatFinder(operations, true);
 		compilationUnit.accept(finder);
+
+		if (includeStringBufferBuilder) {
+			Set<String> excludedNames= new HashSet<>();
+			StringBufferFinder finder2= new StringBufferFinder(operations, excludedNames);
+			compilationUnit.accept(finder2);
+			Map<ExpressionStatement, ChangeStringBufferToTextBlock> conversions= finder2.getConversionMap();
+			for (CompilationUnitRewriteOperation operation : operations) {
+				if (operation instanceof ChangeStringBufferToTextBlock) {
+					for (Statement s : ((ChangeStringBufferToTextBlock)operation).getStatements()) {
+						if (conversions.containsKey(s)) {
+							ChangeStringBufferToTextBlock op= conversions.get(s);
+							op.resetAssignmentToConvert();
+						}
+					}
+				}
+			}
+		}
 
 		if (operations.isEmpty()) {
 			return null;
@@ -321,8 +757,13 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 		List<CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation> operations= new ArrayList<>();
 		StringConcatFinder finder= new StringConcatFinder(operations, true);
 		exp.accept(finder);
-		if (operations.isEmpty())
+		if (operations.isEmpty()) {
+			StringBufferFinder finder2= new StringBufferFinder(operations, new HashSet<String>());
+			exp.accept(finder2);
+		}
+		if (operations.isEmpty()) {
 			return null;
+		}
 		return new StringConcatToTextBlockFixCore(FixMessages.StringConcatToTextBlockFix_convert_msg, root, new CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation[] { operations.get(0) });
 	}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -625,22 +625,14 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			MethodInvocation firstToStringCall= fToStringList.get(0);
 			AST ast= firstToStringCall.getAST();
 			if (fToStringList.size() == 1 &&
+					!fNonNLS &&
 					ASTNodes.getLeadingComments(fStatements.get(0)).size() == 0 &&
 					(firstToStringCall.getLocationInParent() == Assignment.RIGHT_HAND_SIDE_PROPERTY ||
 					firstToStringCall.getLocationInParent() == VariableDeclarationFragment.INITIALIZER_PROPERTY)) {
 				// if we only have one use of buffer.toString() and it is assigned to another string variable,
 				// put the text block in place of the buffer.toString() call and delete the whole StringBuffer/StringBuilder
-				if (fNonNLS) {
-					Statement firstStatement= ASTNodes.getFirstAncestorOrNull(firstToStringCall, Statement.class);
-					ICompilationUnit cu= cuRewrite.getCu();
-					String newStmtText= cu.getBuffer().getText(firstStatement.getStartPosition(), firstToStringCall.getStartPosition() - firstStatement.getStartPosition());
-					newStmtText= newStmtText + buf.toString() + (fNonNLS ? "; //$NON-NLS-1$" : ";"); //$NON-NLS-1$ //$NON-NLS-2$
-					Statement newStmt= (Statement)rewrite.createStringPlaceholder(newStmtText, firstStatement.getNodeType());
-					ASTNodes.replaceButKeepComment(rewrite, firstStatement, newStmt, group);
-				} else {
-					TextBlock textBlock= (TextBlock) rewrite.createStringPlaceholder(buf.toString(), ASTNode.TEXT_BLOCK);
-					rewrite.replace(firstToStringCall, textBlock, group);
-				}
+				TextBlock textBlock= (TextBlock) rewrite.createStringPlaceholder(buf.toString(), ASTNode.TEXT_BLOCK);
+				rewrite.replace(firstToStringCall, textBlock, group);
 				for (Statement statement : fStatements) {
 					rewrite.remove(statement, group);
 				}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -412,14 +412,14 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf.append("package test;\n");
 		buf.append("public class Cls {\n");
 		buf.append("    public void foo() {\n");
-		buf.append("        \n");
-		buf.append("        // comment 1\n");
-		buf.append("        String k = \"\"\"\n");
+		buf.append("        String str = \"\"\"\n");
 		buf.append("		\tpublic void foo() {\n");
 		buf.append("		\t    return null;\n");
 		buf.append("		\t}\n");
 		buf.append("		\t\n");
 		buf.append("		\t\"\"\"; //$NON-NLS-1$\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String k = str;\n");
 		buf.append("        \n");
 		buf.append("    }\n");
 		buf.append("}\n");

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -256,6 +256,180 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 	}
 
 	@Test
+	public void testConcatToTextBlock5() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        // comment 1\n");
+		buf.append("        StringBuffer buf= new StringBuffer(\"intro string\\n\");\n");
+		buf.append("        buf.append(\"public void foo() {\\n\");\n");
+		buf.append("        buf.append(\"    return null;\\n\");\n");
+		buf.append("        buf.append(\"}\\n\");\n");
+		buf.append("        buf.append(\"\\n\");\n");
+		buf.append("        System.out.println(buf.toString());\n");
+		buf.append("        System.out.println(buf.toString() + \"abc\");\n");
+		buf.append("        // comment 2\n");
+		buf.append("        buf = new StringBuffer(\"intro string 2\\n\");\n");
+		buf.append("        buf.append(\"some string\\n\");\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("buf");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String str = \"\"\"\n");
+		buf.append("		\tintro string\n");
+		buf.append("		\tpublic void foo() {\n");
+		buf.append("		\t    return null;\n");
+		buf.append("		\t}\n");
+		buf.append("		\t\n");
+		buf.append("		\t\"\"\";\n");
+		buf.append("        System.out.println(str);\n");
+		buf.append("        System.out.println(str + \"abc\");\n");
+		buf.append("        // comment 2\n");
+		buf.append("        StringBuffer buf = new StringBuffer(\"intro string 2\\n\");\n");
+		buf.append("        buf.append(\"some string\\n\");\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testConcatToTextBlock6() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        StringBuilder buf3= new StringBuilder();\n");
+		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
+		buf.append("        buf3.append(\"    return null;\\n\");\n");
+		buf.append("        buf3.append(\"}\\n\");\n");
+		buf.append("        buf3.append(\"\\n\");\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String k = buf3.toString();\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("buf");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String k = \"\"\"\n");
+		buf.append("		\tpublic void foo() {\n");
+		buf.append("		\t    return null;\n");
+		buf.append("		\t}\n");
+		buf.append("		\t\n");
+		buf.append("		\t\"\"\";\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testConcatToTextBlock7() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        StringBuilder buf3= new StringBuilder();\n");
+		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
+		buf.append("        buf3.append(\"    return null;\\n\"); //$NON-NLS-1$\n");
+		buf.append("        buf3.append(\"}\\n\"); //$NON-NLS-1$\n");
+		buf.append("        buf3.append(\"\\n\"); //$NON-NLS-1$\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String k = buf3.toString();\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("buf3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 4);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        \n");
+		buf.append("        // comment 1\n");
+		buf.append("        String k = \"\"\"\n");
+		buf.append("		\tpublic void foo() {\n");
+		buf.append("		\t    return null;\n");
+		buf.append("		\t}\n");
+		buf.append("		\t\n");
+		buf.append("		\t\"\"\"; //$NON-NLS-1$\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
 	public void testNoConcatToTextBlock1() throws Exception {
 		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
 		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
@@ -394,5 +568,152 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
 	}
 
+	@Test
+	public void testNoConcatToTextBlock5() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void noToString() {\n");
+		buf.append("        StringBuilder buf3= new StringBuilder();\n");
+		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
+		buf.append("        buf3.append(\"    return null;\\n\");\n");
+		buf.append("        buf3.append(\"}\\n\");\n");
+		buf.append("        buf3.append(\"\\n\");\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("buf3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+	}
+
+	@Test
+	public void testNoConcatToTextBlock6() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void extraAppend() {\n");
+		buf.append("        StringBuilder buf3= new StringBuilder();\n");
+		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
+		buf.append("        buf3.append(\"    return null;\\n\");\n");
+		buf.append("        buf3.append(\"}\\n\");\n");
+		buf.append("        buf3.append(\"\\n\");\n");
+		buf.append("        String k = buf3.toString();\n");
+		buf.append("        buf3.append(\"extra stuff\\n\");\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("buf3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+	}
+
+	@Test
+	public void testNoConcatToTextBlock7() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void combinedAppend() {\n");
+		buf.append("        StringBuffer buf3= new StringBuffer();\n");
+		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
+		buf.append("        buf3.append(\"    return null;\\n\");\n");
+		buf.append("        buf3.append(\"}\\n\");\n");
+		buf.append("        buf3.append(\"\\n\").append(\"extra append\\n\");\n");
+		buf.append("        String k = buf3.toString();\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("buf3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+	}
+
+	@Test
+	public void testNoConcatToTextBlock8() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void inconsistentNLSMarkers() {\n");
+		buf.append("        StringBuffer buf3= new StringBuffer();\n");
+		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
+		buf.append("        buf3.append(\"    return null;\\n\");\n");
+		buf.append("        buf3.append(\"}\\n\");\n");
+		buf.append("        buf3.append(\"\\n\");\n");
+		buf.append("        String k = buf3.toString();\n");
+		buf.append("        \n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("buf3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+	}
 }
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -137,11 +137,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "public class E {\n" //
 				+ "    public void foo() {\n" //
 				+ "        // comment 1\n" //
-				+ "        StringBuffer buf= new StringBuffer(\"intro string\\n\");\n" //
-				+ "        buf.append(\"public void foo() {\\n\");\n" //
-				+ "        buf.append(\"    return null;\\n\");\n" //
-				+ "        buf.append(\"}\\n\");\n" //
-				+ "        buf.append(\"\\n\");\n" //
+				+ "        StringBuffer buf= new StringBuffer(\"intro string\\n\"); //$NON-NLS-1$\n" //
+				+ "        buf.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n" //
+				+ "        buf.append(\"    return null;\\n\"); //$NON-NLS-1$\n" //
+				+ "        buf.append(\"}\\n\"); //$NON-NLS-1$\n" //
+				+ "        buf.append(\"\\n\"); //$NON-NLS-1$\n" //
 				+ "        System.out.println(buf.toString());\n" //
 				+ "        System.out.println(buf.toString() + \"abc\");\n" //
 				+ "        // comment 2\n" //
@@ -190,7 +190,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "        \t    return null;\n" //
 				+ "        \t}\n" //
 				+ "        \t\n" //
-				+ "        \t\"\"\";\n" //
+				+ "        \t\"\"\"; //$NON-NLS-1$\n" //
 				+ "        System.out.println(str);\n" //
 				+ "        System.out.println(str + \"abc\");\n" //
 				+ "        // comment 2\n" //
@@ -314,6 +314,15 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "        StringBuffer buf = new StringBuffer();\n" //
     	        + "        buf.append(\"abcdef\\n\");\n" //
     	        + "        buf.append(\"123456\\n\");\n" //
+    	        + "        buf.append(\"ghijkl\\n\");\n" //
+    	        + "        buf.append(3);\n" //
+				+ "        String x = buf.toString();\n" //
+    	        + "    }\n" //
+    	        + "\n" //
+   	            + "    public void testInconsistentNLS() {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.append(\"123456\\n\"); //$NON-NLS-1$\n" //
     	        + "        buf.append(\"ghijkl\\n\");\n" //
     	        + "        buf.append(3);\n" //
 				+ "        String x = buf.toString();\n" //

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -73,6 +73,14 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            \"ghijkl\\\"\\\"\\\"\\\"123\\\"\\\"\\\"\" +\n" //
     	        + "            \"mnop\\\\\";\n" //
     	        + "    }\n" //
+    	        + "\n" //
+    	        + "    public void testNoChange() {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.append(\"123456\\n\");\n" //
+    	        + "        buf.append(\"ghijkl\\n\");\n" //
+    	        + "        String k = buf.toString();\n" //
+    	        + "    }\n" //
 				+ "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -107,7 +115,117 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        \tghijkl\\\"\"\"\\\"123\\\"\"\"\\\n" //
     	        + "        \tmnop\\\\\"\"\";\n" //
     	        + "    }\n" //
+    	        + "\n" //
+    	        + "    public void testNoChange() {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.append(\"123456\\n\");\n" //
+    	        + "        buf.append(\"ghijkl\\n\");\n" //
+    	        + "        String k = buf.toString();\n" //
+    	        + "    }\n" //
 				+ "}\n";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testConcatToTextBlock2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public void foo() {\n" //
+				+ "        // comment 1\n" //
+				+ "        StringBuffer buf= new StringBuffer(\"intro string\\n\");\n" //
+				+ "        buf.append(\"public void foo() {\\n\");\n" //
+				+ "        buf.append(\"    return null;\\n\");\n" //
+				+ "        buf.append(\"}\\n\");\n" //
+				+ "        buf.append(\"\\n\");\n" //
+				+ "        System.out.println(buf.toString());\n" //
+				+ "        System.out.println(buf.toString() + \"abc\");\n" //
+				+ "        // comment 2\n" //
+				+ "        buf = new StringBuffer(\"intro string 2\\n\");\n" //
+				+ "        buf.append(\"some string\\n\");\n" //
+				+ "        buf.append(\"    another string\\n\");\n" //
+				+ "        // comment 3\n" //
+				+ "        String k = buf.toString();\n" //
+				+ "        // comment 4\n" //
+				+ "        StringBuilder buf2= new StringBuilder();\n" //
+				+ "        buf2.append(\"public String metaPhone(final String txt2){\\n\");\n" //
+				+ "        buf2.append(\"    return null;\\n\");\n" //
+				+ "        buf2.append(\"}\\n\");\n" //
+				+ "        buf2.append(\"\\n\");\n" //
+				+ "        // comment 5\n" //
+				+ "        k = buf2.toString();\n" //
+				+ "        System.out.println(buf2.toString());\n" //
+				+ "        StringBuilder buf3= new StringBuilder();\n" //
+				+ "        buf3.append(\"public void foo() {\\n\");\n" //
+				+ "        buf3.append(\"    return null;\\n\");\n" //
+				+ "        buf3.append(\"}\\n\");\n" //
+				+ "        buf3.append(\"\\n\");\n" //
+				+ "        // comment 6\n" //
+				+ "        k = buf3.toString();\n" //
+				+ "\n" //
+				+ "        String x = \"abc\\n\" +\n"
+				+ "            \"def\\n\" +\n" //
+				+ "            \"ghi\\n\";\n" //
+				+ "    }\n" //
+				+ "}";
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK);
+		enable(CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER);
+
+		String expected1= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public void foo() {\n" //
+				+ "        // comment 1\n" //
+				+ "        String str = \"\"\"\n" //
+				+ "        \tintro string\n"
+				+ "        \tpublic void foo() {\n" //
+				+ "        \t    return null;\n" //
+				+ "        \t}\n" //
+				+ "        \t\n" //
+				+ "        \t\"\"\";\n" //
+				+ "        System.out.println(str);\n" //
+				+ "        System.out.println(str + \"abc\");\n" //
+				+ "        // comment 2\n" //
+				+ "        String str1 = \"\"\"\n" //
+				+ "        \tintro string 2\n" //
+				+ "        \tsome string\n" //
+				+ "        \t    another string\n" //
+				+ "        \t\"\"\";\n" //
+				+ "        // comment 3\n" //
+				+ "        String k = str1;\n" //
+				+ "        // comment 4\n" //
+				+ "        String str2 = \"\"\"\n" //
+				+ "        \tpublic String metaPhone(final String txt2){\n" //
+				+ "        \t    return null;\n" //
+				+ "        \t}\n" //
+				+ "        \t\n" //
+				+ "        \t\"\"\";\n" //
+				+ "        // comment 5\n" //
+				+ "        k = str2;\n" //
+				+ "        System.out.println(str2);\n" //
+				+ "        // comment 6\n" //
+				+ "        k = \"\"\"\n" //
+				+ "        \tpublic void foo() {\n" //
+				+ "        \t    return null;\n" //
+				+ "        \t}\n" //
+				+ "        \t\n" //
+				+ "        \t\"\"\";\n" //
+				+ "\n" //
+				+ "        String x = \"\"\"\n" //
+				+ "        \tabc\n" //
+				+ "        \tdef\n" //
+				+ "        \tghi\n" //
+				+ "        \t\"\"\";\n" //
+				+ "    }\n" //
+				+ "}";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}
@@ -149,6 +267,62 @@ public class CleanUpTest15 extends CleanUpTestCase {
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
 
 		enable(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
+	}
+
+	@Test
+	public void testNoConcatToTextBlock2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+    	        + "    public void testNoToString() {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.append(\"123456\\n\");\n" //
+    	        + "        buf.append(\"ghijkl\\n\");\n" //
+    	        + "    }\n" //
+    	        + "\n" //
+    	        + "    public void testExtraCallsAfter() {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.append(\"123456\\n\");\n" //
+    	        + "        buf.append(\"ghijkl\\n\");\n" //
+				+ "        String x = buf.toString();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "    }\n" //
+    	        + "\n" //
+      	        + "    public void testExtraCallsBetween(String a) {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.reverse();\n" //
+    	        + "        buf.append(\"ghijkl\\n\");\n" //
+				+ "        String x = buf.toString();\n" //
+    	        + "    }\n" //
+    	        + "\n" //
+   	            + "    public void testSerialCallsNotSupported() {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.append(\"123456\\n\");\n" //
+    	        + "        buf.append(\"ghijkl\\n\").append(\"mnopqrst\\n\");\n" //
+				+ "        String x = buf.toString();\n" //
+    	        + "    }\n" //
+    	        + "\n" //
+   	            + "    public void testAppendingNonString() {\n" //
+				+ "        StringBuffer buf = new StringBuffer();\n" //
+    	        + "        buf.append(\"abcdef\\n\");\n" //
+    	        + "        buf.append(\"123456\\n\");\n" //
+    	        + "        buf.append(\"ghijkl\\n\");\n" //
+    	        + "        buf.append(3);\n" //
+				+ "        String x = buf.toString();\n" //
+    	        + "    }\n" //
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK);
+		enable(CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER);
 
 		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
 	}

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
@@ -188,6 +188,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(JOIN, CleanUpOptions.FALSE);
 		options.setOption(TRY_WITH_RESOURCE, CleanUpOptions.FALSE);
 		options.setOption(STRINGCONCAT_TO_TEXTBLOCK, CleanUpOptions.FALSE);
+		options.setOption(STRINGCONCAT_STRINGBUFFER_STRINGBUILDER, CleanUpOptions.FALSE);
 		options.setOption(MULTI_CATCH, CleanUpOptions.FALSE);
 		options.setOption(REMOVE_REDUNDANT_TYPE_ARGUMENTS, CleanUpOptions.TRUE);
 		options.setOption(USE_AUTOBOXING, CleanUpOptions.FALSE);
@@ -370,6 +371,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(JOIN, CleanUpOptions.FALSE);
 		options.setOption(TRY_WITH_RESOURCE, CleanUpOptions.FALSE);
 		options.setOption(STRINGCONCAT_TO_TEXTBLOCK, CleanUpOptions.FALSE);
+		options.setOption(STRINGCONCAT_STRINGBUFFER_STRINGBUILDER, CleanUpOptions.FALSE);
 		options.setOption(MULTI_CATCH, CleanUpOptions.FALSE);
 		options.setOption(REMOVE_REDUNDANT_TYPE_ARGUMENTS, CleanUpOptions.FALSE);
 		options.setOption(USE_AUTOBOXING, CleanUpOptions.FALSE);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -234,6 +234,8 @@ public class CleanUpMessages extends NLS {
 	public static String JavaFeatureTabPage_CheckboxName_ConstantsForSystemProperty_LineSeparator;
 	public static String JavaFeatureTabPage_CheckboxName_ConstantsForSystemProperty_FileEncoding;
 	public static String JavaFeatureTabPage_CheckboxName_ConstantsForSystemProperty_BoxedTypeProperty;
+
+	public static String JavaFeatureTabPage_CheckboxName_StringBufferBuilderToTextBlock;
 
 	static {
 		// initialize resource bundle

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2005, 2021 IBM Corporation and others.
+# Copyright (c) 2005, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -174,6 +174,7 @@ JavaFeatureTabPage_CheckboxName_PatternMatchingForInstanceof=&Pattern matching f
 JavaFeatureTabPage_GroupName_Java15=Java 15
 
 JavaFeatureTabPage_CheckboxName_StringConcatToTextBlock=Convert String concatenation to Text Block
+JavaFeatureTabPage_CheckboxName_StringBufferBuilderToTextBlock=Include &StringBuffer or StringBuilder concatenations
 
 JavaFeatureTabPage_GroupName_Java14=Java 14
 
@@ -212,3 +213,4 @@ JavaFeatureTabPage_CheckboxName_ConstantsForSystemProperty_FileEncoding=File enc
 JavaFeatureTabPage_CheckboxName_ConstantsForSystemProperty_FileSeparator=File separator
 JavaFeatureTabPage_CheckboxName_ConstantsForSystemProperty_LineSeparator=Line separator
 JavaFeatureTabPage_CheckboxName_ConstantsForSystemProperty_PathSeparator=Path separator
+

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/JavaFeatureTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/JavaFeatureTabPage.java
@@ -73,6 +73,9 @@ public final class JavaFeatureTabPage extends AbstractCleanUpTabPage {
 		Group java15Group= createGroup(numColumns, composite, CleanUpMessages.JavaFeatureTabPage_GroupName_Java15);
 		CheckboxPreference stringConcatToTextBlock= createCheckboxPref(java15Group, numColumns, CleanUpMessages.JavaFeatureTabPage_CheckboxName_StringConcatToTextBlock, CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK, CleanUpModifyDialog.FALSE_TRUE);
 		registerPreference(stringConcatToTextBlock);
+		intent(java15Group);
+		CheckboxPreference convertStringBufferBuilderToTextBlock= createCheckboxPref(java15Group, 1, CleanUpMessages.JavaFeatureTabPage_CheckboxName_StringBufferBuilderToTextBlock, CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER, CleanUpModifyDialog.FALSE_TRUE);
+		registerSlavePreference(stringConcatToTextBlock, new CheckboxPreference[] {convertStringBufferBuilderToTextBlock});
 
 		Group java14Group= createGroup(numColumns, composite, CleanUpMessages.JavaFeatureTabPage_GroupName_Java14);
 


### PR DESCRIPTION
- fixes #725
- add new logic to StringConcatToTextBlockFixCore to support changing a StringBuffer or StringBuilder append sequence to a Text block if the buffer is converted to string
- add new preference to include StringBuffer/StringBuilder sequences for the StringConcatToTextBlock cleanup
- add preference to JavaFeature tab page
- add new tests

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds support to cleanup and quick assist to convert a StringBuffer or StringBuilder sequence
of appends that eventually are used as a String into a Text Block.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and added tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
