### PR TITLE
Fix refactor method false error regarding ambiguous return value

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InputFlowAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InputFlowAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
+import org.eclipse.jdt.core.dom.BreakStatement;
 import org.eclipse.jdt.core.dom.ConditionalExpression;
 import org.eclipse.jdt.core.dom.DoStatement;
 import org.eclipse.jdt.core.dom.EnhancedForStatement;
@@ -67,6 +68,12 @@ public class InputFlowAnalyzer extends FlowAnalyzer {
 			} finally {
 				fFlowContext.setLoopReentranceMode(false);
 			}
+		}
+		@Override
+		public void endVisit(BreakStatement node) {
+			if (node.getStartPosition() + node.getLength() <= fSelection.getExclusiveEnd())
+				return;
+			super.endVisit(node);
 		}
 		@Override
 		public void endVisit(DoStatement node) {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue671.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue671.java
@@ -1,0 +1,28 @@
+package validSelection_in;
+
+public class A_testIssue671 {
+	protected void foo() {
+		while (true) {
+			List<String> line = List.of();
+			if (line == null) {
+				break;
+			}
+			/*[*/// comment
+			MyType plcTableType;
+			String plcTableTypeText = "";
+			if (plcTableTypeText.isEmpty()) {
+				plcTableType = null;
+			} else {
+				plcTableType = new MyType();
+			}
+			// comment 2/*]*/
+
+			if (plcTableType == null) {
+				return;
+			}
+		}
+	}
+
+	public static class MyType {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue671.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue671.java
@@ -1,0 +1,33 @@
+package validSelection_out;
+
+public class A_testIssue671 {
+	protected void foo() {
+		while (true) {
+			List<String> line = List.of();
+			if (line == null) {
+				break;
+			}
+			MyType plcTableType = extracted();
+
+			if (plcTableType == null) {
+				return;
+			}
+		}
+	}
+
+	protected MyType extracted() {
+		/*[*/// comment
+		MyType plcTableType;
+		String plcTableTypeText = "";
+		if (plcTableTypeText.isEmpty()) {
+			plcTableType = null;
+		} else {
+			plcTableType = new MyType();
+		}
+		// comment 2/*]*/
+		return plcTableType;
+	}
+
+	public static class MyType {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2674,5 +2674,11 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	@Test
 	public void test2005() throws Exception {
 		wikiTest();
+	}
+
+	//--- Test Issues
+	@Test
+	public void testIssue671() throws Exception {
+		validSelectionTestChecked();
 	}
 }

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -646,7 +646,7 @@ import org.eclipse.jdt.internal.ui.viewsupport.BindingLabelProvider;
 		outer: for (int i= 0; i < returnValues.length && localReads.size() < returnValues.length; i++) {
 			IVariableBinding binding= returnValues[i];
 			for (IVariableBinding read : reads) {
-				if (read == binding) {
+				if (read.isEqualTo(binding)) {
 					localReads.add(binding);
 					fReturnValue= binding;
 					continue outer;


### PR DESCRIPTION
- fixes #671
- add BreakStatement method in InputFlowAnalyzer.LoopReentranceVisitor to ignore break statements that precede the selected code
- fix binding equality check in ExtractMethodAnalyzer
- add new test to ExtractMethodTests

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test or issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
