### PR TITLE
Fix NPE for StringConcatToTextBlockFixCore

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -52,7 +52,14 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "package test1;\n" //
 				+ "\n" //
 				+ "public class E {\n" //
-				+ "    public void testSimple() {\n"
+				+ "    static String str = \"\" + //$NON-NLS-1$\n" //
+				+ "            \"public class B { \\n\" + //$NON-NLS-1$\n" //
+				+ "            \"   public \\nvoid foo() {\\n\" + //$NON-NLS-1$\n" //
+				+ "            \"       System.out.println(\\\"abc\\\");\\n\" + //$NON-NLS-1$\n" //
+				+ "            \"   }\\n\" + //$NON-NLS-1$\n" //
+				+ "            \"}\"; //$NON-NLS-1$\n" //
+				+ "\n" //
+				+ "    public void testSimple() {\n" //
 				+ "        // comment 1\n" //
 				+ "        String x = \"\" + //$NON-NLS-1$\n" //
     	        + "            \"public void foo() {\\n\" + //$NON-NLS-1$\n" //
@@ -91,6 +98,14 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "package test1;\n" //
 				+ "\n" //
 				+ "public class E {\n" //
+				+ "    static String str = \"\"\"\n" //
+				+ "    \tpublic class B {\\s\n" //
+				+ "    \t   public\\s\n" //
+				+ "    \tvoid foo() {\n" //
+				+ "    \t       System.out.println(\"abc\");\n" //
+				+ "    \t   }\n" //
+				+ "    \t}\"\"\"; //$NON-NLS-1$\n" //
+				+ "\n" //
 				+ "    public void testSimple() {\n" //
 				+ "        // comment 1\n" //
 				+ "        String x = \"\"\"\n" //
@@ -269,6 +284,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            \"abcdef\" +\n" //
     	        + "            \"ghijkl\" + //$NON-NLS-1$\n" //
     	        + "            \"mnop\";\n" //
+    	        + "    }\n" //
+    	        + "\n" //
+   	            + "    public void testArrayInitializer() {\n" //
+				+ "        String[] x = { \"\" +\n" //
+    	        + "            \"abcdef\" +\n" //
+    	        + "            \"ghijkl\" + //$NON-NLS-1$\n" //
+    	        + "            \"mnop\"};\n" //
     	        + "    }\n" //
 				+ "}\n";
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);


### PR DESCRIPTION
- make sure before creating a change operation that any InfixExpression that has NLS tags has either a Statement or FieldDeclaration ancestor in StringConcatToTextBlockFixCore
- add new tests to CleanUpTest15
- fixes #779

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes potential NPE in string concat to text block cleanup/quick-fix.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Declare a String field that initializes using a string concatenation and has at least one NLS tag for concatenation parts.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
