### PR TITLE
Fix UI on Mac OS preview viewer

### DIFF
--- a/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.ltk.ui.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.ltk.ui.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ltk.ui.refactoring; singleton:=true
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.14.100.qualifier
 Bundle-Activator: org.eclipse.ltk.internal.ui.refactoring.RefactoringUIPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.ltk.ui.refactoring/pom.xml
+++ b/org.eclipse.ltk.ui.refactoring/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.ltk</groupId>
   <artifactId>org.eclipse.ltk.ui.refactoring</artifactId>
-  <version>3.13.100-SNAPSHOT</version>
+  <version>3.14.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringWizardDialog2.java
+++ b/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/RefactoringWizardDialog2.java
@@ -331,6 +331,7 @@ public class RefactoringWizardDialog2 extends TrayDialog implements IWizardConta
 		}
 	}
 
+
 	private Map<String, Object> aboutToStart(boolean cancelable) {
 		Map<String, Object> savedState = null;
 		Shell shell= getShell();

--- a/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/TextEditChangePreviewViewer.java
+++ b/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/internal/ui/refactoring/TextEditChangePreviewViewer.java
@@ -19,6 +19,7 @@ import java.io.UnsupportedEncodingException;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
@@ -40,6 +41,7 @@ import org.eclipse.ui.model.IWorkbenchAdapter;
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.CompareUI;
 import org.eclipse.compare.CompareViewerSwitchingPane;
+import org.eclipse.compare.ICompareContainer;
 import org.eclipse.compare.IEncodedStreamContentAccessor;
 import org.eclipse.compare.IResourceProvider;
 import org.eclipse.compare.ITypedElement;
@@ -55,6 +57,7 @@ import org.eclipse.ltk.ui.refactoring.IChangePreviewViewer;
 public class TextEditChangePreviewViewer implements IChangePreviewViewer {
 
 	private ComparePreviewer fViewer;
+	private ICompareContainer fContainer;
 
 	private static class TextEditBasedChangeInput extends ChangePreviewViewerInput {
 		TextEditBasedChangeGroup group;
@@ -73,9 +76,10 @@ public class TextEditChangePreviewViewer implements IChangePreviewViewer {
 		private String fLabel;
 		private ImageDescriptor fDescriptor;
 		private Image fImage;
-		public ComparePreviewer(Composite parent) {
+		public ComparePreviewer(Composite parent, ICompareContainer container) {
 			super(parent, SWT.BORDER | SWT.FLAT, true);
 			fCompareConfiguration= new CompareConfiguration();
+			fCompareConfiguration.setContainer(container);
 			fCompareConfiguration.setLeftEditable(false);
 			fCompareConfiguration.setLeftLabel(RefactoringUIMessages.ComparePreviewer_original_source);
 			fCompareConfiguration.setRightEditable(false);
@@ -84,6 +88,8 @@ public class TextEditChangePreviewViewer implements IChangePreviewViewer {
 				if (fImage != null && !fImage.isDisposed())
 					fImage.dispose();
 			});
+			FormData gd= new FormData(parent.getClientArea().width, parent.getClientArea().height);
+			setLayoutData(gd);
 			Dialog.applyDialogFont(this);
 		}
 		public void setLabel(String label) {
@@ -181,7 +187,7 @@ public class TextEditChangePreviewViewer implements IChangePreviewViewer {
 
 	@Override
 	public void createControl(Composite parent) {
-		fViewer= new ComparePreviewer(parent);
+		fViewer= new ComparePreviewer(parent, fContainer);
 	}
 
 	@Override
@@ -225,6 +231,11 @@ public class TextEditChangePreviewViewer implements IChangePreviewViewer {
 
 	public void refresh() {
 		fViewer.getViewer().refresh();
+	}
+
+	@Override
+	public void initialize(ICompareContainer container) {
+		this.fContainer= container;
 	}
 
 	private void setInput(TextEditBasedChange change, String left, String right, String type) {

--- a/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/ui/refactoring/IChangePreviewViewer.java
+++ b/org.eclipse.ltk.ui.refactoring/src/org/eclipse/ltk/ui/refactoring/IChangePreviewViewer.java
@@ -16,6 +16,8 @@ package org.eclipse.ltk.ui.refactoring;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import org.eclipse.compare.ICompareContainer;
+
 /**
  * Viewer to present the preview for a {@link org.eclipse.ltk.core.refactoring.Change}.
  * <p>
@@ -36,6 +38,15 @@ import org.eclipse.swt.widgets.Control;
  * @since 3.0
  */
 public interface IChangePreviewViewer {
+
+	/**
+	 * @param container connected to this viewer
+	 *
+	 * @since 3.14
+	 */
+	default void initialize(ICompareContainer container) {
+		// do nothing
+	}
 
 	/**
 	 * Creates the preview viewer's widget hierarchy. This method


### PR DESCRIPTION
## What it does

Fixes UI issues on Mac OS, originally reported on platform side: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1173

To fix this, I introduced new method in IChangePreviewViewer, that allow to inject ICompareContainer

PreviewWizardPage, contribute own ICompareContainer to it's viewers

## How to test

Run some refactoring changes on JDT project and switch between texts. More details in bug

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
