### PR TITLE
Add compliance checking to AccessClassCreator

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.14.600.qualifier
+Bundle-Version: 3.14.700.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.14.600-SNAPSHOT</version>
+  <version>3.14.700-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSSourceModifierTest1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSSourceModifierTest1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -53,14 +53,14 @@ import org.eclipse.jdt.internal.corext.refactoring.nls.changes.CreateTextFileCha
 import org.eclipse.jdt.internal.corext.refactoring.typeconstraints.ASTCreator;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
-import org.eclipse.jdt.ui.tests.core.rules.Java9ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.Java1d8ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
-public class NLSSourceModifierTest {
+public class NLSSourceModifierTest1d8 {
 	@Rule
-	public ProjectTestSetup pts= new Java9ProjectTestSetup();
+	public ProjectTestSetup pts= new Java1d8ProjectTestSetup();
 
     private IJavaProject javaProject;
 
@@ -161,8 +161,7 @@ public class NLSSourceModifierTest {
       buf.append("import org.eclipse.osgi.util.NLS;\n");
       buf.append("\n");
       buf.append("public class Accessor extends NLS {\n");
-      buf.append("    private static final String BUNDLE_NAME = Accessor.class.getPackageName()\n");
-      buf.append("            + \".test\"; //$NON-NLS-1$\n");
+      buf.append("    private static final String BUNDLE_NAME = \"test.test\"; //$NON-NLS-1$\n");
       buf.append("    public static String key_0;\n");
       buf.append("    static {\n");
       buf.append("        // initialize resource bundle\n");
@@ -240,8 +239,7 @@ public class NLSSourceModifierTest {
         buf.append("import org.eclipse.osgi.util.NLS;\n");
         buf.append("\n");
         buf.append("public class Accessor extends NLS {\n");
-        buf.append("    private static final String BUNDLE_NAME = Accessor.class.getPackageName()\n");
-        buf.append("            + \".test\"; //$NON-NLS-1$\n");
+        buf.append("    private static final String BUNDLE_NAME = \"test.test\"; //$NON-NLS-1$\n");
         buf.append("\n");
         buf.append("    static {\n");
         buf.append("        // initialize resource bundle\n");
@@ -327,8 +325,7 @@ public class NLSSourceModifierTest {
         buf.append("import org.eclipse.osgi.util.NLS;\n");
         buf.append("\n");
         buf.append("public class Accessor extends NLS {\n");
-        buf.append("    private static final String BUNDLE_NAME = Accessor.class.getPackageName()\n");
-        buf.append("            + \".test\"; //$NON-NLS-1$\n");
+        buf.append("    private static final String BUNDLE_NAME = \"test.test\"; //$NON-NLS-1$\n");
         buf.append("    public static String key_0;\n");
         buf.append("    static {\n");
         buf.append("        // initialize resource bundle\n");
@@ -406,8 +403,7 @@ public class NLSSourceModifierTest {
         buf.append("import org.eclipse.osgi.util.NLS;\n");
         buf.append("\n");
         buf.append("public class Accessor extends NLS {\n");
-        buf.append("    private static final String BUNDLE_NAME = Accessor.class.getPackageName()\n");
-        buf.append("            + \".test\"; //$NON-NLS-1$\n");
+        buf.append("    private static final String BUNDLE_NAME = \"test.test\"; //$NON-NLS-1$\n");
         buf.append("\n");
         buf.append("    static {\n");
         buf.append("        // initialize resource bundle\n");
@@ -894,8 +890,7 @@ public class NLSSourceModifierTest {
         buf.append("import org.eclipse.osgi.util.NLS;\n");
         buf.append("\n");
         buf.append("public class Accessor extends NLS {\n");
-        buf.append("    private static final String BUNDLE_NAME = Accessor.class.getPackageName()\n");
-        buf.append("            + \".test\"; //$NON-NLS-1$\n");
+        buf.append("    private static final String BUNDLE_NAME = \"test.test\"; //$NON-NLS-1$\n");
         buf.append("    public static String key_0;\n");
         buf.append("    static {\n");
         buf.append("        // initialize resource bundle\n");
@@ -1402,8 +1397,7 @@ public class NLSSourceModifierTest {
         buf.append("import java.util.ResourceBundle;\n");
         buf.append("\n");
         buf.append("public class Accessor {\n");
-        buf.append("    private static final String BUNDLE_NAME = Accessor.class.getPackageName()\n");
-        buf.append("            + \".test\"; //$NON-NLS-1$\n");
+        buf.append("    private static final String BUNDLE_NAME = \"test.test\"; //$NON-NLS-1$\n");
         buf.append("\n");
         buf.append("    private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle\n");
         buf.append("            .getBundle(BUNDLE_NAME);\n");

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSTestSuite.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ import org.junit.runners.Suite;
 		NlsRefactoringCheckFinalConditionsTest.class,
 		NlsRefactoringCreateChangeTest.class,
 		NLSSourceModifierTest.class,
+		NLSSourceModifierTest1d8.class,
 		NLSHintTest.class,
 		NLSHintHelperTest.class,
 		PropertyFileDocumentModellTest.class,

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/nls/AccessorClassCreator.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/nls/AccessorClassCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -223,7 +223,7 @@ public class AccessorClassCreator {
 	private String getBundleNameFieldValue() throws CoreException {
 		IPath resourceBundleContainerPath= fResourceBundlePath.removeLastSegments(1);
 		IPath accessorContainerPath= fAccessorPath.removeLastSegments(1);
-		if (Objects.equals(accessorContainerPath, resourceBundleContainerPath)) {
+		if (JavaModelUtil.is9OrHigher(fCu.getJavaProject()) && Objects.equals(accessorContainerPath, resourceBundleContainerPath)) {
 			return fAccessorClassName + ".class.getPackageName() + \"." + getPropertyFileNameWithoutExtension() + "\""; //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return "\"" + getResourceBundleName() + "\""; //$NON-NLS-1$//$NON-NLS-2$


### PR DESCRIPTION
- add check for Java 9 or above compliance before using the Class.getPackageName() method which was added in Java 9
- add new NLSSourceModifierTest1d8 test to NLSTestSuite
- fixes #466

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds compliance checking before using getPackageName() which was added in Java 9.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test case.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
