### PR TITLE
performance: avoid O(n^2) in ContentProviders

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/DestinationContentProvider.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/DestinationContentProvider.java
@@ -14,9 +14,12 @@
 package org.eclipse.jdt.internal.ui.refactoring.reorg;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
@@ -104,6 +107,13 @@ public final class DestinationContentProvider extends StandardJavaElementContent
 				return members;
 			boolean isFolderOnClasspath = javaProject.isOnClasspath(container);
 			List<IResource> nonJavaResources= new ArrayList<>();
+			Set<IPath> classRootPaths= new HashSet<>();
+			for (IPackageFragmentRoot classpathRoot : javaProject.getAllPackageFragmentRoots()) {
+				IPath classRootPath= classpathRoot.getPath();
+				if (classRootPath != null) {
+					classRootPaths.add(classRootPath);
+				}
+			}
 			// Can be on classpath but as a member of non-java resource folder
 			for (IResource member : members) {
 				// A resource can also be a java element
@@ -111,7 +121,7 @@ public final class DestinationContentProvider extends StandardJavaElementContent
 				// We therefore exclude Java elements from the list
 				// of non-Java resources.
 				if (isFolderOnClasspath) {
-					if (javaProject.findPackageFragmentRoot(member.getFullPath()) == null) {
+					if (!classRootPaths.contains(member.getFullPath())) {
 						nonJavaResources.add(member);
 					}
 				} else if (!javaProject.isOnClasspath(member)) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/StandardJavaElementContentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/StandardJavaElementContentProvider.java
@@ -15,9 +15,12 @@ package org.eclipse.jdt.ui;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -393,6 +396,13 @@ public class StandardJavaElementContentProvider implements ITreeContentProvider,
 			return members;
 		boolean isFolderOnClasspath = javaProject.isOnClasspath(folder);
 		List<IResource> nonJavaResources= new ArrayList<>();
+		Set<IPath> classRootPaths= new HashSet<>();
+		for (IPackageFragmentRoot classpathRoot : javaProject.getAllPackageFragmentRoots()) {
+			IPath classRootPath= classpathRoot.getPath();
+			if (classRootPath != null) {
+				classRootPaths.add(classRootPath);
+			}
+		}
 		// Can be on classpath but as a member of non-java resource folder
 		for (IResource member : members) {
 			// A resource can also be a java element
@@ -400,7 +410,7 @@ public class StandardJavaElementContentProvider implements ITreeContentProvider,
 			// We therefore exclude Java elements from the list
 			// of non-Java resources.
 			if (isFolderOnClasspath) {
-				if (javaProject.findPackageFragmentRoot(member.getFullPath()) == null) {
+				if (!classRootPaths.contains(member.getFullPath())) {
 					nonJavaResources.add(member);
 				}
 			} else if (!javaProject.isOnClasspath(member)) {
@@ -417,7 +427,6 @@ public class StandardJavaElementContentProvider implements ITreeContentProvider,
 		}
 		return nonJavaResources.toArray();
 	}
-
 	/**
 	 * Tests if the a Java element delta contains a class path change
 	 *


### PR DESCRIPTION
findPackageFragmentRoot() searches through all PackageFragment Roots for every IContainer.member. This can be slow due to involved file access. see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/303

Instead call getAllPackageFragmentRoots() only once, index the result and use O(1) hash access.
