### PR TITLE
isExpandableNode API usage is removed.

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaOutlinePage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaOutlinePage.java
@@ -424,9 +424,6 @@ public class JavaOutlinePage extends Page implements IContentOutlinePage, IAdapt
 				 */
 				@Override
 				public boolean isExpandable(Object element) {
-					if (isExpandableNode(element)) {
-						return false;
-					}
 					if (hasFilters()) {
 						return getFilteredChildren(element).length > 0;
 					}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
@@ -285,9 +285,6 @@ public class PackageExplorerPart extends ViewPart
 			if (parent instanceof IPackageFragmentRoot && ((IPackageFragmentRoot) parent).isArchive()) {
 				return false;
 			}
-			if(isExpandableNode(parent)) {
-				return false;
-			}
 			return true;
 		}
 


### PR DESCRIPTION
As we had introduced changes in getRawChildren to return remaining elements as children for ExpandableNode we had to explicitly make this change. Now we don't return remaining elements as children for ExpndableNode.