### PR TITLE
[Mac/Win] Unable to add a new source folder to a Java project

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/CreateMultipleSourceFoldersDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/CreateMultipleSourceFoldersDialog.java
@@ -168,6 +168,7 @@ public class CreateMultipleSourceFoldersDialog extends TrayDialog {
 						return wizard;
 					}
 				};
+				action.setShell(getShell());
 				action.addPropertyChangeListener(event -> {
 					if (IAction.RESULT.equals(event.getProperty())) {
 						if (event.getNewValue().equals(Boolean.TRUE)) {


### PR DESCRIPTION
... using the Java Build Path properties.

Fixed regression introduced via
https://github.com/eclipse-platform/eclipse.platform.ui/pull/243/ in 4.25.

The default wizard modality was changed from SWT.APPLICATION_MODAL to SWT.PRIMARY_MODAL. This seem to break nested modal dialogs opened from the Java Build Path property page on Mac and Windows.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/557