### PR TITLE
Add unicode support to Javadoc hover

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 GK Software SE and others.
+ * Copyright (c) 2020, 2023 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -155,6 +155,67 @@ public class JavadocHoverTests extends CoreTests {
 			    " *    for (String s : strings) {\n" +
 			    " *        if (s.equals(value)) {\n" +
 			    " *            return 0;\n" +
+			    " *        }\n" +
+			    " *        if (s.startsWith(value)) {\n" +
+			    " *            return 1;\n" +
+			    " *        }\n" +
+			    " *    }\n" +
+			    " *    return -1;\n" +
+			    " * }</pre>\n" +
+			    " */\n" +
+				"int check (String value, String[] strings) {\n" +
+				"	for (String s : strings) {\n" +
+				"		if (s.equals(value)) {\n" +
+				"			return 0;\n" +
+				"		}\n" +
+				"		if (s.startsWith(value)) {\n" +
+				"			return 1;\n" +
+				"		}\n" +
+				"	}\n" +
+				"	return -1;\n" +
+				"}\n";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/TestClass.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		IType type= cu.getType("TestClass");
+		// check javadoc on each member:
+		for (IJavaElement member : type.getChildren()) {
+			IJavaElement[] elements= { member };
+			ISourceRange range= ((ISourceReference) member).getNameRange();
+			JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(elements, cu, new Region(range.getOffset(), range.getLength()), null);
+			String actualHtmlContent= hoverInfo.getHtml();
+
+			String expectedCodeSequence= "<pre><code>\n"
+					+ "    for (String s : strings) {\n"
+					+ "        if (s.equals(value)) {\n"
+					+ "            return 0;\n"
+					+ "        }\n"
+					+ "        if (s.startsWith(value)) {\n"
+					+ "            return 1;\n"
+					+ "        }\n"
+					+ "    }\n"
+					+ "    return -1;\n"
+					+ " </code></pre>";
+
+			// value should be expanded:
+			int index= actualHtmlContent.indexOf("<pre><code>");
+			assertFalse(index == -1);
+			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
+			assertEquals("sequence doesn't match", actualSnippet, expectedCodeSequence);
+		}
+	}
+
+	@Test
+	public void testUnicode() throws Exception {
+		String source=
+				"package p;\n" +
+				"public class TestClass {\n" +
+			    "/**\n" +
+			    " * Performs:\u005cn" +
+			    " * <pre>{@code\n" +
+			    " *    for (String s : strings) {\u005cn" +
+			    " *        if (s.equals(value)) {\n" +
+			    " *            return \u0030;\n" +
 			    " *        }\n" +
 			    " *        if (s.startsWith(value)) {\n" +
 			    " *            return 1;\n" +


### PR DESCRIPTION
- fixes #743
- add new test to JavadocHoverTests

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds unicode support in Javadoc hover so unicode characters are properly displayed.  See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test and issue scenarios.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
