### PR TITLE
Enable StringBuffer to Text Block quick assist

### DIFF
--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.15.200.qualifier
+Bundle-Version: 3.15.300.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.15.200-SNAPSHOT</version>
+  <version>3.15.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -3832,6 +3832,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		if (node instanceof Assignment
 				|| node instanceof VariableDeclarationFragment
 				|| node instanceof FieldDeclaration
+				|| node instanceof VariableDeclarationStatement
 				|| node instanceof InfixExpression) {
 			exp= node;
 		} else {
@@ -3839,10 +3840,16 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 			if (parent instanceof Assignment
 					|| parent instanceof VariableDeclarationFragment
 					|| parent instanceof FieldDeclaration
+					|| parent instanceof VariableDeclarationStatement
 					|| parent instanceof InfixExpression) {
 				exp= parent;
 			}
 		}
+
+		if (exp == null) {
+			exp= ASTNodes.getFirstAncestorOrNull(node, FieldDeclaration.class, VariableDeclarationStatement.class);
+		}
+
 		if (exp == null)
 			return false;
 
@@ -3856,6 +3863,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
 		Map<String, String> options= new HashMap<>();
 		options.put(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK, CleanUpOptions.TRUE);
+		options.put(CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER, CleanUpOptions.TRUE);
 		ICleanUp cleanUp= new StringConcatToTextBlockCleanUp(options);
 		FixCorrectionProposal proposal= new FixCorrectionProposal(fix, cleanUp, IProposalRelevance.CONVERT_TO_TEXT_BLOCK, image, context);
 		resultingCollections.add(proposal);


### PR DESCRIPTION
- fix logic in QuickAssistProcessor.getStringConcatToTextBlockProposal() to also support StringBuffer or StringBuilder variable declaration that can be converted to Text Block
- add new test to AssistQuickFixTest15
- fixes #882

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Provides a quick assist to convert a StringBuffer or StringBuilder concatenation to a text block similar to what is offered
in a cleanup.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
