### PR TITLE
Remove unused data from compilation unit annotation model util map #665

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitDocumentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitDocumentProvider.java
@@ -20,6 +20,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -434,83 +435,86 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 	}
 
 	/**
-	 * Internal structure for mapping positions to some value.
+	 * Internal structure for mapping positions to JavaMarkerAnnotations.
 	 * The reason for this specific structure is that positions can
 	 * change over time. Thus a lookup is based on value and not
 	 * on hash value.
 	 */
-	protected static class ReverseMap {
+	private static class ReverseJavaMarkerAnnotationsMap {
 
 		static class Entry {
-			Position fPosition;
-			Object fValue;
-		}
+			private final Position position;
 
-		private List<Entry> fList= new ArrayList<>(2);
-		private int fAnchor= 0;
+			final List<JavaMarkerAnnotation> annotations= new ArrayList<>();
 
-		public ReverseMap() {
-		}
-
-		public Object get(Position position) {
-
-			Entry entry;
-
-			// behind anchor
-			int length= fList.size();
-			for (int i= fAnchor; i < length; i++) {
-				entry= fList.get(i);
-				if (entry.fPosition.equals(position)) {
-					fAnchor= i;
-					return entry.fValue;
-				}
+			public Entry(Position position) {
+				this.position= position;
 			}
 
-			// before anchor
-			for (int i= 0; i < fAnchor; i++) {
-				entry= fList.get(i);
-				if (entry.fPosition.equals(position)) {
-					fAnchor= i;
-					return entry.fValue;
+			public boolean isFor(Position positionToCheck) {
+				return position.equals(positionToCheck);
+			}
+		}
+
+		private List<Entry> entries= new ArrayList<>(2);
+
+		private int anchorIndex= 0;
+
+		public Iterable<JavaMarkerAnnotation> get(Position position) {
+			// Start behind and store anchor because usually retrieval is performed sequentially over positions
+			Entry entry= getEntry(position, true);
+			if (entry != null) {
+				return entry.annotations;
+			} else {
+				return Collections.emptyList();
+			}
+		}
+
+		private Entry getEntry(Position position, boolean useAndStoreAnchor) {
+			int startIndex= useAndStoreAnchor ? anchorIndex : 0;
+			int numberOfIndices= entries.size();
+			for (int i= 0; i < numberOfIndices; i++) {
+				int indexToCheck= (i + startIndex) % numberOfIndices;
+				Entry entry= entries.get(indexToCheck);
+				if (entry.isFor(position)) {
+					if (useAndStoreAnchor) {
+						anchorIndex= indexToCheck;
+					}
+					return entry;
 				}
 			}
-
 			return null;
 		}
 
-		private int getIndex(Position position) {
-			Entry entry;
-			int length= fList.size();
-			for (int i= 0; i < length; i++) {
-				entry= fList.get(i);
-				if (entry.fPosition.equals(position))
-					return i;
-			}
-			return -1;
+		public void put(Position position, JavaMarkerAnnotation annotation) {
+			Entry entry= getOrCreateEntry(position);
+			entry.annotations.add(annotation);
 		}
 
-		public void put(Position position,  Object value) {
-			int index= getIndex(position);
-			if (index == -1) {
-				Entry entry= new Entry();
-				entry.fPosition= position;
-				entry.fValue= value;
-				fList.add(entry);
-			} else {
-				Entry entry= fList.get(index);
-				entry.fValue= value;
+		private Entry getOrCreateEntry(Position position) {
+			Entry entry= getEntry(position, false);
+			if (entry == null) {
+				entry= new Entry(position);
+				entries.add(entry);
 			}
+			return entry;
 		}
 
-		public void remove(Position position) {
-			int index= getIndex(position);
-			if (index > -1)
-				fList.remove(index);
+		public void remove(Position position, JavaMarkerAnnotation annotation) {
+			Entry entry= getEntry(position, false);
+			if (entry != null) {
+				if (entry.annotations.size() == 1) {
+					entries.remove(entry);
+				} else {
+					entry.annotations.remove(annotation);
+				}
+			}
 		}
 
 		public void clear() {
-			fList.clear();
+			entries.clear();
 		}
+
 	}
 
 	/**
@@ -534,7 +538,7 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 		private boolean fIsActive= false;
 		private boolean fIsHandlingTemporaryProblems;
 
-		private ReverseMap fReverseMap= new ReverseMap();
+		private ReverseJavaMarkerAnnotationsMap fReverseMap= new ReverseJavaMarkerAnnotationsMap();
 		private List<JavaMarkerAnnotation> fPreviouslyOverlaid= null;
 		private List<JavaMarkerAnnotation> fCurrentlyOverlaid= new ArrayList<>();
 		private Thread fActiveThread;
@@ -738,31 +742,22 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 		}
 
 		/**
-		 * Overlays value with problem annotation.
+		 * Overlays Java marker annotation with problem annotation.
 		 *
-		 * @param value the value
+		 * @param annotation the Java marker annotation to attach a problem annotation to
 		 * @param problemAnnotation the problem annotation
 		 */
-		private void setOverlay(Object value, ProblemAnnotation problemAnnotation) {
-			if (value instanceof  JavaMarkerAnnotation) {
-				JavaMarkerAnnotation annotation= (JavaMarkerAnnotation) value;
-				if (annotation.isProblem()) {
-					annotation.setOverlay(problemAnnotation);
-					fPreviouslyOverlaid.remove(annotation);
-					fCurrentlyOverlaid.add(annotation);
-				}
-			} else {
+		private void setOverlay(JavaMarkerAnnotation annotation, ProblemAnnotation problemAnnotation) {
+			if (annotation.isProblem()) {
+				annotation.setOverlay(problemAnnotation);
+				fPreviouslyOverlaid.remove(annotation);
+				fCurrentlyOverlaid.add(annotation);
 			}
 		}
 
-		private void  overlayMarkers(Position position, ProblemAnnotation problemAnnotation) {
-			Object value= getAnnotations(position);
-			if (value instanceof List) {
-				List<?> list= (List<?>) value;
-				for (Object name : list)
-					setOverlay(name, problemAnnotation);
-			} else {
-				setOverlay(value, problemAnnotation);
+		private void overlayMarkers(Position position, ProblemAnnotation problemAnnotation) {
+			for (JavaMarkerAnnotation annotation : getJavaMarkerAnnotations(position)) {
+				setOverlay(annotation, problemAnnotation);
 			}
 		}
 
@@ -826,7 +821,7 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 
 		}
 
-		private Object getAnnotations(Position position) {
+		private Iterable<JavaMarkerAnnotation> getJavaMarkerAnnotations(Position position) {
 			synchronized (getLockObject()) {
 				return fReverseMap.get(position);
 			}
@@ -839,19 +834,9 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 		protected void addAnnotation(Annotation annotation, Position position, boolean fireModelChanged) throws BadLocationException {
 			super.addAnnotation(annotation, position, fireModelChanged);
 
-			synchronized (getLockObject()) {
-				Object cached= fReverseMap.get(position);
-				if (cached == null)
-					fReverseMap.put(position, annotation);
-				else if (cached instanceof List) {
-					@SuppressWarnings("unchecked")
-					List<Object> list= (List<Object>) cached;
-					list.add(annotation);
-				} else if (cached instanceof Annotation) {
-					List<Object> list= new ArrayList<>(2);
-					list.add(cached);
-					list.add(annotation);
-					fReverseMap.put(position, list);
+			if (annotation instanceof JavaMarkerAnnotation javaAnnotation) {
+				synchronized (getLockObject()) {
+					fReverseMap.put(position, javaAnnotation);
 				}
 			}
 		}
@@ -873,18 +858,9 @@ public class CompilationUnitDocumentProvider extends TextFileDocumentProvider im
 		@Override
 		protected void removeAnnotation(Annotation annotation, boolean fireModelChanged) {
 			Position position= getPosition(annotation);
-			synchronized (getLockObject()) {
-				Object cached= fReverseMap.get(position);
-				if (cached instanceof List) {
-					@SuppressWarnings("unchecked")
-					List<Object> list= (List<Object>) cached;
-					list.remove(annotation);
-					if (list.size() == 1) {
-						fReverseMap.put(position, list.get(0));
-						list.clear();
-					}
-				} else if (cached instanceof Annotation) {
-					fReverseMap.remove(position);
+			if (annotation instanceof JavaMarkerAnnotation javaAnnotation) {
+				synchronized (getLockObject()) {
+					fReverseMap.remove(position, javaAnnotation);
 				}
 			}
 			super.removeAnnotation(annotation, fireModelChanged);


### PR DESCRIPTION
## What it does

The `CompilationUnitDocumentProvider` uses in its Java-specific annotation model a utility map to navigate from document positions back to annotations (called `ReverseMap`). The current implementation is slow whenever a document contains plenty of annotations (such as the occurrences of the name of a marked method), as the map internally uses a list for representing the annotations which becomes slow in adding/removing when containing plenty of data. This is especially a problem on batch replacements of annotations (e.g. when selecting a different method to be marked in the document), as every single annotation is processed by the map individually. In addition, the map currently stores data that is never used, as only the specific JavaMarkerAnnotations are used from that map.

This change thus does the following:
- Specializes the utility map to only contain the required type of annotations
- Refactors the map implementation to simplify the code and make it more comprehensible

## How to test

Navigate through some large Java file and perform something that produces many annotation in the file. For example, use the test class as described and provided in #665. Without the change of this PR, the application freezes when navigating through the file, especially when selecting the `oftenCalledMethod`. With the change, the application stays responsive.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

Fixes #665

