### PR TITLE
Add more validity checking to While to for each cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Carsten Hammer.
+ * Copyright (c) 2021, 2023 Carsten Hammer.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -233,6 +233,23 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 							hit.isInvalid= true;
 							return false;
 						}
+					}
+				}
+			}
+			return true;
+		});
+		HelperVisitor.callSimpleNameVisitor(iterDeclarationParent, dataholder, nodesprocessed, (sn, holder2) -> {
+			if (sn.getIdentifier().equals(hit.iteratorName)) {
+				Statement parentStatement= ASTNodes.getFirstAncestorOrNull(sn, Statement.class);
+				if (parentStatement == null) {
+					hit.isInvalid= true;
+					return false;
+				}
+				if (sn.getParent() != iterDeclFragment && parentStatement != hit.iteratorCall && sn.getLocationInParent() != MethodInvocation.EXPRESSION_PROPERTY) {
+					IBinding binding= sn.resolveBinding();
+					if (binding == null || binding.isEqualTo(iterBinding)) {
+						hit.isInvalid= true;
+						return false;
 					}
 				}
 			}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -5081,6 +5081,29 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				        + "            String s = (String) it.next();\n"
 				        + "            System.out.println(s);\n"
 				        + "            System.err.println(s);\n"
+				        + "        }\n"
+				        + "    }\n"
+				        + "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
+	}
+
+	@Test
+	public void testDoNotWhileIssue373() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n"
+				        + "import java.util.*;\n"
+				        + "public class Test {\n"
+				        + "    void m(List<String> strings) {\n"
+				        + "        Iterator it = strings.iterator();\n"
+				        + "        while (it.hasNext()) {\n"
+				        + "            String s = (String) it.next();\n"
+				        + "            System.out.println(s);\n"
+				        + "            System.err.println(it);\n"
 				        + "        }\n"
 				        + "    }\n"
 				        + "}\n";


### PR DESCRIPTION
- fixes #373

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds more validity checking to While to for each cleanup so that if the iterator variable
is referenced outside of valid usage, the cleanup will not occur.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
