### PR TITLE
BestMatchHover: do not use readOnly - fixes #1005

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/BestMatchHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/BestMatchHover.java
@@ -26,8 +26,6 @@ import org.eclipse.jface.text.information.IInformationProviderExtension2;
 
 import org.eclipse.ui.IEditorPart;
 
-import org.eclipse.jdt.core.JavaCore;
-
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.text.java.hover.IJavaEditorTextHover;
 
@@ -129,7 +127,7 @@ public class BestMatchHover extends AbstractJavaEditorTextHover {
 	 */
 	@Override
 	public Object getHoverInfo2(ITextViewer textViewer, IRegion hoverRegion) {
-		return JavaCore.callReadOnly(() -> getHoverInfo2(textViewer, hoverRegion, false));
+		return getHoverInfo2(textViewer, hoverRegion, false);
 	}
 
 	/**


### PR DESCRIPTION
regression from "Performance: cache JARs during UI Operations" #933

During hover of problems sometimes a dummy quickfix is applied. partial revert of 763d4d0a4c1cc6d5809639ec356a7d499f4d9018
