### PR TITLE
Fix Externalize Strings when input is a Text Block

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/nls/NLSHint.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/nls/NLSHint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -47,6 +48,8 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
+
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 
 /**
@@ -215,9 +218,9 @@ public class NLSHint {
 					AccessorClassReference accessorClassReference= NLSHintHelper.getAccessorClassReference(astRoot, nlsElement);
 					if (accessorClassReference == null) {
 						// no accessor class => not translated
-						result.add(new NLSSubstitution(NLSSubstitution.IGNORED, stripQuotes(nlsElement.getValue()), nlsElement));
+						result.add(new NLSSubstitution(NLSSubstitution.IGNORED, stripQuotes(nlsElement.getValue(), fAccessorPackage.getJavaProject()), nlsElement));
 					} else {
-						String key= stripQuotes(nlsElement.getValue());
+						String key= stripQuotes(nlsElement.getValue(), fAccessorPackage.getJavaProject());
 						String value= props.getProperty(key);
 						result.add(new NLSSubstitution(NLSSubstitution.EXTERNALIZED, key, value, nlsElement, accessorClassReference));
 					}
@@ -225,7 +228,7 @@ public class NLSHint {
 					String key= nlsElement.getValue();
 					result.add(new NLSSubstitution(NLSSubstitution.EXTERNALIZED, key, props.getProperty(key), nlsElement, nlsElement.getAccessorClassReference()));
 				} else {
-					result.add(new NLSSubstitution(NLSSubstitution.INTERNALIZED, stripQuotes(nlsElement.getValue()), nlsElement));
+					result.add(new NLSSubstitution(NLSSubstitution.INTERNALIZED, stripQuotes(nlsElement.getValue(), fAccessorPackage.getJavaProject()), nlsElement));
 				}
 			}
 		}
@@ -257,7 +260,12 @@ public class NLSHint {
 		return null;
 	}
 
-	private static String stripQuotes(String str) {
+	public static String stripQuotes(String str, IJavaProject project) {
+		if (JavaModelUtil.is15OrHigher(project)) {
+			if (str.startsWith("\"\"\"") && str.endsWith("\"\"\"")) { //$NON-NLS-1$ //$NON-NLS-2$
+				return getTextBlock(str.substring(3, str.length() - 3));
+			}
+		}
 		return str.substring(1, str.length() - 1);
 	}
 
@@ -294,5 +302,262 @@ public class NLSHint {
 		return fSubstitutions;
 	}
 
+	private static char[] normalize(char[] content) {
+		StringBuilder result = new StringBuilder();
+		boolean isCR = false;
+		for (char c : content) {
+			switch (c) {
+				case '\r':
+					result.append(c);
+					isCR = true;
+					break;
+				case '\n':
+					if (!isCR) {
+						result.append(c);
+					}
+					isCR = false;
+					break;
+				default:
+					result.append(c);
+					isCR = false;
+					break;
+			}
+		}
+		return result.toString().toCharArray();
+	}
+
+	private static String getTextBlock(String x) {
+		// 1. Normalize line endings
+		char[] all = normalize(x.toCharArray());
+		// 2. Split into lines. Consider both \n and \r as line separators
+		char[][] lines = CharOperation.splitOn('\n', all);
+		int size = lines.length;
+		List<char[]> list = new ArrayList<>(lines.length);
+		for(int i = 1; i < lines.length; i++) {
+			char[] line = lines[i];
+			if (i + 1 == size && line.length == 0) {
+				list.add(line);
+				break;
+			}
+			char[][] sub = CharOperation.splitOn('\r', line);
+			if (sub.length == 0) {
+				list.add(line);
+			} else {
+				for (char[] cs : sub) {
+					list.add(cs);
+				}
+			}
+		}
+		size = list.size();
+		lines = list.toArray(new char[size][]);
+
+		// 	3. Handle incidental white space
+		//  3.1. Split into lines and identify determining lines
+		int prefix = -1;
+		for(int i = 0; i < size; i++) {
+			char[] line = lines[i];
+			boolean blank = true;
+			int whitespaces = 0;
+	 		for (char c : line) {
+				if (blank) {
+					if (Character.isWhitespace(c)) {
+						whitespaces++;
+					} else {
+						blank = false;
+					}
+				}
+			}
+	 		// The last line with closing delimiter is part of the
+	 		// determining line list even if empty
+			if (!blank || (i+1 == size)) {
+				if (prefix < 0 || whitespaces < prefix) {
+	 				prefix = whitespaces;
+				}
+			}
+		}
+		// 3.2. Remove the common white space prefix
+		// 4. Handle escape sequences  that are not already done in getNextToken0()
+		if (prefix == -1)
+			prefix = 0;
+		StringBuilder result = new StringBuilder();
+		boolean newLine = false;
+		for(int i = 0; i < lines.length; i++) {
+			char[] l  = lines[i];
+			// Remove the common prefix from each line
+			// And remove all trailing whitespace
+			// Finally append the \n at the end of the line (except the last line)
+			int length = l.length;
+			int trail = length;
+			for(;trail > 0;) {
+				if (!Character.isWhitespace(l[trail-1])) {
+					break;
+				}
+				trail--;
+			}
+			if (i >= (size -1)) {
+				if (newLine) result.append('\n');
+				if (trail < prefix)
+					continue;
+				newLine = getLineContent(result, l, prefix, trail-1, false, true);
+			} else {
+				if (i > 0 && newLine)
+					result.append('\n');
+				if (trail <= prefix) {
+					newLine = true;
+				} else {
+					boolean merge = length > 0 && l[length - 1] == '\\';
+					newLine = getLineContent(result, l, prefix, trail-1, merge, false);
+				}
+			}
+		}
+		return result.toString();
+
+	}
+	// This method is for handling the left over escaped characters during the first
+	// scanning (scanForStringLiteral). Admittedly this goes over the text block
+	// content again char by char, but this is required in order to correctly
+	// treat all the white space and line endings
+	private static boolean getLineContent(StringBuilder result, char[] line, int start, int end, boolean merge, boolean lastLine) {
+		int lastPointer = 0;
+		for(int i = start; i < end;) {
+			char c = line[i];
+			if (c != '\\') {
+				i++;
+				continue;
+			}
+			if (i < end) {
+				if (lastPointer + 1 <= i) {
+					result.append(CharOperation.subarray(line, lastPointer == 0 ? start : lastPointer, i));
+				}
+				char next = line[++i];
+				switch (next) {
+					case '\\' :
+						result.append('\\');
+						if (i == end)
+							merge = false;
+						break;
+					case 's' :
+						result.append(' ');
+						break;
+					case '"':
+						result.append('"');
+						break;
+					case 'b' :
+						result.append('\b');
+						break;
+					case 'n' :
+						result.append('\n');
+						break;
+					case 'r' :
+						result.append('\r');
+						break;
+					case 't' :
+						result.append('\t');
+						break;
+					case 'f' :
+						result.append('\f');
+						break;
+					default :
+						// Direct copy from scanEscapeCharacter
+						int pos = i + 1;
+						int number = getHexadecimalValue(next);
+						if (number >= 0 && number <= 7) {
+							boolean zeroToThreeNot = number > 3;
+							if (Character.isDigit(next = line[pos])) {
+								pos++;
+								int digit = getHexadecimalValue(next);
+								if (digit >= 0 && digit <= 7) {
+									number = (number * 8) + digit;
+									if (Character.isDigit(next = line[pos])) {
+										pos++;
+										if (zeroToThreeNot) {
+											// has read \NotZeroToThree OctalDigit Digit --> ignore last character
+										} else {
+											digit = getHexadecimalValue(next);
+											if (digit >= 0 && digit <= 7){ // has read \ZeroToThree OctalDigit OctalDigit
+												number = (number * 8) + digit;
+											} else {
+												// has read \ZeroToThree OctalDigit NonOctalDigit --> ignore last character
+											}
+										}
+									} else {
+										// has read \OctalDigit NonDigit--> ignore last character
+									}
+								} else {
+									// has read \OctalDigit NonOctalDigit--> ignore last character
+								}
+							} else {
+								// has read \OctalDigit --> ignore last character
+							}
+							if (number < 255) {
+								next = (char) number;
+							}
+							result.append(next);
+							lastPointer = i = pos;
+							continue;
+						} else {
+							// Dealing with just '\'
+							result.append(c);
+							lastPointer = i;
+							continue;
+						}
+				}
+				lastPointer = ++i;
+			}
+		}
+		end = merge ? end : end >= line.length ? end : end + 1;
+		char[] chars = lastPointer == 0 ?
+				CharOperation.subarray(line, start, end) :
+					CharOperation.subarray(line, lastPointer, end);
+		// The below check is because CharOperation.subarray tend to return null when the
+		// boundaries produce a zero sized char[]
+		if (chars != null && chars.length > 0)
+			result.append(chars);
+		return (!merge && !lastLine);
+	}
+	private static int getHexadecimalValue(char c) {
+		switch(c) {
+			case '0' :
+				return 0;
+			case '1' :
+				return 1;
+			case '2' :
+				return 2;
+			case '3' :
+				return 3;
+			case '4' :
+				return 4;
+			case '5' :
+				return 5;
+			case '6' :
+				return 6;
+			case '7' :
+				return 7;
+			case '8' :
+				return 8;
+			case '9' :
+				return 9;
+			case 'A' :
+			case 'a' :
+				return 10;
+			case 'B' :
+			case 'b' :
+				return 11;
+			case 'C' :
+			case 'c' :
+				return 12;
+			case 'D' :
+			case 'd' :
+				return 13;
+			case 'E' :
+			case 'e' :
+				return 14;
+			case 'F' :
+			case 'f' :
+				return 15;
+			default:
+				return -1;
+		}
+	}
 
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.15.200.qualifier
+Bundle-Version: 3.15.300.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.15.200-SNAPSHOT</version>
+  <version>3.15.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintStripQuotesTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintStripQuotesTest.java
@@ -88,4 +88,25 @@ public class NLSHintStripQuotesTest {
     	String expected= "abc \ndef\n";
     	assertEquals(expected, y);
     }
+    @Test
+    public void test06() throws Exception {
+    	String x="\"\"\" \nabc  \\s\ndef\n\"\"\"";
+    	String y= NLSHint.stripQuotes(x, javaProject15.getJavaProject());
+    	String expected= "abc   \ndef\n";
+    	assertEquals(expected, y);
+    }
+    @Test
+    public void test07() throws Exception {
+    	String x="\"\"\" \nabc  \\\ndef\n\"\"\"";
+    	String y= NLSHint.stripQuotes(x, javaProject15.getJavaProject());
+    	String expected= "abc  def\n";
+    	assertEquals(expected, y);
+    }
+    @Test
+    public void test08() throws Exception {
+    	String x="\"\"\" \n   abc\ndef\n\"\"\"";
+    	String y= NLSHint.stripQuotes(x, javaProject15.getJavaProject());
+    	String expected= "   abc\ndef\n";
+    	assertEquals(expected, y);
+    }
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintStripQuotesTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintStripQuotesTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.refactoring.nls;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.jdt.core.IJavaProject;
+
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSHint;
+
+import org.eclipse.jdt.ui.tests.core.rules.Java15ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+public class NLSHintStripQuotesTest {
+
+	@Rule
+	public ProjectTestSetup pts= new ProjectTestSetup();
+
+	@Rule
+	public Java15ProjectTestSetup pts15= new Java15ProjectTestSetup();
+
+    private IJavaProject javaProject;
+    private IJavaProject javaProject15;
+
+
+    @Before
+	public void setUp() throws Exception {
+        javaProject= pts.getProject();
+        javaProject15= pts15.getProject();
+    }
+
+    @After
+	public void tearDown() throws Exception {
+        JavaProjectHelper.clear(javaProject, pts.getDefaultClasspath());
+        JavaProjectHelper.clear(javaProject15, pts15.getDefaultClasspath());
+    }
+
+    @Test
+    public void test01() throws Exception {
+    	String x= "\"abc\n\"";
+    	String y= NLSHint.stripQuotes(x, javaProject.getJavaProject());
+    	String expected= "abc\n";
+    	assertEquals(expected, y);
+    }
+    @Test
+    public void test02() throws Exception {
+    	String x= "\"\"\"abc\n\"\"\"";
+    	String y= NLSHint.stripQuotes(x, javaProject.getJavaProject());
+    	String expected= "\"\"abc\n\"\"";
+    	assertEquals(expected, y);
+    }
+    @Test
+    public void test03() throws Exception {
+    	String x="\"\"\"\nabc\ndef\n\"\"\"";
+    	String y= NLSHint.stripQuotes(x, javaProject15.getJavaProject());
+    	String expected= "abc\ndef\n";
+    	assertEquals(expected, y);
+    }
+    @Test
+    public void test04() throws Exception {
+    	String x="\"\"\" \nabc\\s\ndef\n\"\"\"";
+    	String y= NLSHint.stripQuotes(x, javaProject15.getJavaProject());
+    	String expected= "abc \ndef\n";
+    	assertEquals(expected, y);
+    }
+    @Test
+    public void test05() throws Exception {
+    	String x="\"\"\" \n    abc\\s\n    def\n    \"\"\"";
+    	String y= NLSHint.stripQuotes(x, javaProject15.getJavaProject());
+    	String expected= "abc \ndef\n";
+    	assertEquals(expected, y);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSTestSuite.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSTestSuite.java
@@ -34,7 +34,8 @@ import org.junit.runners.Suite;
 		PropertyFileDocumentModellTest.class,
 		SimpleLineReaderTest.class,
 		NLSHolderTest.class,
-		NLSSubstitutionTest.class
+		NLSSubstitutionTest.class,
+		NLSHintStripQuotesTest.class,
 })
 public class NLSTestSuite {
 }


### PR DESCRIPTION
- fixes: #906
- fix NLSHint.stripQuotes() to recognize a text block
- add new NLSHintStripQuotesTest class

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes Externalize Strings wizard to recognize a text block input and properly calculate the externalized string.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests or issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
