### PR TITLE
Don't add nls markers for lines covered by SuppressWarnings

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringCleanUp.java
@@ -52,6 +52,8 @@ public class StringCleanUp extends AbstractMultiFix {
 		super();
 	}
 
+	private CompilationUnit fSavedCompilationUnit= null;
+
 	@Override
 	public CleanUpRequirements getRequirements() {
 		boolean requireAST= requireAST();
@@ -69,7 +71,7 @@ public class StringCleanUp extends AbstractMultiFix {
 		if (compilationUnit == null)
 			return null;
 
-		ICleanUpFixCore coreFix= StringFixCore.createCleanUp(compilationUnit,
+		ICleanUpFixCore coreFix= StringFixCore.createCleanUp(fSavedCompilationUnit == null ? compilationUnit : fSavedCompilationUnit,
 				isEnabled(CleanUpConstants.ADD_MISSING_NLS_TAGS),
 				isEnabled(CleanUpConstants.REMOVE_UNNECESSARY_NLS_TAGS));
 		return coreFix == null ? null : new CleanUpFixWrapper(coreFix);
@@ -143,6 +145,7 @@ public class StringCleanUp extends AbstractMultiFix {
 			return 0;
 		}
 
+		fSavedCompilationUnit= compilationUnit;
 		int result= 0;
 		IProblem[] problems= compilationUnit.getProblems();
 		if (isEnabled(CleanUpConstants.ADD_MISSING_NLS_TAGS))


### PR DESCRIPTION
- when doing a quick fix for missing nls markers and choosing to fix n instances of same warning, don't add missing NLS markers to lines covered by a SuppressWarnings(nls) whereby they don't cause a problem info of warning to be generated
- fixes #626

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes add nls quick fix when missing nls markers are a warning to not extraneously fix missing nls markers that are
covered by a SuppressWarnings("nls") statement

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
