### PR TITLE
Add back some missing methods to FixCorrectionProposal

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
@@ -37,6 +37,7 @@ import org.eclipse.jface.text.contentassist.ICompletionProposalExtension2;
 import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ltk.core.refactoring.RefactoringCore;
+import org.eclipse.ltk.core.refactoring.TextChange;
 
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
@@ -156,6 +157,17 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 	public boolean validate(IDocument document, int offset, DocumentEvent event) {
 		return false;
 	}
+
+	@Override
+	protected TextChange createTextChange() throws CoreException {
+		return ((FixCorrectionProposalCore)getDelegate()).createTextChange();
+	}
+
+	@Override
+	public int getRelevance() {
+		return ((FixCorrectionProposalCore)getDelegate()).getRelevance();
+	}
+
 	@Override
 	public String getStatusMessage() {
 		ICleanUpCore cleanup = ((FixCorrectionProposalCore)getDelegate()).getCleanUp();


### PR DESCRIPTION
- add createTextChange() that uses delegate into FixCorrectProposal
- add getRelevance() method to call delegate as well
- fixes #826

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes regression #826

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Try using CTRL+1 on String concatenation and selecting to change to Text Block.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
