### PR TITLE
Fix string concat to text block cleanup logic when in annotation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
@@ -180,11 +181,14 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				return false;
 			}
 			boolean isTagged= false;
-			if (hasComments) {
+			if (hasComments && ASTNodes.getFirstAncestorOrNull(visited, Annotation.class) == null) {
 				// we must ensure that NLS comments are consistent for all string literals in concatenation
 				ICompilationUnit cu= (ICompilationUnit)((CompilationUnit)leftHand.getRoot()).getJavaElement();
 				try {
 				   NLSLine nlsLine= NLSUtil.scanCurrentLine(cu, leftHand.getStartPosition());
+				   if (nlsLine == null) {
+					   return false;
+				   }
 				   isTagged= nlsLine.getElements()[0].hasTag();
 				   if (!isConsistent(nlsLine, isTagged)) {
 					   return false;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java15ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java15ProjectTestSetup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,9 +17,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.core.rules;
 
+import java.io.File;
+
+import org.osgi.framework.Bundle;
+
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
 
 import org.eclipse.jdt.core.IClasspathAttribute;
@@ -28,6 +33,8 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 
 import org.eclipse.jdt.internal.core.ClasspathEntry;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 
 public class Java15ProjectTestSetup extends ProjectTestSetup {
 
@@ -55,5 +62,16 @@ public class Java15ProjectTestSetup extends ProjectTestSetup {
 		JavaProjectHelper.set15CompilerOptions(javaProject, enable_preview_feature);
 		return javaProject;
 	}
+
+	public static String getJdtAnnotations20Path() {
+		Bundle[] annotationsBundles= JavaPlugin.getDefault().getBundles("org.eclipse.jdt.annotation", "2.0.0"); //$NON-NLS-1$
+		File bundleFile= FileLocator.getBundleFileLocation(annotationsBundles[0]).get();
+		String path= bundleFile.getPath();
+		if (bundleFile.isDirectory()) {
+			path= bundleFile.getPath() + "/bin";
+		}
+		return path;
+	}
+
 
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -16,7 +16,10 @@ package org.eclipse.jdt.ui.tests.quickfix;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -241,6 +244,138 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "        \t\"\"\";\n" //
 				+ "    }\n" //
 				+ "}";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testConcatInAnnotation1() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/824
+		IJavaProject project1= getProject();
+		JavaProjectHelper.addLibrary(project1, new Path(Java15ProjectTestSetup.getJdtAnnotations20Path()));
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import static java.lang.annotation.ElementType.TYPE;\n"
+				+ "import static java.lang.annotation.RetentionPolicy.RUNTIME;\n"
+				+ "\n"
+				+ "import java.lang.annotation.Retention;\n"
+				+ "import java.lang.annotation.Target;\n"
+				+ "\n"
+				+ "@Target({TYPE}) \n"
+				+ "@Retention(RUNTIME)\n"
+				+ "public @interface SampleAnnotation { \n"
+				+ "\n"
+				+ "    String name();\n"
+				+ "\n"
+				+ "    String query();\n"
+				+ "\n"
+				+ "}\n";
+		pack1.createCompilationUnit("SampleAnnotation.java", sample, false, null);
+
+		String sample2= "" //
+				+ "package test1;\n"
+				+ "\n"
+				+ "@SampleAnnotation(name = \"testQuery\",\n"
+				+ " query = \"select * \" +\n"
+				+ " \"from test_entities \" +  \n"
+				+ " \"where test = :test\" ) //comment 1\n"
+				+ "public class E {\n"
+				+ "    public static void main(String[] args) {\n"
+				+ "        final String foo =  \n"
+				+ "            (\"Line1\"+ \n"
+				+ "            \"Line2\"+  \n"
+				+ "            \"Line3\"+\n"
+				+ "            \"Line4\"//comment2\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample2, false, null);
+
+		enable(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK);
+
+		String expected1= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "@SampleAnnotation(name = \"testQuery\",\n"
+				+ " query = \"\"\"\n"
+				+ "\tselect *\\s\\\n"
+				+ "\tfrom test_entities\\s\\\n"
+				+ "\twhere test = :test\"\"\" ) //comment 1\n"
+				+ "public class E {\n"
+				+ "    public static void main(String[] args) {\n"
+				+ "        final String foo =  \n"
+				+ "            (\"\"\"\n"
+				+ "            \tLine1\\\n"
+				+ "            \tLine2\\\n"
+				+ "            \tLine3\\\n"
+				+ "            \tLine4\"\"\"//comment2\n"
+				+ "    }\n"
+				+ "}\n";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testConcatInAnnotation2() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/824
+		IJavaProject project1= getProject();
+		JavaProjectHelper.addLibrary(project1, new Path(Java15ProjectTestSetup.getJdtAnnotations20Path()));
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import static java.lang.annotation.ElementType.TYPE;\n"
+				+ "import static java.lang.annotation.RetentionPolicy.RUNTIME;\n"
+				+ "\n"
+				+ "import java.lang.annotation.Retention;\n"
+				+ "import java.lang.annotation.Target;\n"
+				+ "\n"
+				+ "@Target({TYPE}) \n"
+				+ "@Retention(RUNTIME)\n"
+				+ "public @interface SampleAnnotation { \n"
+				+ "\n"
+				+ "    String[] value ();\n"
+				+ "\n"
+				+ "}\n";
+		pack1.createCompilationUnit("SampleAnnotation.java", sample, false, null);
+
+		String sample2= "" //
+				+ "package test1;\n"
+				+ "\n"
+				+ "@SampleAnnotation({\n"
+				+ "\"select * \" +\n"
+				+ " \"from test_entities \" +  \n"
+				+ " \"where test = :test\"}) //comment 1\n"
+				+ "public class E {\n"
+				+ "    public static void main(String[] args) {\n"
+				+ "        final String foo =  \n"
+				+ "            (\"Line1\"+ \n"
+				+ "            \"Line2\"+  \n"
+				+ "            \"Line3\"+\n"
+				+ "            \"Line4\"//comment2\n"
+				+ "    }\n"
+				+ "}\n";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample2, false, null);
+
+		enable(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK);
+
+		String expected1= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "@SampleAnnotation({\n"
+				+ "\"\"\"\n"
+				+ "\tselect *\\s\\\n"
+				+ "\tfrom test_entities\\s\\\n"
+				+ "\twhere test = :test\"\"\"}) //comment 1\n"
+				+ "public class E {\n"
+				+ "    public static void main(String[] args) {\n"
+				+ "        final String foo =  \n"
+				+ "            (\"\"\"\n"
+				+ "            \tLine1\\\n"
+				+ "            \tLine2\\\n"
+				+ "            \tLine3\\\n"
+				+ "            \tLine4\"\"\"//comment2\n"
+				+ "    }\n"
+				+ "}\n";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}


### PR DESCRIPTION
- add check for being in Annotation before looking to see if NLS comments are set up
- bail if NLSUtil.scanCurrentLine() fails
- add new tests to CleanUpTest15
- add new setup method to Java15ProjectTestSetup to make annotations accessible
- fixes #824

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes #824

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests or issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
