### PR TITLE
Fix Bug 148012 - add quick fix to assign statement to local variable

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -70,12 +70,12 @@ import org.eclipse.jdt.internal.corext.fix.LinkedProposalPositionGroupCore.Propo
 
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
-import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
 import org.eclipse.jdt.ui.text.java.correction.CUCorrectionProposal;
 import org.eclipse.jdt.ui.text.java.correction.ICommandAccess;
 
 import org.eclipse.jdt.internal.ui.text.correction.AssistContext;
 import org.eclipse.jdt.internal.ui.text.correction.GetterSetterCorrectionSubProcessor.SelfEncapsulateFieldProposal;
+import org.eclipse.jdt.internal.ui.text.correction.IProblemLocationCore;
 import org.eclipse.jdt.internal.ui.text.correction.JavaCorrectionProcessor;
 import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation;
 import org.eclipse.jdt.internal.ui.text.correction.ReorgCorrectionsSubProcessor;
@@ -294,6 +294,19 @@ public class QuickFixTest {
 		if (!proposals.isEmpty()) {
 			assertCorrectContext(context, problem);
 		}
+
+		return proposals;
+	}
+
+	protected static final ArrayList<IJavaCompletionProposal> collectCorrectionsNoCheck(ICompilationUnit cu, IProblem curr, IInvocationContext context) throws CoreException {
+		int offset= curr.getSourceStart();
+		int length= curr.getSourceEnd() + 1 - offset;
+		if (context == null) {
+			context= new AssistContext(cu, offset, length);
+		}
+
+		ProblemLocation problem= new ProblemLocation(curr);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(context, problem);
 
 		return proposals;
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
@@ -2896,7 +2896,7 @@ public class QuickFixTest1d8 extends QuickFixTest {
 		CompilationUnit astRoot= getASTRoot(cu);
 		IProblem[] problems= astRoot.getProblems();
 		assertNumberOfProblems(1, problems);
-		List<IJavaCompletionProposal> proposals= collectCorrections(cu, problems[0], null);
+		List<IJavaCompletionProposal> proposals= collectCorrectionsNoCheck(cu, problems[0], null);
 		assertCorrectLabels(proposals);
 
 		buf= new StringBuilder();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
@@ -2871,4 +2871,65 @@ public class QuickFixTest1d8 extends QuickFixTest {
 		assertExpectedExistInProposals(proposals, new String[] {expected1});
 	}
 
+	// Bug 148012 - https://bugs.eclipse.org/bugs/show_bug.cgi?id=148012
+	@Test
+	public void testBug148012() throws Exception {
+		Hashtable<String, String> options = JavaCore.getOptions();
+		JavaCore.setOptions(options);
+		JavaProjectHelper.addLibrary(fJProject1, new Path(Java1d8ProjectTestSetup.getJdtAnnotations20Path()));
+		IPackageFragment pack2= fSourceFolder.createPackageFragment("test1", false, null);
+
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static void main(String[] args) {\n");
+		buf.append("        foo()[0];\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    static Object[] foo() {\n");
+		buf.append("        return null;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack2.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		IProblem[] problems= astRoot.getProblems();
+		assertNumberOfProblems(1, problems);
+		List<IJavaCompletionProposal> proposals= collectCorrections(cu, problems[0], null);
+		assertCorrectLabels(proposals);
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    public static void main(String[] args) {\n");
+		buf.append("        Object object = foo()[0];\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    static Object[] foo() {\n");
+		buf.append("        return null;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		String expected1 = buf.toString();
+
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("public class E {\n");
+		buf.append("    private static Object object;\n");
+		buf.append("\n");
+		buf.append("    public static void main(String[] args) {\n");
+		buf.append("        object = foo()[0];\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    static Object[] foo() {\n");
+		buf.append("        return null;\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+
+		String expected2 = buf.toString();
+
+		assertExpectedExistInProposals(proposals, new String[] {expected1, expected2});
+	}
+
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -1080,6 +1080,9 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 	}
 
 	public static boolean getAssignToVariableProposals(IInvocationContext context, ASTNode node, IProblemLocationCore[] locations, Collection<ICommandAccess> resultingCollections) {
+		// don't add if already added as quick fix
+		if (containsMatchingProblem(locations, IProblem.ParsingErrorInsertToComplete))
+			return false;
 		Statement statement= ASTResolving.findParentStatement(node);
 		if (!(statement instanceof ExpressionStatement)) {
 			return false;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -340,6 +340,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.EnhancedSwitchMissingDefault:
 			case IProblem.IllegalTotalPatternWithDefault:
 			case IProblem.IllegalFallthroughToPattern:
+			case IProblem.ParsingErrorInsertToComplete:
 				return true;
 			default:
 				return SuppressWarningsSubProcessorCore.hasSuppressWarningsProposal(cu.getJavaProject(), problemId)
@@ -968,6 +969,12 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.PotentiallyUnclosedCloseable:
 				LocalCorrectionsSubProcessor.getTryWithResourceProposals(context, problem, proposals);
 			    break;
+			case IProblem.ParsingErrorInsertToComplete:
+				ICompilationUnit cu= context.getCompilationUnit();
+				CompilationUnit astRoot1= context.getASTRoot();
+				ASTNode selectedNode1= problem.getCoveringNode(astRoot1);
+				QuickAssistProcessor.getAssignToVariableProposals(context, selectedNode1, new IProblemLocationCore[] {problem}, proposals);
+				break;
 			default:
 		}
 		if (JavaModelUtil.is50OrHigher(context.getCompilationUnit().getJavaProject())) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -340,8 +340,8 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.EnhancedSwitchMissingDefault:
 			case IProblem.IllegalTotalPatternWithDefault:
 			case IProblem.IllegalFallthroughToPattern:
-			case IProblem.ParsingErrorInsertToComplete:
 				return true;
+
 			default:
 				return SuppressWarningsSubProcessorCore.hasSuppressWarningsProposal(cu.getJavaProject(), problemId)
 						|| ConfigureProblemSeveritySubProcessor.hasConfigureProblemSeverityProposal(problemId);
@@ -970,10 +970,9 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 				LocalCorrectionsSubProcessor.getTryWithResourceProposals(context, problem, proposals);
 			    break;
 			case IProblem.ParsingErrorInsertToComplete:
-				ICompilationUnit cu= context.getCompilationUnit();
 				CompilationUnit astRoot1= context.getASTRoot();
 				ASTNode selectedNode1= problem.getCoveringNode(astRoot1);
-				QuickAssistProcessor.getAssignToVariableProposals(context, selectedNode1, new IProblemLocationCore[] {problem}, proposals);
+				QuickAssistProcessor.getAssignToVariableProposals(context, selectedNode1, new IProblemLocationCore[] {}, proposals);
 				break;
 			default:
 		}


### PR DESCRIPTION
- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=148012
- use similar logic from QuickAssistProcessor in QuickFixProcessor when problem is IProblem.ParsingErrorInsertToComplete
- add new test to QuickFixTest1d8

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds quick fix to assign an expression to a local or field as per the current quick assist.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original bug or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
