### PR TITLE
Call Hierarchy for Record components does not work

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallerMethodWrapper.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallerMethodWrapper.java
@@ -163,7 +163,7 @@ public class CallerMethodWrapper extends MethodWrapper {
 	}
 
 	private IJavaSearchScope getAccurateSearchScope(IJavaSearchScope defaultSearchScope, IMember member) throws JavaModelException {
-		if (! JdtFlags.isPrivate(member))
+		if (!JdtFlags.isPrivate(member) || isRecordComponent(member))
 			return defaultSearchScope;
 
 		if (member.getCompilationUnit() != null) {
@@ -213,4 +213,7 @@ public class CallerMethodWrapper extends MethodWrapper {
 		return fIsExpandWithConstructorsSet;
 	}
 
+	private static boolean isRecordComponent(IMember member) throws JavaModelException {
+		return member.getElementType() == IJavaElement.FIELD && member instanceof IField f && f.isRecordComponent();
+	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyTestHelper.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyTestHelper.java
@@ -381,6 +381,52 @@ public class CallHierarchyTestHelper {
         assertBuildWithoutErrors(fJavaProject3);
     }
 
+	/**
+	 * Creates a record class and a type that references a field of the record.
+	 */
+	public void createRecordWithCalleeClasses() throws Exception {
+		ProjectTestSetup projectsetup= new Java17ProjectTestSetup(false);
+		fJavaProject3.setRawClasspath(projectsetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set17CompilerOptions(fJavaProject3, false);
+
+		IPackageFragmentRoot fSourceFolder= JavaProjectHelper.addSourceContainer(fJavaProject3, "src");
+
+		String MODULE_INFO_FILE_CONTENT= ""
+				+ "module test {\n"
+				+ "}\n";
+
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", MODULE_INFO_FILE_CONTENT, false, null);
+
+		fPack3= fSourceFolder.createPackageFragment("test", false, null);
+
+		JavaProjectHelper.set16CompilerOptions(fJavaProject1, true);
+
+		ICompilationUnit cu1= fPack3.getCompilationUnit("RecordTest.java");
+		ICompilationUnit cu2= fPack3.getCompilationUnit("CallerTest.java");
+
+		fType1= cu1.createType(
+				"""
+				record RecordTest(int number1) {
+				}
+				""",
+				null,
+				true,
+				null);
+		fType2= cu2.createType(
+				"""
+				public class CallerTest {
+					void foo(RecordTest r) {
+						var n = r.number1();
+					}
+				}
+				""",
+				null,
+				true,
+				null);
+		assertBuildWithoutErrors(fJavaProject3);
+	}
+
     public void createCalleeClasses() throws Exception {
         createPackages();
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/CallHierarchyTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/CallHierarchyTest.java
@@ -521,6 +521,16 @@ public class CallHierarchyTest {
         helper.assertCalls(Arrays.asList(helper.getAbsI1FooMethod(), helper.getAbsI2FooMethod()), secondLevel);
     }
 
+    @Test
+    public void record_testGH571_callHierarchyOfComponent() throws Exception {
+		helper.createRecordWithCalleeClasses();
+
+		IType type= helper.getType1();
+		IMember component= (IMember) type.getChildren()[0];
+		IMethod expectedCaller= helper.getType2().getMethods()[0];
+		checkCalls(component, expectedCaller);
+    }
+
     private void checkCalls(IMember memberToCheck, IMethod... expectedCallers) {
         MethodWrapper[] methodWrappers = CallHierarchy.getDefault().getCallerRoots(new IMember[] { memberToCheck });
         MethodWrapper[] callers = methodWrappers[0].getCalls(new NullProgressMonitor());


### PR DESCRIPTION
Adjust `CallerMethodWrapper.getAccurateSearchScope()` to consider also record components, when checking if a member is private. This avoids reducing the search scope to just the compilation unit of the record defining the component, and so results in the expected search results.

Fixes: #571

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
