### PR TITLE
Fixes broken Unit 4 & 5 support after hamcrest update from 1.x to 2.x

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitPreferencesConstants.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitPreferencesConstants.java
@@ -79,6 +79,11 @@ public class JUnitPreferencesConstants {
 	public static final String HAMCREST_CORE_JAVADOC= JUnitCorePlugin.PLUGIN_ID + ".junit4.hamcrest.core.javadoclocation"; //$NON-NLS-1$
 
 	/**
+	 * Javadoc location for org.hamcrest (JUnit 4)
+	 */
+	public static final String HAMCREST_JAVADOC= JUnitCorePlugin.PLUGIN_ID + ".junit4.hamcrest.javadoclocation"; //$NON-NLS-1$
+
+	/**
 	 * Javadoc location for org.junit.jupiter.api (JUnit 5)
 	 */
 	public static final String JUNIT_JUPITER_API_JAVADOC= JUnitCorePlugin.PLUGIN_ID + ".junit5.jupiter.api.javadoclocation"; //$NON-NLS-1$

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
@@ -232,6 +232,8 @@ public class BuildPathSupport {
 
 				return JavaCore.newLibraryEntry(bundleRootLocation, srcLocation, null, getAccessRules(), attributes, false);
 			}
+			String message = "Unable to compute bundle location for '" + bundleId + "' with range " + versionRange;  //$NON-NLS-1$//$NON-NLS-2$
+			JUnitCorePlugin.log(Status.error(message, new IllegalStateException(message)));
 			return null;
 		}
 
@@ -303,7 +305,10 @@ public class BuildPathSupport {
 			"org.junit", new VersionRange("[4.13.0,5.0.0)"), null, "org.junit_4.*.jar", "org.junit.source", "source-bundle/", JUnitPreferencesConstants.JUNIT4_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
 	private static final JUnitPluginDescription HAMCREST_CORE_PLUGIN= new JUnitPluginDescription(
-			"org.hamcrest.core", new VersionRange("[1.1.0,2.0.0)"), null, "org.hamcrest.core_1.*.jar", "org.hamcrest.core.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_CORE_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+			"org.hamcrest.core", new VersionRange("[2.2.0,2.3.0)"), null, "org.hamcrest.core_2.*.jar", "org.hamcrest.core.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_CORE_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+
+	private static final JUnitPluginDescription HAMCREST_PLUGIN= new JUnitPluginDescription(
+			"org.hamcrest", new VersionRange("[2.2.0,2.3.0)"), null, "org.hamcrest_2.*.jar", "org.hamcrest.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
 	public static final JUnitPluginDescription JUNIT_JUPITER_API_PLUGIN= new JUnitPluginDescription(
 			"junit-jupiter-api", new VersionRange("[5.0.0,6.0.0)"), null, "junit-jupiter-api_5.*.jar", "junit-jupiter-api.source", "", //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$//$NON-NLS-5$
@@ -421,6 +426,13 @@ public class BuildPathSupport {
 	 */
 	public static IClasspathEntry getHamcrestCoreLibraryEntry() {
 		return HAMCREST_CORE_PLUGIN.getLibraryEntry();
+	}
+
+	/**
+	 * @return the org.hamcrest library, or <code>null</code> if not available
+	 */
+	public static IClasspathEntry getHamcrestLibraryEntry() {
+		return HAMCREST_PLUGIN.getLibraryEntry();
 	}
 
 	/**

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
@@ -106,20 +106,16 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 
 	private static JUnitContainer getNewContainer(IPath containerPath) {
 		List<IClasspathEntry> entriesList= new ArrayList<>();
-		IClasspathEntry entry= null;
-		IClasspathEntry entry2= null;
 		String version= containerPath.segment(1);
 		if (null != version) switch (version) {
 		case JUNIT3_8_1:
 		case JUNIT3:
-			entry= BuildPathSupport.getJUnit3LibraryEntry();
-			if (entry == null) { // JUnit 4 includes most of JUnit 3, so let's cheat
-				entry= BuildPathSupport.getJUnit4as3LibraryEntry();
-			}
+			entriesList.add(BuildPathSupport.getJUnit4as3LibraryEntry());
 			break;
 		case JUNIT4:
-			entry= BuildPathSupport.getJUnit4LibraryEntry();
-			entry2= BuildPathSupport.getHamcrestCoreLibraryEntry();
+			entriesList.add(BuildPathSupport.getJUnit4LibraryEntry());
+			entriesList.add(BuildPathSupport.getHamcrestLibraryEntry());
+			entriesList.add(BuildPathSupport.getHamcrestCoreLibraryEntry());
 			break;
 		case JUNIT5:
 			entriesList.add(BuildPathSupport.getJUnitJupiterApiLibraryEntry());
@@ -137,21 +133,15 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 			entriesList.add(BuildPathSupport.getJUnitOpentest4jLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnitApiGuardianLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnit4LibraryEntry());
-			entriesList.add(BuildPathSupport.getHamcrestCoreLibraryEntry());
+			entriesList.add(BuildPathSupport.getHamcrestLibraryEntry());
+ 			entriesList.add(BuildPathSupport.getHamcrestCoreLibraryEntry());
+			// errors will be reported above
+			entriesList.removeIf(e -> e == null);
 			break;
 		default:
 			break;
 		}
-		IClasspathEntry[] entries;
-		if (!entriesList.isEmpty() ) {
-			entries= entriesList.toArray(new IClasspathEntry[entriesList.size()]);
-		} else if (entry == null) {
-			entries= new IClasspathEntry[] { };
-		} else if (entry2 == null) {
-			entries= new IClasspathEntry[] { entry };
-		} else {
-			entries= new IClasspathEntry[] { entry, entry2 };
-		}
+		IClasspathEntry[] entries= entriesList.toArray(new IClasspathEntry[entriesList.size()]);
 		return new JUnitContainer(containerPath, entries);
 	}
 


### PR DESCRIPTION
- additionally avoids returning "null" classpath entries from JUnit 5 container and properly logs if a bundle was missing.

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1245
