### PR TITLE
Fix NPE in AbstractJavaCompletionProposal

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/AbstractJavaCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/AbstractJavaCompletionProposal.java
@@ -1334,6 +1334,9 @@ public abstract class AbstractJavaCompletionProposal implements IJavaCompletionP
 			return true;
 		}
 		IDocument document = fInvocationContext.getDocument();
+		if (document == null) {
+			return false;
+		}
 		try {
 			String documentString = document.get(getReplacementOffset(), getReplacementLength());
 			if(documentString == null) {


### PR DESCRIPTION
Unreproducible exception after bigger code block editing/undoing/switching between editors, and triggering code completion.  

```
Caused by: java.lang.NullPointerException: Cannot invoke "org.eclipse.jface.text.IDocument.get(int, int)" because "document" is null
	at org.eclipse.jdt.internal.ui.text.java.AbstractJavaCompletionProposal.isAutoInsertable(AbstractJavaCompletionProposal.java:1338)
	at org.eclipse.jface.text.contentassist.CompletionProposalPopup.canAutoInsert(CompletionProposalPopup.java:1624)
	at org.eclipse.jface.text.contentassist.CompletionProposalPopup.lambda$0(CompletionProposalPopup.java:513)
	at org.eclipse.swt.custom.BusyIndicator.showWhile(BusyIndicator.java:67)


```

## What it does
Adds an extra check, before IDocument.get(int, int) is called in the code completion generator.

## How to test
As this error happened only once for me, I can't suggest a 100% reproducible test case 

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
