### PR TITLE
Add null check to StringBufferToStringBuilderFixCore

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
@@ -127,7 +127,7 @@ public class StringBufferToStringBuilderFixCore extends CompilationUnitRewriteOp
 		@Override
 		public boolean visit(final MethodInvocation node) {
 			ITypeBinding returnBinding= node.resolveTypeBinding();
-			if (isStringBufferType(returnBinding)) {
+			if (returnBinding != null && isStringBufferType(returnBinding)) { // null check prevents AbortSearchException
 				IMethodBinding methodBinding= node.resolveMethodBinding();
 				if (methodBinding != null) {
 					ITypeBinding type= methodBinding.getDeclaringClass();


### PR DESCRIPTION
- fixes #961

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes an AbortSearchException being thrown in StringBuffer to Stringbuilder cleanup.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
