### PR TITLE
Remove maven nature from org.eclipse.jdt.ui.junit.sampleproject

### DIFF
--- a/org.eclipse.jdt.ui.junit.sampleproject/.project
+++ b/org.eclipse.jdt.ui.junit.sampleproject/.project
@@ -11,13 +11,11 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
## What it does
Remove the _maven_ nature for the sample project `org.eclipse.jdt.ui.junit.sampleproject`.

The tests seem to work just fine without it and the IDE keeps removing it for me anyway, which shows a change to be committed and it's annoying.

## How to test
Run the test suite `/org.eclipse.jdt.ui.junit.sampleproject/src/test/java/junit/samples/AllTests.java`

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
