### PR TITLE
Apply semantic syntax coloring in Java source hover viewer. Fixes #437

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingManager.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingManager.java
@@ -310,16 +310,34 @@ public class SemanticHighlightingManager implements IPropertyChangeListener {
 	}
 
 	/**
+	 * Create semantic highlighting presenter instance to use.
+	 *
+	 * @return semantic highlighting presenter to use
+	 */
+	protected SemanticHighlightingPresenter createSemanticHighlightingPresenter() {
+		return new SemanticHighlightingPresenter();
+	}
+
+	/**
+	 * Create semantic highlighting reconciler instance to use.
+	 *
+	 * @return semantic highlighting reconciler to use
+	 */
+	protected SemanticHighlightingReconciler createSemanticHighlightingReconciler() {
+		return new SemanticHighlightingReconciler();
+	}
+
+	/**
 	 * Enable semantic highlighting.
 	 */
 	private void enable() {
 		initializeHighlightings();
 
-		fPresenter= new SemanticHighlightingPresenter();
+		fPresenter= createSemanticHighlightingPresenter();
 		fPresenter.install(fSourceViewer, fPresentationReconciler);
 
 		if (fEditor != null) {
-			fReconciler= new SemanticHighlightingReconciler();
+			fReconciler= createSemanticHighlightingReconciler();
 			fReconciler.install(fEditor, fSourceViewer, fPresenter, fSemanticHighlightings, fHighlightings);
 		} else {
 			fPresenter.updatePresentation(null, createHardcodedPositions(), new HighlightedPosition[0]);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
@@ -537,11 +537,21 @@ public class SemanticHighlightingReconciler implements IJavaReconcilingListener,
 		fSourceViewer= sourceViewer;
 
 		if (fEditor instanceof CompilationUnitEditor) {
-			((CompilationUnitEditor)fEditor).addReconcileListener(this);
-		} else if (fEditor == null) {
+			if (registerAsEditorReconcilingListener()) {
+				((CompilationUnitEditor)fEditor).addReconcileListener(this);
+			}
+		} else if (fEditor != null) {
 			fSourceViewer.addTextInputListener(this);
 			scheduleJob();
 		}
+	}
+
+	/**
+	 * Decides if this reconciler should also register itself as a reconciling listener on the editor as part of {@link #install} process.
+	 * @return whether this instance should register itself as a reconciling listener on the editor
+	 */
+	protected boolean registerAsEditorReconcilingListener() {
+		return true;
 	}
 
 	/**
@@ -566,10 +576,19 @@ public class SemanticHighlightingReconciler implements IJavaReconcilingListener,
 	}
 
 	/**
+	 * Get the type root java element for which reconciling job should be scheduled.
+	 *
+	 * @return root element for reconciling
+	 */
+	protected ITypeRoot getElement() {
+		return fEditor.getInputJavaElement();
+	}
+
+	/**
 	 * Schedule a background job for retrieving the AST and reconciling the Semantic Highlighting model.
 	 */
 	private void scheduleJob() {
-		final ITypeRoot element= fEditor.getInputJavaElement();
+		final ITypeRoot element= getElement();
 
 		synchronized (fJobLock) {
 			final Job oldJob= fJob;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaSourceHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaSourceHover.java
@@ -14,6 +14,10 @@
 package org.eclipse.jdt.internal.ui.text.java.hover;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
@@ -21,6 +25,7 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.runtime.CoreException;
 
@@ -29,24 +34,31 @@ import org.eclipse.jface.text.BadPartitioningException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentExtension3;
+import org.eclipse.jface.text.IInformationControl;
 import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.SourceViewer;
 
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.part.IWorkbenchPartOrientation;
 
 import org.eclipse.ui.editors.text.EditorsUI;
 
+import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.SourceRange;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
@@ -103,6 +115,12 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 	 */
 	private IJavaElement fJavaElement;
 
+	/** Source range of hovered node within it's origin source content */
+	private ISourceRange fNodeRange;
+
+	/** Lines of bracket-type node's content to keep not skipped in hover viewer */
+	private List<Integer> fKeptLines;
+
 	static class JavaSourceInformationInput {
 		private IJavaElement fElement;
 
@@ -122,16 +140,270 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 		}
 	}
 
+	/**
+	 * Java source information input supporting semantic coloring
+	 */
+	static abstract class JavaSourceSemanticInformationInput extends JavaSourceInformationInput {
+		final ITypeRoot fRootElement;
+		final String fFullContent;
+		final ISourceRange fVisibleRange;
+		SourceViewer fSourceViewer;
+
+		JavaSourceSemanticInformationInput(IJavaElement javaElement, String hoverInfo, ITypeRoot rootElement, String fullContent, ISourceRange visibleRange) {
+			super(javaElement, hoverInfo);
+			fRootElement= rootElement;
+			fFullContent= fullContent;
+			fVisibleRange= visibleRange;
+		}
+
+		public final ITypeRoot getViewerContentTypeRoot() {
+			return fRootElement;
+		}
+
+		public boolean prepareSemanticColoring(SourceViewer sourceViewer) {
+			fSourceViewer= sourceViewer;
+			if (fVisibleRange == null) {
+				return false;
+			}
+
+			// replace viewer content (was fHoverInfo) with full content (for which semantic coloring will be prepared)
+			fSourceViewer.getDocument().set(fFullContent);
+			// then set viewer's visible region
+			setVisibleRegion();
+			return true;
+		}
+
+		void setVisibleRegion() {
+			// limit visible region of whole source content to just area of interest
+			fSourceViewer.setVisibleRegion(fVisibleRange.getOffset(), fVisibleRange.getLength());
+		}
+
+		public abstract void postSemanticColoring();
+	}
+
+	/**
+	 * Java source information input supporting semantic coloring and line trimming in hover viewer's visible content
+	 */
+	static abstract class JavaSourceLineTrimmingInformationInput extends JavaSourceSemanticInformationInput {
+		private List<IRegion> fTrimRegions;
+
+		JavaSourceLineTrimmingInformationInput(IJavaElement javaElement, String hoverInfo, ITypeRoot rootElement, String fullContent, ISourceRange visibleRange) {
+			super(javaElement, hoverInfo, rootElement, fullContent, visibleRange);
+		}
+
+		@Override
+		void setVisibleRegion() {
+			super.setVisibleRegion();
+
+			// prepare lines trimming in visible region
+			fTrimRegions= new LinkedList<>();
+			try {
+				IDocument document= fSourceViewer.getDocument();
+				IRegion visibleRegion= fSourceViewer.getVisibleRegion(); // fVisibleRange extended to start of first line
+				String hoverElementSource= document.get(visibleRegion.getOffset(), visibleRegion.getLength());
+				String[] sourceLines= Strings.convertIntoLines(hoverElementSource);
+				String[] trimmedLines= sourceLines.clone();
+				Strings.trimIndentation(trimmedLines, fRootElement.getJavaProject());
+				int line= document.getLineOfOffset(visibleRegion.getOffset());
+				int offsetShift= 0;
+				for (int i= 0; i < sourceLines.length; i++) {
+					int trimChars= sourceLines[i].indexOf(trimmedLines[i]);
+					if (trimChars > 0) {
+						fTrimRegions.add(new Region(document.getLineOffset(line) - offsetShift, trimChars));
+						offsetShift+= trimChars;
+					}
+					line++;
+				}
+			} catch (BadLocationException e) {
+				JavaPlugin.log(e);
+			}
+		}
+
+		@Override
+		public void postSemanticColoring() {
+			if (fTrimRegions == null) {
+				return;
+			}
+			// apply lines trimming in visible region
+			try {
+				for (IRegion trimRegion : fTrimRegions) {
+					fSourceViewer.getDocument().replace(trimRegion.getOffset(), trimRegion.getLength(), ""); //$NON-NLS-1$
+				}
+			} catch (BadLocationException e) {
+				JavaPlugin.log(e);
+			}
+		}
+	}
+
+	/**
+	 * Java source information input supporting semantic coloring for java elements hover
+	 */
+	static class JavaElementSourceInformationInput extends JavaSourceLineTrimmingInformationInput {
+
+		JavaElementSourceInformationInput(String hoverInfo, IJavaElement javaElement) throws Exception {
+			super(javaElement, hoverInfo, findRootElement(javaElement), findRootElement(javaElement).getSource(),
+					(javaElement instanceof ISourceReference) ? ((ISourceReference) javaElement).getSourceRange() : null);
+		}
+
+		private static ITypeRoot findRootElement(IJavaElement javaElement) {
+			IJavaElement parent= javaElement;
+			while (parent != null && !(parent instanceof ITypeRoot)) {
+				parent= parent.getParent();
+			}
+			if (!(parent instanceof ITypeRoot)) {
+				throw new IllegalArgumentException("Unable to find ITypeRoot parent "); //$NON-NLS-1$
+			}
+			return (ITypeRoot) parent;
+		}
+
+		@Override
+		void setVisibleRegion() {
+			// set range indication to actual beginning of element ('scrolls' past any JavaDoc if present) before setting visible region
+			Document doc= (Document) fSourceViewer.getDocument();
+			int offset= fVisibleRange.getOffset();
+			int lenght= fVisibleRange.getLength();
+			try {
+				ITypedRegion partition= null;
+				int endOffset= offset + lenght;
+				while (offset < endOffset) { // we should never reach end of visible range
+					partition= doc.getPartition(IJavaPartitions.JAVA_PARTITIONING, offset, false);
+					switch (partition.getType()) {
+						case IJavaPartitions.JAVA_DOC:
+						case IJavaPartitions.JAVA_SINGLE_LINE_COMMENT:
+						case IJavaPartitions.JAVA_MULTI_LINE_COMMENT:
+							offset+= partition.getLength();
+							lenght-= partition.getLength();
+							break;
+						default:
+							endOffset= offset; // break out from loop
+							break;
+					}
+				}
+				while (Character.isWhitespace(doc.getChar(offset))) {
+					offset++;
+					lenght--;
+				}
+			} catch (Exception e) {
+				JavaPlugin.log(e);
+				offset= fVisibleRange.getOffset();
+				lenght= fVisibleRange.getLength();
+			}
+			fSourceViewer.setRangeIndication(offset, lenght, true);
+
+			super.setVisibleRegion();
+		}
+	}
+
+	/**
+	 * Java source information input supporting semantic coloring for bracket nodes hover
+	 */
+	static class JavaBracketSourceInformationInput extends JavaSourceLineTrimmingInformationInput {
+		private final int fBracketHoverRegionFirstLine;
+		private final int fBacketHoverRegionLastLine;
+		private final List<Integer> fKeptLines;
+
+		JavaBracketSourceInformationInput(String hoverInfo, ITypeRoot rootElement, IDocument document, ISourceRange nodeRange, List<Integer> keptLines) throws BadLocationException {
+			super(null, hoverInfo, rootElement, document.get(), nodeRange);
+			fBracketHoverRegionFirstLine= document.getLineOfOffset(nodeRange.getOffset());
+			fBacketHoverRegionLastLine= document.getLineOfOffset(nodeRange.getOffset() + nodeRange.getLength());
+			fKeptLines= new LinkedList<>(keptLines);
+		}
+
+		@Override
+		public void postSemanticColoring() {
+			super.postSemanticColoring();
+
+			// apply skipped lines substitutions
+			if (fKeptLines != null && !fKeptLines.isEmpty()) {
+				List<Integer> keptLines= new LinkedList<>(fKeptLines);
+				IDocument document= fSourceViewer.getDocument();
+				try {
+					int currentLine= fBracketHoverRegionFirstLine;
+					int replaceStartOffset= -1;
+					int linesToRemove= 0;
+					int lineShift= 0;
+					for (; currentLine <= fBacketHoverRegionLastLine; currentLine++) {
+						if (!keptLines.remove(Integer.valueOf(currentLine))) { // line to be replaced
+							if (replaceStartOffset == -1) {
+								replaceStartOffset= document.getLineOffset(currentLine - lineShift);
+							}
+							linesToRemove++;
+						} else { // kept line
+							if (replaceStartOffset != -1) {
+								int length= document.getLineOffset(currentLine - lineShift) - 1 - replaceStartOffset;
+								if (document.getChar(replaceStartOffset + length - 1) == '\r') {
+									length--;
+								}
+								document.replace(replaceStartOffset, length, JavaHoverMessages.JavaSourceHover_skippedLinesSymbol);
+								replaceStartOffset= -1;
+								lineShift+= linesToRemove - 1;
+								linesToRemove= 0;
+							}
+						}
+					}
+					if (replaceStartOffset != -1) {
+						// replace remaining lines
+						document.replace(replaceStartOffset, document.getLength() - replaceStartOffset, JavaHoverMessages.JavaSourceHover_skippedLinesSymbol);
+					}
+				} catch (BadLocationException e) {
+					JavaPlugin.log(e);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Java source information input supporting semantic coloring for text blocks hover
+	 */
+	static class JavaTextBlockSourceInformationInput extends JavaSourceSemanticInformationInput {
+
+		JavaTextBlockSourceInformationInput(String hoverInfo) {
+			super(null, hoverInfo, null,
+				// add new lines with 3 quote characters as first and last line (out of visible region) to have text rendered with text block color
+				"\"\"\"\n" + hoverInfo + "\n\"\"\"",  //$NON-NLS-1$//$NON-NLS-2$
+				new SourceRange(4, hoverInfo.length())); // hide first line (3 quote characters + 1 new line character) and last line
+		}
+
+		@Override
+		public boolean prepareSemanticColoring(SourceViewer sourceViewer) {
+			// replace text and set visible region
+			super.prepareSemanticColoring(sourceViewer);
+			// don't trigger semantic coloring job since viewer already renders the content with proper color
+			return false;
+		}
+
+		@Override
+		public void postSemanticColoring() {
+			// no-op
+		}
+	}
+
 	@Override
 	public Object getHoverInfo2(ITextViewer textViewer, IRegion hoverRegion) {
 		String hoverInfoString= getHoverInfo(textViewer, hoverRegion);
 		if (hoverInfoString == null) {
 			return null;
 		}
-		if (fJavaElement == null) {
-			return hoverInfoString;
+		try {
+			if (fJavaElement != null) {
+				if (JavaModelUtil.isModule(fJavaElement)) {
+					// pre-semantic coloring behavior
+					return new JavaSourceInformationInput(fJavaElement, hoverInfoString);
+				}
+				// element hover (source may be from other compilation unit)
+				return new JavaElementSourceInformationInput(hoverInfoString, fJavaElement);
+			}
+			if (fKeptLines != null && !fKeptLines.isEmpty()) {
+				// bracket hover (source from visible editor)
+				return new JavaBracketSourceInformationInput(hoverInfoString, getEditorInputJavaElement(), textViewer.getDocument(), fNodeRange, fKeptLines);
+			}
+			// text block hover (source from visible editor)
+			return new JavaTextBlockSourceInformationInput(hoverInfoString);
+		} catch (Exception e) {
+			JavaPlugin.log(e);
+			// pre-semantic coloring behavior
+			return new JavaSourceInformationInput(fJavaElement, hoverInfoString);
 		}
-		return new JavaSourceInformationInput(fJavaElement, hoverInfoString);
 	}
 
 	@Override
@@ -142,9 +414,11 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 
 		fUpwardShiftInLines= 0;
 		fBracketHoverStatus= null;
+		fNodeRange= null;
+		fKeptLines= new ArrayList<>(16);
 
 		if (result == null || result.length == 0) {
-			String val = getBracketHoverInfo(textViewer, region);
+			String val= getBracketHoverInfo(textViewer, region);
 			if (val == null) {
 				return getTextBlockHoverInfo(textViewer, region);
 			}
@@ -158,8 +432,20 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 		if ((fJavaElement instanceof IMember || fJavaElement instanceof ILocalVariable || fJavaElement instanceof ITypeParameter) && fJavaElement instanceof ISourceReference) {
 			try {
 				String source= ((ISourceReference) fJavaElement).getSource();
+				ISourceRange elementRange= ((ISourceReference) fJavaElement).getSourceRange();
+				IBuffer elementOriginBuffer= fJavaElement.getOpenable().getBuffer();
+				int offset= elementRange.getOffset() - 1;
+				int trimmingOffset= 0;
+				if (offset >= 0 && elementOriginBuffer.getChar(offset) != '\n') {
+					while(offset >= 0 && elementOriginBuffer.getChar(--offset) != '\n') {
+						// no-op
+					}
+					trimmingOffset= elementRange.getOffset() - ++offset;
+					// add indentation of first line of element source segment not contained in text returned by getSource()
+					source= elementOriginBuffer.getText(offset, elementRange.getLength() + trimmingOffset);
+				}
 
-				String[] sourceLines= getTrimmedSource(source, fJavaElement);
+				String[] sourceLines= getTrimmedSource(source, trimmingOffset, fJavaElement);
 				if (sourceLines == null)
 					return null;
 
@@ -236,13 +522,14 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 				nodeStart= node.getStartPosition();
 				nodeLength= ASTNodes.getExclusiveEnd(bracketNode) - nodeStart;
 			}
+			fNodeRange= new SourceRange(nodeStart, nodeLength);
 
-			int line1= document.getLineOfOffset(nodeStart);
-			int sourceOffset= document.getLineOffset(line1);
-			int line2= document.getLineOfOffset(nodeStart + nodeLength);
+			int nodeStartLine= document.getLineOfOffset(nodeStart);
+			int startLineOffset= document.getLineOffset(nodeStartLine);
+			int nodeEndLine= document.getLineOfOffset(nodeStart + nodeLength);
 			int hoveredLine= document.getLineOfOffset(offset);
-			if (line2 > hoveredLine)
-				line2= hoveredLine;
+			if (nodeEndLine > hoveredLine)
+				nodeEndLine= hoveredLine;
 
 			//check if line1 is visible
 			final int[] topIndex= new int[1];
@@ -262,29 +549,29 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 
 			display.syncExec(() -> topIndex[0]= textViewer.getTopIndex());
 
-			int topLine= topIndex[0];
-			if (topLine == -1)
+			int topVisibleLine= topIndex[0];
+			if (topVisibleLine == -1)
 				return null;
 			int noOfSourceLines;
 			IRegion endLine;
 			int skippedLines= 0;
-			int wLine1= ((JavaSourceViewer) textViewer).modelLine2WidgetLine(line1);
-			int wLine2= ((JavaSourceViewer) textViewer).modelLine2WidgetLine(line2);
-			if ((line1 < topLine) || (wLine1 != -1 && (wLine2 - wLine1 != line2 - line1))) {
+			int wNodeStartLine= ((JavaSourceViewer) textViewer).modelLine2WidgetLine(nodeStartLine);
+			int wNodeEndLine= ((JavaSourceViewer) textViewer).modelLine2WidgetLine(nodeEndLine);
+			if ((nodeStartLine < topVisibleLine) || (wNodeStartLine != -1 && (wNodeEndLine - wNodeStartLine != nodeEndLine - nodeStartLine))) {
 				// match not visible or content is folded - see bug 399997
 				if (isElsePart) {
 					return getBracketHoverInfo((IfStatement) node, bracketNode, document, editorInput, delim); // see bug 377141, 201850
 				}
 				noOfSourceLines= 3;
-				if ((line2 - line1) < noOfSourceLines) {
-					noOfSourceLines= line2 - line1;
+				if ((nodeEndLine - nodeStartLine) < noOfSourceLines) {
+					noOfSourceLines= nodeEndLine - nodeStartLine;
 				}
-				skippedLines= Math.abs(line2 - line1 - noOfSourceLines);
+				skippedLines= Math.abs(nodeEndLine - nodeStartLine - noOfSourceLines);
 				if (skippedLines == 1) {
 					noOfSourceLines++;
 					skippedLines= 0;
 				}
-				endLine= document.getLineInformation(line1 + noOfSourceLines);
+				endLine= document.getLineInformation(nodeStartLine + noOfSourceLines);
 				fUpwardShiftInLines= noOfSourceLines;
 				if (skippedLines > 0) {
 					fBracketHoverStatus= Messages.format(JavaHoverMessages.JavaSourceHover_skippedLines, Integer.valueOf(skippedLines));
@@ -295,9 +582,10 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 			if (fUpwardShiftInLines == 0)
 				return null;
 
-			int sourceLength= (endLine.getOffset() + endLine.getLength()) - sourceOffset;
-			String source= document.get(sourceOffset, sourceLength);
-			String[] sourceLines= getTrimmedSource(source, editorInput);
+			IntStream.range(nodeStartLine, nodeStartLine + noOfSourceLines).boxed().forEach(fKeptLines::add);
+			int sourceLength= (endLine.getOffset() + endLine.getLength()) - startLineOffset;
+			String source= document.get(startLineOffset, sourceLength);
+			String[] sourceLines= getTrimmedSource(source, 0, editorInput);
 			if (sourceLines == null)
 				return null;
 			String[] str= new String[noOfSourceLines];
@@ -339,17 +627,17 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 		int nodeStart= ifNode.getStartPosition();
 		while (currentStatement != null) {
 			int nodeLength= ASTNodes.getExclusiveEnd(currentStatement) - nodeStart;
-			int line1= document.getLineOfOffset(nodeStart);
-			int sourceOffset= document.getLineOffset(line1);
-			int line2= document.getLineOfOffset(nodeStart + nodeLength);
-			int line3= line2;
+			int nodeStartLine= document.getLineOfOffset(nodeStart);
+			int startLineOffset= document.getLineOffset(nodeStartLine);
+			int nodeEndLine= document.getLineOfOffset(nodeStart + nodeLength);
+			int nextElseLine= nodeEndLine;
 			if (currentStatement != bracketNode && ifNode != null && ifNode.getElseStatement() != null) {
 				int elseStartOffset= getNextElseOffset(ifNode.getThenStatement(), editorInput);
 				if (elseStartOffset != -1) {
-					line3= document.getLineOfOffset(elseStartOffset); // next 'else'
+					nextElseLine= document.getLineOfOffset(elseStartOffset); // next 'else'
 				}
 			}
-			int noOfTotalLines= (line2 == line3) ? (line2 - line1) : (line2 - line1 + 1);
+			int noOfTotalLines= (nodeEndLine == nextElseLine) ? (nodeEndLine - nodeStartLine) : (nodeEndLine - nodeStartLine + 1);
 			int noOfSourceLines= 3;
 
 			if (noOfTotalLines < noOfSourceLines) {
@@ -362,10 +650,11 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 			}
 
 			if (noOfSourceLines > 0) {
-				IRegion endLine= document.getLineInformation(line1 + noOfSourceLines - 1);
-				int sourceLength= (endLine.getOffset() + endLine.getLength()) - sourceOffset;
-				String source= document.get(sourceOffset, sourceLength);
-				String[] sourceLines= getTrimmedSource(source, editorInput);
+				IntStream.range(nodeStartLine, nodeStartLine + noOfSourceLines).boxed().forEach(fKeptLines::add);
+				IRegion endLine= document.getLineInformation(nodeStartLine + noOfSourceLines - 1);
+				int sourceLength= (endLine.getOffset() + endLine.getLength()) - startLineOffset;
+				String source= document.get(startLineOffset, sourceLength);
+				String[] sourceLines= getTrimmedSource(source, 0, editorInput);
 				if (sourceLines == null)
 					return null;
 				source= Strings.concatenate(sourceLines, delim);
@@ -495,24 +784,25 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 	 * Returns the trimmed source lines.
 	 *
 	 * @param source the source string, could be <code>null</code>
+	 * @param offset the offset to start leading comments removal from
 	 * @param javaElement the java element
 	 * @return the trimmed source lines or <code>null</code>
 	 */
-	private String[] getTrimmedSource(String source, IJavaElement javaElement) {
+	private String[] getTrimmedSource(String source, int offset, IJavaElement javaElement) {
 		if (source == null)
 			return null;
-		source= removeLeadingComments(source);
+		source= removeLeadingComments(source, offset);
 		String[] sourceLines= Strings.convertIntoLines(source);
 		Strings.trimIndentation(sourceLines, javaElement.getJavaProject());
 		return sourceLines;
 	}
 
-	private String removeLeadingComments(String source) {
+	private String removeLeadingComments(String source, int offset) {
 		final JavaCodeReader reader= new JavaCodeReader();
 		IDocument document= new Document(source);
 		int i;
 		try {
-			reader.configureForwardReader(document, 0, document.getLength(), true, false);
+			reader.configureForwardReader(document, offset, document.getLength() - offset, true, false);
 			int c= reader.read();
 			while (c != -1 && (c == '\r' || c == '\n')) {
 				c= reader.read();
@@ -531,6 +821,9 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 
 		if (i < 0)
 			return source;
+		if (i == offset) {
+			return source;
+		}
 		return source.substring(i);
 	}
 
@@ -575,59 +868,96 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 			if (editor instanceof IWorkbenchPartOrientation)
 				orientation= ((IWorkbenchPartOrientation) editor).getOrientation();
 
-			return new SourceViewerInformationControl(parent, isResizable, orientation, statusFieldText) {
-				@Override
-				public void setLocation(Point location) {
-					Point loc= location;
-					if (doShiftUp && fUpwardShiftInLines > 0) {
-						Point size= super.computeSizeConstraints(0, fUpwardShiftInLines + 1);
-						//bracket hover is rendered above '}'
-						int y= location.y - size.y - 5; //AbstractInformationControlManager.fMarginY = 5
-						Rectangle trim= computeTrim();
-						loc= new Point(location.x + trim.x - getViewer().getTextWidget().getLeftMargin(), y - trim.height - trim.y);
-					}
-					super.setLocation(loc);
-				}
+			return createControl(parent, editor, isResizable, orientation, statusFieldText, doShiftUp, null);
+		};
+	}
 
-				@Override
-				public Point computeSizeConstraints(int widthInChars, int heightInChars) {
-					if (doShiftUp && fUpwardShiftInLines > 0) {
-						Point sizeConstraints= super.computeSizeConstraints(widthInChars, heightInChars);
-						return new Point(sizeConstraints.x, 0); //set height as 0 to ensure selection of bottom anchor in AbstractInformationControlManager.computeInformationControlLocation(...)
-					} else {
-						return super.computeSizeConstraints(widthInChars, heightInChars);
-					}
-				}
+	private IInformationControl createControl(final Shell parent, final IEditorPart editor, final boolean isResizable, final int orientation, final String statusFieldText, final boolean doShiftUp, final ISourceViewer mimicSourceViewer) {
+		return new SourceViewerInformationControl(parent, editor, isResizable, orientation, statusFieldText) {
 
-				@Override
-				public void setSize(int width, int height) {
-					if (doShiftUp && fUpwardShiftInLines != 0) {
-						//compute the correct height of hover, this was set to 0 in computeSizeConstraints(..)
-						Point size= super.computeSizeConstraints(0, fUpwardShiftInLines);
-						Rectangle trim= computeTrim();
-						super.setSize(width, size.y + trim.height - trim.y);
-					} else {
-						super.setSize(width, height);
-					}
-				}
+			{
+				// Just re-use content of displayed hover viewer when 'entering into' it
+				if (mimicSourceViewer != null) {
+					getViewer().setDocument(mimicSourceViewer.getDocument());
 
-				@Override
-				public IInformationControlCreator getInformationPresenterControlCreator() {
-					if (doShiftUp && fUpwardShiftInLines > 0) {
-						// Hack: We don't wan't to have auto-enrichment when the mouse moves into the hover,
-						// but we do want F2 to persist the hover. The framework has no way to distinguish the
-						// two requests, so we have to implement this aspect.
-						for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
-							if ("canMoveIntoInformationControl".equals(element.getMethodName()) //$NON-NLS-1$
-									&& "org.eclipse.jface.text.AbstractHoverInformationControlManager".equals(element.getClassName())) //$NON-NLS-1$
-								return null; //do not enrich bracket hover
-						}
-						return JavaSourceHover.this.createInformationControlCreator(isResizable && !isResizable, statusFieldText, false);
-					} else {
-						return super.getInformationPresenterControlCreator();
-					}
+					// replicating previously set range indication with workaround for getRangeIndication() returning null
+					IRegion visibleRegion= mimicSourceViewer.getVisibleRegion();
+					getViewer().setRangeIndication(mimicSourceViewer.getSelectedRange().x, visibleRegion.getLength(), true);
+
+					getViewer().setVisibleRegion(visibleRegion.getOffset(), visibleRegion.getLength());
+
+					getViewer().getTextWidget().setStyleRanges(mimicSourceViewer.getTextWidget().getStyleRanges());
 				}
-			};
+			}
+
+			@Override
+			public void setLocation(Point location) {
+				Point loc= location;
+				if (doShiftUp && fUpwardShiftInLines > 0) {
+					Point size= super.computeSizeConstraints(0, fUpwardShiftInLines + 1);
+					//bracket hover is rendered above '}'
+					int y= location.y - size.y - 5; //AbstractInformationControlManager.fMarginY = 5
+					Rectangle trim= computeTrim();
+					loc= new Point(location.x + trim.x - getViewer().getTextWidget().getLeftMargin(), y - trim.height - trim.y);
+				}
+				super.setLocation(loc);
+			}
+
+			@Override
+			public Point computeSizeConstraints(int widthInChars, int heightInChars) {
+				if (doShiftUp && fUpwardShiftInLines > 0) {
+					Point sizeConstraints= super.computeSizeConstraints(widthInChars, heightInChars);
+					return new Point(sizeConstraints.x, 0); //set height as 0 to ensure selection of bottom anchor in AbstractInformationControlManager.computeInformationControlLocation(...)
+				} else {
+					return super.computeSizeConstraints(widthInChars, heightInChars);
+				}
+			}
+
+			@Override
+			public void setSize(int width, int height) {
+				if (doShiftUp && fUpwardShiftInLines != 0) {
+					//compute the correct height of hover, this was set to 0 in computeSizeConstraints(..)
+					Point size= super.computeSizeConstraints(0, fUpwardShiftInLines);
+					Rectangle trim= computeTrim();
+					super.setSize(width, size.y + trim.height - trim.y);
+				} else {
+					super.setSize(width, height);
+				}
+			}
+
+			@SuppressWarnings("hiding")
+			@Override
+			public IInformationControlCreator getInformationPresenterControlCreator() {
+				if (doShiftUp && fUpwardShiftInLines > 0) {
+					// Hack: We don't wan't to have auto-enrichment when the mouse moves into the hover,
+					// but we do want F2 to persist the hover. The framework has no way to distinguish the
+					// two requests, so we have to implement this aspect.
+					for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+						if ("canMoveIntoInformationControl".equals(element.getMethodName()) //$NON-NLS-1$
+								&& "org.eclipse.jface.text.AbstractHoverInformationControlManager".equals(element.getClassName())) //$NON-NLS-1$
+							return null; //do not enrich bracket hover
+					}
+					return parent -> createControl(parent, null, false, orientation, statusFieldText, false, getViewer());
+				} else {
+					return parent -> createControl(parent, null, true, orientation, null, false, getViewer());
+				}
+			}
+
+			@Override
+			public void setInput(Object input) {
+				// ignore when hover viewer content was re-used
+				if (mimicSourceViewer == null) {
+					super.setInput(input);
+				}
+			}
+
+			@Override
+			public void setInformation(String content) {
+				// ignore when hover viewer content was re-used
+				if (mimicSourceViewer == null) {
+					super.setInformation(content);
+				}
+			}
 		};
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaSourceHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaSourceHover.java
@@ -165,6 +165,8 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 			if (fVisibleRange == null) {
 				return false;
 			}
+			// do not show changes made to viewer document required only for semantic coloring job
+			fSourceViewer.getControl().setRedraw(false);
 
 			// replace viewer content (was fHoverInfo) with full content (for which semantic coloring will be prepared)
 			fSourceViewer.getDocument().set(fFullContent);
@@ -178,7 +180,12 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 			fSourceViewer.setVisibleRegion(fVisibleRange.getOffset(), fVisibleRange.getLength());
 		}
 
-		public abstract void postSemanticColoring();
+		public final void postSemanticColoring() {
+			doPostSemanticColoring();
+			fSourceViewer.getControl().setRedraw(true);
+		}
+
+		public abstract void doPostSemanticColoring();
 	}
 
 	/**
@@ -220,7 +227,7 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 		}
 
 		@Override
-		public void postSemanticColoring() {
+		public void doPostSemanticColoring() {
 			if (fTrimRegions == null) {
 				return;
 			}
@@ -310,8 +317,8 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 		}
 
 		@Override
-		public void postSemanticColoring() {
-			super.postSemanticColoring();
+		public void doPostSemanticColoring() {
+			super.doPostSemanticColoring();
 
 			// apply skipped lines substitutions
 			if (fKeptLines != null && !fKeptLines.isEmpty()) {
@@ -368,12 +375,14 @@ public class JavaSourceHover extends AbstractJavaEditorTextHover {
 		public boolean prepareSemanticColoring(SourceViewer sourceViewer) {
 			// replace text and set visible region
 			super.prepareSemanticColoring(sourceViewer);
+			// enable redraw
+			postSemanticColoring();
 			// don't trigger semantic coloring job since viewer already renders the content with proper color
 			return false;
 		}
 
 		@Override
-		public void postSemanticColoring() {
+		public void doPostSemanticColoring() {
 			// no-op
 		}
 	}


### PR DESCRIPTION
## What it does
Adds full semantic coloring to content of Java source hover viewer.
~~Functionality can be toggled with new checkbox added to Preferences / Java / Editor / Syntax Coloring / "Full semantic syntax coloring in Java source hover" at the very bottom, enabled by default.~~ edit: removed

Behaves exactly like current hover in terms of presented content, size and reaction when trying to "enter into" hover viewer with mouse cursor.
Only difference is that when hovering over class / method / field / constant / variable name, if the element has JavaDoc or single/multi line comment above it's declaration, it will also be part of hover viewer content, but will not be presented / visible right away, but only after user "enters into" viewer and scrolls up.
This difference is intentional since I believe comments, especially JavaDoc, can be also useful piece of information to present in hover viewer.

## How to test
Compare contents, dimensions and behavior (when "entering into" hover viewer with mouse cursor) of Java source hover viewer with one displayed when running current release of Eclipse IDE when (+Shift) hovering over :

- class name
- method name
- field / constant name
- variable name
- end bracket of any loop
- any end bracket within if() {} else{} block (*)
- any end bracket within  if() {} else if() {} (*) (may be multiple "else if" sub-blocks)
- module name

(* starting "if" must be out of source code range displayed by the editor)

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)