### PR TITLE
Fix while to for-each loop logic

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileLoopToChangeHit.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/helper/WhileLoopToChangeHit.java
@@ -32,6 +32,7 @@ public class WhileLoopToChangeHit {
 	public boolean nextFound;
 	public String iteratorName;
 	public boolean isInvalid;
+	public boolean loopVarNameIsVariable;
 
 	public WhileLoopToChangeHit(boolean isInvalid) {
 		this.isInvalid= isInvalid;


### PR DESCRIPTION
- add new name checking logic so the chosen loop var name is not already used
- add some logic to remove added imports if they are found in the current file
- add new test to CleanUpTest1d8
- fixes #798

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes while to for-each loop cleanup.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
