### PR TITLE
Lambdainstanceof

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -953,7 +953,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 					importRemover.registerAddedImports(castType);
 					cicReplacement= cast;
 				}
-				rewrite.replace(classInstanceCreation, cicReplacement, group);
+				ASTNodes.replaceButKeepComment(rewrite, classInstanceCreation, cicReplacement, group);
 
 				importRemover.registerRemovedNode(classInstanceCreation);
 				importRemover.registerRetainedNode(lambdaBody);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -4904,6 +4904,48 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 	}
 
 	@Test
+	public void testConvertLambdaToMethodReference6() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E6 {\n");
+		buf.append("\n");
+		buf.append("    private interface I6 {\n");
+		buf.append("        public boolean isCorrect(Object z);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    public boolean foo() {\n");
+		buf.append("        I6 x = z -> z instanceof String;\n");
+		buf.append("        return x.isCorrect(this);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E6.java", buf.toString(), false, null);
+
+		int offset= buf.toString().indexOf("z ->");
+		AssistContext context= getCorrectionContext(cu, offset, 4);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E6 {\n");
+		buf.append("\n");
+		buf.append("    private interface I6 {\n");
+		buf.append("        public boolean isCorrect(Object z);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    public boolean foo() {\n");
+		buf.append("        I6 x = String.class::isInstance;\n");
+		buf.append("        return x.isCorrect(this);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("}\n");
+		String expected1= buf.toString();
+		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
 	public void testFixParenthesesInLambdaExpressionAdd() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		StringBuilder buf1= new StringBuilder();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -18,21 +18,26 @@ import static org.junit.Assert.assertNotEquals;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.eclipse.core.runtime.CoreException;
+
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
+
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
-import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+
 import org.eclipse.jdt.ui.tests.core.rules.Java1d8ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 
 public class CleanUpTest1d8 extends CleanUpTestCase {
 	@Rule
@@ -363,6 +368,48 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "    public void foo() {\n" //
 				+ "        Runnable r = this::foo2;\n" //
 				+ "        J c = K::routine;\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testConvertToLambda07() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private interface Blah {\n" //
+				+ "        public boolean isCorrect(Object z //\n" //
+				+ "    }\n" //
+				+ "    public boolean foo() {\n" //
+				+ "        Blah x = new Blah() {\n" //
+				+ "            @Override\n" //
+				+ "            public boolean isCorrect(Object z) {\n" //
+				+ "                return z instanceof String;\n" //
+				+ "            }\n" //
+				+ "        }; // comment 1\n" //
+				+ "        return x.isCorrect(this //\n" //
+				+ "    }\n" //
+				+ "}\n";
+		String original= sample;
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", original, false, null);
+
+		enable(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES);
+		enable(CleanUpConstants.USE_LAMBDA);
+		enable(CleanUpConstants.ALSO_SIMPLIFY_LAMBDA);
+
+		sample= "" //
+				+ "package test1;\n" //
+				+ "public class E {\n" //
+				+ "    private interface Blah {\n" //
+				+ "        public boolean isCorrect(Object z //\n" //
+				+ "    }\n" //
+				+ "    public boolean foo() {\n" //
+				+ "        Blah x = String.class::isInstance; // comment 1\n" //
+				+ "        return x.isCorrect(this //\n" //
 				+ "    }\n" //
 				+ "}\n"; //
 		String expected1= sample;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -1119,7 +1119,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 			}
 		}
 
-		rewrite.replace(lambda, replacement, null);
+		ASTNodes.replaceButKeepComment(rewrite, lambda, replacement, null);
 
 		// add correction proposal
 		String label= CorrectionMessages.QuickAssistProcessor_convert_to_method_reference;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds a new quick fix to convert a lambda expression: x -> x instanceof Y; into  x -> Y.class::isInstance;  Also adds logic to lambda cleanup to recognize when an instanceof can be converted into a type method reference.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
