### PR TITLE
Work around API tooling warning regarding unnecessary minor bump.

### DIFF
--- a/org.eclipse.jdt.core.manipulation/.settings/.api_filters
+++ b/org.eclipse.jdt.core.manipulation/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jdt.core.manipulation" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="See https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/914" id="926941240">
+            <message_arguments>
+                <message_argument value="1.21.0"/>
+                <message_argument value="1.20.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="common/org/eclipse/jdt/core/manipulation/ImportReferencesCollector.java" type="org.eclipse.jdt.core.manipulation.ImportReferencesCollector">
         <filter id="576720909">
             <message_arguments>


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/914#issuecomment-1831635568

- jdt.core.manipulation received an unnecessary minor version bump, where a service bump was sufficient