### PR TITLE
QuickAssistProcessor: prevent AIOOBE in getAddMethodDeclaration() #740

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -1845,6 +1845,10 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		}
 		ITypeBinding[] parameterTypes= methodBinding.getParameterTypes();
 		ITypeBinding[] typeArguments= methodBinding.getTypeArguments();
+		if (index >= parameterTypes.length) {
+			// node not found
+			return false;
+		}
 		ITypeBinding[] parameterTypesFunctionalInterface= parameterTypes[index].getFunctionalInterfaceMethod().getParameterTypes();
 		ITypeBinding returnTypeBindingFunctionalInterface= parameterTypes[index].getFunctionalInterfaceMethod().getReturnType();
 		MethodDeclaration newMethodDeclaration= ast.newMethodDeclaration();


### PR DESCRIPTION
was ArrayIndexOutOfBoundsException

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/740

