### PR TITLE
Remove some empty methods from internal class in AbstractInfoView

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/infoviews/AbstractInfoView.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/infoviews/AbstractInfoView.java
@@ -125,21 +125,6 @@ public abstract class AbstractInfoView extends ViewPart implements ISelectionLis
 			if (!ref.getId().equals(getSite().getId()))
 				computeAndSetInput(ref.getPart(false));
 		}
-		@Override
-		public void partActivated(IWorkbenchPartReference ref) {
-		}
-		@Override
-		public void partBroughtToTop(IWorkbenchPartReference ref) {
-		}
-		@Override
-		public void partClosed(IWorkbenchPartReference ref) {
-		}
-		@Override
-		public void partDeactivated(IWorkbenchPartReference ref) {
-		}
-		@Override
-		public void partOpened(IWorkbenchPartReference ref) {
-		}
 	};
 
 


### PR DESCRIPTION
The methods override the default empty implementation with the same empty implementation. This yields an unnecessary "info" in the problems view