### PR TITLE
Using text blocks in org.eclipse.jdt.ui.tests.refactoring

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTestSetup.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTestSetup.java
@@ -88,60 +88,62 @@ public class InlineMethodTestSetup extends RefactoringTestSetup {
 
 		fImport.createCompilationUnit(
 			"Provider.java",
-			"package import_in;\n" +
-			"\n" +
-			"import import_use.List;\n" +
-			"import java.io.File;\n" +
-			"import java.util.ArrayList;\n" +
-			"import java.util.Map;\n" +
-			"import static java.lang.Math.PI;\n" +
-			"\n" +
-			"public class Provider {\n" +
-			"	public File useAsReturn() {\n" +
-			"		return null;\n" +
-			"	}\n" +
-			"	public void useInArgument(File file) {\n" +
-			"		file= null;\n" +
-			"	}\n" +
-			"	public void useInDecl() {\n" +
-			"		List list= null;\n" +
-			"	}\n" +
-			"	public int useInDecl2() {\n" +
-		  	"		return new ArrayList().size();\n" +
-			"	}\n" +
-			"	public Object useInDecl3() {\n" +
-		  	"		return new java.util.HashMap();\n" +
-			"	}\n" +
-			"	public void useInClassLiteral() {\n" +
-			"		Class clazz= File.class;\n" +
-			"	}\n" +
-			"	public void useArray() {\n" +
-			"		List[] lists= null;\n" +
-			"	}\n" +
-			"	public void useInLocalClass() {\n" +
-			"		class Local extends File {\n" +
-			"			private static final long serialVersionUID = 1L;\n" +
-			"			public Local(String s) {\n" +
-			"				super(s);\n" +
-			"			}\n" +
-			"			public void foo(Map map) {\n" +
-			"			}\n" +
-			"			public void bar(Byte b) {\n" +
-			"			}\n" +
-			"		}\n" +
-			"	}\n" +
-			"	public void useStaticImport() {\n" +
-			"		double i= PI;\n" +
-			"	}\n" +
-			"}\n",
+			"""
+				package import_in;
+				
+				import import_use.List;
+				import java.io.File;
+				import java.util.ArrayList;
+				import java.util.Map;
+				import static java.lang.Math.PI;
+				
+				public class Provider {
+					public File useAsReturn() {
+						return null;
+					}
+					public void useInArgument(File file) {
+						file= null;
+					}
+					public void useInDecl() {
+						List list= null;
+					}
+					public int useInDecl2() {
+						return new ArrayList().size();
+					}
+					public Object useInDecl3() {
+						return new java.util.HashMap();
+					}
+					public void useInClassLiteral() {
+						Class clazz= File.class;
+					}
+					public void useArray() {
+						List[] lists= null;
+					}
+					public void useInLocalClass() {
+						class Local extends File {
+							private static final long serialVersionUID = 1L;
+							public Local(String s) {
+								super(s);
+							}
+							public void foo(Map map) {
+							}
+							public void bar(Byte b) {
+							}
+						}
+					}
+					public void useStaticImport() {
+						double i= PI;
+					}
+				}
+				""",
 			true, null);
 
 			IPackageFragment importUse= root.createPackageFragment("import_use", true, null);
 			importUse.createCompilationUnit("List.java",
-			"package import_use;" +
-			"" +
-			"public class List {" +
-			"}",
+			"""
+				package import_use;\
+				public class List {\
+				}""",
 			true, null);
 
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenameRecordElementsTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenameRecordElementsTests.java
@@ -416,13 +416,14 @@ public class RenameRecordElementsTests extends GenericRefactoringTest {
 
 	@Test
 	public void testRenameRecordComponentFail01() throws Exception{
-		String errorMsg = "<ERROR\n" +
-				"	\n" +
-				"ERROR: Method 'void g()' already exists in 'p.A', having same signature as the new accessor method.\n" +
-				"Context: A.java (not open) [in p [in src [in TestProject]]]\n" +
-				"code: none\n" +
-				"Data: null\n" +
-				">";
+		String errorMsg = """
+			<ERROR
+				
+			ERROR: Method 'void g()' already exists in 'p.A', having same signature as the new accessor method.
+			Context: A.java (not open) [in p [in src [in TestProject]]]
+			code: none
+			Data: null
+			>""";
 		renameRecordComponentFail("A","f","g",errorMsg);
 	}
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/changes/TextDiffContentTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/changes/TextDiffContentTest.java
@@ -41,18 +41,20 @@ import org.eclipse.ltk.core.refactoring.TextEditChangeGroup;
  */
 public class TextDiffContentTest {
 	private static final String MODIFIED_SOURCE_CONTENTS =
-		"// my file\n"+
-		"\n"+
-		"CMyClass::CMyClass()\n"+
-		"\t{\n"+
-		"\tGoodCall();\n"+
-		"\tDumbCall();\n"+
-		"\t// [[[ begin\n"+
-		"\tMagicCall();\n"+
-		"\t// ]]] end\n"+
-		"\t}\n"+
-		"\n"+
-		"// other stuff\n";
+		"""
+		// my file
+		
+		CMyClass::CMyClass()
+			{
+			GoodCall();
+			DumbCall();
+			// [[[ begin
+			MagicCall();
+			// ]]] end
+			}
+		
+		// other stuff
+		""";
 
 	private DocumentChange fDocumentChange;
 
@@ -149,14 +151,18 @@ public class TextDiffContentTest {
 	public void testEmptySourceRangeContext() throws Exception {
 		String src = getSource(fEdit1.getRegion(), 2);
 		String preview = getPreview(fChange1, 2);
-		assertEquals("\tMagicCall();\n" +
-				"\t// ]]] end\n" +
-				"\t}\n",
+		assertEquals("""
+				MagicCall();
+				// ]]] end
+				}
+			""",
 				src);
-		assertEquals("	MagicCall();\n" +
-				"	// ]]] end\n" +
-				"	FinalCall();\n" +
-				"	}\n",
+		assertEquals("""
+				MagicCall();
+				// ]]] end
+				FinalCall();
+				}
+			""",
 			preview);
 	}
 	@Test
@@ -182,14 +188,18 @@ public class TextDiffContentTest {
 	public void testEmptyTargetRangeContext() throws Exception {
 		String src = getSource(fEdit3.getRegion(), 2);
 		String preview = getPreview(fChange3, 2);
-		assertEquals("\t{\n"+"\tGoodCall();\n"+
-				"\tDumbCall();\n"+
-				"\t// [[[ begin\n"+
-				"\tMagicCall();",
+		assertEquals("""
+				{
+				GoodCall();
+				DumbCall();
+				// [[[ begin
+				MagicCall();""",
 				src);
-		assertEquals("\t{\n"+"\tGoodCall();\n"+
-				"\t// [[[ begin\n"+
-				"\tMagicCall();",
+		assertEquals("""
+				{
+				GoodCall();
+				// [[[ begin
+				MagicCall();""",
 				preview);
 
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintHelperTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintHelperTest.java
@@ -254,13 +254,15 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName1f() throws Exception {
 	    String source=
-			"package test;\n" +
-			"public class TestMessages {\n" +
-			"	private static final String BUNDLE_NAME = \"test.test\";\n" +
-			"	public static String getString(String s) {" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			public class TestMessages {
+				private static final String BUNDLE_NAME = "test.test";
+				public static String getString(String s) {\
+					return "";
+				}
+			}
+			""";
 
 
 	    assertEquals("test.test", getResourceBundleName(source, "TestMessages", "test"));
@@ -269,16 +271,18 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName1s() throws Exception {
 	    String source=
-			"package test;\n" +
-			"public class TestMessages {\n" +
-			"	private static String BUNDLE_NAME;\n" +
-			"   static {\n" +
-			"		BUNDLE_NAME= \"test.test\";\n" +
-			"   }\n" +
-			"	public static String getString(String s) {" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			public class TestMessages {
+				private static String BUNDLE_NAME;
+			   static {
+					BUNDLE_NAME= "test.test";
+			   }
+				public static String getString(String s) {\
+					return "";
+				}
+			}
+			""";
 
 
 	    assertEquals("test.test", getResourceBundleName(source, "TestMessages", "test"));
@@ -287,13 +291,15 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName2f() throws Exception {
 	    String source=
-			"package test;\n" +
-			"public class TestMessages {\n" +
-			"	private static final String BUNDLE_NAME = TestMessages.class.getName();\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			public class TestMessages {
+				private static final String BUNDLE_NAME = TestMessages.class.getName();
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.TestMessages", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -301,16 +307,18 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName2s() throws Exception {
 	    String source=
-			"package test;\n" +
-			"public class TestMessages {\n" +
-			"	private static String BUNDLE_NAME;\n" +
-			"   static {\n" +
-			"		BUNDLE_NAME = TestMessages.class.getName();\n" +
-			"   }\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			public class TestMessages {
+				private static String BUNDLE_NAME;
+			   static {
+					BUNDLE_NAME = TestMessages.class.getName();
+			   }
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.TestMessages", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -318,14 +326,16 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName3f() throws Exception {
 	    String source=
-			"package test;\n" +
-			"import java.util.ResourceBundle;\n" +
-			"public class TestMessages {\n" +
-			"	private static final ResourceBundle b= ResourceBundle.getBundle(TestMessages.class.getName());\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			import java.util.ResourceBundle;
+			public class TestMessages {
+				private static final ResourceBundle b= ResourceBundle.getBundle(TestMessages.class.getName());
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.TestMessages", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -333,17 +343,19 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName3s() throws Exception {
 	    String source=
-			"package test;\n" +
-			"import java.util.ResourceBundle;\n" +
-			"public class TestMessages {\n" +
-			"	private static ResourceBundle b;\n" +
-			"   static {\n" +
-			"		b= ResourceBundle.getBundle(TestMessages.class.getName());\n" +
-			"   }\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			import java.util.ResourceBundle;
+			public class TestMessages {
+				private static ResourceBundle b;
+			   static {
+					b= ResourceBundle.getBundle(TestMessages.class.getName());
+			   }
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.TestMessages", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -351,14 +363,16 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName4f() throws Exception {
 	    String source=
-			"package test;\n" +
-			"import java.util.ResourceBundle;\n" +
-			"public class TestMessages {\n" +
-			"	private static final ResourceBundle b= ResourceBundle.getBundle(\"test.test\");\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			import java.util.ResourceBundle;
+			public class TestMessages {
+				private static final ResourceBundle b= ResourceBundle.getBundle("test.test");
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.test", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -366,17 +380,19 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName4s() throws Exception {
 	    String source=
-			"package test;\n" +
-			"import java.util.ResourceBundle;\n" +
-			"public class TestMessages {\n" +
-			"	private static ResourceBundle b;\n" +
-			"   static {\n" +
-			"		b= ResourceBundle.getBundle(\"test.test\");\n" +
-			"   }\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			import java.util.ResourceBundle;
+			public class TestMessages {
+				private static ResourceBundle b;
+			   static {
+					b= ResourceBundle.getBundle("test.test");
+			   }
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.test", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -384,15 +400,17 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName5f() throws Exception {
 	    String source=
-			"package test;\n" +
-			"import java.util.ResourceBundle;\n" +
-			"public class TestMessages {\n" +
-			"	private static final String RESOURCE_BUNDLE= TestMessages.class.getName();\n" +
-			"	private static final ResourceBundle b= ResourceBundle.getBundle(RESOURCE_BUNDLE);\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			import java.util.ResourceBundle;
+			public class TestMessages {
+				private static final String RESOURCE_BUNDLE= TestMessages.class.getName();
+				private static final ResourceBundle b= ResourceBundle.getBundle(RESOURCE_BUNDLE);
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.TestMessages", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -400,18 +418,20 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName5s() throws Exception {
 	    String source=
-			"package test;\n" +
-			"import java.util.ResourceBundle;\n" +
-			"public class TestMessages {\n" +
-			"	private static final String RESOURCE_BUNDLE= TestMessages.class.getName();\n" +
-			"	private static ResourceBundle b;\n" +
-			"   static {\n" +
-			"		b= ResourceBundle.getBundle(RESOURCE_BUNDLE);\n" +
-			"   }\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			import java.util.ResourceBundle;
+			public class TestMessages {
+				private static final String RESOURCE_BUNDLE= TestMessages.class.getName();
+				private static ResourceBundle b;
+			   static {
+					b= ResourceBundle.getBundle(RESOURCE_BUNDLE);
+			   }
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.TestMessages", getResourceBundleName(source, "TestMessages", "test"));
 	}
@@ -419,15 +439,17 @@ public class NLSHintHelperTest {
 	@Test
 	public void findResourceBundleName6() throws Exception {
 	    String source=
-			"package test;\n" +
-			"import java.util.ResourceBundle;\n" +
-			"public class TestMessages {\n" +
-			"	private static final String RESOURCE_BUNDLE= TestMessages.class.getName();\n" +
-			"	private static ResourceBundle fgResourceBundle= ResourceBundle.getBundle(RESOURCE_BUNDLE);\n" +
-			"	public static String getString(String s) {\n" +
-			"		return \"\";\n" +
-			"	}\n" +
-			"}\n";
+			"""
+			package test;
+			import java.util.ResourceBundle;
+			public class TestMessages {
+				private static final String RESOURCE_BUNDLE= TestMessages.class.getName();
+				private static ResourceBundle fgResourceBundle= ResourceBundle.getBundle(RESOURCE_BUNDLE);
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
 	    assertEquals("test.TestMessages", getResourceBundleName(source, "TestMessages", "test"));
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHintTest.java
@@ -51,17 +51,21 @@ public class NLSHintTest {
     private IPackageFragmentRoot fSourceFolder;
 
     private final static String TEST_KLAZZ =
-        "public class Test {" +
-        "	private String str=TestMessages.getString(\"whateverKey\");//$NON-NLS-1$\n" +
-        "}\n";
+        """
+		public class Test {\
+			private String str=TestMessages.getString("whateverKey");//$NON-NLS-1$
+		}
+		""";
 
     private final static String ACCESSOR_KLAZZ =
-		"public class TestMessages {\n" +
-		"	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" +
-		"	public static String getString(String s) {" +
-		"		return \"\";\n" +
-		"	}\n" +
-		"}\n";
+		"""
+		public class TestMessages {
+			private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+			public static String getString(String s) {\
+				return "";
+			}
+		}
+		""";
 
     @Before
 	public void setUp() throws Exception {
@@ -81,10 +85,12 @@ public class NLSHintTest {
 	public void nlsedButNotTranslated() throws Exception {
     	IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
     	String klazz =
-    		"package test;\n" +
-    		"public class Test {" +
-			"	private String str=\"whateverKey\";//$NON-NLS-1$\n" +
-			"}\n";
+    		"""
+			package test;
+			public class Test {\
+				private String str="whateverKey";//$NON-NLS-1$
+			}
+			""";
     	ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
         NLSHint hint = createNLSHint(cu);
         assertEquals("Messages", hint.getAccessorClassName());
@@ -97,10 +103,12 @@ public class NLSHintTest {
 	public void looksLikeAccessor() throws Exception {
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	String[] foo = {\"ab\", String.valueOf(Boolean.valueOf(\"cd\")), \"de\"}; //$NON-NLS-1$ //$NON-NLS-2$\n" +
-			"}\n";
+            """
+			package test;
+			public class Test {
+				String[] foo = {"ab", String.valueOf(Boolean.valueOf("cd")), "de"}; //$NON-NLS-1$ //$NON-NLS-2$
+			}
+			""";
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
         NLSHint hint = createNLSHint(cu);
         assertEquals("Messages", hint.getAccessorClassName());
@@ -116,10 +124,12 @@ public class NLSHintTest {
 	public void noAccessorClassHint1() throws Exception {
     	IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
     	String klazz =
-    		"package test;\n" +
-    		"public class Test {" +
-			"	private String str=\"whateverKey\".toString();//$NON-NLS-1$\n" +
-			"}\n";
+    		"""
+			package test;
+			public class Test {\
+				private String str="whateverKey".toString();//$NON-NLS-1$
+			}
+			""";
     	ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
         NLSHint hint = createNLSHint(cu);
         assertEquals("Messages", hint.getAccessorClassName());
@@ -132,16 +142,20 @@ public class NLSHintTest {
 	public void noAccessorClassHint2() throws Exception {
     	IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
     	String klazz =
-    		"package test;\n" +
-    		"public class Test {" +
-			"	private String str=new Wrong().meth(\"whatever\");//$NON-NLS-1$\n" +
-			"}\n";
+    		"""
+			package test;
+			public class Test {\
+				private String str=new Wrong().meth("whatever");//$NON-NLS-1$
+			}
+			""";
 
     	String klazz2 =
-    		"package test;\n" +
-			"public class Wrong {\n" +
-			"	public void meth(String str) {};\n" +
-			"}\n";
+    		"""
+			package test;
+			public class Wrong {
+				public void meth(String str) {};
+			}
+			""";
     	ICompilationUnit cu= pack.createCompilationUnit("Wrong.java", klazz2, false, null);
     	cu= pack.createCompilationUnit("Test.java", klazz, false, null);
 
@@ -226,13 +240,16 @@ public class NLSHintTest {
 
         IPackageFragment fooPackage = fSourceFolder.createPackageFragment("test.foo", false, null);
         klazz =
-            "package test.foo;\n" +
-            "public class TestMessages {\n" +
-            "	private static final String BUNDLE_NAME = TestMessages.class.getName();\n" +
-            "	public static String getString(String s) {\n" +
-            "		return \"\"\n;" +
-            "	}\n" +
-            "}\n";
+            """
+				package test.foo;
+				public class TestMessages {
+					private static final String BUNDLE_NAME = TestMessages.class.getName();
+					public static String getString(String s) {
+						return ""
+				;\
+					}
+				}
+				""";
         fooPackage.createCompilationUnit("TestMessages.java", klazz, false, null);
 
         NLSHint hint = createNLSHint(cu);
@@ -267,13 +284,16 @@ public class NLSHintTest {
 
         IPackageFragment fooPackage = fSourceFolder.createPackageFragment("test.foo", false, null);
         klazz =
-            "package test.foo;\n" +
-            "public class TestMessages {\n" +
-            "	private static final String BUNDLE_NAME = TestMessages.class.getName();\n" +
-            "	public static String getString(String s) {\n" +
-            "		return \"\"\n;" +
-            "	}\n" +
-            "}\n";
+            """
+				package test.foo;
+				public class TestMessages {
+					private static final String BUNDLE_NAME = TestMessages.class.getName();
+					public static String getString(String s) {
+						return ""
+				;\
+					}
+				}
+				""";
         fooPackage.createCompilationUnit("TestMessages.java", klazz, false, null);
 
         createResource(fooPackage, "TestMessages.properties", "a=0");

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHolderTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSHolderTest.java
@@ -42,7 +42,15 @@ public class NLSHolderTest {
 
 	private IPackageFragmentRoot fSourceFolder;
 
-	private final static String ACCESSOR_KLAZZ= "package test;\n" + "public class TestMessages {\n" + "	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" + "	public static String getString(String s) {" + "		return \"\";\n" + "	}\n" + "}\n";
+	private final static String ACCESSOR_KLAZZ= """
+		package test;
+		public class TestMessages {
+			private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+			public static String getString(String s) {\
+				return "";
+			}
+		}
+		""";
 
 	@Before
 	public void setUp() throws Exception {
@@ -57,7 +65,12 @@ public class NLSHolderTest {
 
 	@Test
 	public void substitutionWithAccessor() throws Exception {
-		String klazz= "package test;\n" + "public class Test {" + "	private String str=TestMessages.getString(\"Key.5\");//$NON-NLS-1$\n" + "}\n";
+		String klazz= """
+			package test;
+			public class Test {\
+				private String str=TestMessages.getString("Key.5");//$NON-NLS-1$
+			}
+			""";
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
 		ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
 		pack.createCompilationUnit("TestMessages.java", ACCESSOR_KLAZZ, false, null);

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSScannerTester.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSScannerTester.java
@@ -254,11 +254,13 @@ public class NLSScannerTester {
 	@Test
 	public void test19() throws Exception {
 		String text=
-				"@interface Annotation {\r\n" +
-				"	String a() default \"a\" + \"b\";\r\n" +
-				"	String b() default \"bee\";\r\n" +
-				"	String c() default true ? \"x\" : \"y\";\r\n" +
-				"}\r\n";
+				"""
+			@interface Annotation {\r
+				String a() default "a" + "b";\r
+				String b() default "bee";\r
+				String c() default true ? "x" : "y";\r
+			}\r
+			""";
 		NLSLine[] l= NLSScanner.scan(text);
 		assertEquals(0, l.length);
 	}
@@ -267,16 +269,17 @@ public class NLSScannerTester {
 	@Test
 	public void test20() throws Exception {
 		String text=
-			"class C {\r\n" +
-			"    void m() {\r\n" +
-			"        switch (42) {\r\n" +
-			"            default: String s= \"x\";\r\n" +
-			"        }\r\n" +
-			"        switch (1) {\r\n" +
-			"            default /*standard*/: String s= \"x\";\r\n" +
-			"        }\r\n" +
-			"    }\r\n" +
-			"}";
+			"""
+			class C {\r
+			    void m() {\r
+			        switch (42) {\r
+			            default: String s= "x";\r
+			        }\r
+			        switch (1) {\r
+			            default /*standard*/: String s= "x";\r
+			        }\r
+			    }\r
+			}""";
 		NLSLine[] l= NLSScanner.scan(text);
 
 		assertEquals(2, l.length);
@@ -295,16 +298,17 @@ public class NLSScannerTester {
 	@Test
 	public void test21() throws Exception {
 		String text=
-			"class C {\r\n" +
-			"    void m() {\r\n" +
-			"        System.out.println(new Object() {\r\n" +
-			"            @Override\r\n" +
-			"            public String toString() {\r\n" +
-			"                return \"me\";\r\n" +
-			"            };\r\n" +
-			"        });\r\n" +
-			"    }\r\n" +
-			"}";
+			"""
+			class C {\r
+			    void m() {\r
+			        System.out.println(new Object() {\r
+			            @Override\r
+			            public String toString() {\r
+			                return "me";\r
+			            };\r
+			        });\r
+			    }\r
+			}""";
 		NLSLine[] l= NLSScanner.scan(text);
 
 		assertEquals(1, l.length);
@@ -319,16 +323,17 @@ public class NLSScannerTester {
 	@Test
 	public void test22() throws Exception {
 		String text=
-			"class C {\r\n" +
-			"    void m() {\r\n" +
-			"        Object var= ((((new Object() {\r\n" +
-			"            @Override\r\n" +
-			"            public String toString() {\r\n" +
-			"                return \"me\";\r\n" +
-			"            };\r\n" +
-			"        }))));\r\n" +
-			"    }\r\n" +
-			"}";
+			"""
+			class C {\r
+			    void m() {\r
+			        Object var= ((((new Object() {\r
+			            @Override\r
+			            public String toString() {\r
+			                return "me";\r
+			            };\r
+			        }))));\r
+			    }\r
+			}""";
 		NLSLine[] l= NLSScanner.scan(text);
 
 		assertEquals(1, l.length);
@@ -343,14 +348,15 @@ public class NLSScannerTester {
 	@Test
 	public void test23() throws Exception {
 		String text=
-			"class C {\r\n" +
-			"    Object field= (new Object() {\r\n" +
-			"        @java.lang.Override\r\n" +
-			"        public String toString() {\r\n" +
-			"            return \"me\";\r\n" +
-			"        };\r\n" +
-			"    });\r\n" +
-			"}";
+			"""
+			class C {\r
+			    Object field= (new Object() {\r
+			        @java.lang.Override\r
+			        public String toString() {\r
+			            return "me";\r
+			        };\r
+			    });\r
+			}""";
 		NLSLine[] l= NLSScanner.scan(text);
 
 		assertEquals(1, l.length);
@@ -365,9 +371,10 @@ public class NLSScannerTester {
 	@Test
 	public void test24() throws Exception {
 		String text=
-			"class C {\r\n" +
-			"    @java.lang.Deprecated int field2= (\"me\").length();\r\n" +
-			"}";
+			"""
+			class C {\r
+			    @java.lang.Deprecated int field2= ("me").length();\r
+			}""";
 		NLSLine[] l= NLSScanner.scan(text);
 
 		assertEquals(1, l.length);
@@ -382,9 +389,11 @@ public class NLSScannerTester {
 	@Test
 	public void test25() throws Exception {
 		String text=
-				"@SuppressWarnings(\"unchecked\") //$NON-NLS-1$\r\n" +
-				"public class B {}\r\n" +
-				"\r\n";
+				"""
+			@SuppressWarnings("unchecked") //$NON-NLS-1$\r
+			public class B {}\r
+			\r
+			""";
 		NLSLine[] l= NLSScanner.scan(text);
 		assertEquals(0, l.length);
 	}
@@ -393,17 +402,18 @@ public class NLSScannerTester {
 	@Test
 	public void test26() throws Exception {
 		String text=
-				"@interface Ann {\n" +
-				"	String[] strings() default {\"a\", \"2\"};\n" +
-				"	String string() default \"s\";\n" +
-				"	String string2() default ((true) ? \"t\" : \"f\");\n" +
-				"}\n" +
-				"\n" +
-				"public interface Intf {\n" +
-				"	default void foo() {\n" +
-				"		System.out.println(\"Hello\");\n" +
-				"	}\n" +
-				"}";
+				"""
+			@interface Ann {
+				String[] strings() default {"a", "2"};
+				String string() default "s";
+				String string2() default ((true) ? "t" : "f");
+			}
+			
+			public interface Intf {
+				default void foo() {
+					System.out.println("Hello");
+				}
+			}""";
 		NLSLine[] l= NLSScanner.scan(text);
 
 		assertEquals(1, l.length);

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSSourceModifierTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSSourceModifierTest.java
@@ -98,9 +98,11 @@ public class NLSSourceModifierTest {
 	public void fromSkippedToTranslated() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -118,9 +120,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -128,9 +132,11 @@ public class NLSSourceModifierTest {
 	public void fromSkippedToTranslatedEclipseNew() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -148,9 +154,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.key_0;\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.key_0;
+					}
+					""",
             	doc.get());
 
       CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, defaultSubst, null);
@@ -179,9 +187,11 @@ public class NLSSourceModifierTest {
 	public void fromSkippedToNotTranslated() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -198,9 +208,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -208,9 +220,11 @@ public class NLSSourceModifierTest {
 	public void fromSkippedToNotTranslatedEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -227,9 +241,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -261,9 +277,11 @@ public class NLSSourceModifierTest {
 	public void fromNotTranslatedToTranslated() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -282,9 +300,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -292,9 +312,11 @@ public class NLSSourceModifierTest {
 	public void fromNotTranslatedToTranslatedEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -313,9 +335,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.key_0; \n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.key_0;\s
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -345,9 +369,11 @@ public class NLSSourceModifierTest {
 	public void fromNotTranslatedToSkipped() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -364,9 +390,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; \n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever";\s
+					}
+					""",
             	doc.get());
     }
 
@@ -374,9 +402,11 @@ public class NLSSourceModifierTest {
 	public void fromNotTranslatedToSkippedEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -393,9 +423,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; \n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever";\s
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -429,19 +461,23 @@ public class NLSSourceModifierTest {
 	public void fromTranslatedToNotTranslated() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+			}
+			""";
 
         String accessorKlazz =
-            "package test;\n" +
-    		"public class Accessor {\n" +
-    		"	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" +
-    		"	public static String getString(String s) {\n" +
-    		"		return \"\";\n" +
-    		"	}\n" +
-    		"}\n";
+            """
+			package test;
+			public class Accessor {
+				private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Accessor.java", accessorKlazz, false, null);
@@ -460,10 +496,12 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -471,10 +509,12 @@ public class NLSSourceModifierTest {
 	public void fromTranslatedToNotTranslatedEclipse() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.k_0;\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.k_0;
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -512,10 +552,12 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -544,19 +586,23 @@ public class NLSSourceModifierTest {
 	public void fromTranslatedToSkipped() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+			}
+			""";
 
         String accessorKlazz =
-            "package test;\n" +
-    		"public class Accessor {\n" +
-    		"	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" +
-    		"	public static String getString(String s) {\n" +
-    		"		return \"\";\n" +
-    		"	}\n" +
-    		"}\n";
+            """
+			package test;
+			public class Accessor {
+				private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Accessor.java", accessorKlazz, false, null);
@@ -575,10 +621,12 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; \n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever";\s
+					}
+					""",
             	doc.get());
     }
 
@@ -586,10 +634,12 @@ public class NLSSourceModifierTest {
 	public void fromTranslatedToSkippedEclipse() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.key_0;\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.key_0;
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -627,10 +677,12 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\";\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever";
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -658,19 +710,23 @@ public class NLSSourceModifierTest {
 	@Test
 	public void replacementOfKey() throws Exception {
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+			}
+			""";
 
         String accessorKlazz =
-            "package test;\n" +
-    		"public class Accessor {\n" +
-    		"	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" +
-    		"	public static String getString(String s) {\n" +
-    		"		return \"\";\n" +
-    		"	}\n" +
-    		"}\n";
+            """
+			package test;
+			public class Accessor {
+				private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Accessor.java", accessorKlazz, false, null);
@@ -688,20 +744,24 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=Accessor.getString(\"nls.0\"); //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str=Accessor.getString("nls.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
 	@Test
 	public void replacementOfKeyEclipse() throws Exception {
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.key_0; \n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.key_0;\s
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -740,10 +800,12 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=Accessor.nls_0; \n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str=Accessor.nls_0;\s
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -774,11 +836,13 @@ public class NLSSourceModifierTest {
 	public void replacementOfKeysBug223865() throws Exception {
 
 		String klazz=
-			"package test;\n" +
-			"public class Test {\n" +
-			"	private String str=Accessor.key_0;\n" +
-			"	private String str=Accessor.key_1;\n" +
-			"}\n";
+			"""
+			package test;
+			public class Test {
+				private String str=Accessor.key_0;
+				private String str=Accessor.key_1;
+			}
+			""";
 
 		StringBuilder buf= new StringBuilder();
 		buf.append("package test;\n");
@@ -824,11 +888,13 @@ public class NLSSourceModifierTest {
 		change.getEdit().apply(doc);
 
 		assertEquals(
-				"package test;\n" +
-				"public class Test {\n" +
-				"	private String str=Accessor.key_0;\n" +
-				"	private String str=Accessor.key_0;\n" +
-				"}\n", doc.get());
+				"""
+					package test;
+					public class Test {
+						private String str=Accessor.key_0;
+						private String str=Accessor.key_0;
+					}
+					""", doc.get());
 
 		TextChange accessorChange= (TextChange) AccessorClassModifier.create(accessorCu, nlsSubstitutions);
 		Document accessorDoc= new Document(accessorKlazz);
@@ -856,10 +922,12 @@ public class NLSSourceModifierTest {
 	@Test
 	public void bug95708_1() throws Exception {
         String klazz =
-            "public class Test {\n" +
-            "	private String str1=\"whatever\";\n" +
-            "	private String str2=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str1="whatever";
+				private String str2="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -880,10 +948,12 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str1=Accessor.key_0;\n" +
-                "	private String str2=Accessor.key_0;\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str1=Accessor.key_0;
+						private String str2=Accessor.key_0;
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -911,10 +981,12 @@ public class NLSSourceModifierTest {
 	@Test
 	public void bug95708_2() throws Exception {
         String klazz =
-            "public class Test {\n" +
-            "	private String str1=Accessor.key_0;\n" +
-            "	private String str2=Accessor.key_0;\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str1=Accessor.key_0;
+				private String str2=Accessor.key_0;
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -952,10 +1024,12 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str1=Accessor.nls_0;\n" +
-                "	private String str2=Accessor.key_0;\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str1=Accessor.nls_0;
+						private String str2=Accessor.key_0;
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -984,13 +1058,15 @@ public class NLSSourceModifierTest {
 	@Test
 	public void insertionOrder1() throws Exception {
          String klazz =
-             "public class Test {\n" +
-             "	private String str1=Accessor.key_b;\n" +
-             "	private String str2=Accessor.key_y;\n" +
-             "	private String str3=\"h\";\n" +
-             "	private String str4=\"a\";\n" +
-             "	private String str5=\"z\";\n" +
-             "}\n";
+             """
+			public class Test {
+				private String str1=Accessor.key_b;
+				private String str2=Accessor.key_y;
+				private String str3="h";
+				private String str4="a";
+				private String str5="z";
+			}
+			""";
 
          StringBuilder buf= new StringBuilder();
          buf.append("package test;\n");
@@ -1036,13 +1112,15 @@ public class NLSSourceModifierTest {
          change.getEdit().apply(doc);
 
          assertEquals(
-                 "public class Test {\n" +
-                 "	private String str1=Accessor.key_b;\n" +
-                 "	private String str2=Accessor.key_y;\n" +
-                 "	private String str3=Accessor.key_h;\n" +
-                 "	private String str4=Accessor.key_a;\n" +
-                 "	private String str5=Accessor.key_z;\n" +
-                 "}\n",
+                 """
+					public class Test {
+						private String str1=Accessor.key_b;
+						private String str2=Accessor.key_y;
+						private String str3=Accessor.key_h;
+						private String str4=Accessor.key_a;
+						private String str5=Accessor.key_z;
+					}
+					""",
              	doc.get());
 
          TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -1074,13 +1152,15 @@ public class NLSSourceModifierTest {
 	@Test
 	public void insertionOrder2() throws Exception {
         String klazz =
-            "public class Test {\n" +
-            "	private String str1=Accessor.key_b;\n" +
-            "	private String str2=Accessor.key_y;\n" +
-            "	private String str3=\"h\";\n" +
-            "	private String str4=\"a\";\n" +
-            "	private String str5=\"z\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str1=Accessor.key_b;
+				private String str2=Accessor.key_y;
+				private String str3="h";
+				private String str4="a";
+				private String str5="z";
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -1128,13 +1208,15 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str1=Accessor.key_g;\n" +
-                "	private String str2=Accessor.key_i;\n" +
-                "	private String str3=Accessor.key_h;\n" +
-                "	private String str4=Accessor.key_a;\n" +
-                "	private String str5=Accessor.key_z;\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str1=Accessor.key_g;
+						private String str2=Accessor.key_i;
+						private String str3=Accessor.key_h;
+						private String str4=Accessor.key_a;
+						private String str5=Accessor.key_z;
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -1368,9 +1450,11 @@ public class NLSSourceModifierTest {
 	public void bug131323() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -1388,9 +1472,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.getFoo(\"key.0\"); //$NON-NLS-1$\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.getFoo("key.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), false, nlsSubstitutions, subpattern, null);
@@ -1425,9 +1511,11 @@ public class NLSSourceModifierTest {
 	@Test
 	public void checkBundleNameWhenResourceAndAccessorAreInDifferentPackages() throws Exception {
 
-		String klazz= "public class Test {\n" +
-				"	private String str=\"whatever\";\n" +
-				"}\n";
+		String klazz= """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
 		ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -1445,9 +1533,11 @@ public class NLSSourceModifierTest {
 		change.getEdit().apply(doc);
 
 		assertEquals(
-				"public class Test {\n" +
-						"	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-						"}\n",
+				"""
+					public class Test {
+						private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+					}
+					""",
 				doc.get());
 		IPackageFragment resourcePackage= fSourceFolder.createPackageFragment("test.messages", false, null);
 		CreateTextFileChange accessorChange= (CreateTextFileChange) AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack,
@@ -1483,9 +1573,11 @@ public class NLSSourceModifierTest {
 	public void checkBundleNameWhenResourceAndAccessorAreInDifferentPackagesEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -1503,9 +1595,11 @@ public class NLSSourceModifierTest {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.key_0;\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.key_0;
+					}
+					""",
             	doc.get());
       IPackageFragment resourcePackage = fSourceFolder.createPackageFragment("test.messages", false, null);
       CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, resourcePackage.getPath().append("test.properties"), true, nlsSubstitutions, defaultSubst, null);

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSSourceModifierTest1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/NLSSourceModifierTest1d8.java
@@ -98,9 +98,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromSkippedToTranslated() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -118,9 +120,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -128,9 +132,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromSkippedToTranslatedEclipseNew() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -148,9 +154,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.key_0;\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.key_0;
+					}
+					""",
             	doc.get());
 
       CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, defaultSubst, null);
@@ -178,9 +186,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromSkippedToNotTranslated() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -197,9 +207,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -207,9 +219,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromSkippedToNotTranslatedEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -226,9 +240,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -259,9 +275,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromNotTranslatedToTranslated() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -280,9 +298,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -290,9 +310,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromNotTranslatedToTranslatedEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -311,9 +333,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.key_0; \n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.key_0;\s
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -342,9 +366,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromNotTranslatedToSkipped() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -361,9 +387,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; \n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever";\s
+					}
+					""",
             	doc.get());
     }
 
@@ -371,9 +399,11 @@ public class NLSSourceModifierTest1d8 {
 	public void fromNotTranslatedToSkippedEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever"; //$NON-NLS-1$
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -390,9 +420,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; \n" +
-                "}\n",
+                """
+					public class Test {
+						private String str="whatever";\s
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -425,19 +457,23 @@ public class NLSSourceModifierTest1d8 {
 	public void fromTranslatedToNotTranslated() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+			}
+			""";
 
         String accessorKlazz =
-            "package test;\n" +
-    		"public class Accessor {\n" +
-    		"	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" +
-    		"	public static String getString(String s) {\n" +
-    		"		return \"\";\n" +
-    		"	}\n" +
-    		"}\n";
+            """
+			package test;
+			public class Accessor {
+				private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Accessor.java", accessorKlazz, false, null);
@@ -456,10 +492,12 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
@@ -467,10 +505,12 @@ public class NLSSourceModifierTest1d8 {
 	public void fromTranslatedToNotTranslatedEclipse() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.k_0;\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.k_0;
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -508,10 +548,12 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever"; //$NON-NLS-1$
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -540,19 +582,23 @@ public class NLSSourceModifierTest1d8 {
 	public void fromTranslatedToSkipped() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+			}
+			""";
 
         String accessorKlazz =
-            "package test;\n" +
-    		"public class Accessor {\n" +
-    		"	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" +
-    		"	public static String getString(String s) {\n" +
-    		"		return \"\";\n" +
-    		"	}\n" +
-    		"}\n";
+            """
+			package test;
+			public class Accessor {
+				private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Accessor.java", accessorKlazz, false, null);
@@ -571,10 +617,12 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\"; \n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever";\s
+					}
+					""",
             	doc.get());
     }
 
@@ -582,10 +630,12 @@ public class NLSSourceModifierTest1d8 {
 	public void fromTranslatedToSkippedEclipse() throws Exception {
 
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.key_0;\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.key_0;
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -623,10 +673,12 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=\"whatever\";\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str="whatever";
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -654,19 +706,23 @@ public class NLSSourceModifierTest1d8 {
 	@Test
 	public void replacementOfKey() throws Exception {
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+			}
+			""";
 
         String accessorKlazz =
-            "package test;\n" +
-    		"public class Accessor {\n" +
-    		"	private static final String BUNDLE_NAME = \"test.test\";//$NON-NLS-1$\n" +
-    		"	public static String getString(String s) {\n" +
-    		"		return \"\";\n" +
-    		"	}\n" +
-    		"}\n";
+            """
+			package test;
+			public class Accessor {
+				private static final String BUNDLE_NAME = "test.test";//$NON-NLS-1$
+				public static String getString(String s) {
+					return "";
+				}
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Accessor.java", accessorKlazz, false, null);
@@ -684,20 +740,24 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=Accessor.getString(\"nls.0\"); //$NON-NLS-1$\n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str=Accessor.getString("nls.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
     }
 
 	@Test
 	public void replacementOfKeyEclipse() throws Exception {
         String klazz =
-            "package test;\n" +
-            "public class Test {\n" +
-            "	private String str=Accessor.key_0; \n" +
-            "}\n";
+            """
+			package test;
+			public class Test {
+				private String str=Accessor.key_0;\s
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -736,10 +796,12 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "package test;\n" +
-                "public class Test {\n" +
-                "	private String str=Accessor.nls_0; \n" +
-                "}\n",
+                """
+					package test;
+					public class Test {
+						private String str=Accessor.nls_0;\s
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -770,11 +832,13 @@ public class NLSSourceModifierTest1d8 {
 	public void replacementOfKeysBug223865() throws Exception {
 
 		String klazz=
-			"package test;\n" +
-			"public class Test {\n" +
-			"	private String str=Accessor.key_0;\n" +
-			"	private String str=Accessor.key_1;\n" +
-			"}\n";
+			"""
+			package test;
+			public class Test {
+				private String str=Accessor.key_0;
+				private String str=Accessor.key_1;
+			}
+			""";
 
 		StringBuilder buf= new StringBuilder();
 		buf.append("package test;\n");
@@ -820,11 +884,13 @@ public class NLSSourceModifierTest1d8 {
 		change.getEdit().apply(doc);
 
 		assertEquals(
-				"package test;\n" +
-				"public class Test {\n" +
-				"	private String str=Accessor.key_0;\n" +
-				"	private String str=Accessor.key_0;\n" +
-				"}\n", doc.get());
+				"""
+					package test;
+					public class Test {
+						private String str=Accessor.key_0;
+						private String str=Accessor.key_0;
+					}
+					""", doc.get());
 
 		TextChange accessorChange= (TextChange) AccessorClassModifier.create(accessorCu, nlsSubstitutions);
 		Document accessorDoc= new Document(accessorKlazz);
@@ -852,10 +918,12 @@ public class NLSSourceModifierTest1d8 {
 	@Test
 	public void bug95708_1() throws Exception {
         String klazz =
-            "public class Test {\n" +
-            "	private String str1=\"whatever\";\n" +
-            "	private String str2=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str1="whatever";
+				private String str2="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -876,10 +944,12 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str1=Accessor.key_0;\n" +
-                "	private String str2=Accessor.key_0;\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str1=Accessor.key_0;
+						private String str2=Accessor.key_0;
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), true, nlsSubstitutions, NLSRefactoring.DEFAULT_SUBST_PATTERN, null);
@@ -906,10 +976,12 @@ public class NLSSourceModifierTest1d8 {
 	@Test
 	public void bug95708_2() throws Exception {
         String klazz =
-            "public class Test {\n" +
-            "	private String str1=Accessor.key_0;\n" +
-            "	private String str2=Accessor.key_0;\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str1=Accessor.key_0;
+				private String str2=Accessor.key_0;
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -947,10 +1019,12 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str1=Accessor.nls_0;\n" +
-                "	private String str2=Accessor.key_0;\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str1=Accessor.nls_0;
+						private String str2=Accessor.key_0;
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -979,13 +1053,15 @@ public class NLSSourceModifierTest1d8 {
 	@Test
 	public void insertionOrder1() throws Exception {
          String klazz =
-             "public class Test {\n" +
-             "	private String str1=Accessor.key_b;\n" +
-             "	private String str2=Accessor.key_y;\n" +
-             "	private String str3=\"h\";\n" +
-             "	private String str4=\"a\";\n" +
-             "	private String str5=\"z\";\n" +
-             "}\n";
+             """
+			public class Test {
+				private String str1=Accessor.key_b;
+				private String str2=Accessor.key_y;
+				private String str3="h";
+				private String str4="a";
+				private String str5="z";
+			}
+			""";
 
          StringBuilder buf= new StringBuilder();
          buf.append("package test;\n");
@@ -1031,13 +1107,15 @@ public class NLSSourceModifierTest1d8 {
          change.getEdit().apply(doc);
 
          assertEquals(
-                 "public class Test {\n" +
-                 "	private String str1=Accessor.key_b;\n" +
-                 "	private String str2=Accessor.key_y;\n" +
-                 "	private String str3=Accessor.key_h;\n" +
-                 "	private String str4=Accessor.key_a;\n" +
-                 "	private String str5=Accessor.key_z;\n" +
-                 "}\n",
+                 """
+					public class Test {
+						private String str1=Accessor.key_b;
+						private String str2=Accessor.key_y;
+						private String str3=Accessor.key_h;
+						private String str4=Accessor.key_a;
+						private String str5=Accessor.key_z;
+					}
+					""",
              	doc.get());
 
          TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -1069,13 +1147,15 @@ public class NLSSourceModifierTest1d8 {
 	@Test
 	public void insertionOrder2() throws Exception {
         String klazz =
-            "public class Test {\n" +
-            "	private String str1=Accessor.key_b;\n" +
-            "	private String str2=Accessor.key_y;\n" +
-            "	private String str3=\"h\";\n" +
-            "	private String str4=\"a\";\n" +
-            "	private String str5=\"z\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str1=Accessor.key_b;
+				private String str2=Accessor.key_y;
+				private String str3="h";
+				private String str4="a";
+				private String str5="z";
+			}
+			""";
 
         StringBuilder buf= new StringBuilder();
         buf.append("package test;\n");
@@ -1123,13 +1203,15 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str1=Accessor.key_g;\n" +
-                "	private String str2=Accessor.key_i;\n" +
-                "	private String str3=Accessor.key_h;\n" +
-                "	private String str4=Accessor.key_a;\n" +
-                "	private String str5=Accessor.key_z;\n" +
-                "}\n",
+                """
+					public class Test {
+						private String str1=Accessor.key_g;
+						private String str2=Accessor.key_i;
+						private String str3=Accessor.key_h;
+						private String str4=Accessor.key_a;
+						private String str5=Accessor.key_z;
+					}
+					""",
             	doc.get());
 
         TextChange accessorChange= (TextChange)AccessorClassModifier.create(accessorCu, nlsSubstitutions);
@@ -1363,9 +1445,11 @@ public class NLSSourceModifierTest1d8 {
 	public void bug131323() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -1383,9 +1467,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.getFoo(\"key.0\"); //$NON-NLS-1$\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.getFoo("key.0"); //$NON-NLS-1$
+					}
+					""",
             	doc.get());
 
         CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, pack.getPath().append("test.properties"), false, nlsSubstitutions, subpattern, null);
@@ -1419,9 +1505,11 @@ public class NLSSourceModifierTest1d8 {
 	@Test
 	public void checkBundleNameWhenResourceAndAccessorAreInDifferentPackages() throws Exception {
 
-		String klazz= "public class Test {\n" +
-				"	private String str=\"whatever\";\n" +
-				"}\n";
+		String klazz= """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
 		ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -1439,9 +1527,11 @@ public class NLSSourceModifierTest1d8 {
 		change.getEdit().apply(doc);
 
 		assertEquals(
-				"public class Test {\n" +
-						"	private String str=Accessor.getString(\"key.0\"); //$NON-NLS-1$\n" +
-						"}\n",
+				"""
+					public class Test {
+						private String str=Accessor.getString("key.0"); //$NON-NLS-1$
+					}
+					""",
 				doc.get());
 		IPackageFragment resourcePackage= fSourceFolder.createPackageFragment("test.messages", false, null);
 		CreateTextFileChange accessorChange= (CreateTextFileChange) AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack,
@@ -1477,9 +1567,11 @@ public class NLSSourceModifierTest1d8 {
 	public void checkBundleNameWhenResourceAndAccessorAreInDifferentPackagesEclipse() throws Exception {
 
         String klazz =
-            "public class Test {\n" +
-            "	private String str=\"whatever\";\n" +
-            "}\n";
+            """
+			public class Test {
+				private String str="whatever";
+			}
+			""";
 
         IPackageFragment pack = fSourceFolder.createPackageFragment("test", false, null);
         ICompilationUnit cu= pack.createCompilationUnit("Test.java", klazz, false, null);
@@ -1497,9 +1589,11 @@ public class NLSSourceModifierTest1d8 {
         change.getEdit().apply(doc);
 
         assertEquals(
-                "public class Test {\n" +
-                "	private String str=Accessor.key_0;\n" +
-            	"}\n",
+                """
+					public class Test {
+						private String str=Accessor.key_0;
+					}
+					""",
             	doc.get());
       IPackageFragment resourcePackage = fSourceFolder.createPackageFragment("test.messages", false, null);
       CreateTextFileChange accessorChange= (CreateTextFileChange)AccessorClassCreator.create(cu, "Accessor", pack.getPath().append("Accessor.java"), pack, resourcePackage.getPath().append("test.properties"), true, nlsSubstitutions, defaultSubst, null);

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/PropertyFileDocumentModellTest.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/nls/PropertyFileDocumentModellTest.java
@@ -70,9 +70,11 @@ public class PropertyFileDocumentModellTest {
 		insert(props, "org.eclipse.nls.2", "value");
 
 		assertEquals(
-				"org.eclipse.nls.1=value\n" +
-				"org.eclipse.nls.2=value\n" +
-				"org.eclipse=value\n", props.get());
+				"""
+					org.eclipse.nls.1=value
+					org.eclipse.nls.2=value
+					org.eclipse=value
+					""", props.get());
 	}
 
 	@Test
@@ -84,9 +86,11 @@ public class PropertyFileDocumentModellTest {
 		insert(props, "arg.1", "value");
 
 		assertEquals(
-				"arg.1=value\n" +
-				"org.1=value\n" +
-				"org.2=value\n", props.get());
+				"""
+					arg.1=value
+					org.1=value
+					org.2=value
+					""", props.get());
 	}
 
 	@Test
@@ -98,9 +102,11 @@ public class PropertyFileDocumentModellTest {
 		insert(props, "Test_B_2", "value");
 
 		assertEquals(
-				"Test_B_1=value\n" +
-				"Test_B_2=value\n" +
-				"Test_A_1=value\n", props.get());
+				"""
+					Test_B_1=value
+					Test_B_2=value
+					Test_A_1=value
+					""", props.get());
 	}
 
 	@Test
@@ -114,13 +120,14 @@ public class PropertyFileDocumentModellTest {
 
 		insert(props, new KeyValuePair[] {new KeyValuePair("Test_Ba", ""), new KeyValuePair("Test_Az", "")});
 
-		assertEquals("Test_Aa=value\n" +
-				"Test_Ab=value\n" +
-				"Test_Az=\n" +
-				"\n" +
-				"Test_Ba=\n" +
-				"Test_Bb=\n" +
-				"Test_Bc=", props.get());
+		assertEquals("""
+			Test_Aa=value
+			Test_Ab=value
+			Test_Az=
+			
+			Test_Ba=
+			Test_Bb=
+			Test_Bc=""", props.get());
 	}
 
 	@Test
@@ -139,15 +146,17 @@ public class PropertyFileDocumentModellTest {
 				new KeyValuePair("org.eclipse.xyzblabla.pipapo", "value")});
 
 		assertEquals(
-				"org.apache=value\n" +
-				"org.eclipse.nls=value\n" +
-				"org.eclipse.nls.1=value\n" +
-				"org.eclipse.nls.2=value\n" +
-				"\n" +
-				"org.eclipse=value\n" +
-				"org.eclipse.2=value\n" +
-				"org.eclipse.xyzblabla.pipapo=value\n" +
-				"org.xenon=value\n",
+				"""
+					org.apache=value
+					org.eclipse.nls=value
+					org.eclipse.nls.1=value
+					org.eclipse.nls.2=value
+					
+					org.eclipse=value
+					org.eclipse.2=value
+					org.eclipse.xyzblabla.pipapo=value
+					org.xenon=value
+					""",
 				props.get());
 	}
 
@@ -161,12 +170,14 @@ public class PropertyFileDocumentModellTest {
 		insert(props, new KeyValuePair[] {new KeyValuePair("key_c", "value"), new KeyValuePair("key_a", "value"), new KeyValuePair("key_z", "value")});
 
 		assertEquals(
-				"key_a=value\n" +
-				"key_b=value\n" +
-				"key_c=value\n" +
-				"\n" +
-				"key_y=value\n" +
-				"key_z=value\n", props.get());
+				"""
+					key_a=value
+					key_b=value
+					key_c=value
+					
+					key_y=value
+					key_z=value
+					""", props.get());
 	}
 
 	@Test
@@ -179,11 +190,13 @@ public class PropertyFileDocumentModellTest {
 		insert(props, new KeyValuePair[] {new KeyValuePair("key_b_1", "value"), new KeyValuePair("key_b_0", "value")});
 
 		assertEquals(
-				"key_a=value\n" +
-				"\n" +
-				"key_b_0=value\n" +
-				"key_b_1=value\n" +
-				"key_b_2=value\n", props.get());
+				"""
+					key_a=value
+					
+					key_b_0=value
+					key_b_1=value
+					key_b_2=value
+					""", props.get());
 	}
 
 	@Test
@@ -197,10 +210,12 @@ public class PropertyFileDocumentModellTest {
 				new KeyValuePair("Clazz.Posers", "value")});
 
 		assertEquals(
-				"Clazz.Pong=Pong\n" +
-				"Clazz.Posers=value\n" +
-				"Clazz.Ping=Ping\n" +
-				"Clazz.Pizza=value\n", props.get());
+				"""
+					Clazz.Pong=Pong
+					Clazz.Posers=value
+					Clazz.Ping=Ping
+					Clazz.Pizza=value
+					""", props.get());
 	}
 
 	@Test
@@ -214,10 +229,12 @@ public class PropertyFileDocumentModellTest {
 				new KeyValuePair("Clazz.PosersWithAVeryLongName", "p")});
 
 		assertEquals(
-				"Clazz.P=p\n" +
-				"Clazz.Pong=Pong\n" +
-				"Clazz.PosersWithAVeryLongName=p\n" +
-				"Clazz.Ping=Ping\n", props.get());
+				"""
+					Clazz.P=p
+					Clazz.Pong=Pong
+					Clazz.PosersWithAVeryLongName=p
+					Clazz.Ping=Ping
+					""", props.get());
 	}
 
 	@Test
@@ -229,10 +246,12 @@ public class PropertyFileDocumentModellTest {
 		insert(props, new KeyValuePair[] {new KeyValuePair("org.eclipse.nls.1", "value"), new KeyValuePair("org.eclipse.nls.2", "value")});
 
 		assertEquals(
-				"org.eclipse.1=value\n" +
-				"org.eclipse.2=value\n" +
-				"org.eclipse.nls.1=value\n" +
-				"org.eclipse.nls.2=value\n", props.get());
+				"""
+					org.eclipse.1=value
+					org.eclipse.2=value
+					org.eclipse.nls.1=value
+					org.eclipse.nls.2=value
+					""", props.get());
 	}
 
 	@Test
@@ -245,10 +264,12 @@ public class PropertyFileDocumentModellTest {
 		insert(props, "org.eclipse.test", "value2");
 
 		assertEquals(
-				"org.eclipse=value\n" +
-				"\n" +
-				"org.eclipse.test=value\n" +
-				"org.eclipse.test=value2\n", props.get());
+				"""
+					org.eclipse=value
+					
+					org.eclipse.test=value
+					org.eclipse.test=value2
+					""", props.get());
 	}
 
 	@Test
@@ -261,10 +282,12 @@ public class PropertyFileDocumentModellTest {
 		insert(props, "a.c", "v");
 
 		assertEquals(
-				"a.b=v\n" +
-				"a.c=v\n" +
-				"\n" +
-				"org.eclipse.test=value\n", props.get());
+				"""
+					a.b=v
+					a.c=v
+					
+					org.eclipse.test=value
+					""", props.get());
 	}
 
 	@Test
@@ -276,9 +299,11 @@ public class PropertyFileDocumentModellTest {
 		insert(props, "org.eclipse.nix", "value");
 
 		assertEquals(
-				"org.eclipse.nix=value\n" +
-				"org.eclipse.ok:value\n" +
-				"org.eclipse.what value\n", props.get());
+				"""
+					org.eclipse.nix=value
+					org.eclipse.ok:value
+					org.eclipse.what value
+					""", props.get());
 	}
 
 	@Test
@@ -322,7 +347,11 @@ public class PropertyFileDocumentModellTest {
 		ReplaceEdit replaceEdit= modell.replace(new KeyValuePair("org.eclipse.2", "value\n"), new KeyValuePair("org.1", "value\n"));
 		replaceEdit.apply(props);
 
-		assertEquals("org.eclipse.1=value1\n" + "org.1=value\n" + "org.eclipse.3=value3\n", props.get());
+		assertEquals("""
+			org.eclipse.1=value1
+			org.1=value
+			org.eclipse.3=value3
+			""", props.get());
 	}
 
 	// Escaping stuff


### PR DESCRIPTION
By using text block for the text, they become much easier to read (and it will be easier to write new tests too).

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
