### PR TITLE
Fix string concat to text block when string is a parameter

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -87,44 +87,6 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			fAllConcats= allConcats;
 		}
 
-		private boolean isStringType(Type type) {
-			if (type instanceof ArrayType) {
-				return false;
-			}
-			ITypeBinding typeBinding= type.resolveBinding();
-			if (typeBinding == null || !typeBinding.getQualifiedName().equals(JAVA_STRING)) {
-				return false;
-			}
-			return true;
-		}
-
-		@Override
-		public boolean visit(final VariableDeclarationStatement visited) {
-			Type type= visited.getType();
-			if (!isStringType(type)) {
-				return false;
-			}
-			return true;
-		}
-
-		@Override
-		public boolean visit(final FieldDeclaration visited) {
-			Type type= visited.getType();
-			if (!isStringType(type)) {
-				return false;
-			}
-			return true;
-		}
-
-		@Override
-		public boolean visit(final Assignment visited) {
-			ITypeBinding typeBinding= visited.resolveTypeBinding();
-			if (typeBinding == null || !typeBinding.getQualifiedName().equals(JAVA_STRING)) {
-				return false;
-			}
-			return true;
-		}
-
 		@Override
 		public boolean visit(final InfixExpression visited) {
 			if (visited.getOperator() != InfixExpression.Operator.PLUS

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -91,6 +91,22 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        buf.append(\"ghijkl\\n\");\n" //
     	        + "        String k = buf.toString();\n" //
     	        + "    }\n" //
+    	        + "    public Integer foo(String x) {\n" //
+    	        + "        return Integer.valueOf(x.length());\n" //
+    	        + "    }\n" //
+    	        + "    public void testParameter() {\n" //
+    	        + "        Integer k = foo(\"\" + \n" //
+    	        + "                  \"abcdef\\n\" + \n" //
+    	        + "                  \"123456\\n\" + \n" //
+    	        + "                  \"klm\");\n" //
+    	        + "    }\n" //
+    	        + "    public void testAssignment() {\n" //
+    	        + "        Integer k = null;\n" //
+    	        + "        k = foo(\"\" + \n" //
+    	        + "                  \"abcdef\\n\" + \n" //
+    	        + "                  \"123456\\n\" + \n" //
+    	        + "                  \"klm\");\n" //
+    	        + "    }\n" //
 				+ "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -140,6 +156,22 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        buf.append(\"123456\\n\");\n" //
     	        + "        buf.append(\"ghijkl\\n\");\n" //
     	        + "        String k = buf.toString();\n" //
+    	        + "    }\n" //
+    	        + "    public Integer foo(String x) {\n" //
+    	        + "        return Integer.valueOf(x.length());\n" //
+    	        + "    }\n" //
+    	        + "    public void testParameter() {\n" //
+    	        + "        Integer k = foo(\"\"\"\n" //
+    	        + "        \tabcdef\n" //
+    	        + "        \t123456\n" //
+    	        + "        \tklm\"\"\");\n" //
+    	        + "    }\n" //
+    	        + "    public void testAssignment() {\n" //
+    	        + "        Integer k = null;\n" //
+    	        + "        k = foo(\"\"\"\n" //
+    	        + "        \tabcdef\n" //
+    	        + "        \t123456\n" //
+    	        + "        \tklm\"\"\");\n" //
     	        + "    }\n" //
 				+ "}\n";
 


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore to not bail on a method parameter or assignment where a method is called and the result of the method is not String
- add new test scenarios to CleanUpTest15
- fixes #935

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes string concat to text block cleanup to not exclude some valid scenarios whereby the concatenation
is a parameter to a method that may not return a String.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new test scenarios.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
