### PR TITLE
Fix problem with adding type arguments to var variable

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/Java50FixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/Java50FixCore.java
@@ -442,7 +442,7 @@ public class Java50FixCore extends CompilationUnitRewriteOperationsFixCore {
 		return null;
 	}
 
-	private static SimpleType getRawReference(SimpleName name, CompilationUnit compilationUnit) {
+	public static SimpleType getRawReference(SimpleName name, CompilationUnit compilationUnit) {
 		for (SimpleName n : LinkedNodeFinder.findByNode(compilationUnit, name)) {
 			if (n.getParent() instanceof VariableDeclarationFragment) {
 				VariableDeclarationFragment fragment= (VariableDeclarationFragment) n.getParent();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/generics/InferTypeArgumentsRefactoring.java
@@ -361,6 +361,10 @@ public class InferTypeArgumentsRefactoring extends Refactoring {
 		if (node instanceof Name && node.getParent() instanceof Type) {
 			Type originalType= (Type) node.getParent();
 
+			if (originalType.isVar()) {
+				return null;
+			}
+
 			if (types != null && !has(types, originalType))
 				return null;
 


### PR DESCRIPTION
- fixes #774
- add var check in InferTypeArgumentsRefactoring.rewriteTypeVariable()
- make Java50FixCore.getRawReference() method public
- modify LocalCorrectionsSubProcessor.referencesVar() method to handle more cases
- add new test to LocalCorrectionsQuickFixText10

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test case.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
