### PR TITLE
IOOBE when moving JUnit5 container from module path to classpath

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/BuildPathBasePage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/BuildPathBasePage.java
@@ -332,7 +332,7 @@ public abstract class BuildPathBasePage {
 				if (rootCPListElement.isTargetRootNode(changeNodeDirection)) {
 					if (rootCPListElement.getChildren().contains(selElement))
 						break;
-					if (indexOfSelElement != -1) {
+					if (indexOfSelElement != -1 && indexOfSelElement < rootCPListElement.getChildren().size()) {
 						rootCPListElement.getChildren().add(indexOfSelElement, selElement);
 					} else {
 						rootCPListElement.addCPListElement(selElement);


### PR DESCRIPTION
Adjust `BuildPathBasePage.moveCPElementAcrossNode()` to use selection index only if this index is in the bounds of the new container.

Fixes: #478

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
