### PR TITLE
Don't offer to add type parameters to var type variable

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.19.100.qualifier
+Bundle-Version: 1.19.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/Java50FixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/Java50FixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -325,7 +325,7 @@ public class Java50FixCore extends CompilationUnitRewriteOperationsFixCore {
 				ASTNode node= problem.getCoveredNode(compilationUnit);
 				if (node instanceof ClassInstanceCreation) {
 					Type rawReference= (Type)node.getStructuralProperty(ClassInstanceCreation.TYPE_PROPERTY);
-					if (isRawTypeReference(rawReference)) {
+					if (!rawReference.isVar() && isRawTypeReference(rawReference)) {
 						result.add((SimpleType) rawReference);
 					}
 				} else if (node instanceof SimpleName) {
@@ -333,14 +333,15 @@ public class Java50FixCore extends CompilationUnitRewriteOperationsFixCore {
 					if (isRawTypeReference(rawReference)) {
 						ASTNode parent= rawReference.getParent();
 						if (!(parent instanceof ArrayType)
-								&& !(parent instanceof ParameterizedType))
+								&& !(parent instanceof ParameterizedType)
+								&& !((SimpleType)rawReference).isVar())
 							result.add((SimpleType) rawReference);
 					}
 				} else if (node instanceof MethodInvocation) {
 					MethodInvocation invocation= (MethodInvocation)node;
 
 					SimpleType rawReference= getRawReference(invocation, compilationUnit);
-					if (rawReference != null) {
+					if (rawReference != null && !rawReference.isVar()) {
 						result.add(rawReference);
 					}
 				}
@@ -401,7 +402,7 @@ public class Java50FixCore extends CompilationUnitRewriteOperationsFixCore {
 		}
 	}
 
-	private static SimpleType getRawReference(MethodInvocation invocation, CompilationUnit compilationUnit) {
+	public static SimpleType getRawReference(MethodInvocation invocation, CompilationUnit compilationUnit) {
 		Name name1= (Name)invocation.getStructuralProperty(MethodInvocation.NAME_PROPERTY);
 		if (name1 instanceof SimpleName) {
 			SimpleType rawReference= getRawReference((SimpleName)name1, compilationUnit);
@@ -471,7 +472,7 @@ public class Java50FixCore extends CompilationUnitRewriteOperationsFixCore {
 		return null;
 	}
 
-	private static boolean isRawTypeReference(ASTNode node) {
+	public static boolean isRawTypeReference(ASTNode node) {
 		if (!(node instanceof SimpleType))
 			return false;
 

--- a/org.eclipse.jdt.core.manipulation/pom.xml
+++ b/org.eclipse.jdt.core.manipulation/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.manipulation</artifactId>
-  <version>1.19.100-SNAPSHOT</version>
+  <version>1.19.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.15.200.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.15.100-SNAPSHOT</version>
+  <version>3.15.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest10.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest10.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.testplugin.TestOptions;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+
+import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.core.rules.Java10ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+/**
+ * Those tests are made to run on Java 10..
+ */
+public class LocalCorrectionsQuickFixTest10 extends QuickFixTest {
+
+	@Rule
+    public ProjectTestSetup projectSetup= new Java10ProjectTestSetup();
+
+	private IJavaProject fJProject1;
+
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setUp() throws Exception {
+		Hashtable<String, String> options= TestOptions.getDefaultOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, "4");
+		options.put(DefaultCodeFormatterConstants.FORMATTER_NUMBER_OF_EMPTY_LINES_TO_PRESERVE, String.valueOf(99));
+		options.put(JavaCore.COMPILER_PB_STATIC_ACCESS_RECEIVER, JavaCore.ERROR);
+		options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.IGNORE);
+		options.put(JavaCore.COMPILER_PB_MISSING_HASHCODE_METHOD, JavaCore.WARNING);
+		options.put(JavaCore.COMPILER_PB_REDUNDANT_TYPE_ARGUMENTS, JavaCore.WARNING);
+
+		JavaCore.setOptions(options);
+
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.CODEGEN_ADD_COMMENTS, false);
+
+		StubUtility.setCodeTemplate(CodeTemplateContextType.CATCHBLOCK_ID, "", null);
+		StubUtility.setCodeTemplate(CodeTemplateContextType.CONSTRUCTORSTUB_ID, "", null);
+		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "", null);
+
+		fJProject1= projectSetup.getProject();
+
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		JavaProjectHelper.clear(fJProject1, projectSetup.getDefaultClasspath());
+	}
+
+	@Test
+    public void testTypeParametersToRawTypeReferenceIssue765() throws Exception {
+            Hashtable<String, String> options= JavaCore.getOptions();
+            options.put(JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE, JavaCore.WARNING);
+            options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.WARNING);
+            JavaCore.setOptions(options);
+
+            IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+
+            StringBuilder buf= new StringBuilder();
+            buf.append("package test1;\n");
+            buf.append("import java.util.List;\n");
+            buf.append("\n");
+            buf.append("class E1 {\n");
+            buf.append("    void f() {\n");
+            buf.append("        var list = T.forClass(List.class);\n");
+            buf.append("        doSomethingWith(list.get()); // (1)\n");
+            buf.append("    }\n");
+            buf.append("    @SuppressWarnings(\"unused\")\n");
+            buf.append("    void doSomethingWith(List<Object> list) {}\n");
+            buf.append("    static class T<A> {\n");
+            buf.append("        static <O> T<O> forClass(@SuppressWarnings(\"unused\") Class<O> clazz) { return null; }\n");
+            buf.append("        A get() { return null; }\n");
+            buf.append("    }\n");
+            buf.append("}\n");
+
+            ICompilationUnit cu= pack1.createCompilationUnit("E1.java", buf.toString(), false, null);
+
+            CompilationUnit astRoot= getASTRoot(cu);
+            ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
+    		assertNumberOfProposals(proposals, 2);
+
+    		assertProposalDoesNotExist(proposals, "Add type arguments to 'var'");
+    		assertProposalDoesNotExist(proposals, "Infer Generic Type Arguments...");
+    		assertProposalExists(proposals, "Configure problem severity");
+    		assertProposalExists(proposals, "Add @SuppressWarnings 'unchecked' to 'f()'");
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTestSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTestSuite.java
@@ -35,6 +35,7 @@ import org.junit.runners.Suite;
 	LocalCorrectionsQuickFixTest.class,
 	LocalCorrectionsQuickFixTest1d7.class,
 	LocalCorrectionsQuickFixTest1d8.class,
+	LocalCorrectionsQuickFixTest10.class,
 	LocalCorrectionsQuickFixTest15.class,
 	TypeMismatchQuickFixTests.class,
 	ReorgQuickFixTest.class,

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -1817,7 +1817,9 @@ public class LocalCorrectionsSubProcessor {
 		} else if (node instanceof MethodInvocation) {
 			MethodInvocation invocation= (MethodInvocation)node;
 			SimpleType rawReference= Java50FixCore.getRawReference(invocation, compilationUnit);
-			return rawReference.isVar();
+			if (rawReference != null) {
+				return rawReference.isVar();
+			}
 		}
 		return false;
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -97,6 +97,7 @@ import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.PrefixExpression;
 import org.eclipse.jdt.core.dom.PrimitiveType;
@@ -1766,6 +1767,9 @@ public class LocalCorrectionsSubProcessor {
 		}
 		if (!hasInferTypeArgumentsProposal) {
 			final ICompilationUnit cu= context.getCompilationUnit();
+			if (referencesVar(problem, context.getASTRoot()))  {
+				return;
+			}
 			ChangeCorrectionProposal proposal= new ChangeCorrectionProposal(CorrectionMessages.LocalCorrectionsSubProcessor_InferGenericTypeArguments, null,
 					IProposalRelevance.INFER_GENERIC_TYPE_ARGUMENTS, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE)) {
 				@Override
@@ -1794,6 +1798,28 @@ public class LocalCorrectionsSubProcessor {
 		}
 
 		addTypeArgumentsFromContext(context, problem, proposals);
+	}
+
+	private static boolean referencesVar(IProblemLocation problem, CompilationUnit compilationUnit) {
+		ASTNode node= problem.getCoveredNode(compilationUnit);
+		if (node instanceof ClassInstanceCreation) {
+			Type rawReference= (Type)node.getStructuralProperty(ClassInstanceCreation.TYPE_PROPERTY);
+			return rawReference.isVar();
+		} else if (node instanceof SimpleName) {
+			ASTNode rawReference= node.getParent();
+			if (Java50FixCore.isRawTypeReference(rawReference)) {
+				ASTNode parent= rawReference.getParent();
+				if (!(parent instanceof ArrayType)
+						&& !(parent instanceof ParameterizedType)) {
+					return ((SimpleType)rawReference).isVar();
+				}
+			}
+		} else if (node instanceof MethodInvocation) {
+			MethodInvocation invocation= (MethodInvocation)node;
+			SimpleType rawReference= Java50FixCore.getRawReference(invocation, compilationUnit);
+			return rawReference.isVar();
+		}
+		return false;
 	}
 
 	private static void addTypeArgumentsFromContext(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {


### PR DESCRIPTION
- add var checks to Java50FixCore.createRawTypeReferenceOperation()
- make some static methods public in Java50FixCore regarding raw type reference checking
- add var checking to LocalCorrectionsSubProcessor
- add new LocalCorrectionsQuickFixTest10
- fixes #765

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Removes proposals to add type parameters to a var typed variable declaration.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new test case.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
