### PR TITLE
Fix extract local to recognize super() and this() constructor calls

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_in.java
@@ -1,0 +1,14 @@
+package p; // 11, 13, 11, 32
+
+import java.io.File;
+
+public class A extends File
+{
+	private String l;
+
+	public A(String parent, String child) {
+		super(parent, child.toLowerCase());
+		l = child.toLowerCase();
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_out.java
@@ -1,0 +1,15 @@
+package p; // 11, 13, 11, 32
+
+import java.io.File;
+
+public class A extends File
+{
+	private String l;
+
+	public A(String parent, String child) {
+		super(parent, child.toLowerCase());
+		String lowerCase= child.toLowerCase();
+		l = lowerCase;
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_in.java
@@ -1,0 +1,18 @@
+package p; // 11, 13, 11, 32
+
+import java.io.File;
+
+public class A extends File
+{
+	private String l;
+
+	public A(String parent, String child) {
+		this(parent, child.toLowerCase(), null);
+		l = child.toLowerCase();
+	}
+
+	public A(String parent, String child, Object k) {
+		super(parent, child);
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_out.java
@@ -1,0 +1,19 @@
+package p; // 11, 13, 11, 32
+
+import java.io.File;
+
+public class A extends File
+{
+	private String l;
+
+	public A(String parent, String child) {
+		this(parent, child.toLowerCase(), null);
+		String lowerCase= child.toLowerCase();
+		l = lowerCase;
+	}
+
+	public A(String parent, String child, Object k) {
+		super(parent, child);
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
@@ -25,25 +25,20 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Hashtable;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import org.eclipse.core.runtime.NullProgressMonitor;
-
-import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
-
 import org.eclipse.jdt.internal.corext.refactoring.code.ExtractTempRefactoring;
-
 import org.eclipse.jdt.ui.tests.refactoring.infra.TextRangeUtil;
 import org.eclipse.jdt.ui.tests.refactoring.rules.RefactoringTestSetup;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
 
 public class ExtractTempTests extends GenericRefactoringTest {
 	private static final String REFACTORING_PATH= "ExtractTemp/";
@@ -1039,6 +1034,18 @@ public class ExtractTempTests extends GenericRefactoringTest {
 	public void test152() throws Exception {
 		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/432
 		helper1(10, 17, 10, 20, true, false, "f", "f");
+	}
+
+	@Test
+	public void test153() throws Exception {
+		//test for https://bugs.eclipse.org/bugs/show_bug.cgi?id=573643
+		helper1(11, 13, 11, 32, true, false, "lowerCase", "lowerCase");
+	}
+
+	@Test
+	public void test154() throws Exception {
+		//test for https://bugs.eclipse.org/bugs/show_bug.cgi?id=573643
+		helper1(11, 13, 11, 32, true, false, "lowerCase", "lowerCase");
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -36,18 +36,6 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubProgressMonitor;
-
-import org.eclipse.text.edits.CopySourceEdit;
-import org.eclipse.text.edits.TextEdit;
-import org.eclipse.text.edits.TextEditGroup;
-import org.eclipse.text.edits.TextEditVisitor;
-
-import org.eclipse.ltk.core.refactoring.Change;
-import org.eclipse.ltk.core.refactoring.Refactoring;
-import org.eclipse.ltk.core.refactoring.RefactoringChangeDescriptor;
-import org.eclipse.ltk.core.refactoring.RefactoringDescriptor;
-import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
@@ -115,7 +103,6 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.ExtractLocalDescriptor;
-
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
@@ -147,11 +134,18 @@ import org.eclipse.jdt.internal.corext.refactoring.util.SideEffectChecker;
 import org.eclipse.jdt.internal.corext.refactoring.util.UnsafeCheckTester;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
-
-import org.eclipse.jdt.ui.JavaElementLabels;
-
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.viewsupport.BindingLabelProvider;
+import org.eclipse.jdt.ui.JavaElementLabels;
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.Refactoring;
+import org.eclipse.ltk.core.refactoring.RefactoringChangeDescriptor;
+import org.eclipse.ltk.core.refactoring.RefactoringDescriptor;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.text.edits.CopySourceEdit;
+import org.eclipse.text.edits.TextEdit;
+import org.eclipse.text.edits.TextEditGroup;
+import org.eclipse.text.edits.TextEditVisitor;
 
 /**
  * Extract Local Variable (from selected expression inside method or initializer).
@@ -222,6 +216,10 @@ public class ExtractTempRefactoring extends Refactoring {
 		if (isReferringToLocalVariableFromFor((Expression) node))
 			return false;
 		if (isUsedInForInitializerOrUpdater((Expression) node))
+			return false;
+		if (parent instanceof SuperConstructorInvocation)
+			return false;
+		if (parent instanceof ConstructorInvocation)
 			return false;
 		if (parent instanceof SwitchCase)
 			return true;


### PR DESCRIPTION
- fixes: https://bugs.eclipse.org/bugs/show_bug.cgi?id=573643

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Prevents an extract local from placing a new declaration above a super() or this() call in a constructor.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests added.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
