### PR TITLE
Make string concat to text block NLS consistent

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -4206,6 +4206,26 @@ public class ASTNodes {
 		for (Comment commentFromList : commentList) {
 			if (commentFromList.getStartPosition() > node.getStartPosition()
 					&& commentFromList.getStartPosition() < extendedStart + extendedLength) {
+				comments.add(commentFromList);
+			}
+		}
+		return comments;
+	}
+
+	/**
+	 * Return a list of comments for a region
+	 *
+	 * @param cu - CompilationUnit
+	 * @param start - start of region
+	 * @param length - length of region
+	 * @return list of Comment nodes
+	 */
+	public static List<Comment> getCommentsForRegion(CompilationUnit cu, int start, int length) {
+		List<Comment> comments= new ArrayList<>();
+		List<Comment> commentList= cu.getCommentList();
+		for (Comment commentFromList : commentList) {
+			if (commentFromList.getStartPosition() > start
+					&& commentFromList.getStartPosition() < start + length) {
 				comments.add(commentFromList);
 			}
 		}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/nls/NLSUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/nls/NLSUtil.java
@@ -152,7 +152,7 @@ public class NLSUtil {
 		return result.toArray(new TextEdit[result.size()]);
 	}
 
-	private static NLSLine scanCurrentLine(ICompilationUnit cu, int position) throws JavaModelException {
+	public static NLSLine scanCurrentLine(ICompilationUnit cu, int position) throws JavaModelException {
 		try {
 			Assert.isTrue(position >= 0 && position <= cu.getBuffer().getLength());
 			for (NLSLine line : NLSScanner.scan(cu)) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -75,10 +75,10 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf.append("public class Cls {\n");
 		buf.append("    public void foo() {\n");
 		buf.append("        // comment 1\n");
-		buf.append("        String x = \"\" +\n");
-        buf.append("            \"public void foo() {\\n\" +\n");
-        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" +\n");
-        buf.append("            \"}\\n\"; // comment 2\n");
+		buf.append("        String x = \"\" + //$NON-NLS-1$\n");
+        buf.append("            \"public void foo() {\\n\" + //$NON-NLS-1$\n");
+        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" + //$NON-NLS-1$\n");
+        buf.append("            \"}\\n\"; //$NON-NLS-1$ // comment 2\n");
         buf.append("    }\n");
 		buf.append("}\n");
 		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
@@ -97,7 +97,7 @@ public class AssistQuickFixTest15 extends QuickFixTest {
         buf.append("		\tpublic void foo() {\n");
         buf.append("		\t    System.out.println(\"abc\");\n");
         buf.append("		\t}\n");
-        buf.append("		\t\"\"\"; // comment 2\n");
+        buf.append("		\t\"\"\"; //$NON-NLS-1$ // comment 2\n");
         buf.append("    }\n");
 		buf.append("}\n");
 		String expected= buf.toString();
@@ -710,6 +710,41 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 
 		int index= buf.indexOf("buf3");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+	}
+
+	@Test
+	public void testNoConcatToTextBlock9() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void inconsistentNLS() {\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String x = \"\" + //$NON-NLS-1$\n");
+        buf.append("            \"public void foo() {\\n\" +\n");
+        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" + //$NON-NLS-1$\n");
+        buf.append("            \"}\\n\"; //$NON-NLS-1$ // comment 2\n");
+        buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("x");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 1);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -54,10 +54,10 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "public class E {\n" //
 				+ "    public void testSimple() {\n"
 				+ "        // comment 1\n" //
-				+ "        String x = \"\" +\n" //
-    	        + "            \"public void foo() {\\n\" +\n" //
-    	        + "            \"    System.out.println(\\\"abc\\\");\\n\" +\n" //
-    	        + "            \"}\\n\"; // comment 2\n" //
+				+ "        String x = \"\" + //$NON-NLS-1$\n" //
+    	        + "            \"public void foo() {\\n\" + //$NON-NLS-1$\n" //
+    	        + "            \"    System.out.println(\\\"abc\\\");\\n\" + //$NON-NLS-1$\n" //
+    	        + "            \"}\\n\"; //$NON-NLS-1$ // comment 2\n" //
     	        + "    }\n" //
     	        + "\n" //
 				+ "    public void testTrailingSpacesAndInnerNewlines() {\n"
@@ -97,7 +97,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        \tpublic void foo() {\n" //
     	        + "        \t    System.out.println(\"abc\");\n" //
     	        + "        \t}\n" //
-    	        + "        \t\"\"\"; // comment 2\n" //
+    	        + "        \t\"\"\"; //$NON-NLS-1$ // comment 2\n" //
     	        + "    }\n" //
     	        + "\n" //
 				+ "    public void testTrailingSpacesAndInnerNewlines() {\n" //
@@ -262,6 +262,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            \"abcdef\" +\n" //
     	        + "            \"ghijkl\" +\n" //
     	        + "            3;\n;"
+    	        + "    }\n" //
+    	        + "\n" //
+   	            + "    public void testInconsistentNLS() {\n" //
+				+ "        String x = \"\" +\n" //
+    	        + "            \"abcdef\" +\n" //
+    	        + "            \"ghijkl\" + //$NON-NLS-1$\n" //
+    	        + "            \"mnop\";\n" //
     	        + "    }\n" //
 				+ "}\n";
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);


### PR DESCRIPTION
- add new method getCommentsForRegion() to ASTNodes
- modify StringConcatToTextBlockFixCore to support NLS comment checking for the various lines of the string concatenation and fail if inconsistent
- make NLSUtil scanCurrentLine() public
- add new tests to CleanUpTest15 and AssistQuickFixTest15

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds checking to the string concat to text block cleanup and quick fix so that it does not occur if all segments are not consistent in being non-NLS or not.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
