### PR TITLE
Preserve comment on variable cast when doing pattern instanceof cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -18,6 +18,9 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.text.edits.TextEditGroup;
+
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -39,10 +42,11 @@ import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
+
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
-import org.eclipse.text.edits.TextEditGroup;
 
 public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteOperationsFixCore {
 	public static final class PatternMatchingForInstanceofFinder extends ASTVisitor {
@@ -207,7 +211,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			ASTNodes.replaceButKeepComment(rewrite, nodeToComplete, newInstanceof, group);
 
 			if (ASTNodes.canHaveSiblings(statementToRemove) || statementToRemove.getLocationInParent() == IfStatement.ELSE_STATEMENT_PROPERTY) {
-				rewrite.remove(statementToRemove, group);
+				ASTNodes.removeButKeepComment(rewrite, statementToRemove, group);
 			} else {
 				ASTNodes.replaceButKeepComment(rewrite, statementToRemove, ast.newBlock(), group);
 			}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -18,17 +18,22 @@ import static org.junit.Assert.assertNotEquals;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.eclipse.core.runtime.CoreException;
+
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
+
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+
 import org.eclipse.jdt.ui.tests.core.rules.Java16ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 
 /**
  * Tests the cleanup features related to Java 16.
@@ -126,6 +131,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "    public long matchPatternForInstanceof(Object object) {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        if (object instanceof Date) {\n" //
+				+ "            // Keep this comment too\n" //
 				+ "            Date date = (Date) object;\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
@@ -136,6 +142,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "    public long matchPatternForInstanceofOnFinalVariable(Object object) {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        if (object instanceof Date) {\n" //
+				+ "            // Keep this comment too\n" //
 				+ "            final Date date = (Date) object;\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
@@ -145,6 +152,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long matchPatternInConditionalAndExpression(Object object, boolean isValid) {\n" //
 				+ "        if (isValid && object instanceof Date) {\n" //
+				+ "            // Keep this comment\n" //
 				+ "            Date date = (Date) object;\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
@@ -155,6 +163,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long matchPatternInAndExpression(Object object, boolean isValid) {\n" //
 				+ "        if (object instanceof Date & isValid) {\n" //
+				+ "            // Keep this comment\n" //
 				+ "            Date date = (Date) object;\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
@@ -219,6 +228,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "    public long matchPatternForInstanceof(Object object) {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        if (object instanceof Date date) {\n" //
+				+ "            // Keep this comment too\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
 				+ "\n" //
@@ -228,6 +238,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "    public long matchPatternForInstanceofOnFinalVariable(Object object) {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        if (object instanceof final Date date) {\n" //
+				+ "            // Keep this comment too\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
 				+ "\n" //
@@ -236,6 +247,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long matchPatternInConditionalAndExpression(Object object, boolean isValid) {\n" //
 				+ "        if (isValid && object instanceof Date date) {\n" //
+				+ "            // Keep this comment\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
 				+ "\n" //
@@ -245,6 +257,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long matchPatternInAndExpression(Object object, boolean isValid) {\n" //
 				+ "        if (object instanceof Date date & isValid) {\n" //
+				+ "            // Keep this comment\n" //
 				+ "            return date.getTime();\n" //
 				+ "        }\n" //
 				+ "\n" //


### PR DESCRIPTION
- retain the comment for the declared variable that is cast to the type in the instanceof expression that will be converted to instanceof pattern
- modify existing test in CleanUpTest16
- fixes #729

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the pattern instanceof cleanup to preserve the comment for the cast statement that gets removed.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See test modification.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
