### PR TITLE
Increase timeout in FatJarExporTests to reduce the chances of tests failing randomly on slow hardware

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/jarexport/FatJarExportTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/jarexport/FatJarExportTests.java
@@ -112,7 +112,7 @@ public class FatJarExportTests {
 	@Rule
 	public TestName tn=new TestName();
 
-	private static final int JAVA_RUN_TIMEOUT= 50; // 10th of a second
+	private static final int JAVA_RUN_TIMEOUT= 300; // 10th of a second
 
 	@BeforeClass
 	public static void setUpTest() {


### PR DESCRIPTION
## What it does
Increase timeout to 30s per test instead of 5s. This doesn't slow down the tests execution, it just lets the tests run a bit longer if the hardware is slow.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/699

## How to test
Run the tests in `org.eclipse.jdt.ui.tests.jarexport.FatJarExportTests`, they should pass.

## Author checklist

✔️  I have thoroughly tested my changes
✔️ The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
✔️ I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
