### PR TITLE
Automated Name Recommendation For The Extract Local Variable Refactoring

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.19.0.qualifier
+Bundle-Version: 1.19.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertForLoopOperation.java
@@ -825,7 +825,7 @@ public class ConvertForLoopOperation extends ConvertLoopOperation {
 
 	private String[] getVariableNameProposals(ITypeBinding arrayTypeBinding, IJavaProject project) {
 		String[] variableNames= getUsedVariableNames();
-		String baseName= modifybasename(fArrayBinding.getName());
+		String baseName= modifyBaseName(fArrayBinding.getName());
 		String[] elementSuggestions= StubUtility.getLocalNameSuggestions(project, baseName, 0, variableNames);
 
 		String type= arrayTypeBinding.getElementType().getName();
@@ -841,7 +841,7 @@ public class ConvertForLoopOperation extends ConvertLoopOperation {
 		String[] variableNames= getUsedVariableNames();
 		Expression exp= sizeMethodAccess.getExpression();
 		String name= exp instanceof SimpleName ? ((SimpleName)exp).getFullyQualifiedName() : ""; //$NON-NLS-1$
-		String baseName= modifybasename(name);
+		String baseName= modifyBaseName(name);
 		String[] elementSuggestions= StubUtility.getLocalNameSuggestions(project, baseName, 0, variableNames);
 
 		ITypeBinding[] typeArgs= fSizeMethodBinding.getDeclaringClass().getTypeArguments();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertIterableLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertIterableLoopOperation.java
@@ -160,9 +160,9 @@ public final class ConvertIterableLoopOperation extends ConvertLoopOperation {
 		String baseName= FOR_LOOP_ELEMENT_IDENTIFIER;
 		if (fExpression != null) {
 			if  (fExpression instanceof SimpleName) {
-				baseName= ConvertLoopOperation.modifybasename(((SimpleName)fExpression).getFullyQualifiedName());
+				baseName= ConvertLoopOperation.modifyBaseName(((SimpleName)fExpression).getFullyQualifiedName());
 			} else if (fExpression instanceof QualifiedName) {
-				baseName= ConvertLoopOperation.modifybasename(((QualifiedName)fExpression).getName().getFullyQualifiedName());
+				baseName= ConvertLoopOperation.modifyBaseName(((QualifiedName)fExpression).getName().getFullyQualifiedName());
 			}
 		}
 		String[] elementSuggestions= StubUtility.getLocalNameSuggestions(getJavaProject(), baseName, 0, variableNames);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertLoopOperation.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Red Hat Inc. - refactored to jdt.core.manipulation
+ *     Taiming Wang - add some plural words frequently used in code.
  *******************************************************************************/
 /**
  *
@@ -59,7 +60,21 @@ public abstract class ConvertLoopOperation extends CompilationUnitRewriteOperati
 			new AbstractMap.SimpleImmutableEntry<>("Children", "Child"), //$NON-NLS-1$ //$NON-NLS-2$
 			new AbstractMap.SimpleImmutableEntry<>("Entries", "Entry"), //$NON-NLS-1$ //$NON-NLS-2$
 			new AbstractMap.SimpleImmutableEntry<>("Proxies", "Proxy"), //$NON-NLS-1$ //$NON-NLS-2$
-			new AbstractMap.SimpleImmutableEntry<>("Indices", "Index")) //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Indices", "Index"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("People", "Person"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Properties", "Property"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Factories", "Factory"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Archives", "archive"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Aliases", "Alias"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Alternatives", "Alternative"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Capabilities", "Capability"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Hashes", "Hash"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Directories", "Directory"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Statuses", "Status"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Instances", "Instance"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Classes", "Class"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Deliveries", "Delivery"), //$NON-NLS-1$ //$NON-NLS-2$
+			new AbstractMap.SimpleImmutableEntry<>("Vertices", "Vertex")) //$NON-NLS-1$ //$NON-NLS-2$
 			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
 	private static final Set<String> NO_BASE_TYPES	= Stream.of(
@@ -179,7 +194,7 @@ public abstract class ConvertLoopOperation extends CompilationUnitRewriteOperati
 		ASTNodes.replaceButKeepComment(rewrite, node, statement, group);
 	}
 
-	public static String modifybasename(String suggestedName) {
+	public static String modifyBaseName(String suggestedName) {
 		String name= suggestedName;
 		for(String prefix : CUT_PREFIX) {
 			if(prefix.length() >= suggestedName.length()) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileToForEach.java
@@ -114,12 +114,12 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 							}
 							hit.whileStatement= whilestatement;
 							if (hit.self) {
-								hit.loopVarName= ConvertLoopOperation.modifybasename("i"); //$NON-NLS-1$
+								hit.loopVarName= ConvertLoopOperation.modifyBaseName("i"); //$NON-NLS-1$
 							} else {
 								if (hit.collectionExpression instanceof SimpleName) {
-									hit.loopVarName= ConvertLoopOperation.modifybasename(((SimpleName)hit.collectionExpression).getIdentifier());
+									hit.loopVarName= ConvertLoopOperation.modifyBaseName(((SimpleName)hit.collectionExpression).getIdentifier());
 								} else {
-									hit.loopVarName= ConvertLoopOperation.modifybasename("element"); //$NON-NLS-1$
+									hit.loopVarName= ConvertLoopOperation.modifyBaseName("element"); //$NON-NLS-1$
 								}
 							}
 							operationsMap.put(whilestatement, hit);
@@ -165,12 +165,12 @@ public class WhileToForEach extends AbstractTool<WhileLoopToChangeHit> {
 									hit.loopVarName= vdf.getName().getIdentifier();
 								} else {
 									if (hit.self) {
-										hit.loopVarName= ConvertLoopOperation.modifybasename("i"); //$NON-NLS-1$
+										hit.loopVarName= ConvertLoopOperation.modifyBaseName("i"); //$NON-NLS-1$
 									} else {
 										if (hit.collectionExpression instanceof SimpleName) {
-											hit.loopVarName= ConvertLoopOperation.modifybasename(((SimpleName)hit.collectionExpression).getIdentifier());
+											hit.loopVarName= ConvertLoopOperation.modifyBaseName(((SimpleName)hit.collectionExpression).getIdentifier());
 										} else {
-											hit.loopVarName= ConvertLoopOperation.modifybasename("element"); //$NON-NLS-1$
+											hit.loopVarName= ConvertLoopOperation.modifyBaseName("element"); //$NON-NLS-1$
 										}
 									}
 									hit.nextWithoutVariableDeclaration= true;

--- a/org.eclipse.jdt.core.manipulation/pom.xml
+++ b/org.eclipse.jdt.core.manipulation/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.manipulation</artifactId>
-  <version>1.19.0-SNAPSHOT</version>
+  <version>1.19.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.15.0-SNAPSHOT</version>
+  <version>3.15.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_in.java
@@ -1,0 +1,40 @@
+package p; // 23, 32, 23, 49
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class A {
+	public static void main(String[] args) {
+		List<Person> list = new ArrayList<Person>();
+		
+		Person p1 = new Person("Wang",19);
+		Person p2 = new Person("Li",20);
+		Person p3 = new Person("Zhang",21);
+		Person p4 = new Person("Liu",18);
+		
+		list.add(p1);
+		list.add(p2);
+		list.add(p3);
+		list.add(p4);
+		
+		Iterator<Person> iterPeople = list.iterator();
+		
+		while(iterPeople.hasNext()) {
+			System.out.println(iterPeople.next().getName()+" "+iterPeople.next().getAge());
+		}
+	}
+}
+class Person{
+	public Person(String name, int age){
+		this.name = name;
+		this.age = age;
+	}
+	String name;
+	int age;
+	public String getName() {
+		return name;
+	}
+	public int getAge() {
+		return age;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test153_out.java
@@ -1,0 +1,41 @@
+package p; // 23, 32, 23, 49
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class A {
+	public static void main(String[] args) {
+		List<Person> list = new ArrayList<Person>();
+		
+		Person p1 = new Person("Wang",19);
+		Person p2 = new Person("Li",20);
+		Person p3 = new Person("Zhang",21);
+		Person p4 = new Person("Liu",18);
+		
+		list.add(p1);
+		list.add(p2);
+		list.add(p3);
+		list.add(p4);
+		
+		Iterator<Person> iterPeople = list.iterator();
+		
+		while(iterPeople.hasNext()) {
+			Person iterPerson= iterPeople.next();
+			System.out.println(iterPerson.getName()+" "+iterPerson.getAge());
+		}
+	}
+}
+class Person{
+	public Person(String name, int age){
+		this.name = name;
+		this.age = age;
+	}
+	String name;
+	int age;
+	public String getName() {
+		return name;
+	}
+	public int getAge() {
+		return age;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_in.java
@@ -1,0 +1,40 @@
+package p; // 23, 32, 23, 45
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class A {
+	public static void main(String[] args) {
+		List<Person> list = new ArrayList<Person>();
+		
+		Person p1 = new Person("Wang",19);
+		Person p2 = new Person("Li",20);
+		Person p3 = new Person("Zhang",21);
+		Person p4 = new Person("Liu",18);
+		
+		list.add(p1);
+		list.add(p2);
+		list.add(p3);
+		list.add(p4);
+		
+		Iterator<Person> people = list.iterator();
+		
+		while(people.hasNext()) {
+			System.out.println(people.next().getName()+" "+people.next().getAge());
+		}
+	}
+}
+class Person{
+	public Person(String name, int age){
+		this.name = name;
+		this.age = age;
+	}
+	String name;
+	int age;
+	public String getName() {
+		return name;
+	}
+	public int getAge() {
+		return age;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test154_out.java
@@ -1,0 +1,41 @@
+package p; // 23, 32, 23, 45
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class A {
+	public static void main(String[] args) {
+		List<Person> list = new ArrayList<Person>();
+		
+		Person p1 = new Person("Wang",19);
+		Person p2 = new Person("Li",20);
+		Person p3 = new Person("Zhang",21);
+		Person p4 = new Person("Liu",18);
+		
+		list.add(p1);
+		list.add(p2);
+		list.add(p3);
+		list.add(p4);
+		
+		Iterator<Person> people = list.iterator();
+		
+		while(people.hasNext()) {
+			Person person= people.next();
+			System.out.println(person.getName()+" "+person.getAge());
+		}
+	}
+}
+class Person{
+	public Person(String name, int age){
+		this.name = name;
+		this.age = age;
+	}
+	String name;
+	int age;
+	public String getName() {
+		return name;
+	}
+	public int getAge() {
+		return age;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
@@ -16,6 +16,7 @@
  *     Xiaye Chi <xychichina@gmail.com> - [extract local] Improve the Safety of Extract Local Variable Refactorings concering ClassCasts. - https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/331
  *     Xiaye Chi <xychichina@gmail.com> - [extract local] Improve the Safety of Extract Local Variable Refactorings by Identifying the Side Effect of Selected Expression. - https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/348
  *     Xiaye Chi <xychichina@gmail.com> - [extract local] Improve the Safety of Extract Local Variable Refactorings by identifying statements that may change the value of the extracted expressions - https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/432
+ *     Taiming Wang <3120205503@bit.edu.cn> - [extract local] Automated Name Recommendation For The Extract Local Variable Refactoring - https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/601
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.refactoring;
 
@@ -1039,6 +1040,19 @@ public class ExtractTempTests extends GenericRefactoringTest {
 	public void test152() throws Exception {
 		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/432
 		helper1(10, 17, 10, 20, true, false, "f", "f");
+	}
+
+
+	@Test
+	public void test153() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/601
+		helper1(23, 32, 23, 49, true, false, "iterPerson", "iterPerson");
+	}
+
+	@Test
+	public void test154() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/601
+		helper1(23, 32, 23, 45, true, false, "person", "person");
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.15.0-SNAPSHOT</version>
+  <version>3.15.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ConvertLoopOperationTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ConvertLoopOperationTest.java
@@ -78,7 +78,7 @@ public class ConvertLoopOperationTest extends ConvertForLoopOperation {
 
 	@Test
 	public void testModifybasename() {
-		Assert.assertEquals(expectedResult, ConvertLoopOperation.modifybasename(name));
+		Assert.assertEquals(expectedResult, ConvertLoopOperation.modifyBaseName(name));
 	}
 
 }

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.29.0.qualifier
+Bundle-Version: 3.29.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.29.0-SNAPSHOT</version>
+  <version>3.29.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <code.ignoredWarnings>-warn:-deprecation,unavoidableGenericProblems</code.ignoredWarnings>


### PR DESCRIPTION
- modify StubUtility() to add new rules to generate names for extracted local variables.
- add popular plural words (irregular cases) to ConvertLoopOperation.java to support the singularization of plural words.
- add test to ExtractTempTests.
- fixes #601 .

## What it does
see issue cited.

## How to test
Run test153, and test154 in ExtractTempTests.
## Author checklist


- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
