### PR TITLE
Add usedproperties files for known used messages in org.eclipse.jdt.ui

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/ReorgMessages.usedproperties
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/ReorgMessages.usedproperties
@@ -1,0 +1,25 @@
+###############################################################################
+# Copyright (c) 2000, 2023 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+
+# DO NOT REMOVE, used in a product, see https://bugs.eclipse.org/297392
+ReorgGroup_paste=&Paste
+
+# DO NOT REMOVE, used in a product, see https://bugs.eclipse.org/297392
+ReorgGroup_delete=&Delete
+
+# DO NOT REMOVE, used in a product, see https://bugs.eclipse.org/297392
+CutSourceReferencesToClipboardAction_cut=Cu&t
+
+# DO NOT REMOVE, used in a product
+JdtMoveAction_update_references=Update &references to the moved element(s)

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaUIMessages.usedproperties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaUIMessages.usedproperties
@@ -1,0 +1,25 @@
+###############################################################################
+# Copyright (c) 2000, 2023 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Mateusz Matela <mateusz.matela@gmail.com> - [code manipulation] [dcr] toString() builder wizard - https://bugs.eclipse.org/bugs/show_bug.cgi?id=26070
+#     Mateusz Matela <mateusz.matela@gmail.com> - [toString] Template edit dialog has usability issues - https://bugs.eclipse.org/bugs/show_bug.cgi?id=267916
+#     Mateusz Matela <mateusz.matela@gmail.com> - [toString] finish toString() builder wizard - https://bugs.eclipse.org/bugs/show_bug.cgi?id=267710
+#     Mateusz Matela <mateusz.matela@gmail.com> - [toString] toString() generator: Fields in declaration order - https://bugs.eclipse.org/bugs/show_bug.cgi?id=279924
+#     Pierre-Yves B. <pyvesdev@gmail.com> - Generation of equals and hashcode with java 7 Objects.equals and Objects.hashcode - https://bugs.eclipse.org/bugs/show_bug.cgi?id=424214
+###############################################################################
+
+# DO NOT REMOVE, used in a product.
+TypeSelectionDialog_lowerLabel=&Qualifier:
+
+# DO NOT REMOVE, used in a product.
+TypeSelectionDialog_upperLabel=&Matching types:
+

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ActionMessages.usedproperties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ActionMessages.usedproperties
@@ -1,0 +1,21 @@
+###############################################################################
+# Copyright (c) 2000, 2023 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+#     Sebastian Davids <sdavids@gmx.de> - Bug 114276
+#     Mateusz Matela <mateusz.matela@gmail.com> - [code manipulation] [dcr] toString() builder wizard - https://bugs.eclipse.org/bugs/show_bug.cgi?id=26070
+#     Pierre-Yves B. <pyvesdev@gmail.com> - Check whether enclosing instance implements hashCode and equals - https://bugs.eclipse.org/539900
+###############################################################################
+# DO NOT REMOVE, used in a product, see https://bugs.eclipse.org/296836
+OrganizeImportsAction_summary_added={0} import(s) added.
+
+# DO NOT REMOVE, used in a product, see https://bugs.eclipse.org/296836
+OrganizeImportsAction_summary_removed={0} import(s) removed.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/FoldingMessages.usedproperties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/FoldingMessages.usedproperties
@@ -1,0 +1,52 @@
+###############################################################################
+# Copyright (c) 2005, 2006 IBM Corporation and others.
+#
+# This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License 2.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###############################################################################
+Projection.Toggle.label= &Enable Folding
+Projection.Toggle.tooltip= Toggles Folding
+Projection.Toggle.description= Toggles folding for the current editor
+Projection.Toggle.image=
+
+Projection.ExpandAll.label= Expand &All
+Projection.ExpandAll.tooltip= Expands All Collapsed Regions
+Projection.ExpandAll.description= Expands any collapsed regions in the current editor
+Projection.ExpandAll.image=
+
+Projection.Expand.label= E&xpand
+Projection.Expand.tooltip= Expands the Current Collapsed Region
+Projection.Expand.description= Expands the collapsed region at the current selection
+Projection.Expand.image=
+
+Projection.CollapseAll.label= Collapse A&ll
+Projection.CollapseAll.tooltip= Collapses All Expanded Regions
+Projection.CollapseAll.description= Collapse any expanded regions in the current editor
+Projection.CollapseAll.image=
+
+Projection.Collapse.label= Colla&pse
+Projection.Collapse.tooltip= Collapses the Current Region
+Projection.Collapse.description= Collapses the Current Region
+Projection.Collapse.image=
+
+Projection.Restore.label= &Reset Structure
+Projection.Restore.tooltip= Restore the Original Folding Structure
+Projection.Restore.description= Restores the original folding structure
+Projection.Restore.image=
+
+Projection.CollapseComments.label= Collapse &Comments
+Projection.CollapseComments.tooltip= Collapses All Comments
+Projection.CollapseComments.description= Collapses all comments
+Projection.CollapseComments.image=
+
+Projection.CollapseMembers.label= Collapse &Members
+Projection.CollapseMembers.tooltip= Collapses All Members
+Projection.CollapseMembers.description= Collapses all members
+Projection.CollapseMembers.image=


### PR DESCRIPTION
- part of #555

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds .usedproperties files to protect known used messages that are normally flagged when searching for broken externalized strings.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Perform a Find Broken Externalized Strings actions on org.eclipse.jdt.ui.  Messages and keys in these files will not show up as unused.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
