### PR TITLE
Don't make a field final if used in lambda exp used to initialize field

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -5446,4 +5446,63 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
 	}
+
+	@Test
+	public void testDoNotAddFinalForFieldUsedInLambdaFieldInitializer() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/769
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\n" //
+				+ "public class E {\n" //
+				+ "    interface I {\n" //
+				+ "        void run( //\n" //
+				+ "    }\n" //
+				+ "    private String f;\n" //
+				+ "    private String g;\n" //
+				+ "    I x = () -> {\n" //
+				+ "        g.concat(\"abc\");\n" //
+				+ "    };\n" //
+				+ "    public E() {\n" //
+				+ "        this.f= \"abc\";\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        x.run( //\n" //
+				+ "        System.out.println(f //\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "}\n" //
+				+ "\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL);
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_PARAMETERS);
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_PRIVATE_FIELDS);
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_LOCAL_VARIABLES);
+
+		sample= "" //
+				+ "package test;\n" //
+				+ "public class E {\n" //
+				+ "    interface I {\n" //
+				+ "        void run( //\n" //
+				+ "    }\n" //
+				+ "    private final String f;\n" //
+				+ "    private String g;\n" //
+				+ "    I x = () -> {\n" //
+				+ "        g.concat(\"abc\");\n" //
+				+ "    };\n" //
+				+ "    public E() {\n" //
+				+ "        this.f= \"abc\";\n" //
+				+ "    }\n" //
+				+ "    public void foo() {\n" //
+				+ "        x.run( //\n" //
+				+ "        System.out.println(f //\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "}\n" //
+				+ "\n";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] {cu1}, new String[] {expected1},
+				new HashSet<>(Arrays.asList(FixMessages.VariableDeclarationFix_changeModifierOfUnknownToFinal_description)));
+	}
+
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -5463,6 +5463,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "    };\n" //
 				+ "    public E() {\n" //
 				+ "        this.f= \"abc\";\n" //
+				+ "        this.g= \"def\";\n" //
 				+ "    }\n" //
 				+ "    public void foo() {\n" //
 				+ "        x.run( //\n" //
@@ -5491,6 +5492,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "    };\n" //
 				+ "    public E() {\n" //
 				+ "        this.f= \"abc\";\n" //
+				+ "        this.g= \"def\";\n" //
 				+ "    }\n" //
 				+ "    public void foo() {\n" //
 				+ "        x.run( //\n" //


### PR DESCRIPTION
- if an uninitialized field is used inside a lambda expression to initialize another field, it cannot be made final
- add this logic to VariableDeclarationFixCore
- add new test to CleanUpTest1d8
- fixes #769

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds checks to the add final specifier to private fields cleanup so it doesn't do this for fields that are used in other field's initializers that are lambdas.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test or issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
