### PR TITLE
Move functionality and migrate callers from StubUtility2 to StubUtility2Core

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
@@ -87,6 +87,7 @@ import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
+import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileManagerCore;
 import org.eclipse.jdt.internal.ui.util.ASTHelper;
 
 /**
@@ -95,6 +96,129 @@ import org.eclipse.jdt.internal.ui.util.ASTHelper;
  * @since 1.10
  */
 public final class StubUtility2Core {
+
+	/* This method should work with all AST levels. */
+	public static MethodDeclaration createImplementationStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context,
+			IMethodBinding binding, ITypeBinding targetType, CodeGenerationSettings settings, boolean inInterface, ASTNode astNode) throws CoreException {
+		return createImplementationStub(unit, rewrite, imports, context, binding, null, targetType, settings, inInterface, astNode);
+	}
+
+	public static MethodDeclaration createImplementationStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context,
+			IMethodBinding binding, String[] parameterNames, ITypeBinding targetType, CodeGenerationSettings settings, boolean inInterface, ASTNode astNode) throws CoreException {
+		Assert.isNotNull(imports);
+		Assert.isNotNull(rewrite);
+
+		AST ast= rewrite.getAST();
+		String type= Bindings.getTypeQualifiedName(targetType);
+
+		IJavaProject javaProject= unit.getJavaProject();
+		EnumSet<TypeLocation> nullnessDefault= null;
+		if (astNode != null && JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, true)))
+			nullnessDefault= RedundantNullnessTypeAnnotationsFilter.determineNonNullByDefaultLocations(astNode, RedundantNullnessTypeAnnotationsFilter.determineNonNullByDefaultNames(javaProject));
+
+		MethodDeclaration decl= ast.newMethodDeclaration();
+		decl.modifiers().addAll(StubUtility2Core.getImplementationModifiers(ast, binding, inInterface, imports, context, nullnessDefault));
+
+		decl.setName(ast.newSimpleName(binding.getName()));
+		decl.setConstructor(false);
+
+		ITypeBinding bindingReturnType= binding.getReturnType();
+		bindingReturnType = StubUtility2Core.replaceWildcardsAndCaptures(bindingReturnType);
+
+		if (JavaModelUtil.is50OrHigher(javaProject)) {
+			StubUtility2Core.createTypeParameters(imports, context, ast, binding, decl);
+
+		} else {
+			bindingReturnType= bindingReturnType.getErasure();
+		}
+
+		decl.setReturnType2(imports.addImport(bindingReturnType, ast, context, TypeLocation.RETURN_TYPE));
+
+		List<SingleVariableDeclaration> parameters= StubUtility2Core.createParameters(javaProject, imports, context, ast, binding, parameterNames, decl, nullnessDefault);
+
+		StubUtility2Core.createThrownExceptions(decl, binding, imports, context, ast);
+
+		String delimiter= unit.findRecommendedLineSeparator();
+		int modifiers= binding.getModifiers();
+		ITypeBinding declaringType= binding.getDeclaringClass();
+		ITypeBinding typeObject= ast.resolveWellKnownType("java.lang.Object"); //$NON-NLS-1$
+		if (!inInterface || (declaringType != typeObject && JavaModelUtil.is1d8OrHigher(javaProject))) {
+			// generate a method body
+
+			Map<String, String> options= FormatterProfileManagerCore.getProjectSettings(javaProject);
+
+			Block body= ast.newBlock();
+			decl.setBody(body);
+
+			String bodyStatement= ""; //$NON-NLS-1$
+			if (Modifier.isAbstract(modifiers)) {
+				Expression expression= ASTNodeFactory.newDefaultExpression(ast, decl.getReturnType2(), bindingReturnType, decl.getExtraDimensions());
+				if (expression != null) {
+					ReturnStatement returnStatement= ast.newReturnStatement();
+					returnStatement.setExpression(expression);
+					bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, delimiter, options);
+				}
+			} else {
+				SuperMethodInvocation invocation= ast.newSuperMethodInvocation();
+				if (declaringType.isInterface()) {
+					ITypeBinding supertype= Bindings.findImmediateSuperTypeInHierarchy(targetType, declaringType.getTypeDeclaration().getQualifiedName());
+					if (supertype == null) { // should not happen, but better use the type we have rather than failing
+						supertype= declaringType;
+					}
+					if (supertype.isInterface()) {
+						String qualifier= imports.addImport(supertype.getTypeDeclaration(), context);
+						Name name= ASTNodeFactory.newName(ast, qualifier);
+						invocation.setQualifier(name);
+					}
+				}
+				invocation.setName(ast.newSimpleName(binding.getName()));
+				SingleVariableDeclaration varDecl= null;
+				for (Iterator<SingleVariableDeclaration> iterator= parameters.iterator(); iterator.hasNext();) {
+					varDecl= iterator.next();
+					invocation.arguments().add(ast.newSimpleName(varDecl.getName().getIdentifier()));
+				}
+				Expression expression= invocation;
+				Type returnType= decl.getReturnType2();
+				if (returnType instanceof PrimitiveType && ((PrimitiveType) returnType).getPrimitiveTypeCode().equals(PrimitiveType.VOID)) {
+					bodyStatement= ASTNodes.asFormattedString(ast.newExpressionStatement(expression), 0, delimiter, options);
+				} else {
+					ReturnStatement returnStatement= ast.newReturnStatement();
+					returnStatement.setExpression(expression);
+					bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, delimiter, options);
+				}
+			}
+
+			String placeHolder= CodeGeneration.getMethodBodyContent(unit, type, binding.getName(), false, bodyStatement, delimiter);
+			if (placeHolder != null) {
+				ReturnStatement todoNode= (ReturnStatement) rewrite.createStringPlaceholder(placeHolder, ASTNode.RETURN_STATEMENT);
+				body.statements().add(todoNode);
+			}
+		}
+
+		if (settings != null && settings.createComments) {
+			String string= CodeGeneration.getMethodComment(unit, type, decl, binding, delimiter);
+			if (string != null) {
+				Javadoc javadoc= (Javadoc) rewrite.createStringPlaceholder(string, ASTNode.JAVADOC);
+				decl.setJavadoc(javadoc);
+			}
+		}
+
+		// According to JLS8 9.2, an interface doesn't implicitly declare non-public members of Object,
+		// and JLS8 9.6.4.4 doesn't allow @Override for these methods (clone and finalize).
+		boolean skipOverride= inInterface && declaringType == typeObject && !Modifier.isPublic(modifiers);
+
+		if (!skipOverride) {
+			StubUtility2Core.addOverrideAnnotation(settings, javaProject, rewrite, imports, decl, binding.getDeclaringClass().isInterface(), null);
+		}
+
+		return decl;
+	}
+
+
+	public static MethodDeclaration createConstructorStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context, IMethodBinding binding, String type, int modifiers, boolean omitSuperForDefConst, boolean todo, CodeGenerationSettings settings) throws CoreException {
+		return StubUtility2Core.createConstructorStub(unit, rewrite, imports, context, binding, type, modifiers, omitSuperForDefConst, todo, settings, FormatterProfileManagerCore.getProjectSettings(unit.getJavaProject()));
+	}
+
 
 	/* This method should work with all AST levels. */
 	public static MethodDeclaration createConstructorStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context, IMethodBinding binding, String type,

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddUnimplementedMethodsOperation.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddUnimplementedMethodsOperation.java
@@ -217,7 +217,7 @@ public final class AddUnimplementedMethodsOperation implements IWorkspaceRunnabl
 			}
 
 			for (IMethodBinding curr : methodsToImplement) {
-				MethodDeclaration stub= StubUtility2.createImplementationStub(cu, astRewrite, importRewrite, context, curr, currTypeBinding, settings, currTypeBinding.isInterface(), insertion);
+				MethodDeclaration stub= StubUtility2Core.createImplementationStub(cu, astRewrite, importRewrite, context, curr, currTypeBinding, settings, currTypeBinding.isInterface(), insertion);
 				if (stub != null) {
 					fCreatedMethods.add(curr.getKey());
 					if (insertion != null)

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2.java
@@ -16,46 +16,21 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.codemanipulation;
 
-import java.util.EnumSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.Block;
-import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
-import org.eclipse.jdt.core.dom.Modifier;
-import org.eclipse.jdt.core.dom.Name;
-import org.eclipse.jdt.core.dom.PrimitiveType;
-import org.eclipse.jdt.core.dom.ReturnStatement;
-import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
-import org.eclipse.jdt.core.dom.SuperMethodInvocation;
-import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
-import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
-import org.eclipse.jdt.core.manipulation.CodeGeneration;
 
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
-import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
-import org.eclipse.jdt.internal.corext.dom.ASTNodes;
-import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.util.JDTUIHelperClasses;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
-import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileManager;
+import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileManagerCore;
 
 /**
  * Utilities for code generation based on AST rewrite.
@@ -68,123 +43,17 @@ public final class StubUtility2 {
 
 	/* This method should work with all AST levels. */
 	public static MethodDeclaration createConstructorStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context, IMethodBinding binding, String type, int modifiers, boolean omitSuperForDefConst, boolean todo, CodeGenerationSettings settings) throws CoreException {
-		return StubUtility2Core.createConstructorStub(unit, rewrite, imports, context, binding, type, modifiers, omitSuperForDefConst, todo, settings, FormatterProfileManager.getProjectSettings(unit.getJavaProject()));
+		return StubUtility2Core.createConstructorStub(unit, rewrite, imports, context, binding, type, modifiers, omitSuperForDefConst, todo, settings, FormatterProfileManagerCore.getProjectSettings(unit.getJavaProject()));
 	}
 
 	public static MethodDeclaration createImplementationStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context,
 			IMethodBinding binding, ITypeBinding targetType, CodeGenerationSettings settings, boolean inInterface, ASTNode astNode) throws CoreException {
-		return createImplementationStub(unit, rewrite, imports, context, binding, null, targetType, settings, inInterface, astNode);
+		return StubUtility2Core.createImplementationStub(unit, rewrite, imports, context, binding, null, targetType, settings, inInterface, astNode);
 	}
 
 	public static MethodDeclaration createImplementationStub(ICompilationUnit unit, ASTRewrite rewrite, ImportRewrite imports, ImportRewriteContext context,
 			IMethodBinding binding, String[] parameterNames, ITypeBinding targetType, CodeGenerationSettings settings, boolean inInterface, ASTNode astNode) throws CoreException {
-		Assert.isNotNull(imports);
-		Assert.isNotNull(rewrite);
-
-		AST ast= rewrite.getAST();
-		String type= Bindings.getTypeQualifiedName(targetType);
-
-		IJavaProject javaProject= unit.getJavaProject();
-		EnumSet<TypeLocation> nullnessDefault= null;
-		if (astNode != null && JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, true)))
-			nullnessDefault= RedundantNullnessTypeAnnotationsFilter.determineNonNullByDefaultLocations(astNode, RedundantNullnessTypeAnnotationsFilter.determineNonNullByDefaultNames(javaProject));
-
-		MethodDeclaration decl= ast.newMethodDeclaration();
-		decl.modifiers().addAll(StubUtility2Core.getImplementationModifiers(ast, binding, inInterface, imports, context, nullnessDefault));
-
-		decl.setName(ast.newSimpleName(binding.getName()));
-		decl.setConstructor(false);
-
-		ITypeBinding bindingReturnType= binding.getReturnType();
-		bindingReturnType = StubUtility2Core.replaceWildcardsAndCaptures(bindingReturnType);
-
-		if (JavaModelUtil.is50OrHigher(javaProject)) {
-			StubUtility2Core.createTypeParameters(imports, context, ast, binding, decl);
-
-		} else {
-			bindingReturnType= bindingReturnType.getErasure();
-		}
-
-		decl.setReturnType2(imports.addImport(bindingReturnType, ast, context, TypeLocation.RETURN_TYPE));
-
-		List<SingleVariableDeclaration> parameters= StubUtility2Core.createParameters(javaProject, imports, context, ast, binding, parameterNames, decl, nullnessDefault);
-
-		StubUtility2Core.createThrownExceptions(decl, binding, imports, context, ast);
-
-		String delimiter= unit.findRecommendedLineSeparator();
-		int modifiers= binding.getModifiers();
-		ITypeBinding declaringType= binding.getDeclaringClass();
-		ITypeBinding typeObject= ast.resolveWellKnownType("java.lang.Object"); //$NON-NLS-1$
-		if (!inInterface || (declaringType != typeObject && JavaModelUtil.is1d8OrHigher(javaProject))) {
-			// generate a method body
-
-			Map<String, String> options= FormatterProfileManager.getProjectSettings(javaProject);
-
-			Block body= ast.newBlock();
-			decl.setBody(body);
-
-			String bodyStatement= ""; //$NON-NLS-1$
-			if (Modifier.isAbstract(modifiers)) {
-				Expression expression= ASTNodeFactory.newDefaultExpression(ast, decl.getReturnType2(), bindingReturnType, decl.getExtraDimensions());
-				if (expression != null) {
-					ReturnStatement returnStatement= ast.newReturnStatement();
-					returnStatement.setExpression(expression);
-					bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, delimiter, options);
-				}
-			} else {
-				SuperMethodInvocation invocation= ast.newSuperMethodInvocation();
-				if (declaringType.isInterface()) {
-					ITypeBinding supertype= Bindings.findImmediateSuperTypeInHierarchy(targetType, declaringType.getTypeDeclaration().getQualifiedName());
-					if (supertype == null) { // should not happen, but better use the type we have rather than failing
-						supertype= declaringType;
-					}
-					if (supertype.isInterface()) {
-						String qualifier= imports.addImport(supertype.getTypeDeclaration(), context);
-						Name name= ASTNodeFactory.newName(ast, qualifier);
-						invocation.setQualifier(name);
-					}
-				}
-				invocation.setName(ast.newSimpleName(binding.getName()));
-				SingleVariableDeclaration varDecl= null;
-				for (Iterator<SingleVariableDeclaration> iterator= parameters.iterator(); iterator.hasNext();) {
-					varDecl= iterator.next();
-					invocation.arguments().add(ast.newSimpleName(varDecl.getName().getIdentifier()));
-				}
-				Expression expression= invocation;
-				Type returnType= decl.getReturnType2();
-				if (returnType instanceof PrimitiveType && ((PrimitiveType) returnType).getPrimitiveTypeCode().equals(PrimitiveType.VOID)) {
-					bodyStatement= ASTNodes.asFormattedString(ast.newExpressionStatement(expression), 0, delimiter, options);
-				} else {
-					ReturnStatement returnStatement= ast.newReturnStatement();
-					returnStatement.setExpression(expression);
-					bodyStatement= ASTNodes.asFormattedString(returnStatement, 0, delimiter, options);
-				}
-			}
-
-			String placeHolder= CodeGeneration.getMethodBodyContent(unit, type, binding.getName(), false, bodyStatement, delimiter);
-			if (placeHolder != null) {
-				ReturnStatement todoNode= (ReturnStatement) rewrite.createStringPlaceholder(placeHolder, ASTNode.RETURN_STATEMENT);
-				body.statements().add(todoNode);
-			}
-		}
-
-		if (settings != null && settings.createComments) {
-			String string= CodeGeneration.getMethodComment(unit, type, decl, binding, delimiter);
-			if (string != null) {
-				Javadoc javadoc= (Javadoc) rewrite.createStringPlaceholder(string, ASTNode.JAVADOC);
-				decl.setJavadoc(javadoc);
-			}
-		}
-
-		// According to JLS8 9.2, an interface doesn't implicitly declare non-public members of Object,
-		// and JLS8 9.6.4.4 doesn't allow @Override for these methods (clone and finalize).
-		boolean skipOverride= inInterface && declaringType == typeObject && !Modifier.isPublic(modifiers);
-
-		if (!skipOverride) {
-			StubUtility2Core.addOverrideAnnotation(settings, javaProject, rewrite, imports, decl, binding.getDeclaringClass().isInterface(), null);
-		}
-
-		return decl;
+		return StubUtility2Core.createImplementationStub(unit, rewrite, imports, context, binding, parameterNames, targetType, settings, inInterface, astNode);
 	}
 
 

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/util/JDTUIHelperClasses.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/util/JDTUIHelperClasses.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.dom.NecessaryParenthesesChecker;
 import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceFactoryRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceFactoryRefactoring.java
@@ -94,7 +94,6 @@ import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
 import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
@@ -649,7 +648,7 @@ public class IntroduceFactoryRefactoring extends Refactoring {
 			CodeGenerationSettings settings= JavaPreferencesSettings.getCodeGenerationSettings(fCUHandle.getJavaProject());
 			ImportRewriteContext context= new ContextSensitiveImportRewriteContext(fFactoryCU, decl.getStartPosition(), fImportRewriter);
 			for (IMethodBinding unImplementedMethod : getUnimplementedMethods(declaringClass)) {
-				MethodDeclaration newMethodDecl= StubUtility2.createImplementationStub(fCUHandle, unitRewriter, fImportRewriter, context,
+				MethodDeclaration newMethodDecl= StubUtility2Core.createImplementationStub(fCUHandle, unitRewriter, fImportRewriter, context,
 					unImplementedMethod, unImplementedMethod.getDeclaringClass(), settings, false, new NodeFinder(fFactoryCU, decl.getStartPosition(), 0).getCoveringNode());
 				decl.bodyDeclarations().add(newMethodDecl);
 			}

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ExtractSupertypeProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ExtractSupertypeProcessor.java
@@ -107,7 +107,6 @@ import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
 import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
@@ -519,7 +518,7 @@ public final class ExtractSupertypeProcessor extends PullUpRefactoringProcessor 
 							MethodDeclaration stub;
 							try {
 								ImportRewriteContext context= new ContextSensitiveImportRewriteContext(targetDeclaration, targetRewrite.getImportRewrite());
-								stub= StubUtility2.createConstructorStub(targetRewrite.getCu(), targetRewrite.getASTRewrite(), targetRewrite.getImportRewrite(), context, curr, binding.getName(),
+								stub= StubUtility2Core.createConstructorStub(targetRewrite.getCu(), targetRewrite.getASTRewrite(), targetRewrite.getImportRewrite(), context, curr, binding.getName(),
 									Modifier.PUBLIC, false, false, fSettings);
 								if (stub != null) {
 									if (!fUninitializedFinalFieldsToMove.isEmpty()) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -134,7 +134,7 @@ import org.eclipse.jdt.internal.core.manipulation.dom.NecessaryParenthesesChecke
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
+import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
@@ -2374,7 +2374,7 @@ public class LocalCorrectionsSubProcessor {
 
 		try {
 			ImportRewriteContext importContext= new ContextSensitiveImportRewriteContext(astRoot, problem.getOffset(), importRewrite);
-			MethodDeclaration hashCode= StubUtility2.createImplementationStub(cu, rewrite, importRewrite, importContext, superHashCode, binding, settings, false, null);
+			MethodDeclaration hashCode= StubUtility2Core.createImplementationStub(cu, rewrite, importRewrite, importContext, superHashCode, binding, settings, false, null);
 			BodyDeclarationRewrite.create(rewrite, typeDeclaration).insert(hashCode, null);
 
 			proposal2.setEndPosition(rewrite.track(hashCode));
@@ -2531,7 +2531,7 @@ public class LocalCorrectionsSubProcessor {
 		ImportRewriteContext importRewriteContext= new ContextSensitiveImportRewriteContext(astRoot, typeNode.getStartPosition(), importRewrite);
 		CodeGenerationSettings settings= JavaPreferencesSettings.getCodeGenerationSettings(cu);
 		try {
-			MethodDeclaration stub= StubUtility2.createImplementationStub(cu, rewrite, importRewrite, importRewriteContext, methodToOverride, typeBinding, settings,
+			MethodDeclaration stub= StubUtility2Core.createImplementationStub(cu, rewrite, importRewrite, importRewriteContext, methodToOverride, typeBinding, settings,
 					typeBinding.isInterface(), new NodeFinder(astRoot, typeNode.getStartPosition(), 0).getCoveringNode());
 			BodyDeclarationRewrite.create(rewrite, typeNode).insert(stub, null);
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/AnonymousTypeCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/AnonymousTypeCompletionProposal.java
@@ -66,7 +66,6 @@ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.core.manipulation.util.Strings;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
 import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
@@ -249,7 +248,7 @@ public class AnonymousTypeCompletionProposal extends JavaTypeCompletionProposal 
 
 			ListRewrite rewriter= rewrite.getListRewrite(declaration, declaration.getBodyDeclarationsProperty());
 			for (IMethodBinding curr : methodsToOverride) {
-				MethodDeclaration stub= StubUtility2.createImplementationStub(workingCopy, rewrite, importRewrite, context, curr, dummyTypeBinding, settings, dummyTypeBinding.isInterface(), focusNode);
+				MethodDeclaration stub= StubUtility2Core.createImplementationStub(workingCopy, rewrite, importRewrite, context, curr, dummyTypeBinding, settings, dummyTypeBinding.isInterface(), focusNode);
 				rewriter.insertFirst(stub, null);
 			}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/OverrideCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/OverrideCompletionProposal.java
@@ -53,7 +53,7 @@ import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
-import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2;
+import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 
@@ -160,7 +160,7 @@ public class OverrideCompletionProposal extends JavaTypeCompletionProposal {
 			}
 			if (methodToOverride != null) {
 				CodeGenerationSettings settings= JavaPreferencesSettings.getCodeGenerationSettings(fCompilationUnit);
-				MethodDeclaration stub= StubUtility2.createImplementationStub(fCompilationUnit, rewrite, importRewrite, context, methodToOverride, declaringType, settings, declaringType.isInterface(), astNode);
+				MethodDeclaration stub= StubUtility2Core.createImplementationStub(fCompilationUnit, rewrite, importRewrite, context, methodToOverride, declaringType, settings, declaringType.isInterface(), astNode);
 				ListRewrite rewriter= rewrite.getListRewrite(node, descriptor);
 				rewriter.insertFirst(stub, null);
 


### PR DESCRIPTION

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/700

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
This patch moves one function out of StubUtility2 and into StubUtilityCore2, as well as migrate callers to using the Core version.  This helps make more logic accessible to headless installations or consumers like jdt.ls. 

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/700


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This is a code cleanup patch and should theoretically have no effect on functionality or performance. 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
