### PR TITLE
[21][quick fix] Provide quick fix to add default case for exhaustive enhanced switch statement

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -324,6 +328,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.DanglingReference:
 			case IProblem.UnclosedCloseable:
 			case IProblem.PotentiallyUnclosedCloseable:
+			case IProblem.EnhancedSwitchMissingDefault:
 				return true;
 			default:
 				return SuppressWarningsSubProcessor.hasSuppressWarningsProposal(cu.getJavaProject(), problemId)
@@ -782,6 +787,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 				break;
 			case IProblem.MissingDefaultCase:
 			case IProblem.SwitchExpressionsYieldMissingDefaultCase:
+			case IProblem.EnhancedSwitchMissingDefault:
 				LocalCorrectionsSubProcessor.addMissingDefaultCaseProposal(context, problem, proposals);
 				break;
 			case IProblem.MissingEnumConstantCaseDespiteDefault:


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/783

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Provides quick fix: Add 'default' case

## How to test

Before:

```
package pkg;

public class Snippet {
	
	int m1(R<X> c) {
		return switch (c) {
		case R<X>(X x, Y y) -> 1;
		case R<X>(Y y, X x) -> 2;
		};
	}
}

class X {}
class Y extends X {}
record R<T> (T x, T y){}
```

After:

```
package pkg;

public class Snippet {
	
	int m1(R<X> c) {
		return switch (c) {
		case R<X>(X x, Y y) -> 1;
		case R<X>(Y y, X x) -> 2;
		default -> throw new IllegalArgumentException("Unexpected value: " + c);
		};
	}
}

class X {}
class Y extends X {}
record R<T> (T x, T y){}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
