### PR TITLE
Set a VM property when JUnit view requested a stop during JUnit 5 tests

### DIFF
--- a/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit5.runtime;singleton:=true
-Bundle-Version: 1.1.100.qualifier
+Bundle-Version: 1.1.200.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit5.runner;x-internal:=true
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.jdt.junit5.runtime/pom.xml
+++ b/org.eclipse.jdt.junit5.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit5.runtime</artifactId>
-  <version>1.1.100-SNAPSHOT</version>
+  <version>1.1.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestReference.java
+++ b/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestReference.java
@@ -31,6 +31,8 @@ import org.eclipse.jdt.internal.junit.runner.TestIdMap;
 
 public class JUnit5TestReference implements ITestReference {
 
+	public static final String STOP_REQUESTED_VM_PROPERTY_NAME = "JDT_JUNIT5_RUNNER_STOP_REQUESTED"; //$NON-NLS-1$
+
 	private LauncherDiscoveryRequest fRequest;
 
 	private Launcher fLauncher;
@@ -87,6 +89,7 @@ public class JUnit5TestReference implements ITestReference {
 
 	@Override
 	public void run(TestExecution execution) {
+		execution.addStopListener(() -> System.setProperty(STOP_REQUESTED_VM_PROPERTY_NAME, Boolean.TRUE.toString()));
 		boolean foundMethodThatAvoidsRedundantDiscovery;
 		try {
 			fLauncher.getClass().getMethod("execute", TestPlan.class, TestExecutionListener[].class); //$NON-NLS-1$


### PR DESCRIPTION
A VM property with name `JDT_JUNIT5_RUNNER_STOP_REQUESTED` is set when the JUnit view requested to stop JUnit 5 test execution.

This property can be used by test frameworks based on JUnit, to stop test execution. JUnit 5 itself doesn't yet support stopping test execution.

Partial workaround for: #889

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
