### PR TITLE
OpenAction: do not use readOnly - fixes #1005

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/OpenAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/OpenAction.java
@@ -45,7 +45,6 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.jdt.internal.core.manipulation.search.IOccurrencesFinder.OccurrenceLocation;
@@ -252,7 +251,7 @@ public class OpenAction extends SelectionDispatchAction {
 	public void run(IStructuredSelection selection) {
 		if (!checkEnabled(selection))
 			return;
-		JavaCore.runReadOnly(() -> run(selection.toArray()));
+		run(selection.toArray());
 	}
 
 	/**


### PR DESCRIPTION
regression from "Performance: cache JARs during UI Operations" #933

During OpenAction arbitrary other events can be executed in swt thread during BusyIndicator.showWhile()

partial revert of 763d4d0a4c1cc6d5809639ec356a7d499f4d9018
