### PR TITLE
Quick Fix: Convert Iterable to Enhanced For Loop Omits Next Method fo…

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertIterableLoopOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertIterableLoopOperation.java
@@ -298,19 +298,20 @@ public final class ConvertIterableLoopOperation extends ConvertLoopOperation {
 				public final boolean visit(final MethodInvocation node) {
 					IMethodBinding binding= node.resolveMethodBinding();
 					if (binding != null && ("next".equals(binding.getName()) || "nextElement".equals(binding.getName()))) { //$NON-NLS-1$ //$NON-NLS-2$
-						List<ASTNode> siblingNodes = Optional.ofNullable(ASTNodes.getParent(node, Statement.class))
-								.map(it -> ASTNodes.getChildren(it))
-								.orElse(new ArrayList<>());
-						if(siblingNodes.stream().allMatch(node::equals)) {
-							Statement parentStatement = ASTNodes.getParent(node, Statement.class);
-							removeorReplaceStatementByTrailingComments(cuRewrite, group, astRewrite, remover, commentList, parentStatement);
-
-						}
 						Expression expression= node.getExpression();
 						if (expression instanceof Name) {
 							IBinding result= ((Name)expression).resolveBinding();
-							if (result != null && result.equals(fIteratorVariable))
-								return replace(node);
+							if (result != null && result.equals(fIteratorVariable)) {
+								List<ASTNode> siblingNodes = Optional.ofNullable(ASTNodes.getParent(node, Statement.class))
+										.map(it -> ASTNodes.getChildren(it))
+										.orElse(new ArrayList<>());
+								if(siblingNodes.stream().allMatch(node::equals)) {
+									Statement parentStatement = ASTNodes.getParent(node, Statement.class);
+									removeorReplaceStatementByTrailingComments(cuRewrite, group, astRewrite, remover, commentList, parentStatement);
+								} else {
+									return replace(node);
+								}
+							}
 						} else if (expression instanceof FieldAccess) {
 							IBinding result= ((FieldAccess)expression).resolveFieldBinding();
 							if (result != null && result.equals(fIteratorVariable))

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ConvertIterableLoopQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ConvertIterableLoopQuickFixTest.java
@@ -139,6 +139,58 @@ public final class ConvertIterableLoopQuickFixTest extends QuickFixTest {
 	}
 
 	@Test
+	public void testNextFromOtherClass() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "import java.util.Iterator;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "public void foo() {\r\n"
+				+ "    class Other {\r\n"
+				+ "        public Object next() {\r\n"
+				+ "            return null;\r\n"
+				+ "        }\r\n"
+				+ "    }\r\n"
+				+ "    Other i = new Other();\r\n"
+				+ "    for (Iterator<String> iterator = c.iterator(); iterator.hasNext();) {\r\n"
+				+ "        i.next();\r\n"
+				+ "        iterator.next();\r\n"
+				+ "    }\r\n"
+				+ "}"
+				+ "}";
+		ICompilationUnit unit= pack.createCompilationUnit("A.java", sample, false, null);
+
+		List<IJavaCompletionProposal> proposals= fetchConvertingProposal(sample, unit);
+
+		assertNotNull(fConvertLoopProposal);
+
+		assertCorrectLabels(proposals);
+
+		String preview= getPreviewContent(fConvertLoopProposal);
+
+		String expected = "" //
+				+ "package test;\r\n" //
+				+ "import java.util.Collection;\r\n" //
+				+ "public class A {\r\n" //
+				+ "	Collection<String> c;\r\n" //
+				+ "public void foo() {\r\n"
+				+ "    class Other {\r\n"
+				+ "        public Object next() {\r\n"
+				+ "            return null;\r\n"
+				+ "        }\r\n"
+				+ "    }\r\n"
+				+ "    Other i = new Other();\r\n"
+				+ "    for (String string : c) {\r\n"
+				+ "        i.next();\r\n"
+				+ "    }\r\n"
+				+ "}"
+				+ "}";
+		assertEqualString(preview, expected);
+	}
+
+	@Test
 	public void testIteratorWithoutAssignment() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= "" //


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

The fix to check if the expression containing next as a method binding is the relevant iterator.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1013

## How to test
The problem is that in the block there's is no check for the iterator variable before performing the operation and it must be added.

```java
public void foo() throws IOException {
	Test i = new Test();
	for (Iterator<String> iterator = c.iterator(); iterator.hasNext();) {
		i.next();
                iterator.next();
	}
}
```
```java
class Test {
	public Object next() {
		return null;
	}
}
```

Upon Conversion:

### Previous Behavior
```java
public void foo() {
    Test i = new Test();
    for (String string: c) {
    }
}
```

### Current/Expected Behavior
```java
public void foo() {
    Test i = new Test();
    for (String string: c) {
        i.next(); 
    }
}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
