### PR TITLE
Stop JUnit 5 execution on JUnit view stop request

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
@@ -177,7 +177,16 @@ public class RemoteTestRunnerClient {
 	    @Override
 		ProcessingState readMessage(String message) {
 	        if (message.startsWith(MessageIds.TRACE_END)) {
-	            notifyTestFailed();
+	        	// Workaround for JUnit 5 test execution stop
+	        	// triggered by user: see JUnit5TestReference
+	        	String trace = fFailedTrace.toString();
+				if(trace.startsWith("java.lang.OutOfMemoryError: Junit5 test stopped by user")) {//$NON-NLS-1$
+					// Faked JUnit5 test error, just stop the test
+					notifyTestRunStopped(0);
+				} else {
+					// default Junit4 handling
+					notifyTestFailed();
+				}
 	            fFailedTrace.setLength(0);
 	            fActualResult.setLength(0);
 	            fExpectedResult.setLength(0);


### PR DESCRIPTION
This change throws an OutOfMemoryError before a test starts (via TestExecutionListener), if the JUnit view requested a test execution stop during JUnit 5 tests.

An OOME is the only type of exception that is not swallowed by the JUnit 5 framework, when notifying a TestExecutionListener.

Fixes: #889

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
