### PR TITLE
Dont show children for JUnit 5 @TestTemplate tests that ran only once

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestSuiteElement.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestSuiteElement.java
@@ -15,6 +15,7 @@
 package org.eclipse.jdt.internal.junit.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.junit.model.ITestElement;
@@ -47,7 +48,8 @@ public class TestSuiteElement extends TestElement implements ITestSuiteElement {
 
 	@Override
 	public ITestElement[] getChildren() {
-		return fChildren.toArray(new ITestElement[fChildren.size()]);
+		TestElement[] elements= fChildren.toArray(new TestElement[fChildren.size()]); // copy list to avoid concurrency problems
+		return Arrays.stream(elements).filter(e -> !isSingleDynamicTest(e)).toArray(ITestElement[]::new);
 	}
 
 	public void addChild(TestElement child) {
@@ -154,4 +156,14 @@ public class TestSuiteElement extends TestElement implements ITestSuiteElement {
 		return "TestSuite: " + getTestName() + " : " + super.toString() + " (" + fChildren.size() + ")";   //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	}
 
+	private static boolean isSingleDynamicTest(TestElement element) {
+		if (element instanceof TestCaseElement) {
+			TestCaseElement testCase = (TestCaseElement) element;
+			TestSuiteElement suite = testCase.getParent();
+			if (testCase.isDynamicTest() && suite.fChildren.size() == 1) {
+				return true;
+			}
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
When running JUnit 5 @TestTemplate tests, extra test suites are shown in the JUnit view to represent the tests in the template. Those suites introduce unnecessary noise when the template contains only one test - e.g. when repeating tests that failed.

This change adjusts TestSuiteElement.getChildren(), pruning each TestSuiteElement that has a single TestCaseElement child that is also a dynamic test.

Fixes: #945

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
