### PR TITLE
Improve hover for Java hex, octal, and binary constants

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaConstantHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaConstantHover.java
@@ -33,20 +33,23 @@ public class JavaConstantHover extends AbstractJavaEditorTextHover {
 			}
 			if (hoverSource != null && hoverSource.startsWith("0")) { //$NON-NLS-1$
 				try {
-					long longValue= hoverSource.startsWith("0b") ? //$NON-NLS-1$
-							Long.parseLong(hoverSource.substring(2), 2) : Long.decode(hoverSource).longValue();
+					long longValue= hoverSource.startsWith("0b") || hoverSource.startsWith("0B") ? //$NON-NLS-1$ //$NON-NLS-2$
+							Long.parseLong(withoutUnderscoreInfixes(hoverSource.substring(2)), 2)
+							: Long.decode(withoutUnderscoreInfixes(hoverSource)).longValue();
 					return "<body><p>" + Long.toString(longValue) + "<b> : [0x" + Long.toHexString(longValue) + "]</p></body>"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				} catch (NumberFormatException e) {
-					try {
-						double doubleValue= Double.valueOf(hoverSource).doubleValue();
-						return "<body><p>" + Double.toString(doubleValue) + "</p></body>"; //$NON-NLS-1$ //$NON-NLS-2$
-					} catch (NumberFormatException e1) {
-						// do nothing
-					}
+					// do nothing
 				}
 			}
 		}
 		return null;
+	}
+
+	private static String withoutUnderscoreInfixes(String s) {
+		if ((s.length() > 0) && (s.indexOf('_') <= 0 || s.lastIndexOf('_') == s.length() - 1) || s.startsWith("0x_") || s.startsWith("0X_")) { //$NON-NLS-1$ //$NON-NLS-2$
+			return s;
+		}
+		return s.replace("_", ""); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaConstantHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaConstantHover.java
@@ -50,11 +50,13 @@ public class JavaConstantHover extends AbstractJavaEditorTextHover {
 			} catch (BadLocationException e) {
 				// should never happen
 			}
+			hoverSource= hoverSource.toLowerCase();
 			if (hoverSource != null && hoverSource.startsWith("0")) { //$NON-NLS-1$
 				try {
-					long longValue= hoverSource.startsWith("0b") || hoverSource.startsWith("0B") ? //$NON-NLS-1$ //$NON-NLS-2$
-							Long.parseLong(withoutUnderscoreInfixes(hoverSource.substring(2)), 2)
-							: Long.decode(withoutUnderscoreInfixes(hoverSource)).longValue();
+					String temp= hoverSource.charAt(hoverSource.length() - 1) == 'l' ? hoverSource.substring(0, hoverSource.length() - 1) : hoverSource;
+					long longValue= temp.startsWith("0b") ? //$NON-NLS-1$
+							Long.parseLong(withoutUnderscoreInfixes(temp.substring(2)), 2)
+							: Long.decode(withoutUnderscoreInfixes(temp)).longValue();
 					return "<body><p>" + Long.toString(longValue) + "<b> : [0x" + Long.toHexString(longValue) + "]</p></body>"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				} catch (NumberFormatException e) {
 					try {


### PR DESCRIPTION
Show hovers also in the following cases:
```java
int bin1 = 0B11111111; // uppercase "0B"
int bin2 = 0b1111_1111; // binary with an underscore
int oct = 0_377;  // octal with an underscore
int hex = 0xff_ff_ff; // hex with underscores
```

Do not show hovers for doubles starting with "0", e.g.:
  double d= 01e6D;

This does not fix the issue that hovers are shown in the following cases where they are not make sense:
```java
double d2= 012.045;
```
- First hover for "012": "10 : [0xa]"
- Second hover for "045": "37 : [0x25]"

See also https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/640