### PR TITLE
Don't filter type for method completion as type is known

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/MethodInsertCompletionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/MethodInsertCompletionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,11 +14,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests.contentassist;
 
-import org.junit.Test;
-
 import org.eclipse.jdt.core.JavaCore;
-
 import org.eclipse.jdt.ui.PreferenceConstants;
+import org.junit.Test;
 
 /**
  *
@@ -143,6 +141,15 @@ public class MethodInsertCompletionTest extends AbstractCompletionTest {
 		getJDTUIPrefs().setValue(PreferenceConstants.CODEASSIST_AUTOINSERT, true);
 		addLocalVariables("String s;");
 		assertMethodBodyIncrementalCompletion("s.Su|", "s.sub|");
+	}
+
+	@Test
+	public void testIssue417() throws Exception {
+		getJDTUIPrefs().setValue(PreferenceConstants.CODEASSIST_PREFIX_COMPLETION, true);
+		getJDTUIPrefs().setValue(PreferenceConstants.CODEASSIST_AUTOINSERT, true);
+		getJDTUIPrefs().setValue(PreferenceConstants.TYPEFILTER_ENABLED, "java.lang.String");
+		addLocalVariables("java.lang.String s;");
+		assertMethodBodyIncrementalCompletion("s.ind|", "s.indexOf|");
 	}
 
 	@Test

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/MethodInsertCompletionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/MethodInsertCompletionTest.java
@@ -147,9 +147,14 @@ public class MethodInsertCompletionTest extends AbstractCompletionTest {
 	public void testIssue417() throws Exception {
 		getJDTUIPrefs().setValue(PreferenceConstants.CODEASSIST_PREFIX_COMPLETION, true);
 		getJDTUIPrefs().setValue(PreferenceConstants.CODEASSIST_AUTOINSERT, true);
+		String oldPrefs= getJDTUIPrefs().getString(PreferenceConstants.TYPEFILTER_ENABLED);
 		getJDTUIPrefs().setValue(PreferenceConstants.TYPEFILTER_ENABLED, "java.lang.String");
-		addLocalVariables("java.lang.String s;");
-		assertMethodBodyIncrementalCompletion("s.ind|", "s.indexOf|");
+		try {
+			addLocalVariables("java.lang.String s;");
+			assertMethodBodyIncrementalCompletion("s.ind|", "s.indexOf|");
+		} finally {
+			getJDTUIPrefs().setValue(PreferenceConstants.TYPEFILTER_ENABLED, oldPrefs);
+		}
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/CompletionProposalCollector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/CompletionProposalCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,19 +18,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.swt.graphics.Image;
-
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
-
-import org.eclipse.jface.resource.ImageDescriptor;
-import org.eclipse.jface.viewers.StyledString;
-
-import org.eclipse.jface.text.contentassist.IContextInformation;
-
 import org.eclipse.jdt.core.CompletionContext;
 import org.eclipse.jdt.core.CompletionProposal;
 import org.eclipse.jdt.core.CompletionRequestor;
@@ -43,11 +35,9 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
-
 import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
 import org.eclipse.jdt.internal.corext.util.CollectionsUtil;
 import org.eclipse.jdt.internal.corext.util.TypeFilter;
-
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileManager;
 import org.eclipse.jdt.internal.ui.text.java.AnnotationAtttributeProposalInfo;
@@ -71,6 +61,10 @@ import org.eclipse.jdt.internal.ui.text.java.RelevanceComputer;
 import org.eclipse.jdt.internal.ui.text.javadoc.JavadocInlineTagCompletionProposal;
 import org.eclipse.jdt.internal.ui.text.javadoc.JavadocLinkTypeCompletionProposal;
 import org.eclipse.jdt.internal.ui.viewsupport.ImageDescriptorRegistry;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.jface.viewers.StyledString;
+import org.eclipse.swt.graphics.Image;
 
 /**
  * Java UI implementation of <code>CompletionRequestor</code>. Produces
@@ -281,8 +275,9 @@ public class CompletionProposalCollector extends CompletionRequestor {
 	public void accept(CompletionProposal proposal) {
 		long start= JavaPlugin.DEBUG_RESULT_COLLECTOR ? System.currentTimeMillis() : 0;
 		try {
-			if (isFiltered(proposal))
+			if (isIgnored(proposal.getKind())) {
 				return;
+			}
 
 			if (proposal.getKind() == CompletionProposal.POTENTIAL_METHOD_DECLARATION) {
 				acceptPotentialMethodDeclaration(proposal);


### PR DESCRIPTION
- fixes #417
- add new test to MethodInsertCompletionTest

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Does not filter out types when completing a method reference as the type is already known and specified.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.  A new test has been added as well to filter out java.lang.String and then to try to complete a method call for a variable declared as java.lang.String.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
