### PR TITLE
Add quick fix to remove default case when present with unconditional pattern in switch #850

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.java
@@ -112,6 +112,7 @@ public final class CorrectionMessages extends NLS {
 	public static String LocalCorrectionsSubProcessor_surroundwith_trymulticatch_description;
 	public static String LocalCorrectionsSubProcessor_surroundwith_trymulticatch_var_description;
 	public static String LocalCorrectionsSubProcessor_add_default_case_description;
+	public static String LocalCorrectionsSubProcessor_remove_default_case_description;
 	public static String LocalCorrectionsSubProcessor_add_missing_cases_description;
 	public static String LocalCorrectionsSubProcessor_addthrows_description;
 	public static String ClasspathFixProcessorDescriptor_error_processing_processors;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.properties
@@ -87,6 +87,7 @@ LocalCorrectionsSubProcessor_surroundwith_trycatch_var_description=Change type o
 LocalCorrectionsSubProcessor_surroundwith_trymulticatch_description=Surround with try/multi-catch
 LocalCorrectionsSubProcessor_surroundwith_trymulticatch_var_description=Change type of ''{0}'' to ''{1}'' and surround with try/multi-catch
 LocalCorrectionsSubProcessor_add_default_case_description=Add 'default' case
+LocalCorrectionsSubProcessor_remove_default_case_description=Remove 'default' case
 LocalCorrectionsSubProcessor_add_missing_cases_description=Add missing case statements
 LocalCorrectionsSubProcessor_addthrows_description=Add throws declaration
 ClasspathFixProcessorDescriptor_error_processing_processors=Exception while processing classpath fix processors

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -340,6 +340,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.UnclosedCloseable:
 			case IProblem.PotentiallyUnclosedCloseable:
 			case IProblem.EnhancedSwitchMissingDefault:
+			case IProblem.IllegalTotalPatternWithDefault:
 				return true;
 			default:
 				return SuppressWarningsSubProcessor.hasSuppressWarningsProposal(cu.getJavaProject(), problemId)
@@ -829,6 +830,9 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.SwitchExpressionsYieldMissingDefaultCase:
 			case IProblem.EnhancedSwitchMissingDefault:
 				LocalCorrectionsSubProcessor.addMissingDefaultCaseProposal(context, problem, proposals);
+				break;
+			case IProblem.IllegalTotalPatternWithDefault:
+				LocalCorrectionsSubProcessor.removeDefaultCaseProposal(context, problem, proposals);
 				break;
 			case IProblem.MissingEnumConstantCaseDespiteDefault:
 				LocalCorrectionsSubProcessor.getMissingEnumConstantCaseProposals(context, problem, proposals);


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/850

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
