### PR TITLE
Extracting RefactorSaveHelper constants into core

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -71,5 +71,6 @@ Export-Package: org.eclipse.jdt.core.manipulation,
  org.eclipse.jdt.internal.ui.text.correction;x-friends:="org.eclipse.jdt.ui,org.eclipse.jdt.debug.ui",
  org.eclipse.jdt.internal.ui.text.correction.proposals;x-friends:="org.eclipse.jdt.ui",
  org.eclipse.jdt.internal.ui.text.template.contentassist;x-friends:="org.eclipse.jdt.ui",
- org.eclipse.jdt.internal.ui.util;x-friends:="org.eclipse.jdt.ui,org.eclipse.jdt.astview,org.eclipse.jdt.junit.core"
+ org.eclipse.jdt.internal.ui.util;x-friends:="org.eclipse.jdt.ui,org.eclipse.jdt.astview,org.eclipse.jdt.junit.core",
+ org.eclipse.jdt.ui.refactoring;manipulation=split;mandatory:=manipulation;x-friends:="org.eclipse.jdt.ui"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIdsCore.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIdsCore.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.core.refactoring.IJavaElementMapper;
  *
  * @see org.eclipse.jdt.core.refactoring.participants.IRefactoringProcessorIds
  *
- * @since 3.0
+ * @since 1.19.200
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
@@ -81,7 +81,7 @@ public interface IRefactoringProcessorIdsCore {
 	 *       fragment to be renamed.</li>
 	 * </ul>
 	 *
-	 * <p>Since 3.3:</p>
+	 * <p>Since 1.19.200:</p>
 	 *
 	 * <p>The refactoring processor moves and renames Java elements and resources.
 	 * Rename package fragment participants can retrieve the new location of
@@ -118,7 +118,7 @@ public interface IRefactoringProcessorIdsCore {
 	 *       unit gets rename as well.</li>
 	 * </ul>
 	 *
-	 * <p>Since 3.2:</p>
+	 * <p>Since 1.19.200:</p>
 	 *
 	 * Participants that declare <pre> &lt;param name="handlesSimilarDeclarations" value="false"/&gt; </pre>
 	 * in their extension contribution will not be loaded if the user selects the
@@ -168,7 +168,7 @@ public interface IRefactoringProcessorIdsCore {
 	 * <ul>
 	 *   <li>participants registered for renaming <code>IModuleDescription</code>.</li>
 	 * </ul>
-	 * @since 3.24
+	 * @since 1.19.200
 	 */
 	String RENAME_MODULE_PROCESSOR= "org.eclipse.jdt.ui.renameModuleProcessor"; //$NON-NLS-1$
 
@@ -180,7 +180,7 @@ public interface IRefactoringProcessorIdsCore {
 	 * <ul>
 	 *   <li>participants registered for renaming <code>IField</code>.</li>
 	 * </ul>
-	 * @since 3.1
+	 * @since 1.19.200
 	 */
 	String RENAME_ENUM_CONSTANT_PROCESSOR= "org.eclipse.jdt.ui.renameEnumConstProcessor"; //$NON-NLS-1$
 
@@ -281,7 +281,7 @@ public interface IRefactoringProcessorIdsCore {
 	 * should be use as the <code>ResourceMappingContext</code> passed to the accept method.
 	 * </p>
 	 * @see org.eclipse.core.resources.mapping.ResourceMapping
-	 * @since 3.3
+	 * @since 1.19.200
 	 */
 	String COPY_PROCESSOR= "org.eclipse.jdt.ui.CopyProcessor"; //$NON-NLS-1$
 }

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIdsCore.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIdsCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc - Copied from org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIds.java
  *******************************************************************************/
 package org.eclipse.jdt.ui.refactoring;
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIdsCore.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIdsCore.java
@@ -37,10 +37,8 @@ import org.eclipse.jdt.core.refactoring.IJavaElementMapper;
  *
  * @noimplement This interface is not intended to be implemented by clients.
  * @noextend This interface is not intended to be extended by clients.
- * @deprecated Please use IRefactoringProcessorIdsCore. Do not update this file.
  */
-public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
-	// All constants have been moved to the IRefactoringProcessorIdsCore interface
+public interface IRefactoringProcessorIdsCore {
 
 	/**
 	 * Processor ID of the rename Java project processor
@@ -52,7 +50,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *   <li>participants registered for renaming <code>IProject</code>.</li>
 	 * </ul>
 	 */
-	String RENAME_JAVA_PROJECT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_JAVA_PROJECT_PROCESSOR;
+	String RENAME_JAVA_PROJECT_PROCESSOR= "org.eclipse.jdt.ui.renameJavaProjectProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename source folder
@@ -64,7 +62,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *   <li>participants registered for renaming <code>IFolder</code>.</li>
 	 * </ul>
 	 */
-	String RENAME_SOURCE_FOLDER_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_SOURCE_FOLDER_PROCESSOR;
+	String RENAME_SOURCE_FOLDER_PROCESSOR= "org.eclipse.jdt.ui.renameSourceFolderProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename package fragment processor
@@ -90,7 +88,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 * {@link IJavaElementMapper} and {@link IResourceMapper}, which can be
 	 * retrieved from the processor using the getAdapter() method.</p>
 	 */
-	String RENAME_PACKAGE_FRAGMENT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_PACKAGE_FRAGMENT_PROCESSOR;
+	String RENAME_PACKAGE_FRAGMENT_PROCESSOR= "org.eclipse.jdt.ui.renamePackageProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename compilation unit processor
@@ -104,7 +102,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *       compilation unit contains a top level type.</li>
 	 * </ul>
 	 */
-	String RENAME_COMPILATION_UNIT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_COMPILATION_UNIT_PROCESSOR;
+	String RENAME_COMPILATION_UNIT_PROCESSOR= "org.eclipse.jdt.ui.renameCompilationUnitProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename type processor
@@ -132,7 +130,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 * processor using the getAdapter() method.</p>
 	 *
 	 */
-	String RENAME_TYPE_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_TYPE_PROCESSOR;
+	String RENAME_TYPE_PROCESSOR= "org.eclipse.jdt.ui.renameTypeProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename method processor
@@ -146,7 +144,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *       For those derived methods participants will be loaded as well.</li>
 	 * </ul>
 	 */
-	String RENAME_METHOD_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_METHOD_PROCESSOR;
+	String RENAME_METHOD_PROCESSOR= "org.eclipse.jdt.ui.renameMethodProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename field processor
@@ -159,7 +157,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *       corresponding setter and getter methods are renamed as well.</li>
 	 * </ul>
 	 */
-	String RENAME_FIELD_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_FIELD_PROCESSOR;
+	String RENAME_FIELD_PROCESSOR= "org.eclipse.jdt.ui.renameFieldProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename module processor
@@ -171,7 +169,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 * </ul>
 	 * @since 3.24
 	 */
-	String RENAME_MODULE_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_MODULE_PROCESSOR;
+	String RENAME_MODULE_PROCESSOR= "org.eclipse.jdt.ui.renameModuleProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename enum constant processor
@@ -183,7 +181,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 * </ul>
 	 * @since 3.1
 	 */
-	String RENAME_ENUM_CONSTANT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_ENUM_CONSTANT_PROCESSOR;
+	String RENAME_ENUM_CONSTANT_PROCESSOR= "org.eclipse.jdt.ui.renameEnumConstProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the rename resource processor
@@ -194,7 +192,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *   <li>participants registered for renaming <code>IResource</code>.</li>
 	 * </ul>
 	 */
-	String RENAME_RESOURCE_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_RESOURCE_PROCESSOR;
+	String RENAME_RESOURCE_PROCESSOR= "org.eclipse.jdt.ui.renameResourceProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the move resource processor
@@ -217,7 +215,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *   <li><code>IResource</code>: participants registered for moving resources.</li>
 	 * </ul>
 	 */
-	String MOVE_PROCESSOR= IRefactoringProcessorIdsCore.MOVE_PROCESSOR;
+	String MOVE_PROCESSOR= "org.eclipse.jdt.ui.MoveProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the move static member processor
@@ -227,7 +225,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 * static Java element that gets moved. No support is available to participate
 	 * in non static member moves.
 	 */
-	String MOVE_STATIC_MEMBERS_PROCESSOR= IRefactoringProcessorIdsCore.MOVE_STATIC_MEMBERS_PROCESSOR;
+	String MOVE_STATIC_MEMBERS_PROCESSOR= "org.eclipse.jdt.ui.MoveStaticMemberProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the delete resource processor
@@ -254,7 +252,7 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 *   <li><code>IResource</code>: participants registered for deleting resources.</li>
 	 * </ul>
 	 */
-	String DELETE_PROCESSOR= IRefactoringProcessorIdsCore.DELETE_PROCESSOR;
+	String DELETE_PROCESSOR= "org.eclipse.jdt.ui.DeleteProcessor"; //$NON-NLS-1$
 
 	/**
 	 * Processor ID of the copy processor (value <code>"org.eclipse.jdt.ui.CopyProcessor"</code>).
@@ -284,5 +282,5 @@ public interface IRefactoringProcessorIds extends IRefactoringProcessorIdsCore {
 	 * @see org.eclipse.core.resources.mapping.ResourceMapping
 	 * @since 3.3
 	 */
-	String COPY_PROCESSOR= IRefactoringProcessorIdsCore.COPY_PROCESSOR;
+	String COPY_PROCESSOR= "org.eclipse.jdt.ui.CopyProcessor"; //$NON-NLS-1$
 }

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringSaveModes.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/ui/refactoring/IRefactoringSaveModes.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.refactoring;
+
+public interface IRefactoringSaveModes {
+
+	/**
+	 * Save mode to save all dirty editors (always ask).
+	 */
+	public static final int SAVE_ALL_ALWAYS_ASK= 1;
+
+	/**
+	 * Save mode to save all dirty editors.
+	 */
+	public static final int SAVE_ALL= 2;
+
+	/**
+	 * Save mode to not save any editors.
+	 */
+	public static final int SAVE_NOTHING= 3;
+
+	/**
+	 * Save mode to save all editors that are known to cause trouble for Java refactorings, e.g.
+	 * editors on compilation units that are not in working copy mode.
+	 */
+	public static final int SAVE_REFACTORING= 4;
+
+}

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/RefactoringExecutionStarter.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/RefactoringExecutionStarter.java
@@ -101,7 +101,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.actions.SelectionDispatchAction;
 import org.eclipse.jdt.ui.cleanup.ICleanUp;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 import org.eclipse.jdt.ui.refactoring.RenameSupport;
 
 import org.eclipse.jdt.internal.ui.actions.ActionMessages;
@@ -216,7 +216,7 @@ public final class RefactoringExecutionStarter {
 
 			Refactoring refactoring= new ProcessorBasedRefactoring(processor);
 			ChangeSignatureWizard wizard= new ChangeSignatureWizard(processor, refactoring);
-			new RefactoringStarter().activate(wizard, shell, wizard.getDefaultPageTitle(), RefactoringSaveHelper.SAVE_REFACTORING);
+			new RefactoringStarter().activate(wizard, shell, wizard.getDefaultPageTitle(), IRefactoringSaveModes.SAVE_REFACTORING);
 		} catch (CoreException e) {
 			ExceptionHandler.handle(e, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringMessages.RefactoringStarter_unexpected_exception);
 		}
@@ -224,7 +224,7 @@ public final class RefactoringExecutionStarter {
 
 	public static void startChangeTypeRefactoring(final ICompilationUnit unit, final Shell shell, final int offset, final int length) {
 		final ChangeTypeRefactoring refactoring= new ChangeTypeRefactoring(unit, offset, length);
-		new RefactoringStarter().activate(new ChangeTypeWizard(refactoring), shell, RefactoringMessages.ChangeTypeAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(new ChangeTypeWizard(refactoring), shell, RefactoringMessages.ChangeTypeAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startCleanupRefactoring(ICompilationUnit[] cus, ICleanUp[] cleanUps, boolean useOptionsFromProfile, Shell shell, boolean showWizard, String actionName) throws InvocationTargetException {
@@ -246,7 +246,7 @@ public final class RefactoringExecutionStarter {
 				context= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 			}
 
-			RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, IStatus.INFO, RefactoringSaveHelper.SAVE_REFACTORING, shell, context);
+			RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, IStatus.INFO, IRefactoringSaveModes.SAVE_REFACTORING, shell, context);
 			try {
 				helper.perform(true, true, true);
 			} catch (InterruptedException e) {
@@ -254,14 +254,14 @@ public final class RefactoringExecutionStarter {
 		} else {
 			CleanUpRefactoringWizard refactoringWizard= new CleanUpRefactoringWizard(refactoring, RefactoringWizard.WIZARD_BASED_USER_INTERFACE);
 			RefactoringStarter starter= new RefactoringStarter();
-			starter.activate(refactoringWizard, shell, actionName, RefactoringSaveHelper.SAVE_REFACTORING);
+			starter.activate(refactoringWizard, shell, actionName, IRefactoringSaveModes.SAVE_REFACTORING);
 		}
 	}
 
 	public static void startConvertAnonymousRefactoring(final ICompilationUnit unit, final int offset, final int length, final Shell shell) {
 		final ConvertAnonymousToNestedRefactoring refactoring= new ConvertAnonymousToNestedRefactoring(unit, offset, length);
 		new RefactoringStarter().activate(new ConvertAnonymousToNestedWizard(refactoring), shell, RefactoringMessages.ConvertAnonymousToNestedAction_dialog_title,
-				RefactoringSaveHelper.SAVE_REFACTORING);
+				IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startCopyRefactoring(IResource[] resources, IJavaElement[] javaElements, Shell shell) throws JavaModelException {
@@ -282,19 +282,19 @@ public final class RefactoringExecutionStarter {
 		processor.setQueries(new ReorgQueries(shell));
 		Refactoring refactoring= new DeleteRefactoring(processor);
 		int stopSeverity= RefactoringCore.getConditionCheckingFailedSeverity();
-		new RefactoringExecutionHelper(refactoring, stopSeverity, RefactoringSaveHelper.SAVE_NOTHING, shell, new ProgressMonitorDialog(shell)).perform(false, false);
+		new RefactoringExecutionHelper(refactoring, stopSeverity, IRefactoringSaveModes.SAVE_NOTHING, shell, new ProgressMonitorDialog(shell)).perform(false, false);
 	}
 
 	public static void startDeleteRefactoring(final Object[] elements, final Shell shell) throws CoreException {
 		Refactoring refactoring= new DeleteRefactoring(new JavaDeleteProcessor(elements));
-		DeleteUserInterfaceManager.getDefault().getStarter(refactoring).activate(refactoring, shell, RefactoringSaveHelper.SAVE_NOTHING);
+		DeleteUserInterfaceManager.getDefault().getStarter(refactoring).activate(refactoring, shell, IRefactoringSaveModes.SAVE_NOTHING);
 	}
 
 	public static void startExtractInterfaceRefactoring(final IType type, final Shell shell) {
 		ExtractInterfaceProcessor processor= new ExtractInterfaceProcessor(type, JavaPreferencesSettings.getCodeGenerationSettings(type.getJavaProject()));
 		Refactoring refactoring= new ProcessorBasedRefactoring(processor);
 		new RefactoringStarter().activate(new ExtractInterfaceWizard(processor, refactoring), shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring,
-				RefactoringSaveHelper.SAVE_REFACTORING);
+				IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startExtractSupertypeRefactoring(final IMember[] members, final Shell shell) throws JavaModelException {
@@ -306,7 +306,7 @@ public final class RefactoringExecutionStarter {
 		ExtractSupertypeProcessor processor= new ExtractSupertypeProcessor(members, JavaPreferencesSettings.getCodeGenerationSettings(project));
 		Refactoring refactoring= new ProcessorBasedRefactoring(processor);
 		ExtractSupertypeWizard wizard= new ExtractSupertypeWizard(processor, refactoring);
-		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startInferTypeArgumentsRefactoring(final IJavaElement[] elements, final Shell shell) {
@@ -315,7 +315,7 @@ public final class RefactoringExecutionStarter {
 				return;
 			final InferTypeArgumentsRefactoring refactoring= new InferTypeArgumentsRefactoring(elements);
 			new RefactoringStarter()
-					.activate(new InferTypeArgumentsWizard(refactoring), shell, RefactoringMessages.InferTypeArgumentsAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+					.activate(new InferTypeArgumentsWizard(refactoring), shell, RefactoringMessages.InferTypeArgumentsAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 		} catch (CoreException e) {
 			ExceptionHandler.handle(e, RefactoringMessages.InferTypeArgumentsAction_dialog_title, RefactoringMessages.OpenRefactoringWizardAction_exception);
 		}
@@ -324,7 +324,7 @@ public final class RefactoringExecutionStarter {
 	public static boolean startInlineConstantRefactoring(final ICompilationUnit unit, final CompilationUnit node, final int offset, final int length, final Shell shell) {
 		final InlineConstantRefactoring refactoring= new InlineConstantRefactoring(unit, node, offset, length);
 		if (! refactoring.checkStaticFinalConstantNameSelected().hasFatalError()) {
-			new RefactoringStarter().activate(new InlineConstantWizard(refactoring), shell, RefactoringMessages.InlineConstantAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+			new RefactoringStarter().activate(new InlineConstantWizard(refactoring), shell, RefactoringMessages.InlineConstantAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 			return true;
 		}
 		return false;
@@ -333,7 +333,7 @@ public final class RefactoringExecutionStarter {
 	public static boolean startInlineMethodRefactoring(final ITypeRoot typeRoot, final CompilationUnit node, final int offset, final int length, final Shell shell) {
 		final InlineMethodRefactoring refactoring= InlineMethodRefactoring.create(typeRoot, node, offset, length);
 		if (refactoring != null) {
-			new RefactoringStarter().activate(new InlineMethodWizard(refactoring), shell, RefactoringMessages.InlineMethodAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+			new RefactoringStarter().activate(new InlineMethodWizard(refactoring), shell, RefactoringMessages.InlineMethodAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 			return true;
 		}
 		return false;
@@ -342,7 +342,7 @@ public final class RefactoringExecutionStarter {
 	public static boolean startInlineTempRefactoring(final ICompilationUnit unit, CompilationUnit node, final ITextSelection selection, final Shell shell) {
 		final InlineTempRefactoring refactoring= new InlineTempRefactoring(unit, node, selection.getOffset(), selection.getLength());
 		if (!refactoring.checkIfTempSelected().hasFatalError()) {
-			new RefactoringStarter().activate(new InlineTempWizard(refactoring), shell, RefactoringMessages.InlineTempAction_inline_temp, RefactoringSaveHelper.SAVE_NOTHING);
+			new RefactoringStarter().activate(new InlineTempWizard(refactoring), shell, RefactoringMessages.InlineTempAction_inline_temp, IRefactoringSaveModes.SAVE_NOTHING);
 			return true;
 		}
 		return false;
@@ -351,44 +351,44 @@ public final class RefactoringExecutionStarter {
 	public static void startIntroduceFactoryRefactoring(final ICompilationUnit unit, final ITextSelection selection, final Shell shell) {
 		final IntroduceFactoryRefactoring refactoring= new IntroduceFactoryRefactoring(unit, selection.getOffset(), selection.getLength());
 		new RefactoringStarter().activate(new IntroduceFactoryWizard(refactoring, RefactoringMessages.IntroduceFactoryAction_use_factory), shell,
-				RefactoringMessages.IntroduceFactoryAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+				RefactoringMessages.IntroduceFactoryAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startIntroduceIndirectionRefactoring(final IClassFile file, final int offset, final int length, final Shell shell) {
 		final IntroduceIndirectionRefactoring refactoring= new IntroduceIndirectionRefactoring(file, offset, length);
 		new RefactoringStarter().activate(new IntroduceIndirectionWizard(refactoring, RefactoringMessages.IntroduceIndirectionAction_dialog_title), shell,
-				RefactoringMessages.IntroduceIndirectionAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+				RefactoringMessages.IntroduceIndirectionAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startIntroduceIndirectionRefactoring(final ICompilationUnit unit, final int offset, final int length, final Shell shell) {
 		final IntroduceIndirectionRefactoring refactoring= new IntroduceIndirectionRefactoring(unit, offset, length);
 		new RefactoringStarter().activate(new IntroduceIndirectionWizard(refactoring, RefactoringMessages.IntroduceIndirectionAction_dialog_title), shell,
-				RefactoringMessages.IntroduceIndirectionAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+				RefactoringMessages.IntroduceIndirectionAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startIntroduceIndirectionRefactoring(final IMethod method, final Shell shell) {
 		final IntroduceIndirectionRefactoring refactoring= new IntroduceIndirectionRefactoring(method);
 		new RefactoringStarter().activate(new IntroduceIndirectionWizard(refactoring, RefactoringMessages.IntroduceIndirectionAction_dialog_title), shell,
-				RefactoringMessages.IntroduceIndirectionAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+				RefactoringMessages.IntroduceIndirectionAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startIntroduceParameter(ICompilationUnit unit, int offset, int length, Shell shell) {
 		final IntroduceParameterRefactoring refactoring= new IntroduceParameterRefactoring(unit, offset, length);
-		new RefactoringStarter().activate(new IntroduceParameterWizard(refactoring), shell, RefactoringMessages.IntroduceParameterAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(new IntroduceParameterWizard(refactoring), shell, RefactoringMessages.IntroduceParameterAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startMoveInnerRefactoring(final IType type, final Shell shell) throws JavaModelException {
 		if (!RefactoringAvailabilityTester.isMoveInnerAvailable(type))
 			return;
 		final MoveInnerToTopRefactoring refactoring= new MoveInnerToTopRefactoring(type, JavaPreferencesSettings.getCodeGenerationSettings(type.getJavaProject()));
-		new RefactoringStarter().activate(new MoveInnerToTopWizard(refactoring), shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(new MoveInnerToTopWizard(refactoring), shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startMoveMethodRefactoring(final IMethod method, final Shell shell) {
 		MoveInstanceMethodProcessor processor= new MoveInstanceMethodProcessor(method, JavaPreferencesSettings.getCodeGenerationSettings(method.getJavaProject()));
 		Refactoring refactoring= new MoveRefactoring(processor);
 		MoveInstanceMethodWizard wizard= new MoveInstanceMethodWizard(processor, refactoring);
-		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.MoveInstanceMethodAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.MoveInstanceMethodAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startMoveRefactoring(final IResource[] resources, final IJavaElement[] elements, final Shell shell) throws JavaModelException {
@@ -414,7 +414,7 @@ public final class RefactoringExecutionStarter {
 		MoveStaticMembersProcessor processor= new MoveStaticMembersProcessor(elements, JavaPreferencesSettings.getCodeGenerationSettings(project));
 		Refactoring refactoring= new MoveRefactoring(processor);
 		MoveMembersWizard wizard= new MoveMembersWizard(processor, refactoring);
-		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startPullUpRefactoring(final IMember[] members, final Shell shell) throws JavaModelException {
@@ -425,7 +425,7 @@ public final class RefactoringExecutionStarter {
 			project= members[0].getJavaProject();
 		PullUpRefactoringProcessor processor= new PullUpRefactoringProcessor(members, JavaPreferencesSettings.getCodeGenerationSettings(project));
 		Refactoring refactoring= new ProcessorBasedRefactoring(processor);
-		new RefactoringStarter().activate(new PullUpWizard(processor, refactoring), shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(new PullUpWizard(processor, refactoring), shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startPushDownRefactoring(final IMember[] members, final Shell shell) throws JavaModelException {
@@ -434,7 +434,7 @@ public final class RefactoringExecutionStarter {
 		PushDownRefactoringProcessor processor= new PushDownRefactoringProcessor(members);
 		Refactoring refactoring= new ProcessorBasedRefactoring(processor);
 		PushDownWizard wizard= new PushDownWizard(processor, refactoring);
-		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startRenameRefactoring(final IJavaElement element, final Shell shell) throws CoreException {
@@ -445,17 +445,17 @@ public final class RefactoringExecutionStarter {
 
 	public static void startRenameResourceRefactoring(final IResource resource, final Shell shell) {
 		RenameResourceWizard wizard= new RenameResourceWizard(resource);
-		new RefactoringStarter().activate(wizard, shell, wizard.getWindowTitle(), RefactoringSaveHelper.SAVE_ALL);
+		new RefactoringStarter().activate(wizard, shell, wizard.getWindowTitle(), IRefactoringSaveModes.SAVE_ALL);
 	}
 
 	public static void startReplaceInvocationsRefactoring(final ITypeRoot typeRoot, final int offset, final int length, final Shell shell) {
 		final ReplaceInvocationsRefactoring refactoring= new ReplaceInvocationsRefactoring(typeRoot, offset, length);
-		new RefactoringStarter().activate(new ReplaceInvocationsWizard(refactoring), shell, RefactoringMessages.ReplaceInvocationsAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(new ReplaceInvocationsWizard(refactoring), shell, RefactoringMessages.ReplaceInvocationsAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startReplaceInvocationsRefactoring(final IMethod method, final Shell shell) {
 		final ReplaceInvocationsRefactoring refactoring= new ReplaceInvocationsRefactoring(method);
-		new RefactoringStarter().activate(new ReplaceInvocationsWizard(refactoring), shell, RefactoringMessages.ReplaceInvocationsAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(new ReplaceInvocationsWizard(refactoring), shell, RefactoringMessages.ReplaceInvocationsAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	public static void startSelfEncapsulateRefactoring(final IField field, final Shell shell) {
@@ -463,7 +463,7 @@ public final class RefactoringExecutionStarter {
 			if (!RefactoringAvailabilityTester.isSelfEncapsulateAvailable(field))
 				return;
 			final SelfEncapsulateFieldRefactoring refactoring= new SelfEncapsulateFieldRefactoring(field);
-			new RefactoringStarter().activate(new SelfEncapsulateFieldWizard(refactoring), shell, "", RefactoringSaveHelper.SAVE_REFACTORING); //$NON-NLS-1$
+			new RefactoringStarter().activate(new SelfEncapsulateFieldWizard(refactoring), shell, "", IRefactoringSaveModes.SAVE_REFACTORING); //$NON-NLS-1$
 		} catch (JavaModelException e) {
 			ExceptionHandler.handle(e, ActionMessages.SelfEncapsulateFieldAction_dialog_title, ActionMessages.SelfEncapsulateFieldAction_dialog_cannot_perform);
 		}
@@ -473,7 +473,7 @@ public final class RefactoringExecutionStarter {
 		UseSuperTypeProcessor processor= new UseSuperTypeProcessor(type);
 		Refactoring refactoring= new ProcessorBasedRefactoring(processor);
 		UseSupertypeWizard wizard= new UseSupertypeWizard(processor, refactoring);
-		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 	private RefactoringExecutionStarter() {
@@ -522,7 +522,7 @@ public final class RefactoringExecutionStarter {
 		if (processor != null) {
 			Refactoring refactoring= new ProcessorBasedRefactoring(processor);
 			IntroduceParameterObjectWizard wizard= new IntroduceParameterObjectWizard(processor, refactoring);
-			new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+			new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 		}
 	}
 
@@ -531,7 +531,7 @@ public final class RefactoringExecutionStarter {
 		descriptor.setType(type);
 		ExtractClassRefactoring refactoring= new ExtractClassRefactoring(descriptor);
 		ExtractClassWizard wizard= new ExtractClassWizard(descriptor, refactoring);
-		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, RefactoringSaveHelper.SAVE_REFACTORING);
+		new RefactoringStarter().activate(wizard, shell, RefactoringMessages.OpenRefactoringWizardAction_refactoring, IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
 }

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/JavaRenameProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/JavaRenameProcessor.java
@@ -31,7 +31,7 @@ import org.eclipse.ltk.core.refactoring.participants.ValidateEditChecker;
 
 import org.eclipse.jdt.internal.corext.refactoring.tagging.INameUpdating;
 
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 
 public abstract class JavaRenameProcessor extends RenameProcessor implements INameUpdating {
@@ -80,9 +80,9 @@ public abstract class JavaRenameProcessor extends RenameProcessor implements INa
 	}
 
 	/**
-	 * @return a save mode from {@link RefactoringSaveHelper}
+	 * @return a save mode from {@link IRefactoringSaveModes}
 	 *
-	 * @see RefactoringSaveHelper
+	 * @see IRefactoringSaveModes
 	 */
 	public abstract int getSaveMode();
 

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameCompilationUnitProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameCompilationUnitProcessor.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.RenameTypeArguments;
 import org.eclipse.jdt.core.refactoring.descriptors.RenameJavaElementDescriptor;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.refactoring.Checks;
 import org.eclipse.jdt.internal.corext.refactoring.JDTRefactoringDescriptorComment;
@@ -62,11 +63,10 @@ import org.eclipse.jdt.internal.corext.util.JavaConventionsUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 public final class RenameCompilationUnitProcessor extends JavaRenameProcessor implements IReferenceUpdating, ITextUpdating, IQualifiedNameUpdating, ISimilarDeclarationUpdating, IResourceMapper, IJavaElementMapper {
 
@@ -94,7 +94,7 @@ public final class RenameCompilationUnitProcessor extends JavaRenameProcessor im
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_COMPILATION_UNIT_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_COMPILATION_UNIT_PROCESSOR;
 	}
 
 	@Override
@@ -143,7 +143,7 @@ public final class RenameCompilationUnitProcessor extends JavaRenameProcessor im
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_REFACTORING;
+		return IRefactoringSaveModes.SAVE_REFACTORING;
 	}
 
 	//---- IRenameProcessor -------------------------------------

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameEnumConstProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameEnumConstProcessor.java
@@ -38,7 +38,7 @@ import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
@@ -137,7 +137,7 @@ public final class RenameEnumConstProcessor extends RenameFieldProcessor {
 	 */
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_ENUM_CONSTANT_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_ENUM_CONSTANT_PROCESSOR;
 	}
 
 	/*

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameFieldProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameFieldProcessor.java
@@ -102,8 +102,8 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -198,7 +198,7 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_FIELD_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_FIELD_PROCESSOR;
 	}
 
 	@Override
@@ -499,7 +499,7 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_REFACTORING;
+		return IRefactoringSaveModes.SAVE_REFACTORING;
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameJavaProjectProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameJavaProjectProcessor.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.RenameJavaElementDescriptor;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.refactoring.JDTRefactoringDescriptorComment;
 import org.eclipse.jdt.internal.corext.refactoring.JavaRefactoringArguments;
@@ -52,10 +53,8 @@ import org.eclipse.jdt.internal.corext.refactoring.tagging.IReferenceUpdating;
 import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.Resources;
 
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
-
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 public final class RenameJavaProjectProcessor extends JavaRenameProcessor implements IReferenceUpdating {
 
@@ -81,7 +80,7 @@ public final class RenameJavaProjectProcessor extends JavaRenameProcessor implem
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_JAVA_PROJECT_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_JAVA_PROJECT_PROCESSOR;
 	}
 
 	@Override
@@ -128,7 +127,7 @@ public final class RenameJavaProjectProcessor extends JavaRenameProcessor implem
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_ALL;
+		return IRefactoringSaveModes.SAVE_ALL;
 	}
 
 	//---- IReferenceUpdating --------------------------------------

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
@@ -53,6 +53,7 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.RenameJavaElementDescriptor;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.refactoring.Checks;
 import org.eclipse.jdt.internal.corext.refactoring.JDTRefactoringDescriptorComment;
@@ -71,10 +72,9 @@ import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 public class RenameLocalVariableProcessor extends JavaRenameProcessor implements IReferenceUpdating {
 
@@ -272,7 +272,7 @@ public class RenameLocalVariableProcessor extends JavaRenameProcessor implements
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_NOTHING;
+		return IRefactoringSaveModes.SAVE_NOTHING;
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
@@ -95,8 +95,8 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -165,7 +165,7 @@ public abstract class RenameMethodProcessor extends JavaRenameProcessor implemen
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_METHOD_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_METHOD_PROCESSOR;
 	}
 
 	@Override
@@ -207,7 +207,7 @@ public abstract class RenameMethodProcessor extends JavaRenameProcessor implemen
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_REFACTORING;
+		return IRefactoringSaveModes.SAVE_REFACTORING;
 	}
 
 	//---- INameUpdating -------------------------------------

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameModuleProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameModuleProcessor.java
@@ -75,8 +75,8 @@ import org.eclipse.jdt.internal.corext.refactoring.util.ResourceUtil;
 import org.eclipse.jdt.internal.corext.refactoring.util.TextChangeManager;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -354,7 +354,7 @@ public class RenameModuleProcessor extends JavaRenameProcessor implements IRefer
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_REFACTORING;
+		return IRefactoringSaveModes.SAVE_REFACTORING;
 	}
 
 	@Override
@@ -364,7 +364,7 @@ public class RenameModuleProcessor extends JavaRenameProcessor implements IRefer
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_MODULE_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_MODULE_PROCESSOR;
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenamePackageProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenamePackageProcessor.java
@@ -109,7 +109,7 @@ import org.eclipse.jdt.internal.corext.util.Resources;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -203,7 +203,7 @@ public class RenamePackageProcessor extends JavaRenameProcessor implements
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_ALL;
+		return IRefactoringSaveModes.SAVE_ALL;
 	}
 
 	//---- ITextUpdating -------------------------------------------------

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameSourceFolderProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameSourceFolderProcessor.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.RenameJavaElementDescriptor;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.refactoring.JDTRefactoringDescriptorComment;
 import org.eclipse.jdt.internal.corext.refactoring.JavaRefactoringArguments;
@@ -48,10 +49,8 @@ import org.eclipse.jdt.internal.corext.refactoring.participants.JavaProcessors;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
-
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 public final class RenameSourceFolderProcessor extends JavaRenameProcessor {
 
@@ -78,7 +77,7 @@ public final class RenameSourceFolderProcessor extends JavaRenameProcessor {
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_SOURCE_FOLDER_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_SOURCE_FOLDER_PROCESSOR;
 	}
 
 	@Override
@@ -113,7 +112,7 @@ public final class RenameSourceFolderProcessor extends JavaRenameProcessor {
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_ALL;
+		return IRefactoringSaveModes.SAVE_ALL;
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeParameterProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeParameterProcessor.java
@@ -44,6 +44,7 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.RenameJavaElementDescriptor;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.SourceRangeFactory;
 import org.eclipse.jdt.internal.corext.dom.HierarchicalASTVisitor;
@@ -64,10 +65,9 @@ import org.eclipse.jdt.internal.corext.refactoring.util.ResourceUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 /**
  * Rename processor to rename type parameters.
@@ -197,7 +197,7 @@ public class RenameTypeParameterProcessor extends JavaRenameProcessor implements
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_NOTHING;
+		return IRefactoringSaveModes.SAVE_NOTHING;
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
@@ -124,8 +124,8 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -221,7 +221,7 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.RENAME_TYPE_PROCESSOR;
+		return IRefactoringProcessorIdsCore.RENAME_TYPE_PROCESSOR;
 	}
 
 	@Override
@@ -332,7 +332,7 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 
 	@Override
 	public int getSaveMode() {
-		return RefactoringSaveHelper.SAVE_REFACTORING;
+		return IRefactoringSaveModes.SAVE_REFACTORING;
 	}
 
 	//---- ITextUpdating -------------------------------------------------

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/JavaCopyProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/JavaCopyProcessor.java
@@ -52,7 +52,7 @@ import org.eclipse.jdt.internal.corext.refactoring.participants.ResourceProcesso
 import org.eclipse.jdt.internal.corext.refactoring.reorg.IReorgPolicy.ICopyPolicy;
 import org.eclipse.jdt.internal.corext.util.Resources;
 
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
 
 public final class JavaCopyProcessor extends CopyProcessor implements IReorgDestinationValidator {
 
@@ -204,7 +204,7 @@ public final class JavaCopyProcessor extends CopyProcessor implements IReorgDest
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.COPY_PROCESSOR;
+		return IRefactoringProcessorIdsCore.COPY_PROCESSOR;
 	}
 
 	public IJavaElement[] getJavaElements() {

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/JavaDeleteProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/JavaDeleteProcessor.java
@@ -88,7 +88,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.internal.corext.util.Resources;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -130,7 +130,7 @@ public final class JavaDeleteProcessor extends DeleteProcessor {
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.DELETE_PROCESSOR;
+		return IRefactoringProcessorIdsCore.DELETE_PROCESSOR;
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/JavaMoveProcessor.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/JavaMoveProcessor.java
@@ -52,7 +52,7 @@ import org.eclipse.jdt.internal.corext.refactoring.reorg.IReorgPolicy.IMovePolic
 import org.eclipse.jdt.internal.corext.refactoring.tagging.IQualifiedNameUpdating;
 import org.eclipse.jdt.internal.corext.util.Resources;
 
-import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIds;
+import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
 
 public final class JavaMoveProcessor extends MoveProcessor implements IQualifiedNameUpdating, IReorgDestinationValidator {
 
@@ -256,7 +256,7 @@ public final class JavaMoveProcessor extends MoveProcessor implements IQualified
 
 	@Override
 	public String getIdentifier() {
-		return IRefactoringProcessorIds.MOVE_PROCESSOR;
+		return IRefactoringProcessorIdsCore.MOVE_PROCESSOR;
 	}
 
 	public IJavaElement[] getJavaElements() {

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
@@ -154,7 +154,7 @@ import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -3424,7 +3424,7 @@ public final class ReorgPolicyFactory {
 
 		@Override
 		public int getSaveMode() {
-			return RefactoringSaveHelper.SAVE_ALL;
+			return IRefactoringSaveModes.SAVE_ALL;
 		}
 
 		@Override
@@ -3689,7 +3689,7 @@ public final class ReorgPolicyFactory {
 
 		@Override
 		public int getSaveMode() {
-			return RefactoringSaveHelper.SAVE_REFACTORING;
+			return IRefactoringSaveModes.SAVE_REFACTORING;
 		}
 
 		private void copyImportsToDestination(IImportContainer container, ASTRewrite rewrite, CompilationUnit sourceCuNode, CompilationUnit destinationCuNode) throws JavaModelException {

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/ExternalizeWizard.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/ExternalizeWizard.java
@@ -26,17 +26,17 @@ import org.eclipse.ltk.ui.refactoring.RefactoringWizard;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSRefactoring;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.actions.ActionMessages;
 import org.eclipse.jdt.internal.ui.refactoring.actions.RefactoringStarter;
 import org.eclipse.jdt.internal.ui.util.ExceptionHandler;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 /**
  * good citizen problems - wizard is only valid after constructor (when the pages toggle
@@ -90,7 +90,7 @@ public class ExternalizeWizard extends RefactoringWizard {
 						NLSUIMessages.ExternalizeWizard_error_message);
 			}
 			if (refactoring != null)
-				new RefactoringStarter().activate(new ExternalizeWizard(refactoring), shell, ActionMessages.ExternalizeStringsAction_dialog_title, RefactoringSaveHelper.SAVE_REFACTORING);
+				new RefactoringStarter().activate(new ExternalizeWizard(refactoring), shell, ActionMessages.ExternalizeStringsAction_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
 		});
 	}
 }

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/PasteAction.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/PasteAction.java
@@ -157,7 +157,7 @@ import org.eclipse.jdt.launching.environments.IExecutionEnvironmentsManager;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.actions.SelectionDispatchAction;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.IJavaStatusConstants;
@@ -1473,7 +1473,7 @@ public class PasteAction extends SelectionDispatchAction{
 
 			public void run(Shell parent) throws InterruptedException, InvocationTargetException {
 				IRunnableContext context= new ProgressMonitorDialog(parent);
-				new RefactoringExecutionHelper(fPasteRefactoring, RefactoringCore.getConditionCheckingFailedSeverity(), RefactoringSaveHelper.SAVE_NOTHING, parent, context).perform(false, false);
+				new RefactoringExecutionHelper(fPasteRefactoring, RefactoringCore.getConditionCheckingFailedSeverity(), IRefactoringSaveModes.SAVE_NOTHING, parent, context).perform(false, false);
 			}
 		}
 		private static class PasteTypedSourcesRefactoring extends Refactoring {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarFileExportOperation.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarFileExportOperation.java
@@ -87,6 +87,7 @@ import org.eclipse.jdt.ui.jarpackager.IJarBuilderExtension;
 import org.eclipse.jdt.ui.jarpackager.IJarDescriptionWriter;
 import org.eclipse.jdt.ui.jarpackager.IJarExportRunnable;
 import org.eclipse.jdt.ui.jarpackager.JarPackageData;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
 
 import org.eclipse.jdt.internal.ui.IJavaStatusConstants;
@@ -1067,7 +1068,7 @@ public class JarFileExportOperation extends WorkspaceModifyOperation implements 
 		if (fParentShell != null) {
 			final boolean[] res= { false };
 			fParentShell.getDisplay().syncExec(() -> {
-				RefactoringSaveHelper refactoringSaveHelper= new RefactoringSaveHelper(RefactoringSaveHelper.SAVE_ALL_ALWAYS_ASK);
+				RefactoringSaveHelper refactoringSaveHelper= new RefactoringSaveHelper(IRefactoringSaveModes.SAVE_ALL_ALWAYS_ASK);
 				res[0]= refactoringSaveHelper.saveEditors(fParentShell);
 				fFilesSaved= refactoringSaveHelper.didSaveFiles();
 			});

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javadocexport/JavadocWizard.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javadocexport/JavadocWizard.java
@@ -83,6 +83,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 
 import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
@@ -166,7 +167,7 @@ public class JavadocWizard extends Wizard implements IExportWizard {
 		fStore.updateDialogSettings(getDialogSettings(), checkedProjects);
 
 		// Wizard should not run with dirty editors
-		if (!new RefactoringSaveHelper(RefactoringSaveHelper.SAVE_ALL_ALWAYS_ASK).saveEditors(getShell())) {
+		if (!new RefactoringSaveHelper(IRefactoringSaveModes.SAVE_ALL_ALWAYS_ASK).saveEditors(getShell())) {
 			return false;
 		}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionSubProcessor.java
@@ -59,6 +59,8 @@ import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.codemanipulation.GetterSetterUtil;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
@@ -67,7 +69,7 @@ import org.eclipse.jdt.internal.corext.refactoring.sef.SelfEncapsulateFieldRefac
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposal;
@@ -80,9 +82,6 @@ import org.eclipse.jdt.internal.ui.refactoring.RefactoringExecutionHelper;
 import org.eclipse.jdt.internal.ui.refactoring.actions.RefactoringStarter;
 import org.eclipse.jdt.internal.ui.refactoring.sef.SelfEncapsulateFieldWizard;
 import org.eclipse.jdt.internal.ui.util.ExceptionHandler;
-
-import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 
 public class GetterSetterCorrectionSubProcessor {
@@ -166,7 +165,7 @@ public class GetterSetterCorrectionSubProcessor {
 				refactoring.setConsiderVisibility(false);//private field references are just searched in local file
 				if (fNoDialog) {
 					IWorkbenchWindow window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-					final RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, RefactoringStatus.ERROR, RefactoringSaveHelper.SAVE_REFACTORING, JavaPlugin.getActiveWorkbenchShell(), window);
+					final RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, RefactoringStatus.ERROR, IRefactoringSaveModes.SAVE_REFACTORING, JavaPlugin.getActiveWorkbenchShell(), window);
 					if (Display.getCurrent() != null) {
 						try {
 							helper.perform(false, false);
@@ -183,7 +182,7 @@ public class GetterSetterCorrectionSubProcessor {
 						});
 					}
 				} else {
-					new RefactoringStarter().activate(new SelfEncapsulateFieldWizard(refactoring), JavaPlugin.getActiveWorkbenchShell(), "", RefactoringSaveHelper.SAVE_REFACTORING); //$NON-NLS-1$
+					new RefactoringStarter().activate(new SelfEncapsulateFieldWizard(refactoring), JavaPlugin.getActiveWorkbenchShell(), "", IRefactoringSaveModes.SAVE_REFACTORING); //$NON-NLS-1$
 				}
 			} catch (JavaModelException e) {
 				ExceptionHandler.handle(e, CorrectionMessages.GetterSetterCorrectionSubProcessor_encapsulate_field_error_title, CorrectionMessages.GetterSetterCorrectionSubProcessor_encapsulate_field_error_message);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
@@ -53,7 +53,7 @@ import org.eclipse.jdt.ui.JavaElementImageDescriptor;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.cleanup.ICleanUp;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
@@ -169,7 +169,7 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 			int stopSeverity= RefactoringCore.getConditionCheckingFailedSeverity();
 			Shell shell= JavaPlugin.getActiveWorkbenchShell();
 			IRunnableContext context= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-			RefactoringExecutionHelper executer= new RefactoringExecutionHelper(refactoring, stopSeverity, RefactoringSaveHelper.SAVE_NOTHING, shell, context);
+			RefactoringExecutionHelper executer= new RefactoringExecutionHelper(refactoring, stopSeverity, IRefactoringSaveModes.SAVE_NOTHING, shell, context);
 			try {
 				executer.perform(true, true);
 			} catch (InterruptedException e) {
@@ -206,7 +206,7 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 		IRunnableContext context= (fork, cancelable, runnable) -> runnable.run(monitor == null ? new NullProgressMonitor() : monitor);
 
 		Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-		RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, IStatus.INFO, RefactoringSaveHelper.SAVE_REFACTORING, shell, context);
+		RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, IStatus.INFO, IRefactoringSaveModes.SAVE_REFACTORING, shell, context);
 		try {
 			helper.perform(true, true);
 		} catch (InterruptedException e) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ConvertLocalToFieldAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ConvertLocalToFieldAction.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTester;
 import org.eclipse.jdt.internal.corext.refactoring.code.PromoteTempToFieldRefactoring;
 
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.actions.ActionUtil;
@@ -89,6 +89,6 @@ public class ConvertLocalToFieldAction extends SelectionDispatchAction {
 			return;
 		ICompilationUnit cunit= SelectionConverter.getInputAsCompilationUnit(fEditor);
 		PromoteTempToFieldRefactoring refactoring= new PromoteTempToFieldRefactoring(cunit, selection.getOffset(), selection.getLength());
-		new RefactoringStarter().activate(new PromoteTempWizard(refactoring), getShell(), RefactoringMessages.ConvertLocalToField_title, RefactoringSaveHelper.SAVE_NOTHING);
+		new RefactoringStarter().activate(new PromoteTempWizard(refactoring), getShell(), RefactoringMessages.ConvertLocalToField_title, IRefactoringSaveModes.SAVE_NOTHING);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ExtractConstantAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ExtractConstantAction.java
@@ -20,7 +20,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTester;
 import org.eclipse.jdt.internal.corext.refactoring.code.ExtractConstantRefactoring;
 
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.actions.ActionUtil;
@@ -82,6 +82,6 @@ public class ExtractConstantAction extends SelectionDispatchAction {
 		if (!ActionUtil.isEditable(fEditor))
 			return;
 		ExtractConstantRefactoring refactoring= new ExtractConstantRefactoring(SelectionConverter.getInputAsCompilationUnit(fEditor), selection.getOffset(), selection.getLength());
-		new RefactoringStarter().activate(new ExtractConstantWizard(refactoring), getShell(), RefactoringMessages.ExtractConstantAction_extract_constant, RefactoringSaveHelper.SAVE_NOTHING);
+		new RefactoringStarter().activate(new ExtractConstantWizard(refactoring), getShell(), RefactoringMessages.ExtractConstantAction_extract_constant, IRefactoringSaveModes.SAVE_NOTHING);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ExtractMethodAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ExtractMethodAction.java
@@ -20,7 +20,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTester;
 import org.eclipse.jdt.internal.corext.refactoring.code.ExtractMethodRefactoring;
 
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.actions.ActionUtil;
@@ -84,6 +84,6 @@ public class ExtractMethodAction extends SelectionDispatchAction {
 		if (!ActionUtil.isEditable(fEditor))
 			return;
 		ExtractMethodRefactoring refactoring= new ExtractMethodRefactoring(SelectionConverter.getInputAsCompilationUnit(fEditor), selection.getOffset(), selection.getLength());
-		new RefactoringStarter().activate(new ExtractMethodWizard(refactoring), getShell(), RefactoringMessages.ExtractMethodAction_dialog_title, RefactoringSaveHelper.SAVE_NOTHING);
+		new RefactoringStarter().activate(new ExtractMethodWizard(refactoring), getShell(), RefactoringMessages.ExtractMethodAction_dialog_title, IRefactoringSaveModes.SAVE_NOTHING);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ExtractTempAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ExtractTempAction.java
@@ -20,7 +20,7 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTester;
 import org.eclipse.jdt.internal.corext.refactoring.code.ExtractTempRefactoring;
 
-import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
+import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.actions.ActionUtil;
@@ -82,6 +82,6 @@ public class ExtractTempAction extends SelectionDispatchAction {
 		if (!ActionUtil.isEditable(fEditor))
 			return;
 		ExtractTempRefactoring refactoring= new ExtractTempRefactoring(SelectionConverter.getInputAsCompilationUnit(fEditor), selection.getOffset(), selection.getLength());
-		new RefactoringStarter().activate(new ExtractTempWizard(refactoring), getShell(), RefactoringMessages.ExtractTempAction_extract_temp, RefactoringSaveHelper.SAVE_NOTHING);
+		new RefactoringStarter().activate(new ExtractTempWizard(refactoring), getShell(), RefactoringMessages.ExtractTempAction_extract_temp, IRefactoringSaveModes.SAVE_NOTHING);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/refactoring/RefactoringSaveHelper.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/refactoring/RefactoringSaveHelper.java
@@ -69,23 +69,23 @@ public class RefactoringSaveHelper {
 	/**
 	 * Save mode to save all dirty editors (always ask).
 	 */
-	public static final int SAVE_ALL_ALWAYS_ASK= 1;
+	public static final int SAVE_ALL_ALWAYS_ASK= IRefactoringSaveModes.SAVE_ALL_ALWAYS_ASK;
 
 	/**
 	 * Save mode to save all dirty editors.
 	 */
-	public static final int SAVE_ALL= 2;
+	public static final int SAVE_ALL= IRefactoringSaveModes.SAVE_ALL;
 
 	/**
 	 * Save mode to not save any editors.
 	 */
-	public static final int SAVE_NOTHING= 3;
+	public static final int SAVE_NOTHING= IRefactoringSaveModes.SAVE_NOTHING;
 
 	/**
 	 * Save mode to save all editors that are known to cause trouble for Java refactorings, e.g.
 	 * editors on compilation units that are not in working copy mode.
 	 */
-	public static final int SAVE_REFACTORING= 4;
+	public static final int SAVE_REFACTORING= IRefactoringSaveModes.SAVE_REFACTORING;
 
 	/**
 	 * Creates a refactoring save helper with the given save mode.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
This patch extracts some constants from RefactoringSaveHelper, specifically the return values of the user prompt. While the refactors themselves do want to know the result of a user prompt, the fact is that a user prompt may be from eclipse UI / swt, or it may be from a CLI (if one is attempting to use jdt.core.manipulations in some type of headless application). 

By extracting this interface and decoupling it from a UI class, we allow other applications (like JDT LS) to make use of these refactors without needing to clone the class. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
