### PR TITLE
Add ability to specify used properties to avoid NLS search marking them

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/search/NLSSearchTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/search/NLSSearchTest.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.internal.ui.refactoring.nls.search.NLSSearchQuery;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 import org.eclipse.search.ui.ISearchResultViewPart;
@@ -267,6 +268,7 @@ public class NLSSearchTest {
 		buf.append("public class Accessor extends NLS {\n");
 		buf.append("\n");
 		buf.append("    public static String Client_s1;\n");
+		buf.append("    public static String Client_s2;\n");
 		buf.append("\n");
 		buf.append("    private Accessor() {}\n");
 		buf.append("    private static final String BUNDLE_NAME = \"test.Accessor\"; //$NON-NLS-1$\n");
@@ -282,13 +284,18 @@ public class NLSSearchTest {
 
 		buf= new StringBuilder();
 		buf.append("Client_s1=foo\n");
+		buf.append("Client_s2=foo2\n");
 		IFile propertiesFile= write((IFolder)pack1.getCorrespondingResource(), buf.toString(), "Accessor.properties");
 
+		// mark Client_s1 as used so it won't be flagged
 		buf= new StringBuilder();
 		buf.append("Client_s1=foo\n");
-		write((IFolder)pack1.getCorrespondingResource(), buf.toString(), "Accessor.usedproperties");
+		write((IFolder)pack1.getCorrespondingResource(), buf.toString(), "Accessor" + NLSSearchQuery.NLS_USED_PROPERTIES_EXT);
 
-		NLSSearchTestHelper.assertNumberOfProblems(accessor, propertiesFile, 0);
+		NLSSearchTestHelper.assertNumberOfProblems(accessor, propertiesFile, 2);
+
+		NLSSearchTestHelper.assertHasUnusedKey(accessor, propertiesFile, "Client_s2", (IFile)accessor.getCorrespondingResource(), true);
+		NLSSearchTestHelper.assertHasUnusedKey(accessor, propertiesFile, "Client_s2", propertiesFile, false);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/search/NLSSearchTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/search/NLSSearchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,33 +18,26 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
-import org.eclipse.jdt.testplugin.JavaProjectHelper;
-
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
-
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IFolder;
-
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filebuffers.LocationKind;
-
-import org.eclipse.search.ui.ISearchResultViewPart;
-import org.eclipse.search.ui.NewSearchUI;
-
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
-
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.search.ui.ISearchResultViewPart;
+import org.eclipse.search.ui.NewSearchUI;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class NLSSearchTest {
 
@@ -263,6 +256,39 @@ public class NLSSearchTest {
 		NLSSearchTestHelper.assertNumberOfProblems(accessor, propertiesFile, 1);
 
 		NLSSearchTestHelper.assertHasDuplicateKey(accessor, propertiesFile, "Client_s1", propertiesFile);
+	}
+
+	@Test
+	public void test07() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("import org.eclipse.osgi.util.NLS;\n");
+		buf.append("public class Accessor extends NLS {\n");
+		buf.append("\n");
+		buf.append("    public static String Client_s1;\n");
+		buf.append("\n");
+		buf.append("    private Accessor() {}\n");
+		buf.append("    private static final String BUNDLE_NAME = \"test.Accessor\"; //$NON-NLS-1$\n");
+		buf.append("    static {NLS.initializeMessages(BUNDLE_NAME, Accessor.class);}\n");
+		buf.append("}\n");
+		ICompilationUnit accessor= pack1.createCompilationUnit("Accessor.java", buf.toString(), false, null);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Client {\n");
+		buf.append("}\n");
+		pack1.createCompilationUnit("Client.java", buf.toString(), false, null);
+
+		buf= new StringBuilder();
+		buf.append("Client_s1=foo\n");
+		IFile propertiesFile= write((IFolder)pack1.getCorrespondingResource(), buf.toString(), "Accessor.properties");
+
+		buf= new StringBuilder();
+		buf.append("Client_s1=foo\n");
+		write((IFolder)pack1.getCorrespondingResource(), buf.toString(), "Accessor.usedproperties");
+
+		NLSSearchTestHelper.assertNumberOfProblems(accessor, propertiesFile, 0);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchQuery.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,19 +14,12 @@
 
 package org.eclipse.jdt.internal.ui.refactoring.nls.search;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubProgressMonitor;
-
-import org.eclipse.core.resources.IFile;
-
-import org.eclipse.search.ui.ISearchQuery;
-import org.eclipse.search.ui.ISearchResult;
-import org.eclipse.search.ui.text.AbstractTextSearchResult;
-import org.eclipse.search.ui.text.Match;
-
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
@@ -39,16 +32,17 @@ import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
-
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSRefactoring;
 import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
-
-import org.eclipse.jdt.ui.JavaElementLabels;
-
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaUIStatus;
+import org.eclipse.jdt.ui.JavaElementLabels;
+import org.eclipse.search.ui.ISearchQuery;
+import org.eclipse.search.ui.ISearchResult;
+import org.eclipse.search.ui.text.AbstractTextSearchResult;
+import org.eclipse.search.ui.text.Match;
 
 
 public class NLSSearchQuery implements ISearchQuery {
@@ -109,7 +103,7 @@ public class NLSSearchQuery implements ISearchQuery {
 								if (!requestor.hasPropertyKey(fieldName)) {
 									fResult.addMatch(new Match(compilationUnit, sourceRange.getOffset(), sourceRange.getLength()));
 								}
-								if (!requestor.isUsedPropertyKey(fieldName)) {
+								if (!requestor.isUsedPropertyKey(fieldName) && !requestor.isSpecifiedAsUsed(fieldName)) {
 									hasUnusedPropertie= true;
 									fResult.addMatch(new Match(groupElement, sourceRange.getOffset(), sourceRange.getLength()));
 								}
@@ -118,7 +112,6 @@ public class NLSSearchQuery implements ISearchQuery {
 					}
 					if (hasUnusedPropertie)
 						fResult.addCompilationUnitGroup(groupElement);
-
 				} catch (CoreException e) {
 					return new Status(e.getStatus().getSeverity(), JavaPlugin.getPluginId(), IStatus.OK, NLSSearchMessages.NLSSearchQuery_error, e);
 				}

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchQuery.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchQuery.java
@@ -47,6 +47,12 @@ import org.eclipse.search.ui.text.Match;
 
 public class NLSSearchQuery implements ISearchQuery {
 
+	/**
+	 * File extension of properties file containing message keys known to be used and
+	 * therefore should not be flagged by an NLS search.
+	 */
+	public static final String NLS_USED_PROPERTIES_EXT= ".usedproperties"; //$NON-NLS-1$
+
 	private NLSSearchResult fResult;
 	private IJavaElement[] fWrapperClass;
 	private IFile[] fPropertiesFile;

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchResultRequestor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchResultRequestor.java
@@ -414,7 +414,7 @@ class NLSSearchResultRequestor extends SearchRequestor {
 		}
 		String propertyFileName= fPropertiesFile.getName();
 		String ignorePropertyFileName=
-				propertyFileName.substring(0, propertyFileName.length() - ".properties".length()).concat(".usedproperties"); //$NON-NLS-1$ //$NON-NLS-2$
+				propertyFileName.substring(0, propertyFileName.length() - ".properties".length()).concat(NLSSearchQuery.NLS_USED_PROPERTIES_EXT); //$NON-NLS-1$
 		IFile ignoredPropertiesFile= (IFile) fPropertiesFile.getParent().findMember(ignorePropertyFileName);
 		if (ignoredPropertiesFile != null) {
 			try (InputStream stream= new BufferedInputStream(createInputStream(ignoredPropertiesFile))) {

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchResultRequestor.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/search/NLSSearchResultRequestor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,21 +22,14 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-
-import org.eclipse.core.resources.IFile;
-
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBuffer;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.filebuffers.LocationKind;
-
-import org.eclipse.jface.text.Position;
-
-import org.eclipse.search.ui.text.Match;
-
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
@@ -51,13 +44,13 @@ import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchRequestor;
-
 import org.eclipse.jdt.internal.corext.refactoring.nls.PropertyFileDocumentModel;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
-
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaUIStatus;
 import org.eclipse.jdt.internal.ui.util.StringMatcher;
+import org.eclipse.jface.text.Position;
+import org.eclipse.search.ui.text.Match;
 
 
 class NLSSearchResultRequestor extends SearchRequestor {
@@ -84,6 +77,7 @@ class NLSSearchResultRequestor extends SearchRequestor {
 	private NLSSearchResult fResult;
 	private IFile fPropertiesFile;
 	private Properties fProperties;
+	private Properties fSpecifiedAsUsedProperties;
 	private HashSet<String> fUsedPropertyNames;
 
 	public NLSSearchResultRequestor(IFile propertiesFile, NLSSearchResult result) {
@@ -165,7 +159,7 @@ class NLSSearchResultRequestor extends SearchRequestor {
 
 		for (Enumeration<?> enumeration= fProperties.propertyNames(); enumeration.hasMoreElements();) {
 			String propertyName= (String) enumeration.nextElement();
-			if (!fUsedPropertyNames.contains(propertyName)) {
+			if (!fUsedPropertyNames.contains(propertyName) && !fSpecifiedAsUsedProperties.containsKey(propertyName)) {
 				addMatch(groupElement, propertyName);
 				hasUnused= true;
 			}
@@ -224,6 +218,10 @@ class NLSSearchResultRequestor extends SearchRequestor {
 
 	public boolean isUsedPropertyKey(String key) {
 		return fUsedPropertyNames.contains(key);
+	}
+
+	public boolean isSpecifiedAsUsed(String key) {
+		return fSpecifiedAsUsedProperties.containsKey(key);
 	}
 
 	/**
@@ -401,24 +399,29 @@ class NLSSearchResultRequestor extends SearchRequestor {
 	private void loadProperties() {
 		Set<Object> duplicateKeys= new HashSet<>();
 		fProperties= new Properties(duplicateKeys);
-		InputStream stream;
-		try {
-			stream= new BufferedInputStream(createInputStream(fPropertiesFile));
-		} catch (CoreException ex) {
-			fProperties= new Properties();
-			return;
-		}
-		try {
+		Set<Object> duplicateKeys2= new HashSet<>();
+		fSpecifiedAsUsedProperties= new Properties(duplicateKeys2);
+		try (InputStream stream= new BufferedInputStream(createInputStream(fPropertiesFile))) {
 			fProperties.load(stream);
-		} catch (IOException ex) {
+		} catch (CoreException | IOException ex) {
 			fProperties= new Properties();
 			return;
 		} finally {
-			try {
-				stream.close();
-			} catch (IOException ex) {
-			}
 			reportDuplicateKeys(duplicateKeys);
+		}
+		if (!"properties".equalsIgnoreCase(fPropertiesFile.getFileExtension())) { //$NON-NLS-1$
+			return;
+		}
+		String propertyFileName= fPropertiesFile.getName();
+		String ignorePropertyFileName=
+				propertyFileName.substring(0, propertyFileName.length() - ".properties".length()).concat(".usedproperties"); //$NON-NLS-1$ //$NON-NLS-2$
+		IFile ignoredPropertiesFile= (IFile) fPropertiesFile.getParent().findMember(ignorePropertyFileName);
+		if (ignoredPropertiesFile != null) {
+			try (InputStream stream= new BufferedInputStream(createInputStream(ignoredPropertiesFile))) {
+				fSpecifiedAsUsedProperties.load(stream);
+			} catch (CoreException | IOException ex) {
+				fSpecifiedAsUsedProperties= new Properties();
+			}
 		}
 	}
 


### PR DESCRIPTION
- add enhancement to be able to specify XXXX.usedproperties file which contains property keys known to be used (e.g. a key that gets dynamically created where it is used such as in ResourceAction
- modify NLSSearchResultRequestor to read .usedproperties files if they exist and keep a set of used properties
- modify NLSSearchQuery to check if an unused key has actually been specified as used via the .usedproperties file
- add new test to NLSSearchTest
- for #555

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds the ability to specify that NLS property keys are known to be used and should be ignored by the "Find broken NLS strings" action.  It does this by allowing properties from XXXX.properties to be added to XXXX.usedproperties.  The NLS search will mark such properties as used and will not report them.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
A new test has been added to NLSSearchTest which shows how it works.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
