### PR TITLE
Fix extract interface to properly specify deprecated methods

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/ExtractInterfaceProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/ExtractInterfaceProcessor.java
@@ -663,7 +663,7 @@ public final class ExtractInterfaceProcessor extends SuperTypeRefactoringProcess
 			} else if (extended.isAnnotation()) {
 				annotation= (Annotation) extended;
 				ITypeBinding binding= annotation.resolveTypeBinding();
-				if (binding != null && "java.lang.Override".equals(binding.getQualifiedName()) || ! Bindings.isAnyNullAnnotation(binding, sourceProject)) //$NON-NLS-1$
+				if (binding != null && !"java.lang.Deprecated".equals(binding.getQualifiedName()) && ("java.lang.Override".equals(binding.getQualifiedName()) || ! Bindings.isAnyNullAnnotation(binding, sourceProject))) //$NON-NLS-1$ //$NON-NLS-2$
 					list.remove(annotation, null);
 			}
 		}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/testDeprecated1/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/testDeprecated1/in/A.java
@@ -1,0 +1,12 @@
+package p;
+
+public class A {
+	@Deprecated
+	public int foo() {
+		return 0;
+	}
+	
+	public int foo2() {
+		return 0;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/testDeprecated1/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/testDeprecated1/out/A.java
@@ -1,0 +1,12 @@
+package p;
+
+public class A implements I {
+	@Deprecated
+	public int foo() {
+		return 0;
+	}
+	
+	public int foo2() {
+		return 0;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/testDeprecated1/out/I.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/testDeprecated1/out/I.java
@@ -1,0 +1,11 @@
+package p;
+
+/** typecomment template*/
+public interface I {
+
+	@Deprecated
+	int foo();
+
+	int foo2();
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractInterfaceTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractInterfaceTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1098,6 +1098,13 @@ public class ExtractInterfaceTests extends GenericRefactoringTest {
 		String[][] signatures= {new String[0], new String[0], new String[0], new String[0]};
 		String[] fieldNames= null;
 		validatePassingTest("A", new String[]{"A"}, "I", true, methodNames, signatures, fieldNames, getPackageQ());
+	}
+
+	@Test
+	public void testDeprecated1() throws Exception{
+		String[] names= new String[]{"foo", "foo2"};
+		String[][] signatures= new String[][]{new String[0], new String[0]};
+		validatePassingTest("A", new String[]{"A"},"I", true, names, signatures, null);
 	}
 
 	@Test


### PR DESCRIPTION
- fixes #630
- add new test

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds '''@Deprecated''' annotation to any deprecated method declared in new interface.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
