### PR TITLE
Final version bump for org.eclipse.ui dependency

### DIFF
--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.24.0,4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.17.0,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.17.0,4.0.0)",
- org.eclipse.ui;bundle-version="[3.203.0,4.0.0)",
+ org.eclipse.ui;bundle-version="[3.204.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.19.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.21.0,4.0.0)",

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -121,7 +121,7 @@ Require-Bundle:
  org.eclipse.team.ui;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.24.0,4.0.0)",
- org.eclipse.ui;bundle-version="[3.203.0,4.0.0)",
+ org.eclipse.ui;bundle-version="[3.204.0,4.0.0)",
  org.eclipse.ui.console;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.17.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.21.0,4.0.0)",


### PR DESCRIPTION
Hard require at least 3.204.0 version of `org.eclipse.ui` which re-exports new API we use from `org.eclipse.ui.workbench`.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1051
