### PR TITLE
Fix ComparingOnCriteriaCleanUp to handle wildcard types

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -2004,6 +2004,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "import java.util.Date;\n" //
 				+ "import java.util.List;\n" //
 				+ "import java.util.Locale;\n" //
+				+ "import java.util.TreeSet;\n" //
 				+ "\n" //
 				+ "public class E {\n" //
 				+ "    private Comparator<Date> refactorField = new Comparator<Date>() {\n" //
@@ -2404,6 +2405,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "\n" //
 				+ "        return listToSort;\n" //
 				+ "    }\n" //
+				+ "\n" //
+				+ "    public class FooBar {\n" //
+				+ "        public String value;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    private final TreeSet<FooBar> foo = new TreeSet<>((a,b) -> b.value.compareTo(a.value));\n" //
+				+ "\n" //
 				+ "}\n";
 
 		String expected= "" //
@@ -2415,6 +2423,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "import java.util.Date;\n" //
 				+ "import java.util.List;\n" //
 				+ "import java.util.Locale;\n" //
+				+ "import java.util.TreeSet;\n" //
 				+ "\n" //
 				+ "public class E {\n" //
 				+ "    private Comparator<Date> refactorField = Comparator.comparing(Date::toString);\n" //
@@ -2608,6 +2617,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "\n" //
 				+ "        return listToSort;\n" //
 				+ "    }\n" //
+				+ "\n" //
+				+ "    public class FooBar {\n" //
+				+ "        public String value;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    private final TreeSet<FooBar> foo = new TreeSet<>(Comparator.comparing((FooBar a) -> a.value).reversed());\n" //
+				+ "\n" //
 				+ "}\n";
 
 		// When

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2023 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.text.edits.TextEditGroup;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
@@ -53,6 +55,7 @@ import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
@@ -70,6 +73,7 @@ import org.eclipse.jdt.internal.corext.util.NodeMatcher;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
 import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
 
 /**
@@ -571,11 +575,37 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 				lambdaExpression.parameters().add(newVariableDeclarationFragment);
 			} else {
 				String comparedClassNameText= importRewrite.addImport(type);
+				String importedName= comparedClassNameText;
 
 				SingleVariableDeclaration newSingleVariableDeclaration= ast.newSingleVariableDeclaration();
-				newSingleVariableDeclaration.setType(ast.newSimpleType(ASTNodeFactory.newName(ast, comparedClassNameText)));
+				if (type.isWildcardType()) {
+					ITypeBinding bound= type.getBound();
+					Type boundType= importRewrite.addImport(bound, ast, importRewrite.getDefaultImportRewriteContext(), TypeLocation.TYPE_BOUND);
+					newSingleVariableDeclaration.setType(boundType);
+					if (bound.isLocal()) {
+						importRewrite.removeImport(bound.getQualifiedName());
+					}
+					importedName= bound.getQualifiedName();
+				} else {
+					newSingleVariableDeclaration.setType(ast.newSimpleType(ASTNodeFactory.newName(ast, comparedClassNameText)));
+				}
+
 				newSingleVariableDeclaration.setName((SimpleName) rewrite.createCopyTarget(name));
 				lambdaExpression.parameters().add(newSingleVariableDeclaration);
+				if (type.isLocal()) {
+					importRewrite.removeImport(importedName);
+				} else {
+					try {
+						IType[] cuTypes= importRewrite.getCompilationUnit().getTypes();
+						for (IType cuType : cuTypes) {
+							if (importedName.startsWith(cuType.getFullyQualifiedName())) {
+								importRewrite.removeImport(importedName);
+							}
+						}
+					} catch (JavaModelException e) {
+						// should not occur
+					}
+				}
 			}
 
 			FieldAccess newFieldAccess= ast.newFieldAccess();


### PR DESCRIPTION
- fixes #174
- add logic to buildField to handle wildcard types
- add new scenario to current test in CleanUpTest1d8

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes exception caused when using Comparator cleanup with wildcard type.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
