### PR TITLE
Fix NPE in string concat to text block fix

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -510,8 +510,8 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			}
 			Statement endStatement= stmtList.get(i - 1);
 			int lastStatementEnd= endStatement.getStartPosition() + endStatement.getLength();
-			IBinding varBinding= originalVarName.resolveBinding();
-			if (varBinding == null) {
+			IBinding varBinding= null;
+			if (originalVarName == null || (varBinding= originalVarName.resolveBinding()) == null) {
 				return false;
 			}
 			CheckValidityVisitor checkValidityVisitor= new CheckValidityVisitor(lastStatementEnd, varBinding);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -107,6 +107,9 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                  \"123456\\n\" + \n" //
     	        + "                  \"klm\");\n" //
     	        + "    }\n" //
+    	        + "    public void testConcatInConstructor() {\n" //
+    	        + "        new StringBuffer(\"abc\\n\" + \"def\\n\" + \"ghi\");\n" //
+    	        + "    }\n" //
 				+ "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -173,6 +176,12 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        \t123456\n" //
     	        + "        \tklm\"\"\");\n" //
     	        + "    }\n" //
+    	        + "    public void testConcatInConstructor() {\n" //
+    	        + "        new StringBuffer(\"\"\"\n" //
+    	        + "        \tabc\n" //
+    	        + "        \tdef\n" //
+    	        + "        \tghi\"\"\");\n" //
+    	        + "    }\n" //
 				+ "}\n";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
@@ -220,6 +229,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "        String x = \"abc\\n\" +\n"
 				+ "            \"def\\n\" +\n" //
 				+ "            \"ghi\\n\";\n" //
+    	        + "        new StringBuffer(\"abc\\n\" + \"def\\n\" + \"ghi\");\n" //
 				+ "    }\n" //
 				+ "}";
 
@@ -274,6 +284,10 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "        \tdef\n" //
 				+ "        \tghi\n" //
 				+ "        \t\"\"\";\n" //
+    	        + "        new StringBuffer(\"\"\"\n" //
+    	        + "        \tabc\n" //
+    	        + "        \tdef\n" //
+    	        + "        \tghi\"\"\");\n" //
 				+ "    }\n" //
 				+ "}";
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes an NPE that occurs when a new StringBuffer() is initialized with a string concatenation and the user has specified
Convert String concenation to Text block cleanup with the StringBuffer/StringBuilder option also checked.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
