### PR TITLE
Bugfix for Quickfix Converting to Enhanced For Loop Creates Invalid Code #1008

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertIterableLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertIterableLoopOperation.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -25,6 +26,7 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.text.edits.TextEditGroup;
 
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTMatcher;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -262,31 +264,7 @@ public final class ConvertIterableLoopOperation extends ConvertLoopOperation {
 				list= astRewrite.getListRewrite(body, Block.STATEMENTS_PROPERTY);
 				for (Expression expression : fOccurrences) {
 					Statement parent= ASTNodes.getParent(expression, Statement.class);
-					if (parent != null && parent.getParent() instanceof Block) {
-						ListRewrite innerList= astRewrite.getListRewrite(parent.getParent(), Block.STATEMENTS_PROPERTY);
-						List<ASTNode> newComments= new ArrayList<>();
-						for (Comment comment : commentList) {
-							CompilationUnit cu= (CompilationUnit)parent.getRoot();
-							if (comment.getStartPosition() >= cu.getExtendedStartPosition(parent)
-									&& comment.getStartPosition() + comment.getLength() < parent.getStartPosition()) {
-								String commentString= cuRewrite.getCu().getBuffer().getText(comment.getStartPosition(), comment.getLength());
-								ASTNode newComment= astRewrite.createStringPlaceholder(commentString, comment.isBlockComment() ? ASTNode.BLOCK_COMMENT : ASTNode.LINE_COMMENT);
-								newComments.add(newComment);
-							}
-						}
-						if (!newComments.isEmpty()) {
-							ASTNode lastComment= newComments.get(0);
-							innerList.replace(parent, lastComment, group);
-							for (int i= 1; i < newComments.size(); ++i) {
-								ASTNode nextComment= newComments.get(i);
-								innerList.insertAfter(nextComment, lastComment, group);
-								lastComment= nextComment;
-							}
-						} else {
-							innerList.remove(parent, group);
-						}
-						remover.registerRemovedNode(parent);
-					}
+					removeorReplaceStatementByTrailingComments(cuRewrite, group, astRewrite, remover, commentList, parent);
 				}
 			} else {
 				list= null;
@@ -320,6 +298,14 @@ public final class ConvertIterableLoopOperation extends ConvertLoopOperation {
 				public final boolean visit(final MethodInvocation node) {
 					IMethodBinding binding= node.resolveMethodBinding();
 					if (binding != null && ("next".equals(binding.getName()) || "nextElement".equals(binding.getName()))) { //$NON-NLS-1$ //$NON-NLS-2$
+						List<ASTNode> siblingNodes = Optional.ofNullable(ASTNodes.getParent(node, Statement.class))
+								.map(it -> ASTNodes.getChildren(it))
+								.orElse(new ArrayList<>());
+						if(siblingNodes.stream().allMatch(node::equals)) {
+							Statement parentStatement = ASTNodes.getParent(node, Statement.class);
+							removeorReplaceStatementByTrailingComments(cuRewrite, group, astRewrite, remover, commentList, parentStatement);
+
+						}
 						Expression expression= node.getExpression();
 						if (expression instanceof Name) {
 							IBinding result= ((Name)expression).resolveBinding();
@@ -379,6 +365,39 @@ public final class ConvertIterableLoopOperation extends ConvertLoopOperation {
 		}
 
 		return fEnhancedForLoop;
+	}
+
+	private void removeorReplaceStatementByTrailingComments(CompilationUnitRewrite cuRewrite, final TextEditGroup group, ASTRewrite astRewrite, ImportRemover remover, List<Comment> commentList, Statement parent) {
+		if (parent != null && parent.getParent() instanceof Block) {
+			ListRewrite innerList= astRewrite.getListRewrite(parent.getParent(), Block.STATEMENTS_PROPERTY);
+			List<ASTNode> newComments= new ArrayList<>();
+			for (Comment comment : commentList) {
+				CompilationUnit cu= (CompilationUnit)parent.getRoot();
+				if (comment.getStartPosition() >= cu.getExtendedStartPosition(parent)
+						&& comment.getStartPosition() + comment.getLength() < parent.getStartPosition()) {
+					String commentString;
+					try {
+						commentString= cuRewrite.getCu().getBuffer().getText(comment.getStartPosition(), comment.getLength());
+					} catch (IndexOutOfBoundsException | JavaModelException e) {
+						commentString = ""; //$NON-NLS-1$
+					}
+					ASTNode newComment= astRewrite.createStringPlaceholder(commentString, comment.isBlockComment() ? ASTNode.BLOCK_COMMENT : ASTNode.LINE_COMMENT);
+					newComments.add(newComment);
+				}
+			}
+			if (!newComments.isEmpty()) {
+				ASTNode lastComment= newComments.get(0);
+				innerList.replace(parent, lastComment, group);
+				for (int i= 1; i < newComments.size(); ++i) {
+					ASTNode nextComment= newComments.get(i);
+					innerList.insertAfter(nextComment, lastComment, group);
+					lastComment= nextComment;
+				}
+			} else {
+				innerList.remove(parent, group);
+			}
+			remover.registerRemovedNode(parent);
+		}
 	}
 
 	public Expression getExpression() {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ConvertIterableLoopQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ConvertIterableLoopQuickFixTest.java
@@ -139,6 +139,129 @@ public final class ConvertIterableLoopQuickFixTest extends QuickFixTest {
 	}
 
 	@Test
+	public void testIteratorWithoutAssignment() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "import java.util.Iterator;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "	public A() {\r\n" //
+				+ "		for (final Iterator<String> iterator= c.iterator(); iterator.hasNext();) {\r\n" //
+				+ "			iterator.next();\r\n" //
+				+ "			System.out.println(\"test\");\r\n" //
+				+ "		}\r\n" //
+				+ "	}\r\n" //
+				+ "}";
+		ICompilationUnit unit= pack.createCompilationUnit("A.java", sample, false, null);
+
+		List<IJavaCompletionProposal> proposals= fetchConvertingProposal(sample, unit);
+
+		assertNotNull(fConvertLoopProposal);
+
+		assertCorrectLabels(proposals);
+
+		String preview= getPreviewContent(fConvertLoopProposal);
+
+		String expected = "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "	public A() {\r\n" //
+				+ "		for (String string : c) {\r\n" //
+				+ "			System.out.println(\"test\");\r\n" //
+				+ "		}\r\n" //
+				+ "	}\r\n" //
+				+ "}";
+		assertEqualString(preview, expected);
+	}
+
+	@Test
+	public void testIteratorWithParentMethodBinding() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "import java.util.Iterator;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "	public A() {\r\n" //
+				+ "		for (final Iterator<String> iterator= c.iterator(); iterator.hasNext();) {\r\n" //
+				+ "			iterator.next().toString();\r\n" //
+				+ "			System.out.println(\"test\");\r\n" //
+				+ "		}\r\n" //
+				+ "	}\r\n" //
+				+ "}";
+		ICompilationUnit unit= pack.createCompilationUnit("A.java", sample, false, null);
+
+		List<IJavaCompletionProposal> proposals= fetchConvertingProposal(sample, unit);
+
+		assertNotNull(fConvertLoopProposal);
+
+		assertCorrectLabels(proposals);
+
+		String preview= getPreviewContent(fConvertLoopProposal);
+
+		String expected= "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "	public A() {\r\n" //
+				+ "		for (String string : c) {\r\n" //
+				+ "			string.toString();\r\n" //
+				+ "			System.out.println(\"test\");\r\n" //
+				+ "		}\r\n" //
+				+ "	}\r\n" //
+				+ "}";
+		assertEqualString(preview, expected);
+	}
+
+	@Test
+	public void testCommentRetainedOnIteratorRemoval() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "import java.util.Iterator;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "	public A() {\r\n" //
+				+ "		for (final Iterator<String> iterator= c.iterator(); iterator.hasNext();) {\r\n" //
+				+ "			// comment\r\n" //
+				+ "			iterator.next();\r\n" //
+				+ "			System.out.println(\"test\");\r\n" //
+				+ "		}\r\n" //
+				+ "	}\r\n" //
+				+ "}";
+		ICompilationUnit unit= pack.createCompilationUnit("A.java", sample, false, null);
+
+		List<IJavaCompletionProposal> proposals= fetchConvertingProposal(sample, unit);
+
+		assertNotNull(fConvertLoopProposal);
+
+		assertCorrectLabels(proposals);
+
+		String preview= getPreviewContent(fConvertLoopProposal);
+
+		String expected = "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "	public A() {\r\n" //
+				+ "		for (String string : c) {\r\n" //
+				+ "			// comment\r\n" //
+				+ "			System.out.println(\"test\");\r\n" //
+				+ "		}\r\n" //
+				+ "	}\r\n" //
+				+ "}";
+		assertEqualString(preview, expected);
+	}
+
+	@Test
 	public void testRawIterator() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= "" //


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1008

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
The change fixes the conversion of an iterator based for loop to an enhanced for loop. When there is an iterator.next() in the body of the for loop and is not assigned to any variable, it becomes variable; on conversion which is an errorful statement in Java.

## How to test
Create a for loop with iterator having iterator.next() in the body in any way possible and convert the loop to enhanced for loop from the quick fixes menu.

## Details

This PR uses the block of code used by fOccurences for replacing them with comments if available. We extract the block of the code in the fix to a new method so that it can be used by ASTVisitors as well for the statements which dont have any assignments but consists of iterator calls. The extracted block throws JavaModelException. So, to deal with it I have used a try catch ball where we are extracting the comment Strings out. Just to make sure if there happens an exception while adding the comments during the conversion we dont just stop the whole operation but rather set the comments to an empty string. The other way could have been to not use try/catch but rather add throws in the method signature of the visit method of the ASTVisitor which is a no go since it is an overridden method.

I have also included some tests which support my changes for the fix.

## Author checklist

- [x ] I have thoroughly tested my changes
- [x ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)