### PR TITLE
Fix regression in UnresolvedElementsSubProcessor

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedTypesQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedTypesQuickFixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1673,4 +1673,41 @@ public class UnresolvedTypesQuickFixTest extends QuickFixTest {
 		assertExpectedExistInProposals(proposals, expected);
 	}
 
+	@Test
+	public void testIssue485() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package pack;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        Date d1= new Date();\n");
+		buf.append("        Date d2;\n");
+		buf.append("        d2=new Date();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 4, 0);
+
+		assertCorrectLabels(proposals);
+
+		String[] expected= new String[1];
+		buf= new StringBuilder();
+		buf.append("package pack;\n");
+		buf.append("\n");
+		buf.append("import java.util.Date;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        Date d1= new Date();\n");
+		buf.append("        Date d2;\n");
+		buf.append("        d2=new Date();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		expected[0]= buf.toString();
+
+		assertExpectedExistInProposals(proposals, expected);
+	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 202 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -895,16 +895,18 @@ public class UnresolvedElementsSubProcessor {
 						try {
 							IJavaProject focus= simpleBinding.getJavaElement().getJavaProject();
 							IType javaElementType= focus.findType(fullName);
-							ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
-							parser.setProject(focus);
-							IBinding[] bindings= parser.createBindings(new IJavaElement[] {javaElementType} , null);
-							qualifiedTypeBinding=(ITypeBinding)bindings[0];
+							if (javaElementType != null) {
+								ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
+								parser.setProject(focus);
+								IBinding[] bindings= parser.createBindings(new IJavaElement[] {javaElementType} , null);
+								qualifiedTypeBinding=(ITypeBinding)bindings[0];
+							}
 						} catch (JavaModelException e) {
 							// fall through
 						}
 
 						if (qualifiedTypeBinding != null) {
-							if (!isInherited(qualifiedTypeBinding, simpleBinding)) {
+							if (!qualifiedTypeBinding.getName().equals(simpleBinding.getName()) && !isInherited(qualifiedTypeBinding, simpleBinding)) {
 								continue;
 							}
 						}


### PR DESCRIPTION
- fix problem introduced by #352
- check for inheritance should not be run if the suggested class binding has same name as the missing class
- fixes #485

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes regression.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run tests specified in new issue and old issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
