### PR TITLE
Deactivate the "Run" button when setting an invalid "Test method" in a JUnit-run-configuration

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -993,7 +993,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 				if (methodName.length() > 0) {
 					Set<String> methodsForType= getMethodsForType(javaProject, type, getSelectedTestKind());
 					if (!methodsForType.contains(methodName)) {
-						super.setErrorMessage(Messages.format(JUnitMessages.JUnitLaunchConfigurationTab_error_test_method_not_found, new String[] { className, methodName, projectName }));
+						setErrorMessage(Messages.format(JUnitMessages.JUnitLaunchConfigurationTab_error_test_method_not_found, new String[] { className, methodName, projectName }));
 						return;
 					}
 				}


### PR DESCRIPTION
## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/686

This PR makes sure that the "Run" button in the dialog "Run configurations" is deactivated if the name of the test in a JUnit configuration is invalid (_i.e._ if the method does not exist).

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
* Open the run configurations
* Edit an existing JUnit configuration
* Set the **Test method** to some non-existing method --> the "Run" button should be deactivated
* Set the **Test method** back to an existing method --> the "Run" button should be activated

## Author checklist

- ✔ I have thoroughly tested my changes
- ✔ The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- ✔ I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
