### PR TITLE
Add either org.hamcrest.core 1.x or org.hamcrest 2.x to junit container

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
@@ -232,8 +232,6 @@ public class BuildPathSupport {
 
 				return JavaCore.newLibraryEntry(bundleRootLocation, srcLocation, null, getAccessRules(), attributes, false);
 			}
-			String message = "Unable to compute bundle location for '" + bundleId + "' with range " + versionRange;  //$NON-NLS-1$//$NON-NLS-2$
-			JUnitCorePlugin.log(Status.error(message, new IllegalStateException(message)));
 			return null;
 		}
 
@@ -305,10 +303,10 @@ public class BuildPathSupport {
 			"org.junit", new VersionRange("[4.13.0,5.0.0)"), null, "org.junit_4.*.jar", "org.junit.source", "source-bundle/", JUnitPreferencesConstants.JUNIT4_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
 	private static final JUnitPluginDescription HAMCREST_CORE_PLUGIN= new JUnitPluginDescription(
-			"org.hamcrest.core", new VersionRange("[2.2.0,2.3.0)"), null, "org.hamcrest.core_2.*.jar", "org.hamcrest.core.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_CORE_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+			"org.hamcrest.core", new VersionRange("[1.1.0,2.0.0)"), null, "org.hamcrest.core_1.*.jar", "org.hamcrest.core.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_CORE_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
 	private static final JUnitPluginDescription HAMCREST_PLUGIN= new JUnitPluginDescription(
-			"org.hamcrest", new VersionRange("[2.2.0,2.3.0)"), null, "org.hamcrest_2.*.jar", "org.hamcrest.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+			"org.hamcrest", new VersionRange("[2.2.0,3.0.0)"), null, "org.hamcrest_2.*.jar", "org.hamcrest.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
 	public static final JUnitPluginDescription JUNIT_JUPITER_API_PLUGIN= new JUnitPluginDescription(
 			"junit-jupiter-api", new VersionRange("[5.0.0,6.0.0)"), null, "junit-jupiter-api_5.*.jar", "junit-jupiter-api.source", "", //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$//$NON-NLS-5$

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
@@ -114,8 +114,7 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 			break;
 		case JUNIT4:
 			entriesList.add(BuildPathSupport.getJUnit4LibraryEntry());
-			entriesList.add(BuildPathSupport.getHamcrestLibraryEntry());
-			entriesList.add(BuildPathSupport.getHamcrestCoreLibraryEntry());
+			addHamcrest(entriesList);
 			break;
 		case JUNIT5:
 			entriesList.add(BuildPathSupport.getJUnitJupiterApiLibraryEntry());
@@ -133,10 +132,7 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 			entriesList.add(BuildPathSupport.getJUnitOpentest4jLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnitApiGuardianLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnit4LibraryEntry());
-			entriesList.add(BuildPathSupport.getHamcrestLibraryEntry());
- 			entriesList.add(BuildPathSupport.getHamcrestCoreLibraryEntry());
-			// errors will be reported above
-			entriesList.removeIf(e -> e == null);
+			addHamcrest(entriesList);
 			break;
 		default:
 			break;
@@ -145,6 +141,20 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 		return new JUnitContainer(containerPath, entries);
 	}
 
+	private static void addHamcrest(List<IClasspathEntry> entriesList) {
+		IClasspathEntry hamcrestLibraryEntry= BuildPathSupport.getHamcrestLibraryEntry();
+		if (hamcrestLibraryEntry != null) {
+			entriesList.add(hamcrestLibraryEntry);
+		} else {
+			IClasspathEntry hamcrestCoreLibraryEntry= BuildPathSupport.getHamcrestCoreLibraryEntry();
+			if (hamcrestCoreLibraryEntry != null) {
+				entriesList.add(hamcrestCoreLibraryEntry);
+			} else {
+				String message = "Either org.hamcrest.core 1.x or org.hamcrest 2.x must be present.";  //$NON-NLS-1$
+				JUnitCorePlugin.log(Status.error(message, new IllegalStateException(message)));
+			}
+		}
+	}
 
 	private static boolean isValidJUnitContainerPath(IPath path) {
 		return path != null && path.segmentCount() == 2 && JUnitCore.JUNIT_CONTAINER_ID.equals(path.segment(0));


### PR DESCRIPTION
The org.hamcrest.core 2.x bundle is effectively an empty redirect to org.hamcrest 2.x, so there's no point in putting it on the classpath.

Favor org.hamcrest 2.x over org.hamcrest 1.x if both are present.

Log an error if neither org.hamcrest.core 1.x nor org.hamcrest 2.x are present.

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/705

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
