### PR TITLE
Allow generate constructor using fields on class with no fields

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateConstructorUsingFieldsTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateConstructorUsingFieldsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -706,6 +706,26 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 				"	}\r\n" +
 				"}\r\n" +
 				"", unit.getSource());
+	}
+	@Test
+	public void test16() throws Exception {  // https://bugs.eclipse.org/bugs/show_bug.cgi?id=552556
+
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"}", true, null);
+		IType typeA= a.getType("A");
+
+		runOperation(typeA, new IField[] {}, null, null, false, false, Modifier.PUBLIC);
+
+		compareSource("package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"\r\n" +
+				"	public A() {\r\n" +
+				"		super();\r\n" +
+				"	}\r\n" +
+				"}", a.getSource());
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -112,6 +112,7 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.20.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.117.0,4.0.0)",
  org.eclipse.ui.console;bundle-version="[3.4.0,4.0.0)",
+ org.eclipse.ui.workbench;bundle-version="[3.131.0, 4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.15.0,4.0.0)",
  org.eclipse.ui.views;bundle-version="[3.3.100,4.0.0)",

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/GenerateConstructorUsingFieldsSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/GenerateConstructorUsingFieldsSelectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -111,7 +111,7 @@ public class GenerateConstructorUsingFieldsSelectionDialog extends SourceActionD
 	private static final int UP_INDEX= 0;
 
 	public GenerateConstructorUsingFieldsSelectionDialog(Shell parent, ILabelProvider labelProvider, GenerateConstructorUsingFieldsContentProvider contentProvider, CompilationUnitEditor editor, IType type, IMethodBinding[] superConstructors) throws JavaModelException {
-		super(parent, labelProvider, contentProvider, editor, type, true);
+		super(parent, labelProvider, contentProvider, editor, type, true, true);
 		fTreeViewerAdapter= new GenerateConstructorUsingFieldsTreeViewerAdapter();
 
 		fSuperConstructors= superConstructors;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/SourceActionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/SourceActionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -131,9 +131,14 @@ public class SourceActionDialog extends CheckedTreeSelectionDialog {
 	private boolean fHasUserChangedPositionIndex;
 	private List<Integer> fAllowedVisibilities;
 
+	public SourceActionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider, CompilationUnitEditor editor,
+			IType type, boolean isConstructor) throws JavaModelException {
+		this(parent, labelProvider, contentProvider, editor, type, isConstructor, false);
+	}
 
-	public SourceActionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider, CompilationUnitEditor editor, IType type, boolean isConstructor) throws JavaModelException {
-		super(parent, labelProvider, contentProvider);
+	public SourceActionDialog(Shell parent, ILabelProvider labelProvider, ITreeContentProvider contentProvider, CompilationUnitEditor editor,
+			IType type, boolean isConstructor, boolean allowEmptyTree) throws JavaModelException {
+		super(parent, labelProvider, contentProvider, allowEmptyTree);
 		fEditor= editor;
 		fContentProvider= contentProvider;
 		fType= type;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/GenerateNewConstructorUsingFieldsAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/GenerateNewConstructorUsingFieldsAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -287,10 +287,8 @@ public class GenerateNewConstructorUsingFieldsAction extends SelectionDispatchAc
 				if (type != null) {
 					if (type.isRecord()) {
 						MessageDialog.openInformation(getShell(), ActionMessages.GenerateConstructorUsingFieldsAction_error_title, ActionMessages.GenerateConstructorUsingFieldsAction_record_not_applicable);
-					} else if (type.getFields().length > 0) {
-						run(type, new IField[0], true);
 					} else {
-						MessageDialog.openInformation(getShell(), ActionMessages.GenerateConstructorUsingFieldsAction_error_title, ActionMessages.GenerateConstructorUsingFieldsAction_typeContainsNoFields_message);
+						run(type, new IField[0], true);
 					}
 					return;
 				}
@@ -356,11 +354,6 @@ public class GenerateNewConstructorUsingFieldsAction extends SelectionDispatchAc
 			if (allSelected.contains(javaElement)) {
 				selected.add(curr);
 			}
-		}
-		if (fieldsToBindings.isEmpty()) {
-			MessageDialog.openInformation(getShell(), ActionMessages.GenerateConstructorUsingFieldsAction_error_title, ActionMessages.GenerateConstructorUsingFieldsAction_typeContainsNoFields_message);
-			notifyResult(false);
-			return;
 		}
 
 		ArrayList<IVariableBinding> fields= new ArrayList<>();


### PR DESCRIPTION
- add new constructor to SourceActionDialog to accept flag that allows empty tree and pass this on to super class
- remove zero fields test in GenerateConstructorUsingFieldsAction
- add new test to GenerateConstructorUsingFieldsTest
- fixes: https://bugs.eclipse.org/bugs/show_bug.cgi?id=552556

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes bug 552556

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
