### PR TITLE
Instanceof pattern cleanup should preserve final modifier

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2023 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,9 +18,6 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.core.runtime.CoreException;
-
-import org.eclipse.text.edits.TextEditGroup;
-
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -30,6 +27,8 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InstanceofExpression;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
 import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
 import org.eclipse.jdt.core.dom.PrefixExpression;
 import org.eclipse.jdt.core.dom.SimpleName;
@@ -40,11 +39,10 @@ import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
-
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+import org.eclipse.text.edits.TextEditGroup;
 
 public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteOperationsFixCore {
 	public static final class PatternMatchingForInstanceofFinder extends ASTVisitor {
@@ -201,6 +199,9 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			SingleVariableDeclaration newSVDecl= ast.newSingleVariableDeclaration();
 			newSVDecl.setName(ASTNodes.createMoveTarget(rewrite, expressionToMove));
 			newSVDecl.setType(ASTNodes.createMoveTarget(rewrite, nodeToComplete.getRightOperand()));
+			if (Modifier.isFinal(statementToRemove.getModifiers())) {
+				newSVDecl.modifiers().add(ast.newModifier(ModifierKeyword.fromFlagValue(Modifier.FINAL)));
+			}
 			newInstanceof.setRightOperand(newSVDecl);
 
 			ASTNodes.replaceButKeepComment(rewrite, nodeToComplete, newInstanceof, group);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2023 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,22 +18,17 @@ import static org.junit.Assert.assertNotEquals;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.eclipse.core.runtime.CoreException;
-
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
-
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-
+import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 import org.eclipse.jdt.ui.tests.core.rules.Java16ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
-
-import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * Tests the cleanup features related to Java 16.
@@ -232,7 +227,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long matchPatternForInstanceofOnFinalVariable(Object object) {\n" //
 				+ "        // Keep this comment\n" //
-				+ "        if (object instanceof Date date) {\n" //
+				+ "        if (object instanceof final Date date) {\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
 				+ "\n" //


### PR DESCRIPTION
- fix PatternMatchingForInstanceofFixCore to check if variable to move has final modifier in which case add it to pattern
- fix CleanUpTest16 test
- fixes #1012

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the instanceof pattern matching cleanup to preserve final modifier if used in variable declaration.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run CleanUpTest16.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
