### PR TITLE
Javadoc error fix for CUCorrectionProposal.setDelegate()

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/correction/CUCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/correction/CUCorrectionProposal.java
@@ -146,8 +146,8 @@ public class CUCorrectionProposal extends ChangeCorrectionProposal implements IC
 	 * @since 3.31
 	 * @param delegate to set
 	 */
-	protected void setDelegate(CUCorrectionProposalCore del) {
-		fProposalCore = del;
+	protected void setDelegate(CUCorrectionProposalCore delegate) {
+		fProposalCore = delegate;
 	}
 
 	/**


### PR DESCRIPTION
See https://download.eclipse.org/eclipse/downloads/drops4/I20230925-1800/compilelogs/jdt.doc.isv.javadoc.txt
```
../../../eclipse.jdt.ui/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/correction/CUCorrectionProposal.java:147: error: @param name not found
	 * @param delegate to set ^
```
Regression from 816a5d21cf7c29294915c50bd95503e0462eff02 / #815 
