### PR TITLE
remove not analysed @SuppressWarnings("javadoc")

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RefactoringAnalyzeUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RefactoringAnalyzeUtil.java
@@ -101,7 +101,6 @@ public class RefactoringAnalyzeUtil {
 	/**
 	 * @noreference This method is not intended to be referenced by clients.
 	 */
-	@SuppressWarnings("javadoc")
 	public static MethodDeclaration getRecordDeclarationCompactConstructor(TextEdit edit, TextChange change, CompilationUnit cuNode){
 		RecordDeclaration recDecl = getRecordDeclaration(edit, change, cuNode);
 		MethodDeclaration compConst= null;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RenameAnalyzeUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RenameAnalyzeUtil.java
@@ -404,7 +404,6 @@ public class RenameAnalyzeUtil {
 	 *
 	 * @noreference This method is not intended to be referenced by clients.
 	 */
-	@SuppressWarnings("javadoc")
 	public static RefactoringStatus analyzeCompactConstructorLocalRenames(LocalAnalyzePackage[] analyzePackages, TextChange cuChange, CompilationUnit oldCUNode, boolean recovery) throws CoreException {
 		return analyzeLocalRenames(analyzePackages, cuChange, oldCUNode, true, recovery);
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceFactoryTestsBase.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceFactoryTestsBase.java
@@ -101,7 +101,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * Test files are assumed to be located in the resources directory.
 	 * @return the ICompilationUnit created from the specified test file
 	 */
-	@SuppressWarnings("javadoc")
 	private ICompilationUnit createCUForSimpleTest(IPackageFragment pack,
 												  boolean positive, boolean input)
 		throws Exception
@@ -141,7 +140,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * @param project can be null if only 1 project exists in the test workspace
 	 * @return the ICompilationUnit created from the specified test file
 	 */
-	@SuppressWarnings("javadoc")
 	private ICompilationUnit createCUForBugTestCase(IJavaProject project,
 													IPackageFragment pack, String baseName, boolean input)
 		throws Exception
@@ -162,7 +160,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * markers is not present in the source string.
 	 * @return an ISourceRange representing the marked selection
 	 */
-	@SuppressWarnings("javadoc")
 	private ISourceRange findSelectionInSource(String source) throws Exception {
 		int		begin= source.indexOf(SELECTION_START_HERALD) + SELECTION_START_HERALD.length();
 		int		end= source.indexOf(SELECTION_END_HERALD);
@@ -234,7 +231,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * Test files are assumed to be located in the resources directory.
 	 * @param protectConstructor true iff IntroduceFactoryRefactoring should make the constructor private
 	 */
-	@SuppressWarnings("javadoc")
 	void singleUnitHelper(boolean protectConstructor)
 		throws Exception
 	{
@@ -252,7 +248,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * @param baseFileName the base file name
 	 * @param protectConstructor true iff IntroduceFactoryRefactoring should make the constructor private
 	 */
-	@SuppressWarnings("javadoc")
 	protected void singleUnitBugHelper(String baseFileName, boolean protectConstructor)
 		throws Exception
 	{
@@ -275,7 +270,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * @param factoryMethodName the name to use for the generated factory method
 	 * @param factoryClassName the name of the factory class
 	 */
-	@SuppressWarnings("javadoc")
 	void namesHelper(String factoryMethodName, String factoryClassName)
 		throws Exception
 	{
@@ -312,7 +306,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * @param pack an IPackageFragment for the containing package
 	 * @return the ICompilationUnit for the newly-created unit
 	 */
-	@SuppressWarnings("javadoc")
 	private ICompilationUnit createCUFromFileName(String fileName, IPackageFragment pack) throws Exception {
 		String fullName = TEST_PATH_PREFIX + getRefactoringPath() + "positive/" + fileName + "_in.java";
 
@@ -358,7 +351,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * @param staticFactoryMethod true iff IntroduceFactoryRefactoring should make the factory method static
 	 * @param inputFileBaseNames an array of input source file base names
 	 */
-	@SuppressWarnings("javadoc")
 	void multiUnitHelper(boolean staticFactoryMethod, String[] inputFileBaseNames)
 		throws Exception
 	{
@@ -384,7 +376,6 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 	 * @param factoryClassName the fully-qualified name of the class to receive the factory method, or null
 	 * if the factory method is to be placed on the class defining the given constructor
 	 */
-	@SuppressWarnings("javadoc")
 	void multiUnitBugHelper(boolean staticFactoryMethod, String[] inputFileBaseNames, String factoryClassName)
 		throws Exception
 	{

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyTestHelper.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyTestHelper.java
@@ -43,7 +43,6 @@ import org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper;
 import org.eclipse.jdt.ui.tests.core.rules.Java17ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 
-@SuppressWarnings("javadoc")
 public class CallHierarchyTestHelper {
     private static final String[] EMPTY= new String[0];
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/HierarchicalASTVisitorTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/HierarchicalASTVisitorTest.java
@@ -48,7 +48,6 @@ import org.eclipse.jdt.core.dom.VariableDeclaration;
 
 import org.eclipse.jdt.internal.corext.dom.HierarchicalASTVisitor;
 
-@SuppressWarnings("javadoc")
 public class HierarchicalASTVisitorTest {
 	private static class TestHierarchicalASTVisitor extends HierarchicalASTVisitor {
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/JarUtil.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/JarUtil.java
@@ -45,7 +45,6 @@ import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 /**
  * This is a reduced and marginally adjusted copy from org.eclipse.jdt.core.tests.util.Util
  */
-@SuppressWarnings("javadoc")
 public class JarUtil {
 
 	// Trace for delete operation


### PR DESCRIPTION
get rid of
"At least one of the problems in category 'javadoc' is not analysed due to a compiler option being ignored"	warnings

