### PR TITLE
Respond to changes in undo API

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/AbstractDeleteChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/AbstractDeleteChange.java
@@ -15,7 +15,7 @@ package org.eclipse.jdt.internal.corext.refactoring.changes;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
@@ -48,8 +48,8 @@ abstract class AbstractDeleteChange extends ResourceChange {
 		ITextFileBuffer buffer= FileBuffers.getTextFileBufferManager().getTextFileBuffer(file.getFullPath(), LocationKind.IFILE);
 		if (buffer != null && buffer.isDirty() &&  buffer.isStateValidated() && buffer.isSynchronized()) {
 			pm.beginTask("", 2); //$NON-NLS-1$
-			buffer.commit(new SubProgressMonitor(pm, 1), false);
-			file.refreshLocal(IResource.DEPTH_ONE, new SubProgressMonitor(pm, 1));
+			buffer.commit(SubMonitor.convert(pm, 1), false);
+			file.refreshLocal(IResource.DEPTH_ONE, SubMonitor.convert(pm, 1));
 		}
 		pm.done();
 	}

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/CopyResourceChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/CopyResourceChange.java
@@ -18,7 +18,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -72,11 +72,11 @@ public class CopyResourceChange extends ResourceChange {
 
 			String newName= getNewResourceName();
 			IResource resource= getResource();
-			boolean performReorg= deleteIfAlreadyExists(new SubProgressMonitor(pm, 1), newName);
+			boolean performReorg= deleteIfAlreadyExists(SubMonitor.convert(pm, 1), newName);
 			if (!performReorg)
 				return null;
 
-			getResource().copy(getDestinationPath(newName), getReorgFlags(), new SubProgressMonitor(pm, 1));
+			getResource().copy(getDestinationPath(newName), getReorgFlags(), SubMonitor.convert(pm, 1));
 
 			markAsExecuted(resource);
 			return null;
@@ -112,9 +112,9 @@ public class CopyResourceChange extends ResourceChange {
 			return false;
 
 		if (current instanceof IFile)
-			((IFile)current).delete(false, true, new SubProgressMonitor(pm, 1));
+			((IFile)current).delete(false, true, SubMonitor.convert(pm, 1));
 		else if (current instanceof IFolder)
-			((IFolder)current).delete(false, true, new SubProgressMonitor(pm, 1));
+			((IFolder)current).delete(false, true, SubMonitor.convert(pm, 1));
 		else
 			Assert.isTrue(false);
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/DeletePackageFragmentRootChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/DeletePackageFragmentRootChange.java
@@ -124,7 +124,7 @@ public class DeletePackageFragmentRootChange extends AbstractDeleteChange {
 
 		root.delete(resourceUpdateFlags, jCoreUpdateFlags, SubMonitor.convert(pm, 1));
 
-		rootDescription.recordStateFromHistory(rootResource, SubMonitor.convert(pm, 1));
+		rootDescription.recordStateFromHistory(SubMonitor.convert(pm, 1));
 		for (Entry<IFile, String> entry : classpathFilesContents.entrySet()) {
 			IFile file= entry.getKey();
 			String contents= entry.getValue();

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/DeleteSourceManipulationChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/DeleteSourceManipulationChange.java
@@ -104,7 +104,7 @@ public class DeleteSourceManipulationChange extends AbstractDeleteChange {
 			IResource resource= unit.getResource();
 			IResourceSnapshot<IResource> resourceDescription = ResourceSnapshotFactory.fromResource(resource);
 			element.delete(false, SubMonitor.convert(pm, 1));
-			resourceDescription.recordStateFromHistory(resource, SubMonitor.convert(pm, 1));
+			resourceDescription.recordStateFromHistory(SubMonitor.convert(pm, 1));
 			return new UndoDeleteResourceChange(resourceDescription);
 
 		} else if (element instanceof IPackageFragment) {

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/PackageFragmentRootReorgChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/PackageFragmentRootReorgChange.java
@@ -18,7 +18,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
@@ -70,7 +70,7 @@ abstract class PackageFragmentRootReorgChange extends ResourceChange {
 			String newName= getNewResourceName();
 			IPackageFragmentRoot root= getRoot();
 			ResourceMapping mapping= JavaElementResourceMapping.create(root);
-			final Change result= doPerformReorg(getDestinationProjectPath().append(newName), new SubProgressMonitor(pm, 1));
+			final Change result= doPerformReorg(getDestinationProjectPath().append(newName), SubMonitor.convert(pm, 1));
 			markAsExecuted(root, mapping);
 			return result;
 		} finally {

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/RenameJavaProjectChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/RenameJavaProjectChange.java
@@ -17,7 +17,7 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectDescription;
@@ -71,12 +71,12 @@ public final class RenameJavaProjectChange extends AbstractJavaElementRenameChan
 		try {
 			pm.beginTask(getName(), 2);
 			if (fUpdateReferences)
-				modifyClassPaths(new SubProgressMonitor(pm, 1));
+				modifyClassPaths(SubMonitor.convert(pm, 1));
 			IProject project= getProject();
 			if (project != null) {
 				IProjectDescription description= project.getDescription();
 				description.setName(getNewName());
-				project.move(description, IResource.FORCE | IResource.SHALLOW, new SubProgressMonitor(pm, 1));
+				project.move(description, IResource.FORCE | IResource.SHALLOW, SubMonitor.convert(pm, 1));
 			}
 		} finally {
 			pm.done();
@@ -128,7 +128,7 @@ public final class RenameJavaProjectChange extends AbstractJavaElementRenameChan
 		for (IProject p : referencing) {
 			IJavaProject jp= JavaCore.create(p);
 			if (jp != null && jp.exists()) {
-				modifyClassPath(jp, new SubProgressMonitor(pm, 1));
+				modifyClassPath(jp, SubMonitor.convert(pm, 1));
 			} else {
 				pm.worked(1);
 			}

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/RenamePackageChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/RenamePackageChange.java
@@ -22,7 +22,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -134,7 +134,7 @@ public final class RenamePackageChange extends AbstractJavaElementRenameChange {
 			try {
 				for (int i= 0; i < count; i++) {
 					IPackageFragment currentPackage= allPackages[insideOut ? count - i - 1 : i];
-					renamePackage(currentPackage, new SubProgressMonitor(pm, 1), createNewPath(currentPackage), getNewName(currentPackage));
+					renamePackage(currentPackage, SubMonitor.convert(pm, 1), createNewPath(currentPackage), getNewName(currentPackage));
 				}
 			} finally {
 				pm.done();
@@ -166,14 +166,14 @@ public final class RenamePackageChange extends AbstractJavaElementRenameChange {
 			IJavaElement element= (IJavaElement) getModifiedElement();
 			// don't check for read-only since we don't go through
 			// validate edit.
-			result.merge(super.isValid(new SubProgressMonitor(pm, 1)));
+			result.merge(super.isValid(SubMonitor.convert(pm, 1)));
 			if (result.hasFatalError())
 				return result;
 			if (element != null && element.exists() && element instanceof IPackageFragment) {
 				IPackageFragment pack= (IPackageFragment) element;
 				if (fRenameSubpackages) {
 					IPackageFragment[] allPackages= JavaElementUtil.getPackageAndSubpackages(pack);
-					SubProgressMonitor subPm= new SubProgressMonitor(pm, 1);
+					SubMonitor subPm= SubMonitor.convert(pm, 1);
 					subPm.beginTask("", allPackages.length); //$NON-NLS-1$
 					for (IPackageFragment pckg : allPackages) {
 						// don't check for read-only since we don't go through
@@ -181,10 +181,10 @@ public final class RenamePackageChange extends AbstractJavaElementRenameChange {
 						checkIfModifiable(result, pckg.getResource(), VALIDATE_NOT_DIRTY);
 						if (result.hasFatalError())
 							return result;
-						isValid(result, pckg, new SubProgressMonitor(subPm, 1));
+						isValid(result, pckg, SubMonitor.convert(subPm, 1));
 					}
 				} else {
-					isValid(result, pack, new SubProgressMonitor(pm, 1));
+					isValid(result, pack, SubMonitor.convert(pm, 1));
 				}
 			}
 		} finally {

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/UndoablePackageDeleteChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/UndoablePackageDeleteChange.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.undo.snapshot.IResourceSnapshot;
@@ -47,12 +47,11 @@ public class UndoablePackageDeleteChange extends DynamicValidationStateChange {
 			pm.worked(1);
 		}
 
-		DynamicValidationStateChange result= (DynamicValidationStateChange) super.perform(new SubProgressMonitor(pm, count));
+		DynamicValidationStateChange result= (DynamicValidationStateChange) super.perform(SubMonitor.convert(pm, count));
 
 		for (int i= 0; i < fPackageDeletes.size(); i++) {
-			IResource resource= fPackageDeletes.get(i);
 			IResourceSnapshot<IResource> resourceDescription= snapshots.get(i);
-			resourceDescription.recordStateFromHistory(resource, new SubProgressMonitor(pm, 1));
+			resourceDescription.recordStateFromHistory(SubMonitor.convert(pm, 1));
 			result.add(new UndoDeleteResourceChange(resourceDescription));
 		}
 		return result;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
The org.eclipse.core.resources.undo new API addition seems to require some cleanup to make it more usable. This PR will respond to that. 

This build is expected to fail until the changes at https://github.com/eclipse-platform/eclipse.platform/pull/729 are merged in. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
A simple build passing for compilation should be sufficient. Risk of change is minimal. 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
