### PR TITLE
Use limit based viewers #631

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestSessionLabelProvider.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestSessionLabelProvider.java
@@ -186,9 +186,8 @@ public class TestSessionLabelProvider extends LabelProvider implements IStyledLa
 			else
 				throw new IllegalStateException(element.toString());
 
-		} else {
-			throw new IllegalArgumentException(String.valueOf(element));
 		}
+		return null;
 	}
 
 	public void setShowTime(boolean showTime) {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -62,6 +62,7 @@ import org.eclipse.jface.viewers.ViewerFilter;
 
 import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.part.PageBook;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -243,6 +244,7 @@ public class TestViewer {
 
 		fTreeViewer= new TreeViewer(fViewerbook, SWT.V_SCROLL | SWT.SINGLE);
 		fTreeViewer.setUseHashlookup(true);
+		WorkbenchViewerSetup.setupViewer(fTreeViewer);
 		fTreeContentProvider= new TestSessionTreeContentProvider();
 		fTreeViewer.setContentProvider(fTreeContentProvider);
 		fTreeLabelProvider= new TestSessionLabelProvider(fTestRunnerPart, TestRunnerViewPart.LAYOUT_HIERARCHICAL);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorBreadcrumb.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorBreadcrumb.java
@@ -47,6 +47,7 @@ import org.eclipse.ui.IEditorSite;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.actions.ActionContext;
 import org.eclipse.ui.actions.ActionGroup;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -205,6 +206,7 @@ public class JavaEditorBreadcrumb extends EditorBreadcrumb {
 			viewer.setLabelProvider(createDropDownLabelProvider());
 			viewer.setComparator(new JavaElementComparator());
 			viewer.addFilter(new SyntheticMembersFilter());
+			WorkbenchViewerSetup.setupViewer(viewer);
 			viewer.addFilter(new ViewerFilter() {
 				@Override
 				public boolean select(Viewer viewer1, Object parentElement, Object element) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaOutlinePage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaOutlinePage.java
@@ -88,6 +88,7 @@ import org.eclipse.ui.part.IShowInTarget;
 import org.eclipse.ui.part.IShowInTargetList;
 import org.eclipse.ui.part.Page;
 import org.eclipse.ui.part.ShowInContext;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 
 import org.eclipse.ui.texteditor.ITextEditorActionConstants;
@@ -423,6 +424,9 @@ public class JavaOutlinePage extends Page implements IContentOutlinePage, IAdapt
 				 */
 				@Override
 				public boolean isExpandable(Object element) {
+					if (isExpandableNode(element)) {
+						return false;
+					}
 					if (hasFilters()) {
 						return getFilteredChildren(element).length > 0;
 					}
@@ -938,6 +942,7 @@ public class JavaOutlinePage extends Page implements IContentOutlinePage, IAdapt
 		);
 
 		fOutlineViewer= new JavaOutlineViewer(tree);
+		WorkbenchViewerSetup.setupViewer(fOutlineViewer);
 		initDragAndDrop();
 		fOutlineViewer.setContentProvider(new ChildrenProvider());
 		fOutlineViewer.setLabelProvider(new DecoratingJavaLabelProvider(lprovider));

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
@@ -90,6 +90,7 @@ import org.eclipse.ui.part.IShowInSource;
 import org.eclipse.ui.part.IShowInTarget;
 import org.eclipse.ui.part.ShowInContext;
 import org.eclipse.ui.part.ViewPart;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 import org.eclipse.ui.views.framelist.Frame;
 import org.eclipse.ui.views.framelist.FrameAction;
 import org.eclipse.ui.views.framelist.FrameList;
@@ -282,6 +283,9 @@ public class PackageExplorerPart extends ViewPart
 				return false;
 			}
 			if (parent instanceof IPackageFragmentRoot && ((IPackageFragmentRoot) parent).isArchive()) {
+				return false;
+			}
+			if(isExpandableNode(parent)) {
 				return false;
 			}
 			return true;
@@ -492,6 +496,7 @@ public class PackageExplorerPart extends ViewPart
 
 		fViewer= createViewer(fDisplayArea);
 		fViewer.setUseHashlookup(true);
+		WorkbenchViewerSetup.setupViewer(fViewer);
 
 		fEmptyWorkspaceHelper.setNonEmptyControl(fViewer.getControl());
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
@@ -56,6 +56,7 @@ import org.eclipse.ui.IDecoratorManager;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.views.WorkbenchViewerSetup;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -575,6 +576,7 @@ public class JavaOutlineInformationControl extends AbstractInformationControl {
 		tree.setLayoutData(gd);
 
 		final TreeViewer treeViewer= new OutlineTreeViewer(tree);
+		WorkbenchViewerSetup.setupViewer(treeViewer);
 
 		// Hard-coded filters
 		treeViewer.addFilter(new NamePatternFilter());


### PR DESCRIPTION
**This PR won't compile unless you have changes from [810](https://github.com/eclipse-platform/eclipse.platform.ui/pull/810) on your workspace**

## What it does

This will limit the number of elements populated in Package Explorer, Outline view for Java editor and editor breadcrumb viewer to the common value defined by the workbench.

## How to test

See https://github.com/eclipse-platform/eclipse.platform.ui/pull/810 for detailed theory of operation and use case examples.
