### PR TITLE
Touch bundles affected by the changed ecj version

### DIFF
--- a/org.eclipse.jdt.bcoview/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.bcoview/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update, add the bug here
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.jeview/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.jeview/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update, add the bug here
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 530709 - Comparator errors in jdt debug and jdt ui in I20180204-2000
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.junit/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit/forceQualifierUpdate.txt
@@ -12,3 +12,4 @@ Bug 574522 - 4.21 I-Build: I20210628-1800 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/439 - Update ICU4J to version 71.1
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.text.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.text.tests/forceQualifierUpdate.txt
@@ -8,3 +8,4 @@ Comparator errors in jdt.ui bundles in Y20200127-1055
 Bug 564399 - [Comparator] Comparator Errors in Y-build Y20200617-2350
 Comparator errors in jdt.ui bundles in I20210317-0330
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.ui.tests.refactoring/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.ui.tests.refactoring/forceQualifierUpdate.txt
@@ -7,3 +7,4 @@ Comparator errors in jdt.ui bundles in Y20200127-1055
 Bug 564399 - [Comparator] Comparator Errors in Y-build Y20200617-2350
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.ui.unittest.junit/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.ui.unittest.junit/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 572789 - Comparator errors in I20210412-1800 after moving to compiler from 4.20 M1
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
