### PR TITLE
JavaElementImplementationHyperlink: fix progress during newTypeHierarchy

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementImplementationHyperlink.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementImplementationHyperlink.java
@@ -269,15 +269,13 @@ public class JavaElementImplementationHyperlink implements IHyperlink {
 				}
 				try {
 					String typeLabel= JavaElementLabels.getElementLabel(type, JavaElementLabels.DEFAULT_QUALIFIED);
-					monitor.beginTask(Messages.format(JavaEditorMessages.JavaElementImplementationHyperlink_search_method_implementors, typeLabel), 10);
+					monitor.setTaskName(Messages.format(JavaEditorMessages.JavaElementImplementationHyperlink_search_method_implementors, typeLabel));
 					links.addAll(Arrays.asList(type.newTypeHierarchy(monitor).getAllSubtypes(type)));
 					if (monitor.isCanceled()) {
 						throw new OperationCanceledException();
 					}
 				} catch (CoreException e) {
 					throw new InvocationTargetException(e);
-				} finally {
-					monitor.done();
 				}
 			};
 


### PR DESCRIPTION
newTypeHierarchy is a JavaModelOperation which uses SubMonitor.convert since https://bugs.eclipse.org/bugs/show_bug.cgi?id=477790 That is not allowed when beginTask is already called. See SubMonitor.convert javadoc.

https://github.com/eclipse-platform/eclipse.platform.ui/issues/1107

