### PR TITLE
Add support for disabling the vintage engine with an attribute

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.13.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/pom.xml
+++ b/org.eclipse.jdt.junit.core/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit.core</artifactId>
-  <version>3.12.200-SNAPSHOT</version>
+  <version>3.13.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/JUnitCore.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/JUnitCore.java
@@ -91,6 +91,12 @@ public class JUnitCore {
 	public final static IPath JUNIT5_CONTAINER_PATH= new Path(JUNIT_CONTAINER_ID).append("5"); //$NON-NLS-1$
 
 	/**
+	 * Attribute to control if <a href="https://junit.org/junit5/docs/current/user-guide/#migrating-from-junit4">junit-vintage</a> engine should be used for JUnit 5, defaults to true if not specified.
+	 * @since 3.13
+	 */
+	public static final String VINTAGE_ATTRIBUTE= "vintage"; //$NON-NLS-1$
+
+	/**
 	 * Adds a listener for test runs.
 	 *
 	 * @param listener listener to be added


### PR DESCRIPTION
This adds the infrastructure for disabling the adding of vintage engine/junit4 to the classpath of the JUnit5 container.

See 
- https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/837

This does not add the UI part yet as I first want to get generals agreement on this before I start with further improvements.

@iloveeclipse @akurtakov can you review and/or suggest a reviewer?
FYI @HeikoKlare 