### PR TITLE
SelectionDispatchAction: do not use readOnly - fixes #1010

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SelectionDispatchAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/SelectionDispatchAction.java
@@ -28,8 +28,6 @@ import org.eclipse.jface.text.ITextSelection;
 
 import org.eclipse.ui.IWorkbenchSite;
 
-import org.eclipse.jdt.core.JavaCore;
-
 import org.eclipse.jdt.internal.ui.javaeditor.JavaTextSelection;
 
 /**
@@ -251,7 +249,7 @@ public abstract class SelectionDispatchAction extends Action implements ISelecti
 
 	@Override
 	public void run() {
-		JavaCore.runReadOnly(() -> dispatchRun(getSelection()));
+		dispatchRun(getSelection());
 	}
 
 	@Override


### PR DESCRIPTION
regression from "Performance: cache JARs during UI Operations" #933

During SelectionDispatchAction arbitrary other events can be executed in swt thread during BusyIndicator.showWhile()

partial revert of 763d4d0a4c1cc6d5809639ec356a7d499f4d9018
