### PR TITLE
Fix StringBuffer to StringBuilder cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
@@ -138,11 +138,14 @@ public class StringBufferToStringBuilderFixCore extends CompilationUnitRewriteOp
 
 		@Override
 		public boolean visit(final MethodInvocation node) {
-			String name= node.getName().getFullyQualifiedName();
-			if (name.equals(GETBUFFER_NAME)) {
+			ITypeBinding returnBinding= node.resolveTypeBinding();
+			if (isStringBufferType(returnBinding)) {
 				IMethodBinding methodBinding= node.resolveMethodBinding();
-				if (isStringWriterType(methodBinding.getDeclaringClass())) {
-					fOperations.add(new ChangeStringBufferToStringBuilder(node));
+				if (methodBinding != null) {
+					ITypeBinding type= methodBinding.getDeclaringClass();
+					if (type != null && !type.isFromSource() && !type.getQualifiedName().equals(STRINGBUFFER_CLASS_NAME)) {
+						fOperations.add(new ChangeStringBufferToStringBuilder(node));
+					}
 				}
 			}
 			return true;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
@@ -74,9 +74,7 @@ import org.eclipse.jdt.internal.ui.util.ASTHelper;
 public class StringBufferToStringBuilderFixCore extends CompilationUnitRewriteOperationsFixCore {
 
 	private static final String STRINGBUFFER_CLASS_NAME= StringBuffer.class.getCanonicalName();
-	private static final String STRINGWRITER_CLASS_NAME= "java.io.StringWriter"; //$NON-NLS-1$
 	private static final String OBJECT_CLASS_NAME= Object.class.getCanonicalName();
-	private static final String GETBUFFER_NAME= "getBuffer"; //$NON-NLS-1$
 	private static final String TOSTRING_NAME= "toString"; //$NON-NLS-1$
 	private static final String STRINGBUIDER_NAME= "StringBuilder"; //$NON-NLS-1$
 
@@ -88,16 +86,6 @@ public class StringBufferToStringBuilderFixCore extends CompilationUnitRewriteOp
 			typeBinding= typeBinding.getElementType();
 		}
 		return typeBinding.getQualifiedName().equals(STRINGBUFFER_CLASS_NAME);
-	}
-
-	private static boolean isStringWriterType(ITypeBinding typeBinding) {
-		if (typeBinding == null) {
-			throw new AbortSearchException();
-		}
-		if (typeBinding.isArray()) {
-			typeBinding= typeBinding.getElementType();
-		}
-		return typeBinding.getQualifiedName().equals(STRINGWRITER_CLASS_NAME);
 	}
 
 	private static boolean isObjectType(ITypeBinding typeBinding) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -4208,6 +4208,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String sample= "" //
 				+ "package test1;\n" //
+				+ "import java.io.StringWriter;\n"
 				+ "\n" //
 				+ "public class TestStringBuilderCleanup extends SuperClass {\n" //
 				+ "    StringBuffer field1;\n" //
@@ -4247,6 +4248,12 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "            a.append(\"abc\");\n" //
 				+ "        };\n" //
 				+ "    }\n" //
+				+ "    public void changeStringWriterInLambda(StringBuffer parm) {\n" //
+				+ "        Runnable r = () -> {\n" //
+				+ "            StringWriter a = new StringWriter();\n" //
+				+ "            StringBuffer k = a.getBuffer().append(\"abc\");\n" //
+				+ "        };\n" //
+				+ "    }\n" //
 				+ "}\n";
 		ICompilationUnit cu1= pack1.createCompilationUnit("TestStringBuilderCleanup.java", sample, false, null);
 
@@ -4265,6 +4272,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected1= "" //
 				+ "package test1;\n" //
+				+ "import java.io.StringWriter;\n"
 				+ "\n" //
 				+ "public class TestStringBuilderCleanup extends SuperClass {\n" //
 				+ "    StringBuilder field1;\n" //
@@ -4302,6 +4310,12 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "            StringBuilder a = new StringBuilder();\n" //
 				+ "            super.method0(a);\n" //
 				+ "            a.append(\"abc\");\n" //
+				+ "        };\n" //
+				+ "    }\n" //
+				+ "    public void changeStringWriterInLambda(StringBuilder parm) {\n" //
+				+ "        Runnable r = () -> {\n" //
+				+ "            StringWriter a = new StringWriter();\n" //
+				+ "            StringBuilder k = new StringBuilder(a.getBuffer().toString()).append(\"abc\");\n" //
 				+ "        };\n" //
 				+ "    }\n" //
 				+ "}\n";


### PR DESCRIPTION
- fixes #869
- add logic to handle StringWriter.getBuffer()
- add new test scenario to CleanUpTest1d8

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes StringBuffer to StringBuilder clean up to handle StringWriter.getBuffer().

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test scenario.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
