### PR TITLE
Tweak SuperTypeConstraintsCreator logic

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeConstraintsCreator.java
@@ -862,7 +862,9 @@ public final class SuperTypeConstraintsCreator extends HierarchicalASTVisitor {
 		final ASTNode parent= node.getParent();
 		final AST ast= node.getAST();
 		if (!(parent instanceof AbstractTypeDeclaration) && !(parent instanceof ClassInstanceCreation) && !(parent instanceof CreationReference) && !(parent instanceof TypeLiteral)
-				&& (!(parent instanceof SingleVariableDeclaration) || ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) && !(parent.getParent() instanceof Pattern)) || parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY)
+				&& (!(parent instanceof SingleVariableDeclaration)
+						|| ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) && !(parent.getParent() instanceof Pattern))
+						|| (ast.apiLevel() <= AST.JLS20 && parent.getLocationInParent() != PatternInstanceofExpression.RIGHT_OPERAND_PROPERTY))
 				&& (!(parent instanceof InstanceofExpression) || fInstanceOf))
 			node.setProperty(PROPERTY_CONSTRAINT_VARIABLE, fModel.createTypeVariable(node));
 	}


### PR DESCRIPTION
- modify endVisit(Type) to support all AST api levels 21 and below

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Tweaks the logic in SuperTypeConstraintsCreator for PatternInstanceofExpression to handle AST api 21 and below.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run the UseSuperTypeWherePossibleTests and UseSuperTypeWherePossibleTests16 tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
