### PR TITLE
New tests for verifying #649

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedTypesQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedTypesQuickFixTest.java
@@ -1710,4 +1710,44 @@ public class UnresolvedTypesQuickFixTest extends QuickFixTest {
 
 		assertExpectedExistInProposals(proposals, expected);
 	}
+
+	@Test
+	public void testIssue649() throws Exception {
+		IPackageFragment defaultPackage= fSourceFolder.createPackageFragment("", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("//Comment 1\n");
+		buf.append("//Comment 2\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        Date d1= new Date();\n");
+		buf.append("        Date d2;\n");
+		buf.append("        d2=new Date();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= defaultPackage.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 4, 0);
+
+		assertCorrectLabels(proposals);
+
+		String[] expected= new String[1];
+		buf= new StringBuilder();
+		buf.append("//Comment 1\n");
+		buf.append("//Comment 2\n");
+		buf.append("\n");
+		buf.append("import java.util.Date;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        Date d1= new Date();\n");
+		buf.append("        Date d2;\n");
+		buf.append("        d2=new Date();\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		expected[0]= buf.toString();
+
+		assertExpectedExistInProposals(proposals, expected);
+	}
 }


### PR DESCRIPTION
- ensure that new imports or package statements don't obliterate header comments

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds tests to verify #649

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run tests or see issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
