### PR TITLE
JUnit view doesn't support "aborted" JUnit result

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/IXMLTags.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/IXMLTags.java
@@ -32,6 +32,7 @@ public interface IXMLTags {
 	String NODE_SYSTEM_OUT= "system-out"; //$NON-NLS-1$
 	String NODE_SYSTEM_ERR= "system-err"; //$NON-NLS-1$
 	String NODE_SKIPPED = "skipped"; //$NON-NLS-1$
+	String NODE_ABORTED = "aborted"; //$NON-NLS-1$
 
 	/**
 	 * value: String

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunHandler.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunHandler.java
@@ -204,6 +204,7 @@ public class TestRunHandler extends DefaultHandler {
 		case IXMLTags.NODE_SYSTEM_OUT:
 		case IXMLTags.NODE_SYSTEM_ERR:
 			break;
+		case IXMLTags.NODE_ABORTED:		// fall through to the skipped
 		case IXMLTags.NODE_SKIPPED:
 			// before Ant 1.9.0: not an Ant JUnit tag, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=276068
 			// later: child of <suite> or <test>, see https://issues.apache.org/bugzilla/show_bug.cgi?id=43969
@@ -291,6 +292,7 @@ public class TestRunHandler extends DefaultHandler {
 		case IXMLTags.NODE_SYSTEM_OUT:
 		case IXMLTags.NODE_SYSTEM_ERR:
 			break;
+		case IXMLTags.NODE_ABORTED:		// fall through to the skipped
 		case IXMLTags.NODE_SKIPPED:
 			{
 				TestElement testElement= fTestCase;


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1000

