### PR TITLE
Forces key binding to Open Type inside JDT editor

### DIFF
--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -4909,6 +4909,13 @@
             sequence="M1+M2+T"
             commandId="org.eclipse.jdt.ui.navigate.open.type"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
+      <!-- Forces M1+M2+T to Open Type inside JDT editor, preventing conflicts with other
+           plugins that provide same binding for other commands in more generic contexts -->
+      <key
+            sequence="M1+M2+T"
+            contextId="org.eclipse.jdt.ui.javaEditorScope"
+            commandId="org.eclipse.jdt.ui.navigate.open.type"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"/>
       <key
             sequence="M1+M2+H"
             commandId="org.eclipse.jdt.ui.navigate.open.type.in.hierarchy"


### PR DESCRIPTION
Preventing conflicts with other plugins that provide same binding for other commands in more generic context

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
