### PR TITLE
Fix build test errors due to AST API >= 20

### DIFF
--- a/org.eclipse.jdt.core.manipulation/.settings/.api_filters
+++ b/org.eclipse.jdt.core.manipulation/.settings/.api_filters
@@ -66,4 +66,13 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java" type="org.eclipse.jdt.internal.corext.fix.PatternMatchingForInstanceofFixCore$PatternMatchingForInstanceofFixOperation">
+        <filter comment="Need to set pattern of TypePatter" id="640712815">
+            <message_arguments>
+                <message_argument value="TypePattern"/>
+                <message_argument value="PatternMatchingForInstanceofFixOperation"/>
+                <message_argument value="setPatternVariable(SingleVariableDeclaration)"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.core.dom.PrefixExpression;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypePattern;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -206,7 +207,13 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			if (Modifier.isFinal(statementToRemove.getModifiers())) {
 				newSVDecl.modifiers().add(ast.newModifier(ModifierKeyword.fromFlagValue(Modifier.FINAL)));
 			}
-			newInstanceof.setRightOperand(newSVDecl);
+			if (ast.apiLevel() >= AST.JLS20) {
+				TypePattern newTypePattern= ast.newTypePattern();
+				newTypePattern.setPatternVariable(newSVDecl);
+				newInstanceof.setPattern(newTypePattern);
+			} else {
+				newInstanceof.setRightOperand(newSVDecl);
+			}
 
 			ASTNodes.replaceButKeepComment(rewrite, nodeToComplete, newInstanceof, group);
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -207,7 +207,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			if (Modifier.isFinal(statementToRemove.getModifiers())) {
 				newSVDecl.modifiers().add(ast.newModifier(ModifierKeyword.fromFlagValue(Modifier.FINAL)));
 			}
-			if (ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) {
+			if ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled()) || ast.apiLevel() > AST.JLS20) {
 				TypePattern newTypePattern= ast.newTypePattern();
 				newTypePattern.setPatternVariable(newSVDecl);
 				newInstanceof.setPattern(newTypePattern);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -207,7 +207,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			if (Modifier.isFinal(statementToRemove.getModifiers())) {
 				newSVDecl.modifiers().add(ast.newModifier(ModifierKeyword.fromFlagValue(Modifier.FINAL)));
 			}
-			if (ast.apiLevel() >= AST.JLS20) {
+			if (ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) {
 				TypePattern newTypePattern= ast.newTypePattern();
 				newTypePattern.setPatternVariable(newSVDecl);
 				newInstanceof.setPattern(newTypePattern);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
@@ -21,6 +21,7 @@ import java.util.Stack;
 import org.eclipse.core.runtime.Assert;
 
 import org.eclipse.jdt.core.SourceRange;
+import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
@@ -56,6 +57,7 @@ import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NullLiteral;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.Pattern;
 import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.ReturnStatement;
@@ -859,7 +861,8 @@ public final class SuperTypeConstraintsCreator extends HierarchicalASTVisitor {
 	public void endVisit(final Type node) {
 		final ASTNode parent= node.getParent();
 		if (!(parent instanceof AbstractTypeDeclaration) && !(parent instanceof ClassInstanceCreation) && !(parent instanceof CreationReference) && !(parent instanceof TypeLiteral)
-				&& (!(parent instanceof SingleVariableDeclaration) || parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY) && (!(parent instanceof InstanceofExpression) || fInstanceOf))
+				&& (!(parent instanceof SingleVariableDeclaration) || (node.getAST().apiLevel() >= AST.JLS20 && parent != null && !(parent.getParent() instanceof Pattern)) || (node.getAST().apiLevel() < AST.JLS20 && parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY))
+				&& (!(parent instanceof InstanceofExpression) || fInstanceOf))
 			node.setProperty(PROPERTY_CONSTRAINT_VARIABLE, fModel.createTypeVariable(node));
 	}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
@@ -860,8 +860,9 @@ public final class SuperTypeConstraintsCreator extends HierarchicalASTVisitor {
 	@Override
 	public void endVisit(final Type node) {
 		final ASTNode parent= node.getParent();
+		final AST ast= node.getAST();
 		if (!(parent instanceof AbstractTypeDeclaration) && !(parent instanceof ClassInstanceCreation) && !(parent instanceof CreationReference) && !(parent instanceof TypeLiteral)
-				&& (!(parent instanceof SingleVariableDeclaration) || (node.getAST().apiLevel() >= AST.JLS20 && parent != null && !(parent.getParent() instanceof Pattern)) || (node.getAST().apiLevel() < AST.JLS20 && parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY))
+				&& (!(parent instanceof SingleVariableDeclaration) || ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) && !(parent.getParent() instanceof Pattern)) || (node.getAST().apiLevel() < AST.JLS20 && parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY))
 				&& (!(parent instanceof InstanceofExpression) || fInstanceOf))
 			node.setProperty(PROPERTY_CONSTRAINT_VARIABLE, fModel.createTypeVariable(node));
 	}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
@@ -862,7 +862,7 @@ public final class SuperTypeConstraintsCreator extends HierarchicalASTVisitor {
 		final ASTNode parent= node.getParent();
 		final AST ast= node.getAST();
 		if (!(parent instanceof AbstractTypeDeclaration) && !(parent instanceof ClassInstanceCreation) && !(parent instanceof CreationReference) && !(parent instanceof TypeLiteral)
-				&& (!(parent instanceof SingleVariableDeclaration) || ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) && !(parent.getParent() instanceof Pattern)) || (node.getAST().apiLevel() < AST.JLS20 && parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY))
+				&& (!(parent instanceof SingleVariableDeclaration) || ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) && !(parent.getParent() instanceof Pattern)) || parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY)
 				&& (!(parent instanceof InstanceofExpression) || fInstanceOf))
 			node.setProperty(PROPERTY_CONSTRAINT_VARIABLE, fModel.createTypeVariable(node));
 	}

--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -16,6 +16,15 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchAnalyzer.java" type="org.eclipse.jdt.internal.corext.refactoring.surround.SurroundWithTryCatchAnalyzer">
+        <filter comment="Support new TypePattern" id="640712815">
+            <message_arguments>
+                <message_argument value="TypePattern"/>
+                <message_argument value="SurroundWithTryCatchAnalyzer"/>
+                <message_argument value="getPatternVariable()"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="internal compatibility/org/eclipse/jdt/internal/corext/SourceRange.java" type="org.eclipse.jdt.internal.corext.SourceRange">
         <filter id="574619656">
             <message_arguments>

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchAnalyzer.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -26,9 +27,11 @@ import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodReference;
+import org.eclipse.jdt.core.dom.Pattern;
 import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.TypePattern;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 
@@ -88,6 +91,14 @@ public class SurroundWithTryCatchAnalyzer extends SurroundWithAnalyzer {
 			@Override
 			public boolean visit(PatternInstanceofExpression node) {
 				SingleVariableDeclaration svd= node.getRightOperand();
+				if (node.getAST().apiLevel() >= AST.JLS20) {
+					Pattern p= node.getPattern();
+					if (p instanceof TypePattern typePattern) {
+						svd= typePattern.getPatternVariable();
+					} else {
+						return false;
+					}
+				}
 				SimpleName name= svd.getName();
 				IBinding binding= name.resolveBinding();
 				if (binding instanceof IVariableBinding) {

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchAnalyzer.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchAnalyzer.java
@@ -91,7 +91,8 @@ public class SurroundWithTryCatchAnalyzer extends SurroundWithAnalyzer {
 			@Override
 			public boolean visit(PatternInstanceofExpression node) {
 				SingleVariableDeclaration svd= node.getRightOperand();
-				if (node.getAST().apiLevel() >= AST.JLS20) {
+				AST ast= node.getAST();
+				if (ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) {
 					Pattern p= node.getPattern();
 					if (p instanceof TypePattern typePattern) {
 						svd= typePattern.getPatternVariable();


### PR DESCRIPTION
- new AST for 20 and up changes PatternInstanceofExpression and this needs to be accommodated in some refactoring logic
- change SuperTypeConstraintsCreator and SurroundWithTryCatchAnalyzer to handle updated version of PatternInstanceofExpression
- fixes #745

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes some problems found in the Y-builds due to newer AST API level.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See tests in question.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
