### PR TITLE
Show progress when searching test methods in JUnit run configuration #653

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
@@ -118,6 +118,8 @@ public final class JUnitMessages extends NLS {
 
 	public static String JUnitLaunchConfigurationTab_error_notJavaProject;
 
+	public static String JUnitLaunchConfigurationTab_error_operation_canceled;
+
 	public static String JUnitLaunchConfigurationTab_error_projectnotdefined;
 
 	public static String JUnitLaunchConfigurationTab_error_projectnotexists;
@@ -372,4 +374,6 @@ public final class JUnitMessages extends NLS {
 	public static String TestRunnerViewPart_JUnitPasteAction_label;
 
 	public static String TestRunnerViewPart_layout_menu;
+
+	public static String TestSearchEngine_search_message_progress_monitor;
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
@@ -169,6 +169,7 @@ JUnitLaunchConfigurationTab_folderdialog_message=Choose a Project, Source Folder
 JUnitLaunchConfigurationTab_error_projectnotdefined=Project not specified
 JUnitLaunchConfigurationTab_error_projectnotexists=Project does not exist
 JUnitLaunchConfigurationTab_error_notJavaProject=Specified project is not a Java project
+JUnitLaunchConfigurationTab_error_operation_canceled=(Operation canceled by the user)
 JUnitLaunchConfigurationTab_error_testnotdefined=Test not specified
 JUnitLaunchConfigurationTab_error_testcasenotonpath=Cannot find class 'junit.framework.TestCase' on project build path.
 JUnitLaunchConfigurationTab_addtag_label=Con&figure...
@@ -276,3 +277,5 @@ JUnitViewEditorLauncher_dialog_title=Import Test Run
 JUnitViewEditorLauncher_error_occurred=An error occurred while opening a test run file.
 ClasspathVariableMarkerResolutionGenerator_use_JUnit3=Use the JUnit 3 library
 ClasspathVariableMarkerResolutionGenerator_use_JUnit3_desc=Changes the classpath variable entry to use the JUnit 3 library
+
+TestSearchEngine_search_message_progress_monitor=Searching for test methods in ''{0}''

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
@@ -83,17 +83,7 @@ public class TestSearchEngine extends CoreTestSearchEngine {
 			return;
 		}
 
-		SubMonitor subMonitor= SubMonitor.convert(monitor, 3 + 3); // Add +3
-
-		// Add this idle wait of 3 seconds and advance the progress in the subMonitor
-		for (int i= 0; i < 3; i++) {
-			try {
-				Thread.sleep(1_000);
-				subMonitor.split(1);
-			} catch (InterruptedException e) {
-				// ignore
-			}
-		}
+		SubMonitor subMonitor= SubMonitor.convert(monitor, 3);
 
 		collectDeclaredMethodNames(type, javaProject, testKindId, methodNames);
 		subMonitor.split(1);

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -83,7 +83,17 @@ public class TestSearchEngine extends CoreTestSearchEngine {
 			return;
 		}
 
-		SubMonitor subMonitor= SubMonitor.convert(monitor, 3);
+		SubMonitor subMonitor= SubMonitor.convert(monitor, 3 + 3); // Add +3
+
+		// Add this idle wait of 3 seconds and advance the progress in the subMonitor
+		for (int i= 0; i < 3; i++) {
+			try {
+				Thread.sleep(1_000);
+				subMonitor.split(1);
+			} catch (InterruptedException e) {
+				// ignore
+			}
+		}
 
 		collectDeclaredMethodNames(type, javaProject, testKindId, methodNames);
 		subMonitor.split(1);

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
@@ -18,14 +18,27 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 
+import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.dom.Modifier;
 
+import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.Messages;
 import org.eclipse.jdt.internal.junit.launcher.ITestKind;
+import org.eclipse.jdt.internal.junit.launcher.TestKind;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+import org.eclipse.jdt.internal.junit.ui.JUnitMessages;
 
 
 /**
@@ -48,4 +61,124 @@ public class TestSearchEngine extends CoreTestSearchEngine {
 		return result;
 	}
 
+	public static Set<String> findTestMethods(IRunnableContext context, final IJavaProject javaProject, IType type, TestKind testKind) throws InvocationTargetException, InterruptedException {
+		final Set<String> result= new HashSet<>();
+
+		IRunnableWithProgress runnable= progressMonitor -> {
+			try {
+				String message= Messages.format(JUnitMessages.TestSearchEngine_search_message_progress_monitor, type.getElementName());
+				SubMonitor subMonitor= SubMonitor.convert(progressMonitor, message, 1);
+
+				collectMethodNames(type, javaProject, testKind.getId(), result, subMonitor.split(1));
+			} catch (CoreException e) {
+				throw new InvocationTargetException(e);
+			}
+		};
+		context.run(true, true, runnable);
+		return result;
+	}
+
+	private static void collectMethodNames(IType type, IJavaProject javaProject, String testKindId, Set<String> methodNames, IProgressMonitor monitor) throws JavaModelException {
+		if (type == null) {
+			return;
+		}
+
+		SubMonitor subMonitor= SubMonitor.convert(monitor, 3);
+
+		collectDeclaredMethodNames(type, javaProject, testKindId, methodNames);
+		subMonitor.split(1);
+
+		String superclassName= type.getSuperclassName();
+		IType superType= getResolvedType(superclassName, type, javaProject);
+		collectMethodNames(superType, javaProject, testKindId, methodNames, subMonitor.split(1));
+
+		String[] superInterfaceNames= type.getSuperInterfaceNames();
+		subMonitor.setWorkRemaining(superInterfaceNames.length);
+		for (String interfaceName : superInterfaceNames) {
+			superType= getResolvedType(interfaceName, type, javaProject);
+			collectMethodNames(superType, javaProject, testKindId, methodNames, subMonitor.split(1));
+		}
+	}
+
+	private static IType getResolvedType(String typeName, IType type, IJavaProject javaProject) throws JavaModelException {
+		IType resolvedType= null;
+		if (typeName != null) {
+			int pos= typeName.indexOf('<');
+			if (pos != -1) {
+				typeName= typeName.substring(0, pos);
+			}
+			String[][] resolvedTypeNames= type.resolveType(typeName);
+			if (resolvedTypeNames != null && resolvedTypeNames.length > 0) {
+				String[] resolvedTypeName= resolvedTypeNames[0];
+				resolvedType= javaProject.findType(resolvedTypeName[0], resolvedTypeName[1]); // secondary types not found by this API
+			}
+		}
+		return resolvedType;
+	}
+
+	private static void collectDeclaredMethodNames(IType type, IJavaProject javaProject, String testKindId, Set<String> methodNames) throws JavaModelException {
+		IMethod[] methods= type.getMethods();
+		for (IMethod method : methods) {
+			String methodName= method.getElementName();
+			int flags= method.getFlags();
+			// Only include public, non-static, no-arg methods that return void and start with "test":
+			if (Modifier.isPublic(flags) && !Modifier.isStatic(flags) &&
+					method.getNumberOfParameters() == 0 && Signature.SIG_VOID.equals(method.getReturnType()) &&
+					methodName.startsWith("test")) { //$NON-NLS-1$
+				methodNames.add(methodName);
+			}
+			boolean isJUnit3= TestKindRegistry.JUNIT3_TEST_KIND_ID.equals(testKindId);
+			boolean isJUnit5= TestKindRegistry.JUNIT5_TEST_KIND_ID.equals(testKindId);
+			if (!isJUnit3 && !Modifier.isPrivate(flags) && !Modifier.isStatic(flags)) {
+				IAnnotation annotation= method.getAnnotation("Test"); //$NON-NLS-1$
+				if (annotation.exists()) {
+					methodNames.add(methodName + JUnitStubUtility.getParameterTypes(method, false));
+				} else if (isJUnit5) {
+					boolean hasAnyTestAnnotation= method.getAnnotation("TestFactory").exists() //$NON-NLS-1$
+							|| method.getAnnotation("Testable").exists() //$NON-NLS-1$
+							|| method.getAnnotation("TestTemplate").exists() //$NON-NLS-1$
+							|| method.getAnnotation("ParameterizedTest").exists() //$NON-NLS-1$
+							|| method.getAnnotation("RepeatedTest").exists(); //$NON-NLS-1$
+					if (hasAnyTestAnnotation || isAnnotatedWithTestable(method, type, javaProject)) {
+						methodNames.add(methodName + JUnitStubUtility.getParameterTypes(method, false));
+					}
+				}
+			}
+		}
+	}
+
+	// See JUnit5TestFinder.Annotation#annotates also.
+	private static boolean isAnnotatedWithTestable(IMethod method, IType declaringType, IJavaProject javaProject) throws JavaModelException {
+		for (IAnnotation annotation : method.getAnnotations()) {
+			IType annotationType= getResolvedType(annotation.getElementName(), declaringType, javaProject);
+			if (annotationType != null) {
+				if (matchesTestable(annotationType)) {
+					return true;
+				}
+				Set<IType> hierarchy= new HashSet<>();
+				if (matchesTestableInAnnotationHierarchy(annotationType, javaProject, hierarchy)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static boolean matchesTestable(IType annotationType) {
+		return annotationType != null && JUnitCorePlugin.JUNIT5_TESTABLE_ANNOTATION_NAME.equals(annotationType.getFullyQualifiedName());
+	}
+
+	private static boolean matchesTestableInAnnotationHierarchy(IType annotationType, IJavaProject javaProject, Set<IType> hierarchy) throws JavaModelException {
+		if (annotationType != null) {
+			for (IAnnotation annotation : annotationType.getAnnotations()) {
+				IType annType= getResolvedType(annotation.getElementName(), annotationType, javaProject);
+				if (annType != null && hierarchy.add(annType)) {
+					if (matchesTestable(annType) || matchesTestableInAnnotationHierarchy(annType, javaProject, hierarchy)) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -808,7 +808,6 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 		} catch (InterruptedException e) {
 			// the user probably canceled the operation. Sadly there is no way to know it for sure since ModalContext::run
 			// doesn't throw the original OperationCanceledException, it throws a new InterruptedException.
-			JUnitPlugin.log(e);
 			fTestMethodsCache.setCanceled(true);
 		}
 	}
@@ -934,7 +933,8 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 	protected void setErrorMessage(String errorMessage) {
 		fIsValid= errorMessage == null;
 		if (fTestMethodsCache.isCanceled()) {
-			super.setErrorMessage(JUnitMessages.JUnitLaunchConfigurationTab_error_operation_canceled + " " + errorMessage); //$NON-NLS-1$
+			super.setErrorMessage(JUnitMessages.JUnitLaunchConfigurationTab_error_operation_canceled +
+					(errorMessage != null ? (" " + errorMessage) : "")); //$NON-NLS-1$ //$NON-NLS-2$
 		} else {
 			super.setErrorMessage(errorMessage);
 		}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/TestMethodsCache.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/TestMethodsCache.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vector Informatik GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.junit.launcher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class has the necessary logic to calculate the cache of all test methods that belong to a
+ * JUnit configuration.
+ */
+class TestMethodsCache {
+	/**
+	 * An <code>AutoCloseable</code> that can contain nested instances and can run a
+	 * <code>Runnable</code> upon closing the <i>outer</i> instance. <br/>
+	 * <br/>
+	 * Example:
+	 *
+	 * <pre>
+	 *
+	 * try (var outer= new NestedAutoCloseable(() -> System.out.println("Bye bye outer"))) {
+	 * 	try (var inner= new NestedAutoCloseable(() -> System.out.println("Bye bye inner"))) {
+	 * 		// ...
+	 * 	} // doesn't print anything
+	 * } // prints "Bye bye outer"
+	 * </pre>
+	 */
+	private static class NestedAutoCloseable implements AutoCloseable {
+		private static int fgDepth;
+
+		NestedAutoCloseable(Runnable onCreateOuterBlock) {
+			if (fgDepth == 0) {
+				onCreateOuterBlock.run();
+			}
+			fgDepth++;
+		}
+
+		@Override
+		public final void close() {
+			fgDepth--;
+		}
+	}
+
+	private boolean fCanceled;
+
+	private final Map<String, Set<String>> fCacheMap= new HashMap<>();
+
+	void put(String key, Set<String> value) {
+		fCacheMap.put(key, value);
+	}
+
+	Set<String> get(String key) {
+		return fCacheMap.get(key);
+	}
+
+	boolean containsKey(String key) {
+		return fCacheMap.containsKey(key);
+	}
+
+	boolean isCanceled() {
+		return fCanceled;
+	}
+
+	void setCanceled(boolean canceled) {
+		fCanceled= canceled;
+	}
+
+	/**
+	 * @return an <code>AutoCloseable</code> that guarantees that searching for test methods needs
+	 *         to be canceled only once even in nested calls.
+	 */
+	NestedAutoCloseable runNestedCancelable() {
+		return new NestedAutoCloseable(() -> fCanceled= false);
+	}
+}


### PR DESCRIPTION
## What it does
Move the logic to search for test methods from `JUnitLaunchConfigurationTab` to `TestSearchEngine::findTestMethods`. Extract the whole logic for caching the results into `TestMethodsCache` (new class) and do the whole searching and caching more efficiently i.e. only when necessary and showing the progress with a monitor by using `ModalContext::run`

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/683
Contributes to https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/653

This PR shows a progress indicator when searching for test methods in a class (which may happen when one opens a JUnit run configuration). The progress indicator looks like this when you first open the _Run configurations_ and a JUnit configuration is selected:

![image](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/2205684/c3f35a85-01b0-44e2-9724-22e465f4bd3b)

... and like this when you select or edit an existing JUnit run configuration and force a new search for test methods (the progress indicator appears at the bottom of the _Run configurations_ dialog).

![image](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/2205684/07808633-da1c-4ea3-91de-cdb406fb4025)


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The main goal is to open some _Run configurations_ for JUnit tests and move between them, letting them search the necessary test methods. 

All of the following must hold true while testing:
* If the UI is blocked (which is normal) then some progress report should appear, either in a separate dialog (when opening the _Run configurations_ for the first time) or in a progress bar at the bottom of the _Run configurations_ dialog.
* Previous results from **the same** run configuration (project + class + JUnit runner) should be cached _e.g._ if you already found all test methods for class `A` in project `B` and for `JUnit5` then changing to class `A2` might trigger a search (if `A2` exists) but setting the class back to `A` should **not** trigger another search.
* Selecting another configuration in the dialog (on the left-side panel) empties the cache.
* If you cancel a search then the _Test method (text field)_ and its _Search_ button should be deactivated since the methods of the class are not known. 
![image](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/2205684/bd7f1522-2c1e-434c-b267-06becfcb333a)
* It follows that if you cancel a search then the configuration is **invalid** _i.e._ the _Run_ button should be deactivated and an error should be displayed in the notification area of the dialog (upper area).

### A small hack to help testing
If you need more time to see the progress dialog/bar then you can modify `TestSearchEngine::collectMethodNames` like this:

```java
	private static void collectMethodNames(IType type, IJavaProject javaProject, String testKindId, Set<String> methodNames, IProgressMonitor monitor) throws JavaModelException {
		if (type == null) {
			return;
		}

		SubMonitor subMonitor= SubMonitor.convert(monitor, 3 + 3); // Add +3

		// Add this idle wait of 3 seconds and advance the progress in the subMonitor
		for (int i= 0; i < 3; i++) {
			try {
				Thread.sleep(1_000);
				subMonitor.split(1);
			} catch (InterruptedException e) {
				// ignore
			}
		}

		// leave the rest unchanged
                ...
	}
```

### How did I test?
These are all the stuff I did and tried when testing:
* I created a hierarchy of 2 test classes so that I may run tests in the super-class from the sub-class
* I added test methods both in the super-class and in the sub-class
* I created _Run configurations_ for the test methods and also for the complete classes (_i.e._ left the _Test method_ empty in the configuration dialog).
* I created a completely empty run configuration which will never be able to run but it helps to empty the cache without closing the _Run configurations_ dialog (selecting it empties the cache of the previous JUnit run configuration).
* I edited the existing JUnit configuration in every possible way I could imagine, entering both valid and invalid values for the project, test class and test method and also switching between JUnit3, 4 and 5 in the drop-down menu ("_Test runner_")
* I also used the `Browse...` and `Search` buttons to change the project and the class in the run configuration
* I sometimes canceled the search for test methods
* I changed the project / test class / test runner back and forth several times (without selecting another _Run configuration_ from the left-side panel) and purposely triggered new searches for test methods. 
* I completely emptied the cache by selecting another (an empty) run configuration in the left-side panel --> no searches should occur if the configuration is empty

## Author checklist

- ✔ I have thoroughly tested my changes
- ✔ The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- ✔ I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
