### PR TITLE
Put back api filter for jdt.core.manipulation version bump error

### DIFF
--- a/org.eclipse.jdt.core.manipulation/.settings/.api_filters
+++ b/org.eclipse.jdt.core.manipulation/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jdt.core.manipulation" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="See https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/914" id="926941240">
+            <message_arguments>
+                <message_argument value="1.21.0"/>
+                <message_argument value="1.20.0"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="common/org/eclipse/jdt/core/manipulation/ImportReferencesCollector.java" type="org.eclipse.jdt.core.manipulation.ImportReferencesCollector">
         <filter id="576720909">
             <message_arguments>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Puts back api filter in jdt.core.manipulation that was fixing an unnecessary version bump warning.  This was removed by the javadoc refactoring patch.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Turn on API warnings/errors for unnecessary version bump.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
