### PR TITLE
Allow Source menu for multi-project selection if at least one is Java

### DIFF
--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -6172,18 +6172,22 @@
 					id="org.eclipse.jdt.ui.navigator.actions.StandardActions"
 					overrides="org.eclipse.ui.navigator.resources.actions.EditActions">
 				<enablement>
-					<or>
-						<and>
-							<instanceof value="org.eclipse.core.resources.IResource" />
-							<test property="org.eclipse.core.resources.projectNature" value="org.eclipse.jdt.core.javanature" />
-						</and>
-						<instanceof value="org.eclipse.jdt.core.IJavaElement" />
-						<instanceof value="org.eclipse.jdt.core.IJarEntryResource" />
-						<instanceof	value="org.eclipse.jdt.internal.ui.packageview.PackageFragmentRootContainer" />
-						<adapt type="java.util.Collection">
-							<count value="0" />
-						</adapt>
-					</or>
+ 					<with variable="selection">
+						<iterate operator="or" ifEmpty="false">
+							<or>
+								<and>
+									<instanceof value="org.eclipse.core.resources.IResource" />
+									<test property="org.eclipse.core.resources.projectNature" value="org.eclipse.jdt.core.javanature" />
+								</and>
+								<instanceof value="org.eclipse.jdt.core.IJavaElement" />
+								<instanceof value="org.eclipse.jdt.core.IJarEntryResource" />
+								<instanceof	value="org.eclipse.jdt.internal.ui.packageview.PackageFragmentRootContainer" />
+								<adapt type="java.util.Collection">
+									<count value="0" />
+								</adapt>
+							</or>
+						</iterate>
+					</with>
 				</enablement>
 			</actionProvider>
 			<actionProvider


### PR DESCRIPTION
- fixes #102

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes enablement for Source menu to work if multiple projects are selected and at least 1 is a Java project.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Create a Java project and a generic project.  Select both the Java project and generic project and invoke the context menu.  The Source menu should appear.  If just the generic project is selected, the Source menu should not appear.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
