### PR TITLE
Enhance NoStringCreationCleanUp

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,20 +31,9 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
-import org.eclipse.jdt.testplugin.JavaProjectHelper;
-import org.eclipse.jdt.testplugin.TestOptions;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-
-import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-import org.eclipse.ltk.core.refactoring.RefactoringStatusEntry;
-
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -58,20 +47,12 @@ import org.eclipse.jdt.core.dom.ASTRequestor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.core.manipulation.CleanUpOptionsCore;
-
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
 import org.eclipse.jdt.internal.corext.fix.UpdateProperty;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 import org.eclipse.jdt.internal.corext.util.Messages;
-
-import org.eclipse.jdt.ui.PreferenceConstants;
-import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
-import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
-import org.eclipse.jdt.ui.tests.core.rules.Java13ProjectTestSetup;
-import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
-
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
@@ -81,6 +62,18 @@ import org.eclipse.jdt.internal.ui.fix.PrimitiveRatherThanWrapperCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.RedundantModifiersCleanUp;
 import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp;
 import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.testplugin.TestOptions;
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+import org.eclipse.jdt.ui.tests.core.rules.Java13ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.RefactoringStatusEntry;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class CleanUpTest extends CleanUpTestCase {
 	@Rule
@@ -27136,11 +27129,38 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "        return new String(\"\");\n" //
 				+ "    }\n" //
 				+ "\n" //
+				+ "    public String replaceNewStringParenthesized() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        return ((new String(\"\")));\n" //
+				+ "    }\n" //
+				+ "\n" //
 				+ "    public String replaceNewStringInMethodInvocation(String s, int i) {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        return new String(s + i).toLowerCase();\n" //
 				+ "    }\n" //
-				+ "}\n";
+				+ "\n" //
+				+ "    public String replaceNewStringInMethodInvocation2(String s, String s2) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        return new String(s.concat(s2)).toLowerCase();\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String replaceNewStringInIf(String s, String s2) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        if ((new String(s)).equals(\"abc\")) {\n" //
+				+ "            return s2;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String replaceNewStringInNestedNewStrings(String s, String s2) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        if ((new String(new String(s))).equals(\"abc\")) {\n" //
+				+ "            return s2;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public void replaceNewStringInFieldAccess(String s) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        Object x = (new String(s)).CASE_INSENSITIVE_ORDER;\n" //
+				+ "    }\n" //
+			+ "}\n";
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
 
 		enable(CleanUpConstants.NO_STRING_CREATION);
@@ -27154,9 +27174,36 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "        return \"\";\n" //
 				+ "    }\n" //
 				+ "\n" //
+				+ "    public String replaceNewStringParenthesized() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        return \"\";\n" //
+				+ "    }\n" //
+				+ "\n" //
 				+ "    public String replaceNewStringInMethodInvocation(String s, int i) {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        return (s + i).toLowerCase();\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String replaceNewStringInMethodInvocation2(String s, String s2) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        return s.concat(s2).toLowerCase();\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String replaceNewStringInIf(String s, String s2) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        if (s.equals(\"abc\")) {\n" //
+				+ "            return s2;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String replaceNewStringInNestedNewStrings(String s, String s2) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        if (s.equals(\"abc\")) {\n" //
+				+ "            return s2;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public void replaceNewStringInFieldAccess(String s) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        Object x = s.CASE_INSENSITIVE_ORDER;\n" //
 				+ "    }\n" //
 				+ "}\n";
 
@@ -27170,8 +27217,15 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "package test1;\n" //
 				+ "\n" //
 				+ "public class E1 {\n" //
-				+ "    public String doNotReplaceNullableString(String s) {\n" //
+				+ "    public String doNotReplaceNullableObject(String s) {\n" //
 				+ "        return new String(s);\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String doNotReplaceCopyString(String s, String s2) {\n" //
+				+ "        String k = new String(s);\n" //
+				+ "        String l = null;\n" //
+				+ "        l = new String(s2);\n" //
+				+ "        return l;\n" //
 				+ "    }\n" //
 				+ "}\n";
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/NoStringCreationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/NoStringCreationCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2023 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,20 +19,22 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
-
-import org.eclipse.text.edits.TextEditGroup;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
@@ -40,10 +42,10 @@ import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModel;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.eclipse.text.edits.TextEditGroup;
 
 /**
  * A fix that removes a String instance from a String literal.
@@ -75,11 +77,16 @@ public class NoStringCreationCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.NO_STRING_CREATION)) {
-			return "String bar = \"foo\";\n"; //$NON-NLS-1$
+			return "" //$NON-NLS-1$
+					+ "String bar = \"foo\";\n" //$NON-NLS-1$
+					+ "String newBar = bar.concat(\"abc\");\n" //$NON-NLS-1$
+					+ "String cantChange = new String(possibleNullObject)\n"; //$NON-NLS-1$
 		}
 
 		return "" //$NON-NLS-1$
-				+ "String bar = new String(\"foo\");\n"; //$NON-NLS-1$
+				+ "String bar = new String(\"foo\");\n" //$NON-NLS-1$
+				+ "String newBar = (new String(bar)).concat(\"abc\");\n" //$NON-NLS-1$
+				+ "String cantChange = new String(possibleNullObject)\n"; //$NON-NLS-1$
 	}
 
 	@Override
@@ -94,12 +101,28 @@ public class NoStringCreationCleanUp extends AbstractMultiFix {
 			@Override
 			public boolean visit(final ClassInstanceCreation node) {
 				if (ASTNodes.hasType(node, String.class.getCanonicalName()) && node.arguments().size() == 1) {
-					Expression arg0= (Expression) node.arguments().get(0);
-
-					if (ASTNodes.hasType(arg0, String.class.getCanonicalName())
-							&& (arg0 instanceof StringLiteral || arg0 instanceof InfixExpression)) {
-						rewriteOperations.add(new NoStringCreationOperation(node, arg0));
-						return false;
+					Expression arg0= ASTNodes.getUnparenthesedExpression((Expression)node.arguments().get(0));
+					while (arg0 instanceof ClassInstanceCreation c && ASTNodes.hasType(c, String.class.getCanonicalName()) &&
+							c.arguments().size() == 1) {
+						arg0= ASTNodes.getUnparenthesedExpression((Expression)c.arguments().get(0));
+					}
+					if (ASTNodes.hasType(arg0, String.class.getCanonicalName())) {
+						if (arg0 instanceof StringLiteral || arg0 instanceof InfixExpression) {
+							rewriteOperations.add(new NoStringCreationOperation(node, arg0));
+							return false;
+						} else if (arg0 instanceof MethodInvocation || arg0 instanceof SimpleName) {
+							ASTNode parent= node.getParent();
+							while (parent instanceof ParenthesizedExpression) {
+								parent= parent.getParent();
+							}
+							if (parent instanceof Assignment || parent instanceof VariableDeclarationFragment) {
+								return true;
+							}
+							if (parent instanceof MethodInvocation || parent instanceof FieldAccess) {
+								rewriteOperations.add(new NoStringCreationOperation(node, arg0));
+							}
+							return false;
+						}
 					}
 				}
 
@@ -141,7 +164,11 @@ public class NoStringCreationCleanUp extends AbstractMultiFix {
 			TextEditGroup group= createTextEditGroup(MultiFixMessages.NoStringCreationCleanUp_description, cuRewrite);
 			ASTNode replacement= ASTNodeFactory.parenthesizeIfNeeded(ast, ASTNodes.createMoveTarget(rewrite, arg0));
 
-			ASTNodes.replaceButKeepComment(rewrite, node, replacement, group);
+			ASTNode nodeToReplace= node;
+			while (nodeToReplace.getParent() instanceof ParenthesizedExpression) {
+				nodeToReplace= nodeToReplace.getParent();
+			}
+			ASTNodes.replaceButKeepComment(rewrite, nodeToReplace, replacement, group);
 		}
 	}
 }


### PR DESCRIPTION
- modify cleanup so that it handles cases where the arguments to new String() are: nested new String() calls, method calls or variable references that are subsequently used to invoke String methods
- don't change new String() calls that are used to copy a String to another
- update preview content
- update CleanUpTest tests
- fixes: https://bugs.eclipse.org/bugs/show_bug.cgi?id=573119

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See commit comment.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run CleanUpTest.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
