### PR TITLE
remove author from default code templates (#374)

### DIFF
--- a/org.eclipse.jdt.ui/templates/default-codetemplates.xml
+++ b/org.eclipse.jdt.ui/templates/default-codetemplates.xml
@@ -35,8 +35,6 @@
  */</template>
 
 <template name="typecomment" id="org.eclipse.jdt.ui.text.codetemplates.typecomment" description="%CodeTemplates.typecomment" context="typecomment_context" enabled="true">/**
- * @author ${user}
- *
  * ${tags}
  */</template>
  
@@ -49,8 +47,6 @@
  */</template>
 
 <template name="modulecomment" id="org.eclipse.jdt.ui.text.codetemplates.modulecomment" description="%CodeTemplates.modulecomment" context="modulecomment_context" enabled="true">/**
- * @author ${user}
- *
  * ${tags}
  */</template>
 


### PR DESCRIPTION
This was useful at times where many people did not have version control or a version control system that was not easy to use and query. Today that leads to lots of problems:

* The same information is better available in the version control history, with attribution by line instead of assuming this one author for every line currently in the file
* People copy/paste classes to create "something similar", without fixing this comment.
* It may leak information of the private user account to the public (at least on Windows, this defaults to your local user account id, and my company admin would surely not like me posting that account id everywhere).
* Even developers without an underlying version control system should not rely on this information, but rather be nudged to set up a real version control system.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
#374: remove the author tag from default code templates

## How to test
Create a new class (in a new workspace). Notice there is no more author tag in the Javadoc comment.

## Author checklist

- [ ] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
