### PR TITLE
Ignore spelling in java string literals should apply to text blocks too

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/JavaSpellingEngine.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/JavaSpellingEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -53,7 +53,7 @@ public class JavaSpellingEngine extends SpellingEngine {
 					if (listener.isProblemsThresholdReached())
 						return;
 					final String type= partition.getType();
-					if (isIgnoringJavaStrings && IJavaPartitions.JAVA_STRING.equals(type))
+					if (isIgnoringJavaStrings && (IJavaPartitions.JAVA_STRING.equals(type) || IJavaPartitions.JAVA_MULTI_LINE_STRING.equals(type)))
 						continue;
 					if (!IDocument.DEFAULT_CONTENT_TYPE.equals(type) && !IJavaPartitions.JAVA_CHARACTER.equals(type))
 						checker.execute(listener, new SpellCheckIterator(document, partition, checker.getLocale(), monitor));


### PR DESCRIPTION
- add text block partitions to ignore logic in JavaSpellingEngine
- replaces #707
- fixes #770

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes spell checking to ignore both Java regular string literals and Java text blocks when the user has chosen to ignore spelling in Java strings.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
