### PR TITLE
Remove ITextSelection references from some refactors

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.15.100-SNAPSHOT</version>
+  <version>3.15.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithResourcesTests1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithResourcesTests1d8.java
@@ -63,7 +63,7 @@ public class SurroundWithResourcesTests1d8 extends AbstractJunit4SelectionTestCa
 	}
 
 	protected SurroundWithTryWithResourcesRefactoring createRefactoring(ICompilationUnit unit) {
-		return SurroundWithTryWithResourcesRefactoring.create(unit, getTextSelection());
+		return SurroundWithTryWithResourcesRefactoring.create(unit, getTextSelection().getOffset(), getTextSelection().getLength());
 	}
 
 	protected void tryResourcesInvalidTest() throws Exception {

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests.java
@@ -54,7 +54,7 @@ public class SurroundWithTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	protected SurroundWithTryCatchRefactoring createRefactoring(ICompilationUnit unit) {
-		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection());
+		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection().getOffset(), getTextSelection().getLength());
 	}
 
 	protected void tryCatchInvalidTest() throws Exception {

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests16.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests16.java
@@ -45,7 +45,7 @@ public class SurroundWithTests16 extends SurroundWithTests {
 
 	@Override
 	protected SurroundWithTryCatchRefactoring createRefactoring(ICompilationUnit unit) {
-		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection(), true);
+		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection().getOffset(), getTextSelection().getLength(), true);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests1d7.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests1d7.java
@@ -45,7 +45,7 @@ public class SurroundWithTests1d7 extends SurroundWithTests {
 
 	@Override
 	protected SurroundWithTryCatchRefactoring createRefactoring(ICompilationUnit unit) {
-		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection(), true);
+		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection().getOffset(), getTextSelection().getLength(), true);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/SurroundWithTests1d8.java
@@ -45,7 +45,7 @@ public class SurroundWithTests1d8 extends SurroundWithTests {
 
 	@Override
 	protected SurroundWithTryCatchRefactoring createRefactoring(ICompilationUnit unit) {
-		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection(), true);
+		return SurroundWithTryCatchRefactoring.create(unit, getTextSelection().getOffset(), getTextSelection().getLength(), true);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchRefactoring.java
@@ -28,8 +28,6 @@ import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.text.edits.TextEditGroup;
 
-import org.eclipse.jface.text.ITextSelection;
-
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -128,16 +126,8 @@ public class SurroundWithTryCatchRefactoring extends Refactoring {
 		fLeaveDirty= false;
 	}
 
-	public static SurroundWithTryCatchRefactoring create(ICompilationUnit cu, ITextSelection selection) {
-		return create(cu, selection, false);
-	}
-
 	public static SurroundWithTryCatchRefactoring create(ICompilationUnit cu, int offset, int length) {
 		return create(cu, offset, length, false);
-	}
-
-	public static SurroundWithTryCatchRefactoring create(ICompilationUnit cu, ITextSelection selection, boolean isMultiCatch) {
-		return new SurroundWithTryCatchRefactoring(cu, Selection.createFromStartLength(selection.getOffset(), selection.getLength()), isMultiCatch);
 	}
 
 	public static SurroundWithTryCatchRefactoring create(ICompilationUnit cu, int offset, int length, boolean isMultiCatch) {

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryWithResourcesRefactoring.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryWithResourcesRefactoring.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.refactoring.surround;
 
-import org.eclipse.jface.text.ITextSelection;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 
 import org.eclipse.jdt.internal.corext.dom.Selection;
@@ -41,10 +39,6 @@ public class SurroundWithTryWithResourcesRefactoring extends SurroundWithTryWith
 
 	public static SurroundWithTryWithResourcesRefactoring create(ICompilationUnit cu, int offset, int length) {
 		return new SurroundWithTryWithResourcesRefactoring(cu, Selection.createFromStartLength(offset, length));
-	}
-
-	public static SurroundWithTryWithResourcesRefactoring create(ICompilationUnit cu, ITextSelection selection) {
-		return new SurroundWithTryWithResourcesRefactoring(cu, Selection.createFromStartLength(selection.getOffset(), selection.getLength()));
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SurroundWithTryCatchAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SurroundWithTryCatchAction.java
@@ -121,7 +121,7 @@ public class SurroundWithTryCatchAction extends SelectionDispatchAction {
 	}
 
 	SurroundWithTryCatchRefactoring createRefactoring(ITextSelection selection, ICompilationUnit cu) {
-		return SurroundWithTryCatchRefactoring.create(cu, selection);
+		return SurroundWithTryCatchRefactoring.create(cu, selection.getOffset(), selection.getLength());
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SurroundWithTryMultiCatchAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SurroundWithTryMultiCatchAction.java
@@ -20,6 +20,7 @@ import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.refactoring.surround.SurroundWithTryCatchRefactoring;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
@@ -28,7 +29,6 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.actions.SelectionConverter;
 import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitEditor;
 import org.eclipse.jdt.internal.ui.refactoring.RefactoringMessages;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 /**
  * Action to surround a set of statements with a try/multi-catch block.
@@ -68,7 +68,7 @@ public class SurroundWithTryMultiCatchAction extends SurroundWithTryCatchAction 
 
 	@Override
 	SurroundWithTryCatchRefactoring createRefactoring(ITextSelection selection, ICompilationUnit cu) {
-		return SurroundWithTryCatchRefactoring.create(cu, selection, true);
+		return SurroundWithTryCatchRefactoring.create(cu, selection.getOffset(), selection.getLength(), true);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SurroundWithTryWithResourcesAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SurroundWithTryWithResourcesAction.java
@@ -133,7 +133,7 @@ public class SurroundWithTryWithResourcesAction extends SelectionDispatchAction 
 	}
 
 	SurroundWithTryWithResourcesRefactoring createRefactoring(ITextSelection selection, ICompilationUnit cu) {
-		return SurroundWithTryWithResourcesRefactoring.create(cu, selection);
+		return SurroundWithTryWithResourcesRefactoring.create(cu, selection.getOffset(), selection.getLength());
 	}
 
 	@Override


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
The refactors themselves should not require UI, whenever possible, while the actions that call them are inherently UI creatures and should have access to the UI classes. 

This patch removes some utility functions which help create SurroundWithTryCatchRefactoring.java and SurroundWithTryWithResourcesAction.java, and ask the action to provide the various required integers themselves instead of passing in a UI element. 

This will help separate core and UI more effectively in the near future. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
