### PR TITLE
Fix extraneous import to class in current CU when inlining method

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_394725.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_394725.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+class Test_394725 {
+
+    private static class C {
+        static void /*]*/f/*[*/() {
+            Object o = C.class;
+        }
+    }
+
+    void f() {
+        C.f();
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_394725.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_394725.java
@@ -1,0 +1,11 @@
+package bugs_out;
+
+class Test_394725 {
+
+    private static class C {
+    }
+
+    void f() {
+        Object o = C.class;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -34,11 +34,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.eclipse.core.runtime.CoreException;
-
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IMethod;
@@ -47,10 +43,11 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InfixExpression.Operator;
-
 import org.eclipse.jdt.internal.core.manipulation.dom.OperatorPrecedence;
 import org.eclipse.jdt.internal.corext.refactoring.code.InlineMethodRefactoring;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	private static final boolean BUG_82166= true;
@@ -418,6 +415,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 
 	@Test
 	public void test_314407_2() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_394725() throws Exception {
 		performBugTest();
 	}
 


### PR DESCRIPTION
- modify InlineMethodRefactoring to verify imports are not in CU
- fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=394725
- add new test to InlineMethodTests

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Removes extraneous import to a class that is in the current CU when doing a method inline.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See added test or bug.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
