### PR TITLE
Fix organize imports when break label used

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -695,11 +695,11 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 				if (unresolvableImports.isEmpty()) {
 					String pref= JavaManipulation.getPreference(JavaManipulationPlugin.CODEASSIST_FAVORITE_STATIC_MEMBERS, importRewrite.getCompilationUnit().getJavaProject());
 					if (pref == null  || pref.isBlank()) {
-						return;
+						continue;
 					}
 					String[] favourites= pref.split(";"); //$NON-NLS-1$
 					if (favourites.length == 0) {
-						return;
+						continue;
 					}
 					try {
 						// check favourite static imports

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3032,6 +3032,62 @@ public class ImportOrganizeTest extends CoreTests {
 		buf.append("\n");
 		buf.append("class Bar {\n");
 		buf.append("    public void testMethod(int something) {\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		assertEqualString(cu.getSource(), buf.toString());
+	}
+
+	@Test
+	public void testIssue853() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test", false, null);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("import static test.StaticImportBug.Test.*;\n");
+		buf.append("\n");
+		buf.append("public class StaticImportBug {\n");
+		buf.append("    static public void methodWithBreakOuter () {\n");
+		buf.append("        outer:\n");
+		buf.append("        while (true)\n");
+		buf.append("            break outer;\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    static public void main (String[] args) throws Throwable {\n");
+		buf.append("        System.out.println(field);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    static public class Test {\n");
+		buf.append("        static public boolean field;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("StaticImportBug.java", buf.toString(), false, null);
+
+		String[] order= new String[] { "", "#"};
+		IChooseImportQuery query= createQuery("StaticImportBug", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 1, false, true, true, query);
+		op.run(null);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("import static test.StaticImportBug.Test.*;\n");
+		buf.append("\n");
+		buf.append("public class StaticImportBug {\n");
+		buf.append("    static public void methodWithBreakOuter () {\n");
+		buf.append("        outer:\n");
+		buf.append("        while (true)\n");
+		buf.append("            break outer;\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    static public void main (String[] args) throws Throwable {\n");
+		buf.append("        System.out.println(field);\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    static public class Test {\n");
+		buf.append("        static public boolean field;\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		assertEqualString(cu.getSource(), buf.toString());


### PR DESCRIPTION
- fix OrganizeImportsOperation.addStaticImports() to not return when static favorite imports preference is unset
- add new test to ImportOrganizeTest
- fixes #853

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes organize imports when a static import is used in addition to a break label.  See issue and new test.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
