### PR TITLE
Add new hover for Java hex, octal, and binary constants

### DIFF
--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2021 IBM Corporation and others.
+# Copyright (c) 2000, 2023 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -640,6 +640,8 @@ HideTestCode.description= Hides test code
 
 sourceHover= Source
 sourceHoverDescription= Shows the source of the selected element, or the source near the matching opening curly brace.
+constantHover= Java Constant
+constantHoverDescription= Shows value of hex, octal, or binary constant.
 javadocHover= Javadoc
 javadocHoverDescription= Shows the Javadoc of the selected element.
 nlsStringHover= Externalized String

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -563,6 +563,12 @@
             class="org.eclipse.jdt.internal.ui.text.java.hover.JavaSourceHover"
             id="org.eclipse.jdt.ui.JavaSourceHover">
       </hover>
+       <hover
+            label="%constantHover"
+            description="%constantHoverDescription"
+            class="org.eclipse.jdt.internal.ui.text.java.hover.JavaConstantHover"
+            id="org.eclipse.jdt.ui.JavaConstantHover">
+      </hover>
    </extension>
    <extension
          point="org.eclipse.ui.perspectives">

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaConstantHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaConstantHover.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.text.java.hover;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+
+public class JavaConstantHover extends AbstractJavaEditorTextHover {
+
+	@Deprecated
+	@Override
+	public String getHoverInfo(ITextViewer textViewer, IRegion hoverRegion) {
+		if (hoverRegion.getLength() > 1) {
+			String hoverSource= null;
+			IDocument document= textViewer.getDocument();
+			try {
+				hoverSource= document.get(hoverRegion.getOffset(), hoverRegion.getLength());
+			} catch (BadLocationException e) {
+				// should never happen
+			}
+			if (hoverSource != null && hoverSource.startsWith("0")) { //$NON-NLS-1$
+				try {
+					long longValue= hoverSource.startsWith("0b") ? //$NON-NLS-1$
+							Long.parseLong(hoverSource.substring(2), 2) : Long.decode(hoverSource).longValue();
+					return "<body><p>" + Long.toString(longValue) + "<b> : [0x" + Long.toHexString(longValue) + "]</p></body>"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				} catch (NumberFormatException e) {
+					try {
+						double doubleValue= Double.valueOf(hoverSource).doubleValue();
+						return "<body><p>" + Double.toString(doubleValue) + "</p></body>"; //$NON-NLS-1$ //$NON-NLS-2$
+					} catch (NumberFormatException e1) {
+						// do nothing
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+}


### PR DESCRIPTION
- add new JavaConstantHover class
- add new hover to o.e.jdt.ui plugin.xml
- add new hover property strings
- fixes #639
- for Bug 559614

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds new hover to use on hex, octal, and binary constants to see value.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See bug.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
