### PR TITLE
Fix convert to switch expression failing to add yield statements

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.18.0.qualifier
+Bundle-Version: 1.18.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
@@ -388,7 +388,11 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 							ThrowStatement throwStatement= (ThrowStatement)oldStatement;
 							newStatement= (Statement)rewrite.createCopyTarget(throwStatement);
 						} else if (oldStatement instanceof ReturnStatement && createReturnStatement) {
-							newStatement= getNewStatementFromReturn(cuRewrite, rewrite, (ReturnStatement)oldStatement);
+							if (forceOldStyle) {
+								newStatement= getNewYieldStatementFromReturn(cuRewrite, rewrite, (ReturnStatement)oldStatement);
+							} else {
+								newStatement= getNewStatementFromReturn(cuRewrite, rewrite, (ReturnStatement)oldStatement);
+							}
 						} else if (forceOldStyle) {
 							newStatement= getNewYieldStatement(cuRewrite, rewrite, (ExpressionStatement)oldStatement);
 						} else {

--- a/org.eclipse.jdt.core.manipulation/pom.xml
+++ b/org.eclipse.jdt.core.manipulation/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.manipulation</artifactId>
-  <version>1.18.0-SNAPSHOT</version>
+  <version>1.18.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.14.700.qualifier
+Bundle-Version: 3.14.800.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.14.700-SNAPSHOT</version>
+  <version>3.14.800-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
@@ -1,5 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+/********************,***********************************************************
+ * Copyright (c) 2020 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -343,6 +343,60 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		buf.append("		};\n");
 		buf.append("		return i;\n");
 		buf.append("	}\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertEqualStringsIgnoreOrder(new String[] { preview }, new String[] { expected });
+	}
+
+	@Test
+	public void testConvertToSwitchExpression5() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public int foo(int i) {\n");
+		buf.append("        switch (i) {\n");
+		buf.append("        case 0: // comment\n");
+		buf.append("            return 0;\n");
+		buf.append("        default:\n");
+		buf.append("            return 1;\n");
+		buf.append("        }\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("switch");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
+		String preview= getPreviewContent(proposal);
+
+		buf= new StringBuilder();
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public int foo(int i) {\n");
+		buf.append("        return switch (i) {\n");
+		buf.append("			case 0: // comment\n");
+		buf.append("				yield 0;\n");
+		buf.append("			default:\n");
+		buf.append("				yield 1;\n");
+		buf.append("		};\n");
+		buf.append("    }\n");
 		buf.append("}\n");
 		String expected= buf.toString();
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -649,6 +649,49 @@ public class CleanUpTest14 extends CleanUpTestCase {
 				+ "                bar(); //\n" //
 				+ "                throw new AssertionError();\n" //
 				+ "            }\n" //
+				+ "        };\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testConvertToSwitchExpressionIssue388() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    public void bar() {\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public int foo(int i) {\n" //
+				+ "        switch (i) {\n" //
+				+ "        case 0: // comment\n" //
+				+ "            return 0;\n" //
+				+ "        default:\n" //
+				+ "            return 1;\n" //
+				+ "        }\n" //
+				+ "    }\n"
+				+ "}\n"; //
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    public void bar() {\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public int foo(int i) {\n" //
+				+ "        return switch (i) {\n" //
+				+ "            case 0: // comment\n" //
+				+ "                yield 0;\n" //
+				+ "            default:\n" //
+				+ "                yield 1;\n" //
 				+ "        };\n" //
 				+ "    }\n" //
 				+ "}\n"; //


### PR DESCRIPTION
- fixes #388
- fix code in SwitchExpressionsFixCore when forced to use old-style case format because of trailing comments to convert return statements into yield statements and not the return expression
- add new tests

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes convert to switch expression quick-assist/clean-up to not convert return statements to expressions when
forced to use old-style case statements due to a trailing comment.  See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.  Tests added.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
