### PR TITLE
Recognize instance main methods as such in the UI

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ltk.core.refactoring;bundle-version="[3.6.0,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.34.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.36.0,4.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.100,4.0.0)",
  org.eclipse.text;bundle-version="[3.12.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="3.19.400",

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
@@ -19,6 +19,10 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -27,16 +31,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SubMonitor;
-
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IStorage;
-import org.eclipse.core.resources.ResourceAttributes;
-
-import org.eclipse.text.edits.TextEdit;
-
-import org.eclipse.ltk.core.refactoring.resource.Resources;
-
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.CompletionProposal;
 import org.eclipse.jdt.core.CompletionRequestor;
@@ -61,13 +55,13 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.compiler.CharOperation;
-
 import org.eclipse.jdt.internal.core.manipulation.JavaManipulationMessages;
-
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMInstall2;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
+import org.eclipse.ltk.core.refactoring.resource.Resources;
+import org.eclipse.text.edits.TextEdit;
 
 /**
  * Utility methods for the Java Model.
@@ -450,7 +444,7 @@ public final class JavaModelUtil {
 	 */
 	public static boolean hasMainMethod(IType type) throws JavaModelException {
 		for (IMethod method : type.getMethods()) {
-			if (method.isMainMethod()) {
+			if (method.isMainMethodCandidate()) {
 				return true;
 			}
 		}


### PR DESCRIPTION
## What it does
If there is a main method candidate it ensures that the class is runnable.
JavaModelUtils is used in JavaElementImageProvider and this change makes classes with instance main methods being shown as runnable in the Outline view if running on Java 21 with --enable-preview set.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
