### PR TITLE
CopyQualifiedNameAction: never copy file eclipse.platform#372

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/CopyQualifiedNameAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/CopyQualifiedNameAction.java
@@ -21,12 +21,9 @@ import org.eclipse.osgi.util.TextProcessor;
 import org.eclipse.swt.SWTError;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.DND;
-import org.eclipse.swt.dnd.FileTransfer;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.graphics.Point;
-
-import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.core.resources.IResource;
 
@@ -199,14 +196,8 @@ public class CopyQualifiedNameAction extends SelectionDispatchAction {
 					resource= (IResource)element;
 
 				if (resource != null) {
-					IPath location= resource.getLocation();
-					if (location != null) {
-						data= new Object[] { qualifiedName, resource, new String[] { location.toOSString() } };
-						dataTypes= new Transfer[] { TextTransfer.getInstance(), ResourceTransfer.getInstance(), FileTransfer.getInstance() };
-					} else {
-						data= new Object[] { qualifiedName, resource };
-						dataTypes= new Transfer[] { TextTransfer.getInstance(), ResourceTransfer.getInstance() };
-					}
+					data= new Object[] { qualifiedName, resource };
+					dataTypes= new Transfer[] { TextTransfer.getInstance(), ResourceTransfer.getInstance() };
 				} else {
 					data= new Object[] { qualifiedName };
 					dataTypes= new Transfer[] { TextTransfer.getInstance() };


### PR DESCRIPTION
## What it does
Only copy the name when the user asks for that.

## How to test
"copy qualified name" from package explorer of any file, paste to Teams/Word

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions]
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
