### PR TITLE
Support 'Show In' similar to 'Link with Editor'.

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
@@ -1355,6 +1355,22 @@ public class PackageExplorerPart extends ViewPart
             if (revealElementOrParent(element))
 	            return IStatus.OK;
         }
+
+        //we tried removing filters, still element was not found. we can try to select any possible element in it's parent hierarchy. Like 'Link with Editor'
+        ISelection newSelection= new StructuredSelection(element);
+		while (element != null && fViewer.getSelection().isEmpty()) {
+			// Try to select parent in case element is filtered
+			element= getParent(element);
+			if (element != null) {
+				newSelection= new StructuredSelection(element);
+				fViewer.setSelection(newSelection, true);
+			}
+		}
+
+		if (!getSite().getSelectionProvider().getSelection().isEmpty()) {
+			return IStatus.OK;
+		}
+
         return IStatus.ERROR;
     }
 


### PR DESCRIPTION
'Link with Editor' tries to select visible parent in case of element being linked is not created yet on tree viewer. Similar implementation is used for 'Show In'

Fixes https://github.com/eclipse-platform/eclipse.platform.ui/issues/1014