### PR TITLE
Merge method ref simplification support into LambdaCleanUpFixCore

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
@@ -118,6 +118,7 @@ public class MultiFixMessages extends NLS {
 	public static String VarCleanUp_description;
 	public static String PatternMatchingForInstanceofCleanup_description;
 	public static String LambdaExpressionsCleanUp_use_lambda_where_possible;
+	public static String LambdaExpressionsCleanUp_use_lambda_and_simplify;
 	public static String LambdaExpressionsCleanUp_use_anonymous;
 	public static String LambdaExpressionAndMethodRefCleanUp_description;
 	public static String PatternCleanup_description;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
@@ -95,6 +95,7 @@ ImportsCleanUp_OrganizeImports_Description=Organize imports
 VarCleanUp_description=Use the local variable type inference where possible
 PatternMatchingForInstanceofCleanup_description=Use pattern matching for instanceof
 LambdaExpressionsCleanUp_use_lambda_where_possible=Use lambda where possible
+LambdaExpressionsCleanUp_use_lambda_and_simplify=Use lambda where possible and simplify expression
 LambdaExpressionsCleanUp_use_anonymous=Use anonymous class creations
 LambdaExpressionAndMethodRefCleanUp_description=Simplify lambda expression and method reference syntax
 PatternCleanup_description=Precompile reused regular expressions

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
@@ -957,6 +957,19 @@ public class CleanUpConstants {
 	public static final String USE_ANONYMOUS_CLASS_CREATION= "cleanup.use_anonymous_class_creation"; //$NON-NLS-1$
 
 	/**
+	 * When replacing anonymous class creations with lambda expressions also simplify lambda body.
+	 * <p>
+	 * Possible values: {TRUE, FALSE}
+	 * <p>
+	 * Only has an effect if {@link #USE_LAMBDA} is TRUE.
+	 *
+	 * @see CleanUpOptionsCore#TRUE
+	 * @see CleanUpOptionsCore#FALSE
+	 * @since 4.29
+	 */
+	public static final String ALSO_SIMPLIFY_LAMBDA= "cleanup.also_simplify_lambda"; //$NON-NLS-1$
+
+	/**
 	 * Removes useless parenthesis, return statements and brackets from lambda expressions and
 	 * method references.
 	 * <p>

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,9 +25,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
-
-import org.eclipse.text.edits.TextEditGroup;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -39,7 +36,9 @@ import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.CreationReference;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionMethodReference;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
@@ -55,6 +54,7 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.NumberLiteral;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.QualifiedType;
 import org.eclipse.jdt.core.dom.ReturnStatement;
@@ -62,11 +62,14 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeMethodReference;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -75,7 +78,6 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
 import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.core.util.IModifierConstants;
-
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
@@ -90,8 +92,8 @@ import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewr
 import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.JdtFlags;
-
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
+import org.eclipse.text.edits.TextEditGroup;
 
 public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFixCore {
 	public static final class FunctionalAnonymousClassesFinder extends ASTVisitor {
@@ -436,11 +438,237 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 		}
 	}
 
+	/**
+	 * In order to make parameters implicit, those ones should be the same in the same order.
+	 *
+	 * @param node the lambda expression
+	 * @param arguments The arguments in the expression
+	 * @return true if the parameters are obvious
+	 */
+	private static boolean areSameIdentifiers(MethodDeclaration node, List<Expression> arguments) {
+		for (int i= 0; i < node.parameters().size(); i++) {
+			Expression expression= ASTNodes.getUnparenthesedExpression(arguments.get(i));
+
+			if (!(expression instanceof SimpleName) || !isSameIdentifier(node, i, (SimpleName) expression)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static boolean isSameIdentifier(final MethodDeclaration node, final int i, final SimpleName argument) {
+		SingleVariableDeclaration decl= (SingleVariableDeclaration) node.parameters().get(i);
+		return decl.getName().getIdentifier().equals(argument.getIdentifier());
+	}
+
+	private enum MethodRefStatus {
+		NO_REF, TYPE_REF, METHOD_REF;
+	}
+
+	private static record MethodInvocationStatus(MethodRefStatus status, ITypeBinding classBinding) {}
+
+	public static MethodInvocationStatus checkMethodInvocation(MethodDeclaration visited, MethodInvocation methodInvocation) {
+		Expression calledExpression= methodInvocation.getExpression();
+		List<Expression> arguments= methodInvocation.arguments();
+		MethodRefStatus actionType= MethodRefStatus.NO_REF;
+		ITypeBinding classBinding= null;
+
+		if (visited.parameters().size() == arguments.size()) {
+			if (areSameIdentifiers(visited, arguments)) {
+				IMethodBinding methodBinding= methodInvocation.resolveMethodBinding();
+				ITypeBinding calledType= null;
+
+				if (methodBinding != null) {
+					calledType= methodBinding.getDeclaringClass();
+				} else if (calledExpression != null) {
+					calledType= calledExpression.resolveTypeBinding();
+				} else {
+					// For an unknown reason, MethodInvocation.resolveMethodBinding() seems to fail when the method is defined in the class we are
+					AbstractTypeDeclaration enclosingType= ASTNodes.getTypedAncestor(visited, AbstractTypeDeclaration.class);
+
+					if (enclosingType != null) {
+						ITypeBinding enclosingTypeBinding= enclosingType.resolveBinding();
+
+						if (enclosingTypeBinding != null) {
+							List<Type> argumentTypes= methodInvocation.typeArguments();
+							String[] parameterTypeNames= new String[methodInvocation.arguments().size()];
+
+							for (int i= 0; i < argumentTypes.size(); i++) {
+								Type argumentType= argumentTypes.get(i);
+
+								if (argumentType.resolveBinding() == null) {
+									return null;
+								}
+
+								parameterTypeNames[i]= argumentType.resolveBinding().getQualifiedName();
+							}
+
+							for (IMethodBinding declaredMethods : enclosingTypeBinding.getDeclaredMethods()) {
+								if (ASTNodes.usesGivenSignature(declaredMethods, enclosingTypeBinding.getQualifiedName(), methodInvocation.getName().getIdentifier(), parameterTypeNames)) {
+									calledType= enclosingTypeBinding;
+									break;
+								}
+							}
+						}
+					}
+				}
+
+				if (Boolean.TRUE.equals(ASTNodes.isStatic(methodInvocation))
+						&& calledType != null) {
+					boolean valid= true;
+
+					if (!arguments.isEmpty()
+							&& arguments.get(0).resolveTypeBinding() != null
+							&& arguments.get(0).resolveTypeBinding().isSubTypeCompatible(calledType)) {
+						String[] remainingParams= new String[arguments.size() - 1];
+
+						for (int i= 0; i < arguments.size() - 1; i++) {
+							ITypeBinding resolveTypeBinding= arguments.get(i + 1).resolveTypeBinding();
+
+							if (resolveTypeBinding == null) {
+								valid= false;
+								break;
+							}
+
+							remainingParams[i]= resolveTypeBinding.getQualifiedName();
+						}
+
+						if (valid) {
+							for (IMethodBinding declaredMethodBinding : calledType.getDeclaredMethods()) {
+								if (!Modifier.isStatic(declaredMethodBinding.getModifiers())
+										&& ASTNodes.usesGivenSignature(declaredMethodBinding, calledType.getQualifiedName(), methodInvocation.getName().getIdentifier(), remainingParams)) {
+									valid= false;
+									break;
+								}
+							}
+						}
+					}
+
+					if (valid) {
+						actionType= MethodRefStatus.TYPE_REF;
+						classBinding= calledType;
+					}
+				}
+
+				if (actionType != MethodRefStatus.TYPE_REF) {
+					if (calledExpression == null) {
+						if (calledType != null) {
+							ITypeBinding enclosingType= Bindings.getBindingOfParentType(visited.getParent().getParent());
+
+							if (enclosingType != null && Bindings.isSuperType(calledType, enclosingType)) {
+								actionType= MethodRefStatus.METHOD_REF;
+							}
+						}
+					} else if (calledExpression instanceof StringLiteral
+							|| calledExpression instanceof NumberLiteral
+							|| calledExpression instanceof ThisExpression) {
+						actionType= MethodRefStatus.METHOD_REF;
+					} else if (calledExpression instanceof FieldAccess) {
+						FieldAccess fieldAccess= (FieldAccess) calledExpression;
+
+						if (fieldAccess.resolveFieldBinding() != null && fieldAccess.resolveFieldBinding().isEffectivelyFinal()) {
+							actionType= MethodRefStatus.METHOD_REF;
+						}
+					} else if (calledExpression instanceof SuperFieldAccess) {
+						SuperFieldAccess fieldAccess= (SuperFieldAccess) calledExpression;
+
+						if (fieldAccess.resolveFieldBinding() != null && fieldAccess.resolveFieldBinding().isEffectivelyFinal()) {
+							actionType= MethodRefStatus.METHOD_REF;
+						}
+					}
+				}
+			}
+		} else if (calledExpression instanceof SimpleName && visited.parameters().size() == arguments.size() + 1) {
+			SimpleName calledObject= (SimpleName) calledExpression;
+
+			if (isSameIdentifier(visited, 0, calledObject)) {
+				boolean valid= true;
+
+				for (int i= 0; i < arguments.size(); i++) {
+					ASTNode expression= ASTNodes.getUnparenthesedExpression(arguments.get(i));
+
+					if (!(expression instanceof SimpleName) || !isSameIdentifier(visited, i + 1, (SimpleName) expression)) {
+						valid= false;
+						break;
+					}
+				}
+
+				if (valid) {
+					ITypeBinding klass= null;
+
+					if (calledExpression.resolveTypeBinding() != null) {
+						klass= calledExpression.resolveTypeBinding();
+					} else if (methodInvocation.resolveMethodBinding() != null && methodInvocation.resolveMethodBinding().getDeclaringClass() != null) {
+						klass= methodInvocation.resolveMethodBinding().getDeclaringClass();
+					}
+
+					if (klass != null) {
+						String[] cumulativeParams= new String[arguments.size() + 1];
+						cumulativeParams[0]= klass.getQualifiedName();
+
+						for (int i= 0; i < arguments.size(); i++) {
+							ITypeBinding resolveTypeBinding= arguments.get(i).resolveTypeBinding();
+
+							if (resolveTypeBinding == null) {
+								valid= false;
+								break;
+							}
+
+							cumulativeParams[i + 1]= resolveTypeBinding.getQualifiedName();
+						}
+
+						if (valid) {
+							for (IMethodBinding declaredMethodBinding : klass.getDeclaredMethods()) {
+								if (Modifier.isStatic(declaredMethodBinding.getModifiers())
+										&& ASTNodes.usesGivenSignature(declaredMethodBinding, klass.getQualifiedName(), methodInvocation.getName().getIdentifier(), cumulativeParams)) {
+									valid= false;
+									break;
+								}
+							}
+						}
+
+						if (valid) {
+							actionType= MethodRefStatus.TYPE_REF;
+							classBinding= klass;
+						}
+					}
+				}
+			}
+		}
+		return new MethodInvocationStatus(actionType, classBinding);
+	}
+
+	private static Type copyType(final CompilationUnitRewrite cuRewrite, final AST ast, final ASTNode node, final ITypeBinding typeBinding) {
+		ImportRewrite importRewrite= cuRewrite.getImportRewrite();
+		ImportRewriteContext importContext= new ContextSensitiveImportRewriteContext(node, importRewrite);
+		ITypeBinding modifiedType;
+
+		if (typeBinding.getTypeParameters().length == 0) {
+			if (typeBinding.isCapture()) {
+				ITypeBinding[] bounds= typeBinding.getTypeBounds();
+				if (bounds.length > 0) {
+					modifiedType= bounds[0];
+				} else {
+					modifiedType= typeBinding.getErasure();
+				}
+			} else {
+				modifiedType= typeBinding.getErasure();
+			}
+		} else {
+			modifiedType= typeBinding;
+		}
+
+		return ASTNodeFactory.newCreationType(ast, modifiedType, importRewrite, importContext);
+	}
+
 	public static class CreateLambdaOperation extends CompilationUnitRewriteOperation {
 		private final List<ClassInstanceCreation> fExpressions;
+		private final boolean fSimplifyLambda;
 
-		public CreateLambdaOperation(List<ClassInstanceCreation> expressions) {
+		public CreateLambdaOperation(List<ClassInstanceCreation> expressions, boolean simplifyLambda) {
 			fExpressions= expressions;
+			fSimplifyLambda= simplifyLambda;
 		}
 
 		@Override
@@ -478,29 +706,6 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 				cicToNewNames.put(classInstanceCreation, new HashSet<>(newNames));
 				List<SingleVariableDeclaration> methodParameters= methodDeclaration.parameters();
 
-				// use short form with inferred parameter types and without parentheses if possible
-				boolean createExplicitlyTypedParameters= false;
-				for (SingleVariableDeclaration methodParameter : methodParameters) {
-					if (AnnotationsFinder.hasAnnotations(methodParameter)) {
-						createExplicitlyTypedParameters= true;
-						break;
-					}
-				}
-
-				LambdaExpression lambdaExpression= ast.newLambdaExpression();
-				List<VariableDeclaration> lambdaParameters= lambdaExpression.parameters();
-				lambdaExpression.setParentheses(createExplicitlyTypedParameters || methodParameters.size() != 1);
-				for (SingleVariableDeclaration methodParameter : methodParameters) {
-					if (createExplicitlyTypedParameters) {
-						lambdaParameters.add((SingleVariableDeclaration) rewrite.createCopyTarget(methodParameter));
-						importRemover.registerRetainedNode(methodParameter);
-					} else {
-						VariableDeclarationFragment lambdaParameter= ast.newVariableDeclarationFragment();
-						lambdaParameter.setName((SimpleName) rewrite.createCopyTarget(methodParameter.getName()));
-						lambdaParameters.add(lambdaParameter);
-					}
-				}
-
 				Block body= methodDeclaration.getBody();
 				List<Statement> statements= body.statements();
 				ASTNode lambdaBody= body;
@@ -517,155 +722,222 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 					}
 				}
 
-				final Set<ITypeBinding> inheritedTypes= new HashSet<>();
-				collectInheritedTypes(anonymTypeDecl.resolveBinding(), inheritedTypes);
+				// use short form with inferred parameter types and without parentheses if possible
+				boolean createExplicitlyTypedParameters= false;
+				for (SingleVariableDeclaration methodParameter : methodParameters) {
+					if (AnnotationsFinder.hasAnnotations(methodParameter)) {
+						createExplicitlyTypedParameters= true;
+						break;
+					}
+				}
 
-				ASTVisitor inheritedFieldsVisitor= new ASTVisitor() {
-					@Override
-					public boolean visit(final SimpleName node) {
-						if ((!(node.getParent() instanceof QualifiedName) || node.getLocationInParent() != QualifiedName.NAME_PROPERTY)
-								&& (!(node.getParent() instanceof FieldAccess) || node.getLocationInParent() != FieldAccess.NAME_PROPERTY)
-								&& (!(node.getParent() instanceof SuperFieldAccess) || node.getLocationInParent() != SuperFieldAccess.NAME_PROPERTY)
-								&& node.resolveBinding() != null
-								&& node.resolveBinding().getKind() == IBinding.VARIABLE) {
-							IVariableBinding variableBinding= (IVariableBinding) node.resolveBinding();
-
-							if (variableBinding != null
-									&& (variableBinding.getModifiers() & Modifier.STATIC) != 0
-									&& variableBinding.isField()
-									&& inheritedTypes.contains(variableBinding.getDeclaringClass())) {
-								Type copyOfClassName= (Type) rewrite.createCopyTarget(classInstanceCreation.getType());
-								QualifiedType replacement= ast.newQualifiedType(copyOfClassName, ASTNodes.createMoveTarget(rewrite, node));
-								rewrite.replace(node, replacement, group);
-								return false;
+				Expression cicReplacement= null;
+				if (fSimplifyLambda) {
+					if (lambdaBody instanceof MethodInvocation methodInvocation) {
+						MethodInvocationStatus methodInvocationCheck= checkMethodInvocation(methodDeclaration, methodInvocation);
+						if (methodInvocationCheck != null) {
+							if (methodInvocationCheck.status() == MethodRefStatus.METHOD_REF) {
+								ExpressionMethodReference methodRef= ast.newExpressionMethodReference();
+								if (methodInvocation.getExpression() != null) {
+									methodRef.setExpression(ASTNodes.createMoveTarget(rewrite, methodInvocation.getExpression()));
+								} else {
+									methodRef.setExpression(ast.newThisExpression());
+								}
+								methodRef.setName(ASTNodes.createMoveTarget(rewrite, methodInvocation.getName()));
+								cicReplacement= methodRef;
+							} else if (methodInvocationCheck.status() == MethodRefStatus.TYPE_REF) {
+								TypeMethodReference typeMethodRef= ast.newTypeMethodReference();
+								typeMethodRef.setType(copyType(cuRewrite, ast, methodInvocation, methodInvocationCheck.classBinding()));
+								typeMethodRef.setName(ASTNodes.createMoveTarget(rewrite, methodInvocation.getName()));
+								cicReplacement= typeMethodRef;
 							}
 						}
+					} else if (lambdaBody instanceof ClassInstanceCreation invokedClassInstanceCreation) {
+						List<Expression> arguments= invokedClassInstanceCreation.arguments();
 
-						return true;
-					}
-				};
-				lambdaBody.accept(inheritedFieldsVisitor);
+						if (methodDeclaration.parameters().size() == arguments.size()
+								&& areSameIdentifiers(methodDeclaration, arguments)
+								&& classInstanceCreation.getAnonymousClassDeclaration() == null) {
+							CreationReference creationRef= ast.newCreationReference();
+							creationRef.setType(copyType(cuRewrite, ast, classInstanceCreation, classInstanceCreation.resolveTypeBinding()));
+							cicReplacement= creationRef;
+						}
+					} else if (lambdaBody instanceof SuperMethodInvocation superMethodInvocation) {
+						List<Expression> arguments= superMethodInvocation.arguments();
 
-				ASTNode fragment= ASTNodes.getFirstAncestorOrNull(classInstanceCreation, VariableDeclarationFragment.class, BodyDeclaration.class);
-
-				if (fragment instanceof VariableDeclarationFragment) {
-					final VariableDeclarationFragment actualFragment= (VariableDeclarationFragment) fragment;
-
-					if (actualFragment.getParent() instanceof FieldDeclaration) {
-						FieldDeclaration fieldDeclaration= (FieldDeclaration) actualFragment.getParent();
-
-						TypeDeclaration declarationClass= ASTNodes.getFirstAncestorOrNull(fieldDeclaration, TypeDeclaration.class);
-
-						if (declarationClass != null) {
-							TypeDeclaration typeDeclaration= declarationClass;
-
-							final List<FieldDeclaration> nextFields= new ArrayList<>(typeDeclaration.getFields().length);
-							boolean isBefore= true;
-
-							for (FieldDeclaration oneField : typeDeclaration.getFields()) {
-								if (oneField == fieldDeclaration) {
-									isBefore= false;
-								}
-
-								if (!isBefore) {
-									nextFields.add(oneField);
-								}
-							}
-
-							ASTVisitor visitor= new ASTVisitor() {
-								@Override
-								public boolean visit(final MethodInvocation node) {
-									ITypeBinding fieldType= fieldDeclaration.getType().resolveBinding();
-									ASTNode declaration= ASTNodes.findDeclaration(node.resolveMethodBinding(), declarationClass);
-
-									if (node.getExpression() == null && fieldType != null && methodDeclaration == declaration) {
-										ASTNode replacement;
-
-										if ((fieldDeclaration.getModifiers() & Modifier.STATIC) != 0) {
-											SimpleName copyOfClassName= (SimpleName) rewrite.createCopyTarget(typeDeclaration.getName());
-											replacement= ast.newQualifiedName(copyOfClassName, (SimpleName) rewrite.createCopyTarget(actualFragment.getName()));
-										} else {
-											FieldAccess newFieldAccess= ast.newFieldAccess();
-											newFieldAccess.setExpression(ast.newThisExpression());
-											newFieldAccess.setName((SimpleName) rewrite.createCopyTarget(actualFragment.getName()));
-											replacement= newFieldAccess;
-										}
-
-										rewrite.set(node, MethodInvocation.EXPRESSION_PROPERTY, replacement, group);
-
-										return false;
-									}
-
-									return true;
-								}
-
-								@Override
-								public boolean visit(final SimpleName node) {
-									if ((!(node.getParent() instanceof QualifiedName) || node.getLocationInParent() != QualifiedName.NAME_PROPERTY)
-											&& (!(node.getParent() instanceof FieldAccess) || node.getLocationInParent() != FieldAccess.NAME_PROPERTY)
-											&& (!(node.getParent() instanceof SuperFieldAccess) || node.getLocationInParent() != SuperFieldAccess.NAME_PROPERTY)) {
-										ASTNode declaration= ASTNodes.findDeclaration(node.resolveBinding(), declarationClass);
-
-										if (declaration instanceof VariableDeclarationFragment && declaration.getParent() instanceof FieldDeclaration) {
-											FieldDeclaration currentField= (FieldDeclaration) declaration.getParent();
-
-											if (nextFields.contains(currentField)) {
-												if ((currentField.getModifiers() & Modifier.STATIC) != 0) {
-													SimpleName copyOfClassName= (SimpleName) rewrite.createCopyTarget(typeDeclaration.getName());
-													QualifiedName replacement= ast.newQualifiedName(copyOfClassName, ASTNodes.createMoveTarget(rewrite, node));
-													rewrite.replace(node, replacement, group);
-												} else {
-													FieldAccess newFieldAccess= ast.newFieldAccess();
-													newFieldAccess.setExpression(ast.newThisExpression());
-													newFieldAccess.setName(ASTNodes.createMoveTarget(rewrite, node));
-													rewrite.replace(node, newFieldAccess, group);
-												}
-
-												return false;
-											}
-										}
-									}
-
-									return true;
-								}
-
-								@Override
-								public boolean visit(final ThisExpression node) {
-									Name qualifier= node.getQualifier();
-
-									if (qualifier != null
-											&& qualifier.resolveBinding() != null
-											&& qualifier.resolveBinding().getKind() == IBinding.TYPE
-											&& Objects.equals(qualifier.resolveBinding(), typeDeclaration.resolveBinding())) {
-										rewrite.remove(qualifier, group);
-									}
-
-									return true;
-								}
-							};
-							lambdaBody.accept(visitor);
+						if (methodDeclaration.parameters().size() == arguments.size() && areSameIdentifiers(methodDeclaration, arguments)) {
+							SuperMethodReference superMethodRef= ast.newSuperMethodReference();
+							superMethodRef.setName(ASTNodes.createMoveTarget(rewrite, superMethodInvocation.getName()));
+							cicReplacement= superMethodRef;
 						}
 					}
 				}
 
-				//TODO: Bug 421479: [1.8][clean up][quick assist] convert anonymous to lambda must consider lost scope of interface
-				//				lambdaBody.accept(new InterfaceAccessQualifier(rewrite, classInstanceCreation.getType().resolveBinding())); //TODO: maybe need a separate ASTRewrite and string placeholder
+				if (cicReplacement == null) {
+					LambdaExpression lambdaExpression= ast.newLambdaExpression();
+					List<VariableDeclaration> lambdaParameters= lambdaExpression.parameters();
+					lambdaExpression.setParentheses(createExplicitlyTypedParameters || methodParameters.size() != 1);
+					for (SingleVariableDeclaration methodParameter : methodParameters) {
+						if (createExplicitlyTypedParameters) {
+							lambdaParameters.add((SingleVariableDeclaration) rewrite.createCopyTarget(methodParameter));
+							importRemover.registerRetainedNode(methodParameter);
+						} else {
+							VariableDeclarationFragment lambdaParameter= ast.newVariableDeclarationFragment();
+							lambdaParameter.setName((SimpleName) rewrite.createCopyTarget(methodParameter.getName()));
+							lambdaParameters.add(lambdaParameter);
+						}
+					}
 
-				lambdaExpression.setBody(ASTNodes.getCopyOrReplacement(rewrite, lambdaBody, group));
+					final Set<ITypeBinding> inheritedTypes= new HashSet<>();
+					collectInheritedTypes(anonymTypeDecl.resolveBinding(), inheritedTypes);
 
-				Expression replacement= lambdaExpression;
+					ASTVisitor inheritedFieldsVisitor= new ASTVisitor() {
+						@Override
+						public boolean visit(final SimpleName node) {
+							if ((!(node.getParent() instanceof QualifiedName) || node.getLocationInParent() != QualifiedName.NAME_PROPERTY)
+									&& (!(node.getParent() instanceof FieldAccess) || node.getLocationInParent() != FieldAccess.NAME_PROPERTY)
+									&& (!(node.getParent() instanceof SuperFieldAccess) || node.getLocationInParent() != SuperFieldAccess.NAME_PROPERTY)
+									&& node.resolveBinding() != null
+									&& node.resolveBinding().getKind() == IBinding.VARIABLE) {
+								IVariableBinding variableBinding= (IVariableBinding) node.resolveBinding();
+
+								if (variableBinding != null
+										&& (variableBinding.getModifiers() & Modifier.STATIC) != 0
+										&& variableBinding.isField()
+										&& inheritedTypes.contains(variableBinding.getDeclaringClass())) {
+									Type copyOfClassName= (Type) rewrite.createCopyTarget(classInstanceCreation.getType());
+									QualifiedType replacement= ast.newQualifiedType(copyOfClassName, ASTNodes.createMoveTarget(rewrite, node));
+									rewrite.replace(node, replacement, group);
+									return false;
+								}
+							}
+
+							return true;
+						}
+					};
+					lambdaBody.accept(inheritedFieldsVisitor);
+
+					ASTNode fragment= ASTNodes.getFirstAncestorOrNull(classInstanceCreation, VariableDeclarationFragment.class, BodyDeclaration.class);
+
+					if (fragment instanceof VariableDeclarationFragment) {
+						final VariableDeclarationFragment actualFragment= (VariableDeclarationFragment) fragment;
+
+						if (actualFragment.getParent() instanceof FieldDeclaration) {
+							FieldDeclaration fieldDeclaration= (FieldDeclaration) actualFragment.getParent();
+
+							TypeDeclaration declarationClass= ASTNodes.getFirstAncestorOrNull(fieldDeclaration, TypeDeclaration.class);
+
+							if (declarationClass != null) {
+								TypeDeclaration typeDeclaration= declarationClass;
+
+								final List<FieldDeclaration> nextFields= new ArrayList<>(typeDeclaration.getFields().length);
+								boolean isBefore= true;
+
+								for (FieldDeclaration oneField : typeDeclaration.getFields()) {
+									if (oneField == fieldDeclaration) {
+										isBefore= false;
+									}
+
+									if (!isBefore) {
+										nextFields.add(oneField);
+									}
+								}
+
+								ASTVisitor visitor= new ASTVisitor() {
+									@Override
+									public boolean visit(final MethodInvocation node) {
+										ITypeBinding fieldType= fieldDeclaration.getType().resolveBinding();
+										ASTNode declaration= ASTNodes.findDeclaration(node.resolveMethodBinding(), declarationClass);
+
+										if (node.getExpression() == null && fieldType != null && methodDeclaration == declaration) {
+											ASTNode replacement;
+
+											if ((fieldDeclaration.getModifiers() & Modifier.STATIC) != 0) {
+												SimpleName copyOfClassName= (SimpleName) rewrite.createCopyTarget(typeDeclaration.getName());
+												replacement= ast.newQualifiedName(copyOfClassName, (SimpleName) rewrite.createCopyTarget(actualFragment.getName()));
+											} else {
+												FieldAccess newFieldAccess= ast.newFieldAccess();
+												newFieldAccess.setExpression(ast.newThisExpression());
+												newFieldAccess.setName((SimpleName) rewrite.createCopyTarget(actualFragment.getName()));
+												replacement= newFieldAccess;
+											}
+
+											rewrite.set(node, MethodInvocation.EXPRESSION_PROPERTY, replacement, group);
+
+											return false;
+										}
+
+										return true;
+									}
+
+									@Override
+									public boolean visit(final SimpleName node) {
+										if ((!(node.getParent() instanceof QualifiedName) || node.getLocationInParent() != QualifiedName.NAME_PROPERTY)
+												&& (!(node.getParent() instanceof FieldAccess) || node.getLocationInParent() != FieldAccess.NAME_PROPERTY)
+												&& (!(node.getParent() instanceof SuperFieldAccess) || node.getLocationInParent() != SuperFieldAccess.NAME_PROPERTY)) {
+											ASTNode declaration= ASTNodes.findDeclaration(node.resolveBinding(), declarationClass);
+
+											if (declaration instanceof VariableDeclarationFragment && declaration.getParent() instanceof FieldDeclaration) {
+												FieldDeclaration currentField= (FieldDeclaration) declaration.getParent();
+
+												if (nextFields.contains(currentField)) {
+													if ((currentField.getModifiers() & Modifier.STATIC) != 0) {
+														SimpleName copyOfClassName= (SimpleName) rewrite.createCopyTarget(typeDeclaration.getName());
+														QualifiedName replacement= ast.newQualifiedName(copyOfClassName, ASTNodes.createMoveTarget(rewrite, node));
+														rewrite.replace(node, replacement, group);
+													} else {
+														FieldAccess newFieldAccess= ast.newFieldAccess();
+														newFieldAccess.setExpression(ast.newThisExpression());
+														newFieldAccess.setName(ASTNodes.createMoveTarget(rewrite, node));
+														rewrite.replace(node, newFieldAccess, group);
+													}
+
+													return false;
+												}
+											}
+										}
+
+										return true;
+									}
+
+									@Override
+									public boolean visit(final ThisExpression node) {
+										Name qualifier= node.getQualifier();
+
+										if (qualifier != null
+												&& qualifier.resolveBinding() != null
+												&& qualifier.resolveBinding().getKind() == IBinding.TYPE
+												&& Objects.equals(qualifier.resolveBinding(), typeDeclaration.resolveBinding())) {
+											rewrite.remove(qualifier, group);
+										}
+
+										return true;
+									}
+								};
+								lambdaBody.accept(visitor);
+							}
+						}
+					}
+
+					//TODO: Bug 421479: [1.8][clean up][quick assist] convert anonymous to lambda must consider lost scope of interface
+					//				lambdaBody.accept(new InterfaceAccessQualifier(rewrite, classInstanceCreation.getType().resolveBinding())); //TODO: maybe need a separate ASTRewrite and string placeholder
+
+					lambdaExpression.setBody(ASTNodes.getCopyOrReplacement(rewrite, lambdaBody, group));
+					cicReplacement= lambdaExpression;
+				}
+
 				ITypeBinding targetTypeBinding= ASTNodes.getTargetType(classInstanceCreation);
-				if (ASTNodes.isTargetAmbiguous(classInstanceCreation, ASTNodes.isExplicitlyTypedLambda(lambdaExpression)) || targetTypeBinding.getFunctionalInterfaceMethod() == null) {
+				if (ASTNodes.isTargetAmbiguous(classInstanceCreation, ASTNodes.isExplicitlyTypedLambda(cicReplacement)) || targetTypeBinding.getFunctionalInterfaceMethod() == null) {
 					CastExpression cast= ast.newCastExpression();
-					cast.setExpression(lambdaExpression);
+					cast.setExpression(cicReplacement);
 					ImportRewrite importRewrite= cuRewrite.getImportRewrite();
 					ImportRewriteContext importRewriteContext= new ContextSensitiveImportRewriteContext(classInstanceCreation, importRewrite);
 					Type castType= importRewrite.addImport(classInstanceCreation.getType().resolveBinding(), ast, importRewriteContext, TypeLocation.CAST);
 					cast.setType(castType);
 					importRemover.registerAddedImports(castType);
-					replacement= cast;
+					cicReplacement= cast;
 				}
-				rewrite.replace(classInstanceCreation, replacement, group);
+				rewrite.replace(classInstanceCreation, cicReplacement, group);
 
 				importRemover.registerRemovedNode(classInstanceCreation);
 				importRemover.registerRetainedNode(lambdaBody);
@@ -894,7 +1166,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			return null;
 		}
 
-		CreateLambdaOperation op= new CreateLambdaOperation(Collections.singletonList(cic));
+		CreateLambdaOperation op= new CreateLambdaOperation(Collections.singletonList(cic), true);
 		String message;
 		if (fConversionRemovesAnnotations) {
 			message= FixMessages.LambdaExpressionsFix_convert_to_lambda_expression_removes_annotations;
@@ -916,7 +1188,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 		return new LambdaExpressionsFixCore(FixMessages.LambdaExpressionsFix_convert_to_anonymous_class_creation, root, new CompilationUnitRewriteOperation[] { op });
 	}
 
-	public static ICleanUpFixCore createCleanUp(CompilationUnit compilationUnit, boolean useLambda, boolean useAnonymous) {
+	public static ICleanUpFixCore createCleanUp(CompilationUnit compilationUnit, boolean useLambda, boolean useAnonymous, boolean simplifyLambda) {
 		if (!JavaModelUtil.is1d8OrHigher(compilationUnit.getJavaElement().getJavaProject())) {
 			return null;
 		}
@@ -928,7 +1200,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			}
 
 			Collections.reverse(convertibleNodes); // process nested anonymous classes first
-			CompilationUnitRewriteOperation op= new CreateLambdaOperation(convertibleNodes);
+			CompilationUnitRewriteOperation op= new CreateLambdaOperation(convertibleNodes, simplifyLambda);
 			return new LambdaExpressionsFixCore(FixMessages.LambdaExpressionsFix_convert_to_lambda_expression, compilationUnit, new CompilationUnitRewriteOperation[] { op });
 
 		} else if (useAnonymous) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1633,7 +1633,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		buf.append("\n");
 		buf.append("public class Test {\n");
 		buf.append("    void foo(ArrayList<String> list) {\n");
-		buf.append("        list.removeIf(t -> t.isEmpty());\n");
+		buf.append("        list.removeIf(String::isEmpty);\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		String expected1= buf.toString();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -18,26 +18,21 @@ import static org.junit.Assert.assertNotEquals;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.eclipse.core.runtime.CoreException;
-
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
-
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
-
+import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 import org.eclipse.jdt.ui.tests.core.rules.Java1d8ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
-
-import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 
 public class CleanUpTest1d8 extends CleanUpTestCase {
 	@Rule
@@ -190,6 +185,189 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.USE_ANONYMOUS_CLASS_CREATION);
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { original }, null);
+	}
+
+	@Test
+	public void testConvertToLambda04() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private class K {\n" //
+				+ "        public void routine(int i) {\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "    private interface J {\n" //
+				+ "        public void routine(K k, int i //\n" //
+				+ "    }\n" //
+				+ "    public void foo2() {\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        Runnable r = new Runnable() {\n" //
+				+ "            @Override\n" //
+				+ "            public void run() {\n" //
+				+ "                foo2();\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "        J c = new J() {\n" //
+				+ "            @Override\n" //
+				+ "            public void routine(K k, int i) {\n" //
+				+ "                k.routine(i);\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String original= sample;
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", original, false, null);
+
+		enable(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES);
+		enable(CleanUpConstants.USE_LAMBDA);
+		disable(CleanUpConstants.ALSO_SIMPLIFY_LAMBDA);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private class K {\n" //
+				+ "        public void routine(int i) {\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "    private interface J {\n" //
+				+ "        public void routine(K k, int i //\n" //
+				+ "    }\n" //
+				+ "    public void foo2() {\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        Runnable r = () -> foo2();\n" //
+				+ "        J c = (k, i) -> k.routine(i);\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+
+		disable(CleanUpConstants.USE_LAMBDA);
+		enable(CleanUpConstants.USE_ANONYMOUS_CLASS_CREATION);
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { original }, null);
+	}
+
+	@Test
+	public void testConvertToLambda05() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private class K {\n" //
+				+ "        public void routine(int i) {\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "    private interface J {\n" //
+				+ "        public void routine(K k, int i //\n" //
+				+ "    }\n" //
+				+ "    public void foo2() {\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        Runnable r = new Runnable() {\n" //
+				+ "            @Override\n" //
+				+ "            public void run() {\n" //
+				+ "                foo2();\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "        J c = new J() {\n" //
+				+ "            @Override\n" //
+				+ "            public void routine(K k, int i) {\n" //
+				+ "                k.routine(i);\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String original= sample;
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", original, false, null);
+
+		enable(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES);
+		enable(CleanUpConstants.USE_LAMBDA);
+		enable(CleanUpConstants.ALSO_SIMPLIFY_LAMBDA);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private class K {\n" //
+				+ "        public void routine(int i) {\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "    private interface J {\n" //
+				+ "        public void routine(K k, int i //\n" //
+				+ "    }\n" //
+				+ "    public void foo2() {\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        Runnable r = this::foo2;\n" //
+				+ "        J c = K::routine;\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testConvertToLambda06() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private class K {\n" //
+				+ "        public void routine(int i) {\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "    private interface J {\n" //
+				+ "        public void routine(K k, int i //\n" //
+				+ "    }\n" //
+				+ "    public void foo2() {\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        Runnable r = new Runnable() {\n" //
+				+ "            @Override\n" //
+				+ "            public void run() {\n" //
+				+ "                foo2();\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "        J c = new J() {\n" //
+				+ "            @Override\n" //
+				+ "            public void routine(K k, int i) {\n" //
+				+ "                k.routine(i);\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String original= sample;
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", original, false, null);
+
+		enable(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES);
+		enable(CleanUpConstants.USE_LAMBDA);
+		disable(CleanUpConstants.ALSO_SIMPLIFY_LAMBDA);
+		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private class K {\n" //
+				+ "        public void routine(int i) {\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "    private interface J {\n" //
+				+ "        public void routine(K k, int i //\n" //
+				+ "    }\n" //
+				+ "    public void foo2() {\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        Runnable r = this::foo2;\n" //
+				+ "        J c = K::routine;\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 IBM Corporation and others.
+ * Copyright (c) 2018, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,13 +16,10 @@
 package org.eclipse.jdt.internal.corext.fix;
 
 import org.eclipse.core.runtime.Assert;
-
-import org.eclipse.jface.preference.IPreferenceStore;
-
-import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
-
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp;
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jface.preference.IPreferenceStore;
 
 public class CleanUpConstantsOptions extends CleanUpConstants {
 	private static void setEclipseDefaultSettings(CleanUpOptions options) {
@@ -183,6 +180,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS, CleanUpOptions.FALSE);
 		options.setOption(USE_VAR, CleanUpOptions.FALSE);
 		options.setOption(USE_LAMBDA, CleanUpOptions.TRUE);
+		options.setOption(ALSO_SIMPLIFY_LAMBDA, CleanUpOptions.TRUE);
 		options.setOption(USE_ANONYMOUS_CLASS_CREATION, CleanUpOptions.FALSE);
 		options.setOption(COMPARING_ON_CRITERIA, CleanUpOptions.FALSE);
 		options.setOption(JOIN, CleanUpOptions.FALSE);
@@ -366,6 +364,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS, CleanUpOptions.FALSE);
 		options.setOption(USE_VAR, CleanUpOptions.FALSE);
 		options.setOption(USE_LAMBDA, CleanUpOptions.TRUE);
+		options.setOption(ALSO_SIMPLIFY_LAMBDA, CleanUpOptions.TRUE);
 		options.setOption(USE_ANONYMOUS_CLASS_CREATION, CleanUpOptions.FALSE);
 		options.setOption(COMPARING_ON_CRITERIA, CleanUpOptions.FALSE);
 		options.setOption(JOIN, CleanUpOptions.FALSE);

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7230,14 +7230,9 @@
             runAfter="org.eclipse.jdt.ui.cleanup.reduce_indentation">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.LambdaExpressionAndMethodRefCleanUp"
-            id="org.eclipse.jdt.ui.cleanup.lambda_and_method_ref"
-            runAfter="org.eclipse.jdt.ui.cleanup.expressions">
-      </cleanUp>
-      <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.ExtractIncrementCleanUp"
             id="org.eclipse.jdt.ui.cleanup.extract_increment"
-            runAfter="org.eclipse.jdt.ui.cleanup.lambda_and_method_ref">
+            runAfter="org.eclipse.jdt.ui.cleanup.expressions">
       </cleanUp>
       <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.PullUpAssignmentCleanUp"
@@ -7580,9 +7575,14 @@
             runAfter="org.eclipse.jdt.ui.cleanup.var">
       </cleanUp>
       <cleanUp
+            class="org.eclipse.jdt.internal.ui.fix.LambdaExpressionAndMethodRefCleanUp"
+            id="org.eclipse.jdt.ui.cleanup.lambda_and_method_ref"
+            runAfter="org.eclipse.jdt.ui.cleanup.lambda">
+      </cleanUp>
+      <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.ComparingOnCriteriaCleanUp"
             id="org.eclipse.jdt.ui.cleanup.comparing_on_criteria"
-            runAfter="org.eclipse.jdt.ui.cleanup.lambda">
+            runAfter="org.eclipse.jdt.ui.cleanup.lambda_and_method_ref">
       </cleanUp>
       <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.JoinCleanUp"

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
@@ -207,6 +207,7 @@ public class CleanUpMessages extends NLS {
 	public static String JavaFeatureTabPage_CheckboxName_ConvertFunctionalInterfaces;
 	public static String JavaFeatureTabPage_RadioName_UseLambdaWherePossible;
 	public static String JavaFeatureTabPage_RadioName_UseAnonymous;
+	public static String JavaFeatureTabPage_CheckboxName_AlsoSimplifyLambda;
 	public static String JavaFeatureTabPage_CheckboxName_ComparingOnCriteria;
 	public static String JavaFeatureTabPage_CheckboxName_Join;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
@@ -187,6 +187,7 @@ JavaFeatureTabPage_GroupName_FunctionalInterfaces=Functional interface instances
 JavaFeatureTabPage_CheckboxName_ConvertFunctionalInterfaces=Con&vert functional interface instances
 JavaFeatureTabPage_RadioName_UseLambdaWherePossible=Use lambda where possible
 JavaFeatureTabPage_RadioName_UseAnonymous=Use anonymous class
+JavaFeatureTabPage_CheckboxName_AlsoSimplifyLambda=Simplify method reference syntax for lambda conversions
 JavaFeatureTabPage_CheckboxName_ComparingOnCriteria=Use Comparator.comparing()
 JavaFeatureTabPage_CheckboxName_Join=Use String.join() &when possible
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/JavaFeatureTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/JavaFeatureTabPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,11 +15,7 @@ package org.eclipse.jdt.internal.ui.preferences.cleanup;
 
 import java.util.Map;
 
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Group;
-
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
 import org.eclipse.jdt.internal.ui.fix.AutoboxingCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ComparingOnCriteriaCleanUp;
@@ -37,6 +33,8 @@ import org.eclipse.jdt.internal.ui.fix.TryWithResourceCleanUp;
 import org.eclipse.jdt.internal.ui.fix.TypeParametersCleanUp;
 import org.eclipse.jdt.internal.ui.fix.UnboxingCleanUp;
 import org.eclipse.jdt.internal.ui.fix.VarCleanUp;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
 
 public final class JavaFeatureTabPage extends AbstractCleanUpTabPage {
 	public static final String ID= "org.eclipse.jdt.ui.cleanup.tabpage.java_feature"; //$NON-NLS-1$
@@ -91,10 +89,15 @@ public final class JavaFeatureTabPage extends AbstractCleanUpTabPage {
 		Group java1d8Group= createGroup(numColumns, composite, CleanUpMessages.JavaFeatureTabPage_GroupName_Java1d8);
 
 		CheckboxPreference convertFunctionalInterfaces= createCheckboxPref(java1d8Group, numColumns, CleanUpMessages.JavaFeatureTabPage_CheckboxName_ConvertFunctionalInterfaces, CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES, CleanUpModifyDialog.FALSE_TRUE);
+		registerPreference(convertFunctionalInterfaces);
 		intent(java1d8Group);
 		RadioPreference useLambdaPref= createRadioPref(java1d8Group, 1, CleanUpMessages.JavaFeatureTabPage_RadioName_UseLambdaWherePossible, CleanUpConstants.USE_LAMBDA, CleanUpModifyDialog.FALSE_TRUE);
 		RadioPreference useAnonymousPref= createRadioPref(java1d8Group, 1, CleanUpMessages.JavaFeatureTabPage_RadioName_UseAnonymous, CleanUpConstants.USE_ANONYMOUS_CLASS_CREATION, CleanUpModifyDialog.FALSE_TRUE);
 		registerSlavePreference(convertFunctionalInterfaces, new RadioPreference[] { useLambdaPref, useAnonymousPref });
+		intent(java1d8Group);
+		intent(java1d8Group);
+		CheckboxPreference simplifyLambda= createCheckboxPref(java1d8Group, 2, CleanUpMessages.JavaFeatureTabPage_CheckboxName_AlsoSimplifyLambda, CleanUpConstants.ALSO_SIMPLIFY_LAMBDA, CleanUpModifyDialog.FALSE_TRUE);
+		registerSlavePreference(convertFunctionalInterfaces, new CheckboxPreference[] { simplifyLambda });
 
 		CheckboxPreference comparingOnCriteria= createCheckboxPref(java1d8Group, numColumns, CleanUpMessages.JavaFeatureTabPage_CheckboxName_ComparingOnCriteria, CleanUpConstants.COMPARING_ON_CRITERIA, CleanUpModifyDialog.FALSE_TRUE);
 		registerPreference(comparingOnCriteria);


### PR DESCRIPTION
- make the default behavior for a quick fix or Java feature convert to lambda cleanup to use method refs
- add new preference under Java feature page for lambda conversion to simplify expression and make it true by default
- have the cleanup check for either the new preference or the preference for simplify lambda expression and method reference syntax which fixes the issue that cleanups are not recursive so user does not have to do two cleanups in a row
- make quick fix default to use method refs
- add new tests to CleanupTests1d8
- fix cleanup ordering in jdt plugin.xml so when recursive cleanups are supported it will just work and duplicated code can be removed
- fixes #629

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Enhances the convert to lambda cleanup to also do method ref simplification instead of forcing the end-user to perform a second cleanup to do lamba expression simplification.  The cleanup uses a new Java feature page sub-preference or else checks the 2nd cleanup preference for lambda expression simplification.  The quick fix is hard-wired to do the cleanup and use method refs if possible.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests in CleanUpTest1d8

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
