### PR TITLE
Cleanup wizard summary must be refreshed on page entry

### DIFF
--- a/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
+++ b/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/PreviewWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -505,6 +505,7 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 	@Override
 	public void setVisible(boolean visible) {
 		fCurrentSelection= null;
+		clearGroupCategories();
 		final RefactoringWizard refactoringWizard= getRefactoringWizard();
 		if (hasChanges()) {
 			fPageContainer.showPage(fStandardPage);
@@ -526,6 +527,7 @@ public class PreviewWizardPage extends RefactoringWizardPage implements IPreview
 						fTreeViewer.setSelection(new StructuredSelection(element));
 					}
 				}
+				updateTreeViewerPaneTitle();
 			} else if (!visible) // dispose the previewer
 				fCurrentPreviewViewer.setInput(new ChangePreviewViewerInput(new NullChange()));
 			((FilterDropDownAction) fFilterDropDownAction).initialize(collectGroupCategories());


### PR DESCRIPTION
- fixes #474

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Properly updates the PreviewWizardPage title when reentered.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.  Perform Source->Cleanup and choose multiple cleanups then hit Next button.  Click the filter icon on top right and choose one of the cleanups to filter.  This will change the message to state which cleanup is being shown.  Hit the Back  button and then re-select the Next button.  When the page is shown again it should not state that items are being filtered in the title message (should just be "Changes to be performed")

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
