### PR TITLE
Make required changes for jdt.ls consumption

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/nls/changes/CreateFileChange.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/nls/changes/CreateFileChange.java
@@ -114,7 +114,7 @@ public class CreateFileChange extends ResourceChange {
 		fPath= path;
 	}
 
-	protected IPath getPath() {
+	public IPath getPath() {
 		return fPath;
 	}
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/AbstractDeleteChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/AbstractDeleteChange.java
@@ -27,7 +27,7 @@ import org.eclipse.core.filebuffers.LocationKind;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.resource.ResourceChange;
 
-abstract class AbstractDeleteChange extends ResourceChange {
+public abstract class AbstractDeleteChange extends ResourceChange {
 
 	protected abstract Change doDelete(IProgressMonitor pm) throws CoreException;
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
@@ -15,12 +15,11 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.refactoring.code;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import java.text.MessageFormat;
 
 import org.eclipse.core.runtime.CoreException;
 
@@ -82,6 +81,8 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
 
+import org.eclipse.jdt.internal.core.manipulation.BindingLabelProviderCore;
+import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
@@ -102,11 +103,7 @@ import org.eclipse.jdt.internal.corext.refactoring.util.JavaStatusContext;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
-import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
-
-import org.eclipse.jdt.internal.core.manipulation.BindingLabelProviderCore;
-
-/* package */ class ExtractMethodAnalyzer extends CodeAnalyzer {
+public class ExtractMethodAnalyzer extends CodeAnalyzer {
 
 	public static final int ERROR=					-2;
 	public static final int UNDEFINED=				-1;
@@ -211,7 +208,7 @@ import org.eclipse.jdt.internal.core.manipulation.BindingLabelProviderCore;
 
 	//---- Activation checking ---------------------------------------------------------------------------
 
-	boolean isValidDestination(ASTNode node) {
+	public boolean isValidDestination(ASTNode node) {
 		boolean isInterface= node instanceof TypeDeclaration && ((TypeDeclaration) node).isInterface();
 		return !(node instanceof AnnotationTypeDeclaration) &&
 				(!isInterface || JavaModelUtil.is1d8OrHigher(fCUnit.getJavaProject()));

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -40,6 +40,9 @@ import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.text.edits.TextEditGroup;
 
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
+
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.RefactoringChangeDescriptor;
@@ -51,6 +54,7 @@ import org.eclipse.ltk.core.refactoring.participants.ResourceChangeChecker;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -107,6 +111,8 @@ import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.ExtractMethodDescriptor;
 import org.eclipse.jdt.core.refactoring.descriptors.JavaRefactoringDescriptor;
 
+import org.eclipse.jdt.internal.core.manipulation.BindingLabelProviderCore;
+import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
@@ -134,10 +140,7 @@ import org.eclipse.jdt.internal.corext.refactoring.util.SelectionAwareSourceRang
 import org.eclipse.jdt.internal.corext.util.JdtFlags;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
-import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
-
 import org.eclipse.jdt.internal.ui.text.correction.ModifierCorrectionSubProcessorCore;
-import org.eclipse.jdt.internal.core.manipulation.BindingLabelProviderCore;
 
 /**
  * Extracts a method in a compilation unit based on a text selection range.
@@ -172,6 +175,7 @@ public class ExtractMethodRefactoring extends Refactoring {
 	// either of type TypeDeclaration or AnonymousClassDeclaration
 	private ASTNode[] fDestinations;
 	private LinkedProposalModelCore fLinkedProposalModel;
+	private Map fFormatterOptions;
 
 	private static final String EMPTY= ""; //$NON-NLS-1$
 
@@ -252,12 +256,17 @@ public class ExtractMethodRefactoring extends Refactoring {
 	 * @param selectionLength selection end
 	 */
 	public ExtractMethodRefactoring(ICompilationUnit unit, int selectionStart, int selectionLength) {
+		this(unit, selectionStart, selectionLength, null);
+	}
+
+	public ExtractMethodRefactoring(ICompilationUnit unit, int selectionStart, int selectionLength, Map formatterOptions) {
 		fCUnit= unit;
 		fRoot= null;
 		fMethodName= "extracted"; //$NON-NLS-1$
 		fSelectionStart= selectionStart;
 		fSelectionLength= selectionLength;
 		fVisibility= -1;
+		fFormatterOptions = formatterOptions;
 	}
 
 	public ExtractMethodRefactoring(JavaRefactoringArguments arguments, RefactoringStatus status) {
@@ -266,6 +275,10 @@ public class ExtractMethodRefactoring extends Refactoring {
    		status.merge(initializeStatus);
 	}
 
+	public ExtractMethodRefactoring(CompilationUnit astRoot, int selectionStart, int selectionLength, Map formatterOptions) {
+		this((ICompilationUnit) astRoot.getTypeRoot(), selectionStart, selectionLength, formatterOptions);
+		fRoot = astRoot;
+	}
 	/**
 	 * Creates a new extract method refactoring
 	 * @param astRoot the AST root of an AST created from a compilation unit
@@ -548,7 +561,13 @@ public class ExtractMethodRefactoring extends Refactoring {
 					new TextEdit[] {edit}
 				));
 			}
+			try {
+				Map formatter = this.fFormatterOptions == null ? fCUnit.getOptions(true) : this.fFormatterOptions;
+				IDocument document = new Document(fCUnit.getSource());
+				root.addChild(fRewriter.rewriteAST(document, formatter));
+			} catch (JavaModelException e) {
 			root.addChild(fRewriter.rewriteAST());
+			}
 			return result;
 		} finally {
 			pm.done();
@@ -779,7 +798,7 @@ public class ExtractMethodRefactoring extends Refactoring {
 
 	private void initializeDuplicates() {
 		ASTNode start= fAnalyzer.getEnclosingBodyDeclaration();
-		while (!(start instanceof AbstractTypeDeclaration)) {
+		while (!(start instanceof AbstractTypeDeclaration || start instanceof AnonymousClassDeclaration)) {
 			start= start.getParent();
 		}
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -540,6 +540,8 @@ public class ExtractTempRefactoring extends Refactoring {
 	private String fEnclosingKey;
 	private HashSet<String> fEnclosingKeySet;
 
+	private Map fFormatterOptions;
+
 	/**
 	 * Creates a new extract temp refactoring
 	 *
@@ -548,6 +550,10 @@ public class ExtractTempRefactoring extends Refactoring {
 	 * @param selectionLength length of selection
 	 */
 	public ExtractTempRefactoring(ICompilationUnit unit, int selectionStart, int selectionLength) {
+		this(unit, selectionStart, selectionLength, null);
+	}
+
+	public ExtractTempRefactoring(ICompilationUnit unit, int selectionStart, int selectionLength, Map formatterOptions) {
 		Assert.isTrue(selectionStart >= 0);
 		Assert.isTrue(selectionLength >= 0);
 		fSelectionStart= selectionStart;
@@ -567,9 +573,14 @@ public class ExtractTempRefactoring extends Refactoring {
 		fEndPoint= -1; // default
 		fEnclosingKey= null;
 		fEnclosingKeySet= new HashSet<>();
+		fFormatterOptions = formatterOptions;
 	}
 
 	public ExtractTempRefactoring(CompilationUnit astRoot, int selectionStart, int selectionLength) {
+		this(astRoot, selectionStart, selectionLength, null);
+	}
+
+	public ExtractTempRefactoring(CompilationUnit astRoot, int selectionStart, int selectionLength, Map formatterOptions) {
 		Assert.isTrue(selectionStart >= 0);
 		Assert.isTrue(selectionLength >= 0);
 		Assert.isTrue(astRoot.getTypeRoot() instanceof ICompilationUnit);
@@ -592,6 +603,7 @@ public class ExtractTempRefactoring extends Refactoring {
 		fEndPoint= -1; // default
 		fEnclosingKey= null;
 		fEnclosingKeySet= new HashSet<>();
+		fFormatterOptions = formatterOptions;
 	}
 
 	public ExtractTempRefactoring(JavaRefactoringArguments arguments, RefactoringStatus status) {
@@ -696,7 +708,7 @@ public class ExtractTempRefactoring extends Refactoring {
 		try {
 			pm.beginTask(RefactoringCoreMessages.ExtractTempRefactoring_checking_preconditions, 4);
 
-			fCURewrite= new CompilationUnitRewrite(fCu, fCompilationUnitNode);
+			fCURewrite= new CompilationUnitRewrite(null, fCu, fCompilationUnitNode, fFormatterOptions);
 			fCURewrite.getASTRewrite().setTargetSourceRangeComputer(new NoCommentSourceRangeComputer());
 
 			RefactoringStatus result= new RefactoringStatus();

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/SnippetFinder.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/SnippetFinder.java
@@ -46,7 +46,7 @@ import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.GenericVisitor;
 
 
-/* package */ class SnippetFinder extends GenericVisitor {
+public class SnippetFinder extends GenericVisitor {
 
 	public static class Match {
 		private List<ASTNode> fNodes;

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameFieldProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameFieldProcessor.java
@@ -67,6 +67,7 @@ import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchPattern;
 
 import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.codemanipulation.GetterSetterUtil;
@@ -104,8 +105,6 @@ import org.eclipse.jdt.internal.corext.util.SearchUtils;
 
 import org.eclipse.jdt.ui.refactoring.IRefactoringProcessorIdsCore;
 import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
-
-import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 
 public class RenameFieldProcessor extends JavaRenameProcessor implements IReferenceUpdating, ITextUpdating, IDelegateUpdating {
 
@@ -168,7 +167,7 @@ public class RenameFieldProcessor extends JavaRenameProcessor implements IRefere
 	 * @param manager the change manager
 	 * @param categorySet the group category set
 	 */
-	RenameFieldProcessor(IField field, TextChangeManager manager, GroupCategorySet categorySet) {
+	public RenameFieldProcessor(IField field, TextChangeManager manager, GroupCategorySet categorySet) {
 		initialize(field);
 		fChangeManager= manager;
 		fCategorySet= categorySet;

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
@@ -53,6 +53,8 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.RenameJavaElementDescriptor;
 
+import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatureDescriptorFactory;
 import org.eclipse.jdt.internal.corext.refactoring.Checks;
@@ -71,10 +73,7 @@ import org.eclipse.jdt.internal.corext.refactoring.util.TextChangeManager;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
-import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
 import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
-
-import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 
 public class RenameLocalVariableProcessor extends JavaRenameProcessor implements IReferenceUpdating {
 
@@ -126,7 +125,7 @@ public class RenameLocalVariableProcessor extends JavaRenameProcessor implements
 	 * @param node the compilation unit node
 	 * @param categorySet the group category set
 	 */
-	RenameLocalVariableProcessor(ILocalVariable localVariable, TextChangeManager manager, CompilationUnit node, GroupCategorySet categorySet) {
+	public RenameLocalVariableProcessor(ILocalVariable localVariable, TextChangeManager manager, CompilationUnit node, GroupCategorySet categorySet) {
 		this(localVariable);
 		fChangeManager= manager;
 		fCategorySet= categorySet;

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameNonVirtualMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameNonVirtualMethodProcessor.java
@@ -59,7 +59,7 @@ public class RenameNonVirtualMethodProcessor extends RenameMethodProcessor {
 	 * @param manager the change manager
 	 * @param categorySet the group category set
 	 */
-	RenameNonVirtualMethodProcessor(IMethod method, TextChangeManager manager, GroupCategorySet categorySet) {
+	public RenameNonVirtualMethodProcessor(IMethod method, TextChangeManager manager, GroupCategorySet categorySet) {
 		super(method, manager, categorySet);
 	}
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
@@ -1086,10 +1086,11 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 					((TextFileChange) textChange).setSaveMode(TextFileChange.FORCE_SAVE);
 				}
 			}
-			result.addAll(fChangeManager.getAllChanges());
+
 			if (willRenameCU()) {
 				IResource resource= fType.getCompilationUnit().getResource();
 				if (resource != null && resource.isLinked()) {
+					result.addAll(fChangeManager.getAllChanges());
 					String ext= resource.getFileExtension();
 					String renamedResourceName;
 					if (ext == null)
@@ -1098,10 +1099,18 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 						renamedResourceName= getNewElementName() + '.' + ext;
 					result.add(new RenameResourceChange(fType.getCompilationUnit().getPath(), renamedResourceName));
 				} else {
+					addTypeDeclarationUpdate(fChangeManager);
+					addConstructorRenames(fChangeManager);
+
+					result.addAll(fChangeManager.getAllChanges());
+
 					String renamedCUName= JavaModelUtil.getRenamedCUName(fType.getCompilationUnit(), getNewElementName());
 					result.add(new RenameCompilationUnitChange(fType.getCompilationUnit(), renamedCUName));
 				}
+			} else {
+				result.addAll(fChangeManager.getAllChanges());
 			}
+
 			monitor.worked(1);
 			return result;
 		} finally {

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameVirtualMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameVirtualMethodProcessor.java
@@ -83,7 +83,7 @@ public class RenameVirtualMethodProcessor extends RenameMethodProcessor {
 	 * methods.
 	 *
 	 */
-	RenameVirtualMethodProcessor(IMethod topLevel, IMethod[] ripples, TextChangeManager changeManager, ITypeHierarchy hierarchy, GroupCategorySet categorySet) {
+	public RenameVirtualMethodProcessor(IMethod topLevel, IMethod[] ripples, TextChangeManager changeManager, ITypeHierarchy hierarchy, GroupCategorySet categorySet) {
 		super(topLevel, changeManager, categorySet);
 		fOriginalMethod= getMethod();
 		fActivationChecked= true; // is top level

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/TextMatchUpdater.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/TextMatchUpdater.java
@@ -52,7 +52,7 @@ import org.eclipse.jdt.internal.corext.refactoring.rename.RefactoringScanner.Tex
 import org.eclipse.jdt.internal.corext.refactoring.tagging.ITextUpdating;
 import org.eclipse.jdt.internal.corext.refactoring.util.TextChangeManager;
 
-class TextMatchUpdater {
+public class TextMatchUpdater {
 
 	private static final String TEXT_EDIT_LABEL= RefactoringCoreMessages.TextMatchUpdater_update;
 
@@ -84,11 +84,11 @@ class TextMatchUpdater {
 		fScanner= new RefactoringScanner(currentName, currentQualifier);
 	}
 
-	static void perform(IProgressMonitor pm, IJavaSearchScope scope, String currentName, String currentQualifier, String newName, TextChangeManager manager, SearchResultGroup[] references, boolean onlyQualified) throws JavaModelException{
+	public static void perform(IProgressMonitor pm, IJavaSearchScope scope, String currentName, String currentQualifier, String newName, TextChangeManager manager, SearchResultGroup[] references, boolean onlyQualified) throws JavaModelException{
 		new TextMatchUpdater(manager, scope, currentName, currentQualifier, newName, references, onlyQualified).updateTextMatches(pm);
 	}
 
-	static void perform(IProgressMonitor pm, IJavaSearchScope scope, ITextUpdating processor, TextChangeManager manager, SearchResultGroup[] references) throws JavaModelException{
+	public static void perform(IProgressMonitor pm, IJavaSearchScope scope, ITextUpdating processor, TextChangeManager manager, SearchResultGroup[] references) throws JavaModelException{
 		new TextMatchUpdater(manager, scope, processor.getCurrentElementName(), processor.getCurrentElementQualifier(), processor.getNewElementName(), references, false).updateTextMatches(pm);
 	}
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ArrayTypeConverter.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ArrayTypeConverter.java
@@ -23,32 +23,32 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 
-class ArrayTypeConverter {
+public class ArrayTypeConverter {
 
 	private ArrayTypeConverter() {
 	}
 
-	static IFile[] toFileArray(Object[] objects){
+	public static IFile[] toFileArray(Object[] objects){
 		List<?> l= Arrays.asList(objects);
 		return l.toArray(new IFile[l.size()]);
 	}
 
-	static IFolder[] toFolderArray(Object[] objects){
+	public static IFolder[] toFolderArray(Object[] objects){
 		List<?> l= Arrays.asList(objects);
 		return l.toArray(new IFolder[l.size()]);
 	}
 
-	static ICompilationUnit[] toCuArray(Object[] objects){
+	public static ICompilationUnit[] toCuArray(Object[] objects){
 		List<?> l= Arrays.asList(objects);
 		return l.toArray(new ICompilationUnit[l.size()]);
 	}
 
-	static IPackageFragmentRoot[] toPackageFragmentRootArray(Object[] objects){
+	public static IPackageFragmentRoot[] toPackageFragmentRootArray(Object[] objects){
 		List<?> l= Arrays.asList(objects);
 		return l.toArray(new IPackageFragmentRoot[l.size()]);
 	}
 
-	static IPackageFragment[] toPackageArray(Object[] objects){
+	public static IPackageFragment[] toPackageArray(Object[] objects){
 		List<?> l= Arrays.asList(objects);
 		return l.toArray(new IPackageFragment[l.size()]);
 	}

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/sef/AccessAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/sef/AccessAnalyzer.java
@@ -65,7 +65,7 @@ import org.eclipse.jdt.internal.corext.refactoring.util.JavaStatusContext;
  * Analyzer to find all references to the field and to determine how to convert
  * them into setter or getter calls.
  */
-class AccessAnalyzer extends ASTVisitor {
+public class AccessAnalyzer extends ASTVisitor {
 
 	private ICompilationUnit fCUnit;
 	private IVariableBinding fFieldBinding;


### PR DESCRIPTION
This patch contains a lot of visibility changes required in jdt.manipulations for the purposes of jdt.ls to consume it properly.

There are also some changes regarding new constructors that accept a formatterOptions map which jdt.ls had in their fork of the code which could be useful upstream. 