### PR TITLE
Use new ILog.of(...) method instead of Platform.getLog(...)

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 1.19.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.28.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ltk.core.refactoring;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.34.0,4.0.0)",

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CoreASTProvider.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CoreASTProvider.java
@@ -15,11 +15,11 @@ package org.eclipse.jdt.core.manipulation;
 
 import java.util.List;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SafeRunner;
 import org.eclipse.core.runtime.Status;
 
@@ -302,7 +302,7 @@ public final class CoreASTProvider {
 			@Override
 			public void handleException(Throwable ex) {
 				IStatus status= new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, IStatus.OK, "Error in JDT Core during AST creation", ex);  //$NON-NLS-1$
-				Platform.getLog(CoreASTProvider.class).log(status);
+				ILog.of(CoreASTProvider.class).log(status);
 			}
 		});
 		return root[0];
@@ -393,7 +393,7 @@ public final class CoreASTProvider {
 			return je.getBuffer() != null;
 		} catch (JavaModelException ex) {
 			IStatus status= new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, IStatus.OK, "Error in JDT Core during AST creation", ex);  //$NON-NLS-1$
-			Platform.getLog(CoreASTProvider.class).log(status);
+			ILog.of(CoreASTProvider.class).log(status);
 		}
 		return false;
 	}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaElementLabelComposerCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaElementLabelComposerCore.java
@@ -18,8 +18,8 @@ import java.util.jar.Attributes.Name;
 
 import org.eclipse.osgi.util.NLS;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -466,7 +466,7 @@ public class JavaElementLabelComposerCore {
 				// don't care, we are decorating already removed element
 				return;
 			}
-			Platform.getLog(this.getClass()).error("Error rendering method label", e); //$NON-NLS-1$ // NotExistsException will not reach this point
+			ILog.of(this.getClass()).error("Error rendering method label", e); //$NON-NLS-1$ // NotExistsException will not reach this point
 		}
 	}
 
@@ -681,7 +681,7 @@ public class JavaElementLabelComposerCore {
 			}
 
 		} catch (JavaModelException e) {
-			Platform.getLog(this.getClass()).error("Error rendering type parameters", e); //$NON-NLS-1$ // NotExistsException will not reach this point
+			ILog.of(this.getClass()).error("Error rendering type parameters", e); //$NON-NLS-1$ // NotExistsException will not reach this point
 		}
 	}
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaManipulationPlugin.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaManipulationPlugin.java
@@ -18,8 +18,8 @@ import org.osgi.framework.BundleContext;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
 
@@ -99,11 +99,11 @@ public class JavaManipulationPlugin extends Plugin implements DebugOptionsListen
 	}
 
 	public static void log(Throwable e) {
-		Platform.getLog(JavaManipulationPlugin.class).log(new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, IStatusConstants.INTERNAL_ERROR, JavaManipulationMessages.JavaManipulationMessages_internalError, e));
+		ILog.of(JavaManipulationPlugin.class).log(new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, IStatusConstants.INTERNAL_ERROR, JavaManipulationMessages.JavaManipulationMessages_internalError, e));
 	}
 
 	public static void log(IStatus status) {
-		Platform.getLog(JavaManipulationPlugin.class).log(status);
+		ILog.of(JavaManipulationPlugin.class).log(status);
 	}
 
 	public static String getPluginId() {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingPresenterCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingPresenterCore.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.BadPositionCategoryException;
@@ -262,7 +262,7 @@ public class SemanticHighlightingPresenterCore {
 		try {
 			event.fDocument.addPosition(category, highlightedPosition);
 		} catch (BadLocationException | BadPositionCategoryException e) {
-			Platform.getLog(this.getClass()).error("Error when adding new highlighting position to the document", e); //$NON-NLS-1$
+			ILog.of(this.getClass()).error("Error when adding new highlighting position to the document", e); //$NON-NLS-1$
 		}
 
 	}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/SerialVersionHashOperationDisplayCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/SerialVersionHashOperationDisplayCore.java
@@ -13,7 +13,7 @@
   *******************************************************************************/
 package org.eclipse.jdt.internal.ui.text.correction;
 
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.ILog;
 
 public class SerialVersionHashOperationDisplayCore {
 
@@ -24,7 +24,7 @@ public class SerialVersionHashOperationDisplayCore {
 	 *            The message to display
 	 */
 	public void displayErrorMessage(final String message) {
-		Platform.getLog(this.getClass()).error(message);
+		ILog.of(this.getClass()).error(message);
 	}
 
 	/**

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/core/refactoring/descriptors/JavaRefactoringDescriptor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/core/refactoring/descriptors/JavaRefactoringDescriptor.java
@@ -18,8 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 
 import org.eclipse.core.resources.IResource;
@@ -303,7 +303,7 @@ public abstract class JavaRefactoringDescriptor extends RefactoringDescriptor {
 				JavaRefactoringContribution javaContribution= (JavaRefactoringContribution) contribution;
 				refactoring= javaContribution.createRefactoring(this, status);
 			} else
-				Platform.getLog(this.getClass()).log(new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, 0, MessageFormat.format(DescriptorMessages.JavaRefactoringDescriptor_no_resulting_descriptor, id), null));
+				ILog.of(this.getClass()).log(new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, 0, MessageFormat.format(DescriptorMessages.JavaRefactoringDescriptor_no_resulting_descriptor, id), null));
 		}
 		return refactoring;
 	}

--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -29,7 +29,7 @@ Require-Bundle:
  org.eclipse.debug.ui;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.34.0,4.0.0)",
  org.eclipse.jdt.ui;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.28.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.jdt.debug.ui;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
@@ -76,6 +76,7 @@ import org.eclipse.core.commands.IHandler;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
@@ -1545,7 +1546,7 @@ public class TestRunnerViewPart extends ViewPart {
 	private void logMessageIfNoTests() {
 		if (fTestRunSession != null && TestKindRegistry.JUNIT5_TEST_KIND_ID.equals(fTestRunSession.getTestRunnerKind().getId()) && fTestRunSession.getTotalCount() == 0) {
 			String msg= Messages.format(JUnitMessages.TestRunnerViewPart_error_notests_kind, fTestRunSession.getTestRunnerKind().getDisplayName());
-			Platform.getLog(getClass()).error(msg);
+			ILog.of(getClass()).error(msg);
 		}
 	}
 

--- a/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Export-Package:
  org.eclipse.jdt.text.tests.spelling,
  org.eclipse.jdt.text.tests.templates
 Require-Bundle: 
- org.eclipse.core.runtime,
+ org.eclipse.core.runtime;bundle-version="[3.28.0,4.0.0)",
  org.eclipse.compare.core,
  org.eclipse.core.filesystem,
  org.eclipse.core.resources,

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/CodeMiningTriggerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/CodeMiningTriggerTest.java
@@ -32,6 +32,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.core.expressions.PropertyTester;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -181,7 +182,7 @@ public class CodeMiningTriggerTest {
 									}
 								}
 							} catch (Exception e) {
-								Platform.getLog(Platform.getBundle("org.eclipse.jdt.text.tests")).log(
+								ILog.of(Platform.getBundle("org.eclipse.jdt.text.tests")).log(
 									new Status(IStatus.ERROR, "org.eclipse.jdt.text.tests", e.getMessage(), e)
 								);
 								return false;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Replace `Platform.getLog` with new `ILog.of` to reduce references to single singelton from split package.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
