### PR TITLE
Fix save actions to not automatically remove unused private parameters

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -80,7 +80,7 @@ public class UnusedCodeCleanUpCore extends AbstractMultiFixCore {
 				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_LOCAL_VARIABLES),
 				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_IMPORTS) && !isEnabled(CleanUpConstants.ORGANIZE_IMPORTS),
 				false,
-				true);
+				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_METHOD_PARAMETERS));
 	}
 
 	@Override
@@ -95,7 +95,7 @@ public class UnusedCodeCleanUpCore extends AbstractMultiFixCore {
 				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_LOCAL_VARIABLES),
 				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_IMPORTS) && !isEnabled(CleanUpConstants.ORGANIZE_IMPORTS),
 				false,
-				true);
+				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_METHOD_PARAMETERS));
 	}
 
 	public Map<String, String> getRequiredOptions() {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2020 IBM Corporation and others.
+ * Copyright (c) 2007, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1116,6 +1116,82 @@ public class SaveParticipantTest extends CleanUpTestCase {
 				+ "}";
 
 		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED);
+
+		// When
+		editCUInEditor(cu1, fileOnEditor);
+
+		// Then
+		assertEquals(expected1, cu1.getBuffer().getContents());
+	}
+
+	@Test
+	public void testIssue313_1() throws Exception {
+		// Given
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String fileOnDisk= "" //
+				+ "package test1;\n" //
+				+ "public class E1 {\n" //
+				+ "\n" //
+				+ "    private void m1(Object p1) {\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", fileOnDisk, false, null);
+
+		String fileOnEditor= "" //
+				+ "package test1;\n" //
+				+ "public class E1 {\n" //
+				+ "\n" //
+				+ "    private void m1(Object p1) {\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+
+		String expected1= "" //
+				+ "package test1;\n" //
+				+ "public class E1 {\n" //
+				+ "\n" //
+				+ "    private void m1() {\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+
+		enable(CleanUpConstants.REMOVE_UNUSED_CODE_METHOD_PARAMETERS);
+
+		// When
+		editCUInEditor(cu1, fileOnEditor);
+
+		// Then
+		assertEquals(expected1, cu1.getBuffer().getContents());
+	}
+
+	@Test
+	public void testIssue313_2() throws Exception {
+		// Given
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String fileOnDisk= "" //
+				+ "package test1;\n" //
+				+ "public class E1 {\n" //
+				+ "\n" //
+				+ "    private void m1(Object p1) {\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", fileOnDisk, false, null);
+
+		String fileOnEditor= "" //
+				+ "package test1;\n" //
+				+ "public class E1 {\n" //
+				+ "\n" //
+				+ "    private void m1(Object p1) {\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+
+		String expected1= "" //
+				+ "package test1;\n" //
+				+ "public class E1 {\n" //
+				+ "\n" //
+				+ "    private void m1(Object p1) {\n" //
+				+ "    }\n" //
+				+ "}\n"; //
 
 		// When
 		editCUInEditor(cu1, fileOnEditor);


### PR DESCRIPTION
- fixes #313
- add new tests to SaveParticipantTest

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes save actions to not remove unused parms when not asked to.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See test case and issue.  Modify file and do a save.  Method parameter should not be removed unless specified in save actions.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
