### PR TITLE
Refine filtering of JUnit stacktraces

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TextualTrace.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TextualTrace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -119,11 +119,15 @@ public class TextualTrace {
 		String line;
 		String[] patterns = filterPatterns;
 		boolean firstLine= true;
+		boolean stackFrameSeen= false;
 		try {
 			while ((line= bufferedReader.readLine()) != null) {
-				if (firstLine || !filterLine(patterns, line))
+				if (firstLine || !stackFrameSeen || !filterLine(patterns, line))
 					printWriter.println(line);
 				firstLine= false;
+				if (!(stackFrameSeen)) {
+					stackFrameSeen= isAStackFrame(line.replace('\t', ' '));
+				}
 			}
 		} catch (IOException e) {
 			return stackTrace; // return the stack unfiltered


### PR DESCRIPTION
- don't start filtering lines until we have the first stack trace line
- fixes #372

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Avoids filtering of JUnit trace until the stack trace lines start.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
