### PR TITLE
Create better fix for #532

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/IndentActionTest15.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/IndentActionTest15.java
@@ -45,7 +45,7 @@ public class IndentActionTest15 {
 	@Rule
 	public TestName tn= new TestName();
 
-	private static final String PROJECT= "IndentTests";
+	private static final String PROJECT= "IndentTests15";
 
 	private final static class IndentTestSetup extends ExternalResource {
 		private IJavaProject fJavaProject;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,14 +14,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import org.eclipse.jdt.text.tests.codemining.CodeMiningTriggerTest;
 import org.eclipse.jdt.text.tests.codemining.ParameterNamesCodeMiningTest;
 import org.eclipse.jdt.text.tests.contentassist.ContentAssistTestSuite;
 import org.eclipse.jdt.text.tests.spelling.SpellCheckEngineTestCase;
 import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 
 /**
@@ -69,6 +68,7 @@ import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
 	EnumConstructorTargetFinderTest.class,
 	ContentAssistTestSuite.class,
 	IndentActionTest.class,
+	IndentActionTest15.class,
 	TemplatesTestSuite.class,
 	JavaElementPrefixPatternMatcherTest.class,
 	CodeMiningTriggerTest.class,

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_5/Before.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_5/Before.java
@@ -1,0 +1,13 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+			String x[] = {
+					"abc",
+				"""
+				This is a text block
+				   with an indent
+				"""
+			};
+	}
+}

--- a/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_5/Modified.java
+++ b/org.eclipse.jdt.text.tests/testResources/indentation15/issue414_5/Modified.java
@@ -1,0 +1,13 @@
+package p;
+
+public class TestTextBlock {
+	public void foo() {
+		String x[] = {
+				"abc",
+				"""
+				This is a text block
+				   with an indent
+				"""
+		};
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/IndentAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/IndentAction.java
@@ -1002,13 +1002,16 @@ public class IndentAction extends TextEditorAction {
 					}
 				}
 			}
-		} else if (minIndent > 0) {
+		}
+		if (minIndent > 0) {
 			IRegion commandLine= document.getLineInformationOfOffset(commandOffset);
-			// handle extra indentation but ignore empty lines or short lines with only white-space
-			if (commandLine.getLength() > minIndent) {
-				String currentLineIndent= getLineIndentation(document, commandLine.getOffset());
-				if (currentLineIndent.length() > minIndent) {
-					commandIndent= currentLineIndent.substring(minIndent);
+			if (commandLine.getOffset() != line.getOffset()) {
+				// handle extra indentation but ignore empty lines or short lines with only white-space
+				if (commandLine.getLength() > minIndent) {
+					String currentLineIndent= getLineIndentation(document, commandLine.getOffset());
+					if (currentLineIndent.length() > minIndent) {
+						commandIndent= currentLineIndent.substring(minIndent);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- fix IndentAction for text blocks to properly identify current line vs opening of text block
- enable IndentActionTest15 in JdtTextTestSuite
- add issue414_5 test

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes moving the opening quotes of a text block in a better manner than fix for #532

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run IndentActionTest15

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
