### PR TITLE
Fix incorrect return value in StaticImportFavoritesCompletionInvoker.

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/StaticImportFavoritesCompletionInvoker.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/StaticImportFavoritesCompletionInvoker.java
@@ -51,6 +51,9 @@ public class StaticImportFavoritesCompletionInvoker {
 		}
 
 		String[] res = createNewCompilationUnit(elementName);
+		if (res.length != 2) {
+			return new String[0];
+		}
 		String dummyCuContent = res[0];
 		int offset= Integer.parseInt(res[1]);
 		fNewCU.getBuffer().setContents(dummyCuContent);
@@ -85,7 +88,7 @@ public class StaticImportFavoritesCompletionInvoker {
 		String packName= fCu.getParent().getElementName();
 		IType type= fCu.findPrimaryType();
 		if (type == null)
-			return null;
+			return new String[0];
 
 		if (packName.length() > 0) {
 			dummyCU.append("package ").append(packName).append(';'); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest16.java
@@ -23,15 +23,21 @@ import org.junit.Test;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+
+import org.eclipse.core.resources.ProjectScope;
+
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.core.manipulation.JavaManipulation;
 import org.eclipse.jdt.core.manipulation.OrganizeImportsOperation;
 import org.eclipse.jdt.core.manipulation.OrganizeImportsOperation.IChooseImportQuery;
 
+import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.tests.core.rules.Java16ProjectTestSetup;
 
 public class ImportOrganizeTest16 extends ImportOrganizeTest {
@@ -99,6 +105,48 @@ public class ImportOrganizeTest16 extends ImportOrganizeTest {
 		op.run(null);
 
 		assertImports(cu, new String[] {
+		});
+	}
+
+	@Test
+	public void testOrganizeImportsModuleInfo() throws Exception {
+		IEclipsePreferences node= new ProjectScope(fJProject1.getProject()).getNode(JavaManipulation.getPreferenceNodeId());
+		node.put(PreferenceConstants.CODEASSIST_FAVORITE_STATIC_MEMBERS, "org.junit.Assert.*");
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("import foo.bar.MyDriverAction;\n");
+		buf.append("import java.sql.DriverAction;\n");
+		buf.append("import java.sql.SQLException;\n");
+		buf.append("\n");
+		buf.append("module mymodule.nine {\n");
+		buf.append("    requires java.sql;\n");
+		buf.append("    exports foo.bar;\n");
+		buf.append("    provides DriverAction with MyDriverAction;\n");
+		buf.append("}\n");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
+		ICompilationUnit cu= pack1.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		buf= new StringBuilder();
+		buf.append("import foo.bar.MyDriverAction;\n");
+		buf.append("\n");
+		buf.append("import java.sql.DriverAction;\n");
+		buf.append("\n");
+		buf.append("module mymodule.nine {\n");
+		buf.append("    requires java.sql;\n");
+		buf.append("    exports foo.bar;\n");
+		buf.append("    provides DriverAction with MyDriverAction;\n");
+		buf.append("}\n");
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("E", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+		assertImports(cu, new String[] {
+				"foo.bar.MyDriverAction",
+				"java.sql.DriverAction"
 		});
 	}
 }


### PR DESCRIPTION
- Helper method createNewCompilationUnit should always return an array.

@robstryker adopted the latest 4.31-I-builds at https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/2947, and they uncovered a regression in the organize imports logic : https://ci.eclipse.org/ls/job/jdt-ls-pr/4816/ when triggered in a module file.

```
java.lang.NullPointerException: Cannot load from object array because "res" is null
	at org.eclipse.jdt.internal.corext.util.StaticImportFavoritesCompletionInvoker.getStaticImportFavorites(StaticImportFavoritesCompletionInvoker.java:54)
	at org.eclipse.jdt.core.manipulation.OrganizeImportsOperation.addStaticImports(OrganizeImportsOperation.java:722)
	at org.eclipse.jdt.core.manipulation.OrganizeImportsOperation.createTextEdit(OrganizeImportsOperation.java:621)
	at org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler.organizeImports(OrganizeImportsHandler.java:98)
	at org.eclipse.jdt.ls.core.internal.handlers.OrganizeImportsHandler$1.addEdits(OrganizeImportsHandler.java:142)
	at org.eclipse.jdt.core.manipulation.CUCorrectionProposalCore.createTextChange(CUCorrectionProposalCore.java:188)
	at org.eclipse.jdt.core.manipulation.CUCorrectionProposalCore.createChange(CUCorrectionProposalCore.java:195)
	at org.eclipse.jdt.core.manipulation.ChangeCorrectionProposalCore.getChange(ChangeCorrectionProposalCore.java:152)
	at org.eclipse.jdt.core.manipulation.CUCorrectionProposalCore.getTextChange(CUCorrectionProposalCore.java:206)
```

Introduced by https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/927 (in 4.31-I-builds).

**Before:**
https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/137f84f326ecb0e0b4663b634915e592b31c7cdc/org.eclipse.jdt.core.manipulation/core%20extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java#L1327-L1331


**After:**
https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/d04cefe7990edef1b35cb5d24932bba6347dc470/org.eclipse.jdt.core.manipulation/core%20extension/org/eclipse/jdt/internal/corext/util/StaticImportFavoritesCompletionInvoker.java#L84-L88

The fix is straightforward.

**Update:** I've added a testcase. Given that the PR that introduced the regression passed when merged, it's safe to say no tests are triggering "Organize Imports" in module files, so  I've added the one we use in JDT-LS. 
