### PR TITLE
Cache the list of names whose favorite static imports we have resolved.

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
@@ -19,21 +19,24 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 
-import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.resources.IStorage;
-import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.SubMonitor;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.resources.ResourceAttributes;
+
+import org.eclipse.text.edits.TextEdit;
+
+import org.eclipse.ltk.core.refactoring.resource.Resources;
+
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
-import org.eclipse.jdt.core.CompletionProposal;
-import org.eclipse.jdt.core.CompletionRequestor;
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -55,13 +58,13 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.compiler.CharOperation;
+
 import org.eclipse.jdt.internal.core.manipulation.JavaManipulationMessages;
+
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.IVMInstall2;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
-import org.eclipse.ltk.core.refactoring.resource.Resources;
-import org.eclipse.text.edits.TextEdit;
 
 /**
  * Utility methods for the Java Model.
@@ -1324,55 +1327,9 @@ public final class JavaModelUtil {
 	}
 
 	public static String[] getStaticImportFavorites(ICompilationUnit cu, final String elementName, boolean isMethod, String[] favorites) throws JavaModelException {
-		StringBuilder dummyCU= new StringBuilder();
-		String packName= cu.getParent().getElementName();
-		IType type= cu.findPrimaryType();
-		if (type == null)
-			return new String[0];
-
-		if (packName.length() > 0) {
-			dummyCU.append("package ").append(packName).append(';'); //$NON-NLS-1$
-		}
-		dummyCU.append("public class ").append(type.getElementName()).append("{\n static {\n").append(elementName); // static initializer  //$NON-NLS-1$//$NON-NLS-2$
-		int offset= dummyCU.length();
-		dummyCU.append("\n}\n }"); //$NON-NLS-1$
-
-		ICompilationUnit newCU= null;
-		try {
-			newCU= cu.getWorkingCopy(null);
-			newCU.getBuffer().setContents(dummyCU.toString());
-
-			final HashSet<String> result= new HashSet<>();
-
-			CompletionRequestor requestor= new CompletionRequestor(true) {
-				@Override
-				public void accept(CompletionProposal proposal) {
-					if (elementName.equals(new String(proposal.getName()))) {
-						for (CompletionProposal curr : proposal.getRequiredProposals()) {
-							if (curr.getKind() == CompletionProposal.METHOD_IMPORT || curr.getKind() == CompletionProposal.FIELD_IMPORT) {
-								result.add(concatenateName(Signature.toCharArray(curr.getDeclarationSignature()), curr.getName()));
-							}
-						}
-					}
-				}
-			};
-
-			if (isMethod) {
-				requestor.setIgnored(CompletionProposal.METHOD_REF, false);
-				requestor.setAllowsRequiredProposals(CompletionProposal.METHOD_REF, CompletionProposal.METHOD_IMPORT, true);
-			} else {
-				requestor.setIgnored(CompletionProposal.FIELD_REF, false);
-				requestor.setAllowsRequiredProposals(CompletionProposal.FIELD_REF, CompletionProposal.FIELD_IMPORT, true);
-			}
-			requestor.setFavoriteReferences(favorites);
-
-			newCU.codeComplete(offset, requestor, new NullProgressMonitor());
-
-			return result.toArray(new String[result.size()]);
-		} finally {
-			if (newCU != null) {
-				newCU.discardWorkingCopy();
-			}
-		}
+		StaticImportFavoritesCompletionInvoker ex = new StaticImportFavoritesCompletionInvoker(cu, favorites);
+		String[] result = ex.getStaticImportFavorites(elementName, isMethod);
+		ex.destroy();
+		return result;
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/StaticImportFavoritesCompletionInvoker.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/StaticImportFavoritesCompletionInvoker.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2023 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from original {@link JavaModelUtil#getStaticImportFavorites(ICompilationUnit, String, boolean, String[])}
+ *
+ *******************************************************************************/
+package org.eclipse.jdt.internal.corext.util;
+
+import java.util.HashSet;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.CompletionRequestor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+
+/**
+ * Copied from {@link JavaModelUtil#getStaticImportFavorites(ICompilationUnit, String, boolean, String[])}
+ * If code completion needs to be called multiple times on a given compilation unit,
+ * this class will perform the operations more efficiently by re-using a working copy.
+ */
+public class StaticImportFavoritesCompletionInvoker {
+	private ICompilationUnit fCu;
+	private ICompilationUnit fNewCU;
+	private String[] fFavourites;
+
+	public StaticImportFavoritesCompletionInvoker (ICompilationUnit cu, String[] favourites) {
+		fCu= cu;
+		fFavourites= favourites;
+	}
+
+	public void destroy () throws JavaModelException {
+		if (fNewCU != null) {
+			fNewCU.discardWorkingCopy();
+		}
+	}
+
+	public String [] getStaticImportFavorites (final String elementName, boolean isMethod) throws JavaModelException {
+		if (fNewCU == null) {
+			fNewCU= fCu.getWorkingCopy(null);
+		}
+
+		String[] res = createNewCompilationUnit(elementName);
+		String dummyCuContent = res[0];
+		int offset= Integer.parseInt(res[1]);
+		fNewCU.getBuffer().setContents(dummyCuContent);
+		final HashSet<String> result= new HashSet<>();
+		CompletionRequestor requestor= new CompletionRequestor(true) {
+			@Override
+			public void accept(CompletionProposal proposal) {
+				if (elementName.equals(new String(proposal.getName()))) {
+					for (CompletionProposal curr : proposal.getRequiredProposals()) {
+						if (curr.getKind() == CompletionProposal.METHOD_IMPORT || curr.getKind() == CompletionProposal.FIELD_IMPORT) {
+							result.add(JavaModelUtil.concatenateName(Signature.toCharArray(curr.getDeclarationSignature()), curr.getName()));
+						}
+					}
+				}
+			}
+		};
+
+		if (isMethod) {
+			requestor.setIgnored(CompletionProposal.METHOD_REF, false);
+			requestor.setAllowsRequiredProposals(CompletionProposal.METHOD_REF, CompletionProposal.METHOD_IMPORT, true);
+		} else {
+			requestor.setIgnored(CompletionProposal.FIELD_REF, false);
+			requestor.setAllowsRequiredProposals(CompletionProposal.FIELD_REF, CompletionProposal.FIELD_IMPORT, true);
+		}
+		requestor.setFavoriteReferences(fFavourites);
+		fNewCU.codeComplete(offset, requestor, new NullProgressMonitor());
+		return result.toArray(new String[result.size()]);
+	}
+
+	private String[] createNewCompilationUnit (final String elementName) {
+		StringBuilder dummyCU= new StringBuilder();
+		String packName= fCu.getParent().getElementName();
+		IType type= fCu.findPrimaryType();
+		if (type == null)
+			return null;
+
+		if (packName.length() > 0) {
+			dummyCU.append("package ").append(packName).append(';'); //$NON-NLS-1$
+		}
+		dummyCU.append("public class ").append(type.getElementName()).append("{\n static {\n").append(elementName); // static initializer  //$NON-NLS-1$//$NON-NLS-2$
+		String offset = Integer.toString(dummyCU.length());
+		dummyCU.append("\n}\n }"); //$NON-NLS-1$
+		return new String [] {dummyCU.toString(), offset};
+	}
+}


### PR DESCRIPTION
Originally from https://github.com/redhat-developer/vscode-java/issues/3383

- Do not recompute favorite static imports for an unknown type
- Reuse compilation unit working copy in code completion logic

I tested at runtime against https://github.com/eclipse/lemminx/blob/main/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/XMLAssert.java by removing all imports and triggering the organize imports functionality. Any easy reproducer is just create some source file with **a lot** of static imports. Remove them all, and call "Organize Imports".

`ImportOrganizeTest*` were useful for testing this. If I have some time, I can investigate adding something to `OrganizeImportsPerfTest`. **Update:** The existing performance tests there don't seem to have any useful assertions as far as I can tell.

`getFavoriteStaticImports(..)` went from ~3s to ~300ms .

**Before**
![organize-static-imports-before](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/1417342/a16e0b38-bc6c-4637-8e4c-1dc9372ad4e3)

**After**
![organize-static-imports-after](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/1417342/f7616376-261e-44a1-a89a-d21ff04929bc)
