### PR TITLE
Add logError(String) to Manipulations plugin

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaManipulationPlugin.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaManipulationPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,10 +20,13 @@ import org.eclipse.osgi.service.debug.DebugOptionsListener;
 
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jdt.core.manipulation.JavaManipulation;
+
+import org.eclipse.jdt.internal.ui.IJavaStatusConstants;
 
 /**
  * The main plug-in class to be used in the workbench.
@@ -104,6 +107,20 @@ public class JavaManipulationPlugin extends Plugin implements DebugOptionsListen
 
 	public static void log(IStatus status) {
 		ILog.of(JavaManipulationPlugin.class).log(status);
+	}
+
+	public static void logErrorMessage(String message) {
+		log(new Status(IStatus.ERROR, getPluginId(), IJavaStatusConstants.INTERNAL_ERROR, message, null));
+	}
+
+	public static void logErrorStatus(String message, IStatus status) {
+		if (status == null) {
+			logErrorMessage(message);
+			return;
+		}
+		MultiStatus multi= new MultiStatus(getPluginId(), IJavaStatusConstants.INTERNAL_ERROR, message, null);
+		multi.add(status);
+		log(multi);
 	}
 
 	public static String getPluginId() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This patch adds some logging utility methods to the Plugin class in jdt.core.manipulations. While these logging functions are not strictly necessary right now, they will be necessary in the very near future when patches that move large numbers of classes from the 'core refactor' folder in jdt.ui  into jdt.core.manipulations are proposed. 

This patch will ensure that those classes can be moved / renamed without having to modify much code during the move other than necessary constants. 

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
