### PR TITLE
Fix JavaSource hover not displayed from ClassFileEditor. Fixes #936

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.31.0.qualifier
+Bundle-Version: 3.31.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.31.0-SNAPSHOT</version>
+  <version>3.31.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <properties>
     <code.ignoredWarnings>-warn:-deprecation,unavoidableGenericProblems</code.ignoredWarnings>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
@@ -541,7 +541,9 @@ public class SemanticHighlightingReconciler implements IJavaReconcilingListener,
 				((CompilationUnitEditor)fEditor).addReconcileListener(this);
 			}
 		} else if (fEditor != null) {
-			fSourceViewer.addTextInputListener(this);
+			if (registerAsSourceViewerTextInputListener()) {
+				fSourceViewer.addTextInputListener(this);
+			}
 			scheduleJob();
 		}
 	}
@@ -551,6 +553,14 @@ public class SemanticHighlightingReconciler implements IJavaReconcilingListener,
 	 * @return whether this instance should register itself as a reconciling listener on the editor
 	 */
 	protected boolean registerAsEditorReconcilingListener() {
+		return true;
+	}
+
+	/**
+	 * Decides if this reconciler should also register itself as a text input listener on the source viewer as part of {@link #install} process.
+	 * @return whether this instance should register itself as a text input listener on the source viewer
+	 */
+	protected boolean registerAsSourceViewerTextInputListener() {
 		return true;
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/SourceViewerInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/SourceViewerInformationControl.java
@@ -726,11 +726,16 @@ public class SourceViewerInformationControl
 
 				@Override
 				protected ITypeRoot getElement() {
-					return fInput.fRootElement;
+					return fInput == null ? null : fInput.fRootElement;
 				}
 
 				@Override
 				protected boolean registerAsEditorReconcilingListener() {
+					return false;
+				}
+
+				@Override
+				protected boolean registerAsSourceViewerTextInputListener() {
 					return false;
 				}
 			};


### PR DESCRIPTION
## What it does
Fixes NPE causing Java source hover viewer to not be displayed from ClassFileEditor.

## How to test
Open any Java class (one coming from library for which there is source code attached) inside ClassFileEditor, e.g. java.lang.String, and try to show Java source of some element, e.g. class itself, by hovering over it (e.g. class name) while holding SHIFT.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
