### PR TITLE
Small cleanup of selection code in JUnit view

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -465,11 +465,11 @@ public class TestViewer {
 
 	private void handleSelected() {
 		IStructuredSelection selection= (IStructuredSelection) fSelectionProvider.getSelection();
-		TestElement testElement= null;
-		if (selection.size() == 1) {
-			testElement= (TestElement) selection.getFirstElement();
+		if (selection.size() == 1 && selection.getFirstElement() instanceof TestElement testElement) {
+			fTestRunnerPart.handleTestSelected(testElement);
+		} else {
+			fTestRunnerPart.handleTestSelected(null);
 		}
-		fTestRunnerPart.handleTestSelected(testElement);
 	}
 
 	public synchronized void setShowTime(boolean showTime) {


### PR DESCRIPTION
The selection listener code assumes the good selection should always have exact one element and only from given type. Let make this code more verbose to reflect the original intent.

See https://github.com/eclipse-platform/eclipse.platform.ui/issues/1360
