### PR TITLE
Fix for Bug 475462

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,13 +22,12 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
-
-import org.eclipse.text.edits.TextEditGroup;
-
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.Expression;
@@ -44,18 +43,17 @@ import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
-
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.GenericVisitor;
 import org.eclipse.jdt.internal.corext.dom.VariableDeclarationRewrite;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.text.edits.TextEditGroup;
 
 public class VariableDeclarationFixCore extends CompilationUnitRewriteOperationsFixCore {
 
@@ -252,12 +250,13 @@ public class VariableDeclarationFixCore extends CompilationUnitRewriteOperations
             }
 
 			MethodDeclaration constructor= writingConstructors.get(0);
-			TypeDeclaration typeDecl= ASTNodes.getParent(constructor, TypeDeclaration.class);
+			AbstractTypeDeclaration typeDecl= ASTNodes.getParent(constructor, AbstractTypeDeclaration.class);
 			if (typeDecl == null)
 				return false;
 
-			for (MethodDeclaration method : typeDecl.getMethods()) {
-	            if (method.isConstructor()) {
+			List<BodyDeclaration> bodyDeclarations= typeDecl.bodyDeclarations();
+			for (BodyDeclaration bodyDeclaration : bodyDeclarations) {
+				if (bodyDeclaration instanceof MethodDeclaration method && method.isConstructor()) {
 	            	IMethodBinding methodBinding= method.resolveBinding();
 	            	if (methodBinding == null)
 	            		return false;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -27118,6 +27118,79 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testAddFinalBug475462_1() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "final class E {\n" //
+				+ "    enum E1 {\n" //
+				+ "        FOO(\"a\");\n" //
+				+ "        private String message;\n" //
+				+ "        E1(final String message) {\n" //
+				+ "            this.message = message;\n" //
+				+ "        }\n" //
+				+ "\n" //
+				+ "        E1() {\n" //
+				+ "        }\n" //
+				+ "\n" //
+				+ "    }\n" //
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL);
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_PRIVATE_FIELDS);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] {cu1});
+	}
+
+	@Test
+	public void testAddFinalBug475462_2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    enum E1 {\n" //
+				+ "        FOO(\"a\");\n" //
+				+ "        private String message;\n" //
+				+ "        public E1(final String message) {\n" //
+				+ "            this.message = message;\n" //
+				+ "        }\n" //
+				+ "\n" //
+				+ "        public E1() {\n" //
+				+ "            this(\"abc\");\n" //
+				+ "        }\n" //
+				+ "\n" //
+				+ "    }\n" //
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL);
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_PRIVATE_FIELDS);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    enum E1 {\n" //
+				+ "        FOO(\"a\");\n" //
+				+ "        private final String message;\n" //
+				+ "        public E1(final String message) {\n" //
+				+ "            this.message = message;\n" //
+				+ "        }\n" //
+				+ "\n" //
+				+ "        public E1() {\n" //
+				+ "            this(\"abc\");\n" //
+				+ "        }\n" //
+				+ "\n" //
+				+ "    }\n" //
+				+ "}\n";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { sample }, null);
+	}
+
+	@Test
 	public void testRemoveStringCreation() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= "" //


### PR DESCRIPTION
- use AbstractTypeDeclation instead of TypeDeclaration to handle enums and their constructors
- add new tests to CleanUpTest

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes: https://bugs.eclipse.org/bugs/show_bug.cgi?id=475462

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests in CleanUpTest and in bug.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
