### PR TITLE
Set a bunch of project encodings to UTF-8

### DIFF
--- a/org.eclipse.jdt.text.tests/testResources/folderLinkTarget1/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.text.tests/testResources/folderLinkTarget1/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/BinaryReferencesWorkspace/BinaryReference/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/BinaryReferencesWorkspace/BinaryReference/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/BinaryReferencesWorkspace/Reference/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/BinaryReferencesWorkspace/Reference/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/BinaryReferencesWorkspace/Source/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/BinaryReferencesWorkspace/Source/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ReplaceInvocationsWorkspace/ReplaceInvocations/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ReplaceInvocationsWorkspace/ReplaceInvocations/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/SefWorkSpace/SefTests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/SefWorkSpace/SefTests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/SurroundWithWorkSpace/SurroundWithTests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/TypeEnvironment/TestProject/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/TypeEnvironment/TestProject/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests/testresources/JUnitWorkspace/JUnit4Tests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests/testresources/JUnitWorkspace/JUnit4Tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.eclipse.jdt.ui.tests/testresources/JUnitWorkspace/JUnitTests/.settings/org.eclipse.core.resources.prefs
+++ b/org.eclipse.jdt.ui.tests/testresources/JUnitWorkspace/JUnitTests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
It was done using a "Quick Fix" and the value set (UTF-8) is the same value that any other project in the workspace uses. The objective of this commit is to declutter the "Problems" view.