### PR TITLE
Propose import quick fix for missing annotation value

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
@@ -2779,4 +2779,96 @@ public class QuickFixTest1d8 extends QuickFixTest {
 		assertProposalDoesNotExist(proposals, FixMessages.InlineDeprecatedMethod_msg);
 	}
 
+	// issue 717 : support import quick fix for annotations
+	@Test
+	public void testIssue717_1() throws Exception {
+		Hashtable<String, String> options = JavaCore.getOptions();
+		JavaCore.setOptions(options);
+		JavaProjectHelper.addLibrary(fJProject1, new Path(Java1d8ProjectTestSetup.getJdtAnnotations20Path()));
+		IPackageFragment pack2= fSourceFolder.createPackageFragment("test1", false, null);
+
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.lang.annotation.Documented;\n");
+		buf.append("import java.lang.annotation.Target;\n");
+		buf.append("\n");
+		buf.append("@Target(ElementType.TYPE_USE)\n");
+		buf.append("@Documented\n");
+		buf.append("@interface NonCritical { }\n");
+		buf.append("class E {\n");
+		buf.append("\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		IProblem[] problems= astRoot.getProblems();
+		assertNumberOfProblems(1, problems);
+		List<IJavaCompletionProposal> proposals= collectCorrections(cu, problems[0], null);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.lang.annotation.Documented;\n");
+		buf.append("import java.lang.annotation.ElementType;\n");
+		buf.append("import java.lang.annotation.Target;\n");
+		buf.append("\n");
+		buf.append("@Target(ElementType.TYPE_USE)\n");
+		buf.append("@Documented\n");
+		buf.append("@interface NonCritical { }\n");
+		buf.append("class E {\n");
+		buf.append("\n");
+		buf.append("}\n");
+
+		String expected1 = buf.toString();
+
+		assertExpectedExistInProposals(proposals, new String[] {expected1});
+	}
+
+	// issue 717 : support import quick fix for annotations
+	@Test
+	public void testIssue717_2() throws Exception {
+		Hashtable<String, String> options = JavaCore.getOptions();
+		JavaCore.setOptions(options);
+		JavaProjectHelper.addLibrary(fJProject1, new Path(Java1d8ProjectTestSetup.getJdtAnnotations20Path()));
+		IPackageFragment pack2= fSourceFolder.createPackageFragment("test1", false, null);
+
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.lang.annotation.Documented;\n");
+		buf.append("import java.lang.annotation.Target;\n");
+		buf.append("\n");
+		buf.append("@Target(value=ElementType.TYPE_USE)\n");
+		buf.append("@Documented\n");
+		buf.append("@interface NonCritical { }\n");
+		buf.append("class E {\n");
+		buf.append("\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		IProblem[] problems= astRoot.getProblems();
+		assertNumberOfProblems(1, problems);
+		List<IJavaCompletionProposal> proposals= collectCorrections(cu, problems[0], null);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.lang.annotation.Documented;\n");
+		buf.append("import java.lang.annotation.ElementType;\n");
+		buf.append("import java.lang.annotation.Target;\n");
+		buf.append("\n");
+		buf.append("@Target(value=ElementType.TYPE_USE)\n");
+		buf.append("@Documented\n");
+		buf.append("@interface NonCritical { }\n");
+		buf.append("class E {\n");
+		buf.append("\n");
+		buf.append("}\n");
+
+		String expected1 = buf.toString();
+
+		assertExpectedExistInProposals(proposals, new String[] {expected1});
+	}
+
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -420,8 +420,6 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 				UnresolvedElementsSubProcessor.getVariableProposals(context, problem, null, proposals);
 				break;
 			case IProblem.UnresolvedVariable:
-				ICompilationUnit cu= context.getCompilationUnit();
-
 				CompilationUnit astRoot= context.getASTRoot();
 				ASTNode selectedNode= problem.getCoveredNode(astRoot);
 				if (selectedNode != null) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -425,14 +425,12 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 				if (selectedNode != null) {
 					// type that defines the variable
 					ITypeBinding declaringTypeBinding= Bindings.getBindingOfParentTypeContext(selectedNode);
-					if (declaringTypeBinding == null) {
-						if (selectedNode.getParent() instanceof QualifiedName &&
+					if (declaringTypeBinding == null && selectedNode.getParent() instanceof QualifiedName &&
 								(selectedNode.getParent().getParent() instanceof SingleMemberAnnotation ||
 										selectedNode.getParent().getParent() instanceof MemberValuePair)) {
-							UnresolvedElementsSubProcessor.getTypeProposals(context, problem, proposals);
-						} else {
-							UnresolvedElementsSubProcessor.getVariableProposals(context, problem, null, proposals);
-						}
+						UnresolvedElementsSubProcessor.getTypeProposals(context, problem, proposals);
+					} else {
+						UnresolvedElementsSubProcessor.getVariableProposals(context, problem, null, proposals);
 					}
 				}
 				break;


### PR DESCRIPTION
- modify QuickFixProcessor to recognize an UndefinedVariable error for an annotation value and propose import if possible
- add new tests to QuickFixTest1d8
- fixes #717

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes old bugzilla bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=421693 which has a missing import for an annotation value and Eclipse does not propose adding an import.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See bug or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
