### PR TITLE
Fix FixCorrectionProposal to properly handle IMultiFix cleanups

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -116,8 +116,7 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 	}
 
 	public ICleanUp getCleanUp() {
-		ICleanUpCore ret = ((FixCorrectionProposalCore)getDelegate()).getCleanUp();
-		return CleanUpCoreWrapper.wrap(ret);
+		return fCleanUp;
 	}
 
 	public IStatus getFixStatus() {
@@ -170,11 +169,7 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 
 	@Override
 	public String getStatusMessage() {
-		ICleanUpCore cleanup = ((FixCorrectionProposalCore)getDelegate()).getCleanUp();
-		if (cleanup == null)
-			return null;
-
-		int count= computeNumberOfFixesForCleanUp(cleanup);
+		int count= computeNumberOfFixesForCleanUp(fCleanUp);
 
 		if (count == -1) {
 			return CorrectionMessages.FixCorrectionProposal_HitCtrlEnter_description;
@@ -192,7 +187,7 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 	 * @return the maximum number of fixes or -1 if unknown
 	 * @since 3.6
 	 */
-	public int computeNumberOfFixesForCleanUp(ICleanUpCore cleanUp) {
+	public int computeNumberOfFixesForCleanUp(ICleanUp cleanUp) {
 		CompilationUnit cu = ((FixCorrectionProposalCore)getDelegate()).getAstCompilationUnit();
 		return cleanUp instanceof IMultiFix ? ((IMultiFix)cleanUp).computeNumberOfFixes(cu) : -1;
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/AbstractAnnotationHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/AbstractAnnotationHover.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -95,7 +95,6 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaAnnotationIterator;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposal;
-import org.eclipse.jdt.internal.ui.util.CleanUpCoreWrapper;
 
 
 /**
@@ -397,7 +396,7 @@ public abstract class AbstractAnnotationHover extends AbstractJavaEditorTextHove
 				list.add(createCompletionProposalLink(composite, prop, 1)); // Original link for single fix, hence pass 1 for count
 				if (prop instanceof FixCorrectionProposal) {
 					FixCorrectionProposal proposal= (FixCorrectionProposal) prop;
-					int count= proposal.computeNumberOfFixesForCleanUp(CleanUpCoreWrapper.wrap(proposal.getCleanUp()));
+					int count= proposal.computeNumberOfFixesForCleanUp(proposal.getCleanUp());
 					if (count > 1) {
 						list.add(createCompletionProposalLink(composite, prop, count));
 					}


### PR DESCRIPTION
- new split of proposals into jdt.core.manipulation changed the computeNumberOfFixesForCleanUp() method to be passed an ICleanUpCore that is wrappered to be an ICleanUp but this code looks for an IMultiFix which gets lost in wrapping
- change computeNumberOfFixesForClean() to use the fCleanUp field that is already stored and is an ICleanUp
- fix getCleanUp() to return fCleanUp
- fix AbstractAnnotationHover.createCompletionProposalsList() to just call proposal.getCleanUp() and don't do any wrapping

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes regression so multiple NLS fixes will be offered for the whole file.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
