### PR TITLE
Always use brackets in blocks of code by default #667

### DIFF
--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
@@ -16,10 +16,13 @@
 package org.eclipse.jdt.internal.corext.fix;
 
 import org.eclipse.core.runtime.Assert;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp;
-import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
-import org.eclipse.jface.preference.IPreferenceStore;
 
 public class CleanUpConstantsOptions extends CleanUpConstants {
 	private static void setEclipseDefaultSettings(CleanUpOptions options) {
@@ -39,7 +42,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(MEMBER_ACCESSES_STATIC_QUALIFY_WITH_DECLARING_CLASS_INSTANCE_ACCESS, CleanUpOptions.TRUE);
 
 		//Control Statements
-		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS, CleanUpOptions.FALSE);
+		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS, CleanUpOptions.TRUE);
 		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS_ALWAYS, CleanUpOptions.TRUE);
 		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS_NO_FOR_RETURN_AND_THROW, CleanUpOptions.FALSE);
 		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS_NEVER, CleanUpOptions.FALSE);
@@ -221,7 +224,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(MEMBER_ACCESSES_STATIC_QUALIFY_WITH_DECLARING_CLASS_INSTANCE_ACCESS, CleanUpOptions.TRUE);
 
 		//Control Statements
-		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS, CleanUpOptions.FALSE);
+		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS, CleanUpOptions.TRUE);
 		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS_ALWAYS, CleanUpOptions.TRUE);
 		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS_NO_FOR_RETURN_AND_THROW, CleanUpOptions.FALSE);
 		options.setOption(CONTROL_STATEMENTS_USE_BLOCKS_NEVER, CleanUpOptions.FALSE);


### PR DESCRIPTION
## What it does
Change the default settings of the built-in clean-up profile and in the "_Additional actions"_ of the "_Save Actions_"; set them to always use brackets for blocks of code (even for one-liners).

These settings are just the defaults, they can be overwritten.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/667

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
### Save actions
* Open a newly created workspace
* Open _Window > Preferences > Java / Editor / Save Actions_
* Check _Perform the selected actions on save_
* Check _Additional actions_
* Click _Configure_
* Switch to the tab _Code Style_ --> _Use blocks in if/while/..._ should be checked
  * If it's not checked then you probably loaded some preferences from your user-space. Click _Restore defaults_ --> it should now be checked.

### Clean up (only the default profile)
* Open a newly created workspace
* Open _Window > Preferences > Java / Code Style / Clean Up_
* Select the default profile: _Eclipse [built-in]_
* Click _Edit..._
* Switch to the tab _Code Style_ --> _Use blocks in if/while/..._ should be checked.

## Author checklist

- ✔ I have thoroughly tested my changes
- ✔ The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- ✔ I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
