### PR TITLE
Make JavaUI view constants final

### DIFF
--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -137,6 +137,38 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="ui/org/eclipse/jdt/ui/JavaUI.java" type="org.eclipse.jdt.ui.JavaUI">
+        <filter comment="View ID constants should be final." id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.ui.JavaUI"/>
+                <message_argument value="ID_BROWSING_PERSPECTIVE"/>
+            </message_arguments>
+        </filter>
+        <filter comment="View ID constants should be final." id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.ui.JavaUI"/>
+                <message_argument value="ID_MEMBERS_VIEW"/>
+            </message_arguments>
+        </filter>
+        <filter comment="View ID constants should be final." id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.ui.JavaUI"/>
+                <message_argument value="ID_PACKAGES_VIEW"/>
+            </message_arguments>
+        </filter>
+        <filter comment="View ID constants should be final." id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.ui.JavaUI"/>
+                <message_argument value="ID_PROJECTS_VIEW"/>
+            </message_arguments>
+        </filter>
+        <filter comment="View ID constants should be final." id="388100214">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.ui.JavaUI"/>
+                <message_argument value="ID_TYPES_VIEW"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="ui/org/eclipse/jdt/ui/StandardJavaElementContentProvider.java" type="org.eclipse.jdt.ui.StandardJavaElementContentProvider">
         <filter comment="For Java 13 Enable Preview feature" id="576725006">
             <message_arguments>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/JavaUI.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/JavaUI.java
@@ -244,7 +244,7 @@ public final class JavaUI {
 	 *
 	 * @since 2.0
 	 */
-	public static String ID_BROWSING_PERSPECTIVE= "org.eclipse.jdt.ui.JavaBrowsingPerspective"; //$NON-NLS-1$
+	public static final String ID_BROWSING_PERSPECTIVE= "org.eclipse.jdt.ui.JavaBrowsingPerspective"; //$NON-NLS-1$
 
 	/**
 	 * The view part id of the Java Browsing Projects view
@@ -252,7 +252,7 @@ public final class JavaUI {
 	 *
 	 * @since 2.0
 	 */
-	public static String ID_PROJECTS_VIEW= "org.eclipse.jdt.ui.ProjectsView"; //$NON-NLS-1$
+	public static final String ID_PROJECTS_VIEW= "org.eclipse.jdt.ui.ProjectsView"; //$NON-NLS-1$
 
 	/**
 	 * The view part id of the Java Browsing Packages view
@@ -260,7 +260,7 @@ public final class JavaUI {
 	 *
 	 * @since 2.0
 	 */
-	public static String ID_PACKAGES_VIEW= "org.eclipse.jdt.ui.PackagesView"; //$NON-NLS-1$
+	public static final String ID_PACKAGES_VIEW= "org.eclipse.jdt.ui.PackagesView"; //$NON-NLS-1$
 
 	/**
 	 * The view part id of the Java Browsing Types view
@@ -268,7 +268,7 @@ public final class JavaUI {
 	 *
 	 * @since 2.0
 	 */
-	public static String ID_TYPES_VIEW= "org.eclipse.jdt.ui.TypesView"; //$NON-NLS-1$
+	public static final String ID_TYPES_VIEW= "org.eclipse.jdt.ui.TypesView"; //$NON-NLS-1$
 
 	/**
 	 * The view part id of the Java Browsing Members view
@@ -276,7 +276,7 @@ public final class JavaUI {
 	 *
 	 * @since 2.0
 	 */
-	public static String ID_MEMBERS_VIEW= "org.eclipse.jdt.ui.MembersView"; //$NON-NLS-1$
+	public static final String ID_MEMBERS_VIEW= "org.eclipse.jdt.ui.MembersView"; //$NON-NLS-1$
 
 
 	/**


### PR DESCRIPTION
It is a plain oversight as I can not imagine anyone wanting these to be overridden.
Added api_filters to not cause extra warnings in the code.

