### PR TITLE
Open call hierarchy view

### DIFF
--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -1219,6 +1219,7 @@ PropertyKeyHyperlinkDetector= Java Property Key
 JavaElementHyperlinkDeclaredTypeDetector= Open Declared Type
 JavaElementHyperlinkReturnTypeDetector= Open Return Type 
 JavaElementHyperlinkSuperImplementationDetector= Open Super Implementation 
+OpenCallHierarchyHyperlinkDetector=Open Call Hierarchy
 
 #--- Clean Up ---
 CleanUpTabPage.CodeStyle.name = &Code Style

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -1596,6 +1596,12 @@
             targetId="org.eclipse.jdt.ui.javaCode">
       </hyperlinkDetector>
       <hyperlinkDetector
+	        class="org.eclipse.jdt.internal.ui.javaeditor.OpenCallHierarchyHyperlinkDetector"
+            id="org.eclipse.jdt.internal.ui.javaeditor.OpenCallHierarchyHyperlinkDetector"
+            name="%OpenCallHierarchyHyperlinkDetector"
+            targetId="org.eclipse.jdt.ui.javaCode">
+      </hyperlinkDetector>
+      <hyperlinkDetector
             class="org.eclipse.jdt.internal.ui.propertiesfileeditor.PropertyKeyHyperlinkDetector"
             id="org.eclipse.jdt.internal.ui.propertiesfileeditor.PropertyKeyHyperlinkDetector"
             name="%PropertyKeyHyperlinkDetector"

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.java
@@ -113,6 +113,7 @@ final class JavaEditorMessages extends NLS {
 	public static String SourceAttachmentForm_attach_error_title;
 	public static String SourceAttachmentForm_attach_error_message;
 	public static String EditorUtility_concatModifierStrings;
+	public static String OpenCallHierarchyHyperlinkDetector_hyperlinkText;
 	public static String OverrideIndicatorManager_implements;
 	public static String OverrideIndicatorManager_intallJob;
 	public static String OverrideIndicatorManager_overrides;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.properties
@@ -142,6 +142,8 @@ JavaEditorBreadcrumbActionGroup_go_to_editor_action_label=&Go to Editor
 JavaElementHyperlink_hyperlinkText= Open Declaration
 JavaElementHyperlink_hyperlinkText_qualified=Open ''{0}''
 
+OpenCallHierarchyHyperlinkDetector_hyperlinkText= Open Call Hierarchy
+
 JavaElementImplementationHyperlink_error_no_implementations_found_message=Problems finding implementations.
 JavaElementImplementationHyperlink_error_status_message=An error occurred while searching for implementations of ''{0}''. See error log for details.
 JavaElementImplementationHyperlink_hyperlinkText= Open Implementation

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OpenCallHierarchyHyperlinkDetector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OpenCallHierarchyHyperlinkDetector.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Zsombor Gegesy
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Zsombor Gegesy - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import java.util.List;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import org.eclipse.ui.IWorkbenchWindow;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMember;
+
+import org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchy;
+
+import org.eclipse.jdt.ui.actions.SelectionDispatchAction;
+
+import org.eclipse.jdt.internal.ui.callhierarchy.CallHierarchyUI;
+
+/**
+ * Provides a hyperlink for method calls, method declarations to open the Call Hierarchy view.
+ */
+public class OpenCallHierarchyHyperlinkDetector extends JavaElementHyperlinkDetector {
+
+	@Override
+	protected void addHyperlinks(List<IHyperlink> hyperlinksCollector, IRegion wordRegion, SelectionDispatchAction openAction, IJavaElement element, boolean qualify, JavaEditor editor) {
+		if ((element.getElementType() == IJavaElement.METHOD || element.getElementType() == IJavaElement.FIELD) && (element instanceof IMember imember)) {
+			hyperlinksCollector.add(new OpenCallHierarchyHyperlink(wordRegion, openAction.getSite().getWorkbenchWindow(), imember));
+		}
+	}
+
+	private static class OpenCallHierarchyHyperlink implements IHyperlink {
+
+		private final IRegion region;
+
+		private final IWorkbenchWindow iWorkbenchWindow;
+
+		private final IMember element;
+
+		public OpenCallHierarchyHyperlink(IRegion region, IWorkbenchWindow iWorkbenchWindow, IMember element) {
+			this.region= region;
+			this.iWorkbenchWindow= iWorkbenchWindow;
+			this.element= element;
+		}
+
+		@Override
+		public IRegion getHyperlinkRegion() {
+			return region;
+		}
+
+		@Override
+		public String getTypeLabel() {
+			return null;
+		}
+
+		@Override
+		public String getHyperlinkText() {
+			return JavaEditorMessages.OpenCallHierarchyHyperlinkDetector_hyperlinkText;
+		}
+
+		@Override
+		public void open() {
+			if (CallHierarchy.isPossibleInputElement(element)) {
+				IMember[] members= new IMember[] { element };
+				CallHierarchyUI.openSelectionDialog(members, iWorkbenchWindow);
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
Add ability to open the Call Hieararchy viewer whenever the user click on a method call or declaration

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Sometimes, when navigating around codebases with the mouse, I miss an easy way to lookup the callers of a method - by default, I must release the mouse, and move my right hand to the keyboard to press the required key-combo to open the view, so I thought, why not add next to the already existing 'Open Declaration'/ etc hyperlinks? And this is what this patch actually does.   

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open a non trivial project, with a couple of methods, calling each others.
2. Control click on method declaration or call.
3. Click on the newly provided 'Open Call Hierarchy' link
4. Happiness 

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
