### PR TITLE
For lower-case for-loop variable without type, only suggest adding type

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedTypesQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedTypesQuickFixTest.java
@@ -1600,6 +1600,7 @@ public class UnresolvedTypesQuickFixTest extends QuickFixTest {
 		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 3, 1);
 
 		assertCorrectLabels(proposals);
+		assertNumberOfProposals(proposals, 1);
 
 		String[] expected= new String[1];
 		buf= new StringBuilder();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsSubProcessor.java
@@ -620,7 +620,10 @@ public class UnresolvedElementsSubProcessor {
 		int kind= evauateTypeKind(selectedNode, javaProject);
 
 		if (kind == TypeKinds.REF_TYPES) {
-			addEnhancedForWithoutTypeProposals(cu, selectedNode, proposals);
+			SimpleName s= addEnhancedForWithoutTypeProposals(cu, selectedNode, proposals);
+			if (s != null && Character.isLowerCase(s.getFullyQualifiedName().charAt(0))) {
+				return;
+			}
 		}
 
 		while (selectedNode.getLocationInParent() == QualifiedName.NAME_PROPERTY) {
@@ -719,7 +722,7 @@ public class UnresolvedElementsSubProcessor {
 		ReorgCorrectionsSubProcessor.addProjectSetupFixProposal(context, problem, node.getFullyQualifiedName(), proposals);
 	}
 
-	private static void addEnhancedForWithoutTypeProposals(ICompilationUnit cu, ASTNode selectedNode, Collection<ICommandAccess> proposals) {
+	private static SimpleName addEnhancedForWithoutTypeProposals(ICompilationUnit cu, ASTNode selectedNode, Collection<ICommandAccess> proposals) {
 		if (selectedNode instanceof SimpleName && (selectedNode.getLocationInParent() == SimpleType.NAME_PROPERTY || selectedNode.getLocationInParent() == NameQualifiedType.NAME_PROPERTY)) {
 			ASTNode type= selectedNode.getParent();
 			if (type.getLocationInParent() == SingleVariableDeclaration.TYPE_PROPERTY) {
@@ -733,10 +736,12 @@ public class UnresolvedElementsSubProcessor {
 						Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_LOCAL);
 
 						proposals.add(new NewVariableCorrectionProposal(label, cu, NewVariableCorrectionProposal.LOCAL, simpleName, null, relevance, image));
+						return simpleName;
 					}
 				}
 			}
 		}
+		return null;
 	}
 
 	private static void addNullityAnnotationTypesProposals(ICompilationUnit cu, Name node, Collection<ICommandAccess> proposals) throws CoreException {


### PR DESCRIPTION
- fixes #657
- add new code in UnresolvedElementsSubProcessor to recognize when a lower-case enhanced for-loop variable that has no type causes a "create loop variable xxxx" proposal and then do not suggest creating new types, records, etc...
- modify existing test in UnresolvedTypesQuickFixTest

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run UnresolvedTypesQuickFixTest.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
