### PR TITLE
Junit, Refactoring: some SubMonitor usage

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceIndirectionRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceIndirectionRefactoring.java
@@ -27,7 +27,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.core.resources.IFile;
 
@@ -233,19 +233,9 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 	 */
 	private Map<IMember, IncomingMemberVisibilityAdjustment> fIntermediaryAdjustments;
 
-
-	private static class NoOverrideProgressMonitor extends SubProgressMonitor {
-
-		public NoOverrideProgressMonitor(IProgressMonitor monitor, int ticks) {
-			super(monitor, ticks, SubProgressMonitor.SUPPRESS_SUBTASK_LABEL);
-		}
-
-		@Override
-		public void setTaskName(String name) {
-			// do nothing
-		}
+	public static IProgressMonitor noOverrideSubMonitor(IProgressMonitor pm, int i) {
+		return SubMonitor.convert(pm, 1).newChild(i, SubMonitor.SUPPRESS_SETTASKNAME);
 	}
-
 	// ********* CONSTRUCTORS AND CLASS CREATION ************
 
 	public IntroduceIndirectionRefactoring(ICompilationUnit unit, int offset, int length) {
@@ -524,7 +514,7 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 
 		if (fUpdateReferences) {
 			pm.setTaskName(RefactoringCoreMessages.IntroduceIndirectionRefactoring_checking_conditions + " " + RefactoringCoreMessages.IntroduceIndirectionRefactoring_looking_for_references); //$NON-NLS-1$
-			result.merge(updateReferences(new NoOverrideProgressMonitor(pm, referenceTicks)));
+			result.merge(updateReferences(noOverrideSubMonitor(pm, referenceTicks)));
 			pm.setTaskName(RefactoringCoreMessages.IntroduceIndirectionRefactoring_checking_conditions);
 		} else {
 			// only update the declaration and/or a selected method invocation
@@ -539,7 +529,7 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 
 				// does call see the intermediary method?
 				// => increase visibility of the type of the intermediary method.
-				result.merge(adjustVisibility(fIntermediaryType, enclosing.getDeclaringType(), new NoOverrideProgressMonitor(pm, 0)));
+				result.merge(adjustVisibility(fIntermediaryType, enclosing.getDeclaringType(), noOverrideSubMonitor(pm, 0))); // XXX 0 ticks?
 			}
 			pm.worked(referenceTicks);
 		}
@@ -565,8 +555,8 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 		pm.worked(creationTicks);
 
 		pm.setTaskName(RefactoringCoreMessages.IntroduceIndirectionRefactoring_checking_conditions + " " + RefactoringCoreMessages.IntroduceIndirectionRefactoring_adjusting_visibility); //$NON-NLS-1$
-		result.merge(updateTargetVisibility(new NoOverrideProgressMonitor(pm, 0)));
-		result.merge(updateIntermediaryVisibility(new NoOverrideProgressMonitor(pm, 0)));
+		result.merge(updateTargetVisibility(noOverrideSubMonitor(pm, 0))); // XXX 0 ticks?
+		result.merge(updateIntermediaryVisibility(noOverrideSubMonitor(pm, 0))); // XXX 0 ticks?
 		pm.worked(visibilityTicks);
 		pm.setTaskName(RefactoringCoreMessages.IntroduceIndirectionRefactoring_checking_conditions);
 
@@ -617,7 +607,7 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 		return result;
 	}
 
-	private RefactoringStatus updateIntermediaryVisibility(NoOverrideProgressMonitor monitor) throws JavaModelException {
+	private RefactoringStatus updateIntermediaryVisibility(IProgressMonitor monitor) throws JavaModelException {
 		return rewriteVisibility(fIntermediaryAdjustments, fRewrites, monitor);
 	}
 
@@ -630,12 +620,12 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 		if (monitor.isCanceled())
 			throw new OperationCanceledException();
 
-		IMethod[] ripple= RippleMethodFinder2.getRelatedMethods(fTargetMethod, false, new NoOverrideProgressMonitor(monitor, 10), null);
+		IMethod[] ripple= RippleMethodFinder2.getRelatedMethods(fTargetMethod, false, noOverrideSubMonitor(monitor, 10), null);
 
 		if (monitor.isCanceled())
 			throw new OperationCanceledException();
 
-		SearchResultGroup[] references= Checks.excludeCompilationUnits(getReferences(ripple, new NoOverrideProgressMonitor(monitor, 10), result), result);
+		SearchResultGroup[] references= Checks.excludeCompilationUnits(getReferences(ripple, noOverrideSubMonitor(monitor,10), result), result);
 
 		if (result.hasFatalError())
 			return result;
@@ -684,7 +674,7 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 
 				// does call see the intermediary method?
 				// => increase visibility of the type of the intermediary method.
-				result.merge(adjustVisibility(fIntermediaryType, enclosingMember.getDeclaringType(), new NoOverrideProgressMonitor(monitor, 0)));
+				result.merge(adjustVisibility(fIntermediaryType, enclosingMember.getDeclaringType(), noOverrideSubMonitor(monitor,0)));
 
 				if (monitor.isCanceled())
 					throw new OperationCanceledException();

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameTypeProcessor.java
@@ -33,7 +33,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.SubProgressMonitor;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -107,6 +106,7 @@ import org.eclipse.jdt.internal.corext.refactoring.base.ReferencesInBinaryContex
 import org.eclipse.jdt.internal.corext.refactoring.changes.DynamicValidationRefactoringChange;
 import org.eclipse.jdt.internal.corext.refactoring.changes.RenameCompilationUnitChange;
 import org.eclipse.jdt.internal.corext.refactoring.changes.TextChangeCompatibility;
+import org.eclipse.jdt.internal.corext.refactoring.code.IntroduceIndirectionRefactoring;
 import org.eclipse.jdt.internal.corext.refactoring.participants.JavaProcessors;
 import org.eclipse.jdt.internal.corext.refactoring.tagging.IQualifiedNameUpdating;
 import org.eclipse.jdt.internal.corext.refactoring.tagging.IReferenceUpdating;
@@ -184,16 +184,6 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 				}
 			}
 			return true;
-		}
-	}
-
-	private static class NoOverrideProgressMonitor extends SubProgressMonitor {
-		public NoOverrideProgressMonitor(IProgressMonitor monitor, int ticks) {
-			super(monitor, ticks, SubProgressMonitor.SUPPRESS_SUBTASK_LABEL);
-		}
-		@Override
-		public void setTaskName(String name) {
-			// do nothing
 		}
 	}
 
@@ -1102,11 +1092,11 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 		if (resource != null && resource.isLinked()) {
 			createChangeForRenamedCUNullOrLinkedResource(type, changeManager, resource, result);
 		} else {
-			createChangeForRenamedCUStandardResource(type, changeManager, resource, result);
+			createChangeForRenamedCUStandardResource(type, changeManager, result);
 		}
 	}
 
-	protected void createChangeForRenamedCUStandardResource(IType type, TextChangeManager changeManager, IResource resource, DynamicValidationRefactoringChange result) throws CoreException {
+	protected void createChangeForRenamedCUStandardResource(IType type, TextChangeManager changeManager, DynamicValidationRefactoringChange result) throws CoreException {
 		result.addAll(changeManager.getAllChanges());
 
 		String renamedCUName = JavaModelUtil.getRenamedCUName(type.getCompilationUnit(), getNewElementName());
@@ -1414,12 +1404,12 @@ public class RenameTypeProcessor extends JavaRenameProcessor implements ITextUpd
 
 			progressMonitor.subTask(Messages.format(RefactoringCoreMessages.RenameTypeProcessor_progress_current_total, new Object[] { String.valueOf(current), String.valueOf(max)}));
 
-			status.merge(processor.checkInitialConditions(new NoOverrideProgressMonitor(progressMonitor, 1)));
+			status.merge(processor.checkInitialConditions(IntroduceIndirectionRefactoring.noOverrideSubMonitor(progressMonitor, 1)));
 
 			if (status.hasFatalError())
 				return status;
 
-			status.merge(processor.checkFinalConditions(new NoOverrideProgressMonitor(progressMonitor, 1), context));
+			status.merge(processor.checkFinalConditions(IntroduceIndirectionRefactoring.noOverrideSubMonitor(progressMonitor, 1), context));
 
 			if (status.hasFatalError())
 				return status;

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnit3TestFinder.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnit3TestFinder.java
@@ -19,8 +19,7 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -43,10 +42,7 @@ public class JUnit3TestFinder implements ITestFinder {
 			throw new IllegalArgumentException();
 		}
 
-		if (pm == null)
-			pm= new NullProgressMonitor();
-
-		pm.beginTask(JUnitMessages.TestSearchEngine_message_searching, 10);
+		SubMonitor subMon= SubMonitor.convert(pm, JUnitMessages.TestSearchEngine_message_searching, 10);
 		try {
 			if (element instanceof IType) {
 				if (isTest((IType) element)) {
@@ -60,17 +56,17 @@ public class JUnit3TestFinder implements ITestFinder {
 					}
 				}
 			} else {
-				findTestCases(element, result, new SubProgressMonitor(pm, 7));
-				if (pm.isCanceled()) {
+				findTestCases(element, result, subMon.newChild(7));
+				if (subMon.isCanceled()) {
 					return;
 				}
-				CoreTestSearchEngine.findSuiteMethods(element, result, new SubProgressMonitor(pm, 3));
+				CoreTestSearchEngine.findSuiteMethods(element, result, subMon.newChild(3));
 			}
-			if (pm.isCanceled()) {
+			if (subMon.isCanceled()) {
 				return;
 			}
 		} finally {
-			pm.done();
+			subMon.done();
 		}
 	}
 

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnit4TestFinder.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnit4TestFinder.java
@@ -22,8 +22,7 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IJavaElement;
@@ -124,14 +123,11 @@ public class JUnit4TestFinder implements ITestFinder {
 			}
 		}
 
-		if (pm == null)
-			pm= new NullProgressMonitor();
-
+		SubMonitor subMon= SubMonitor.convert(pm, JUnitMessages.JUnit4TestFinder_searching_description, 4);
 		try {
-			pm.beginTask(JUnitMessages.JUnit4TestFinder_searching_description, 4);
 
 			IRegion region= CoreTestSearchEngine.getRegion(element);
-			ITypeHierarchy hierarchy= JavaCore.newTypeHierarchy(region, null, new SubProgressMonitor(pm, 1));
+			ITypeHierarchy hierarchy= JavaCore.newTypeHierarchy(region, null, subMon.newChild(1));
 			IType[] allClasses= hierarchy.getAllClasses();
 
 			// filter out anonymous classes which have no name
@@ -154,7 +150,7 @@ public class JUnit4TestFinder implements ITestFinder {
 
 			SearchPattern annotationsPattern= SearchPattern.createOrPattern(runWithPattern, testPattern);
 			SearchParticipant[] searchParticipants= new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() };
-			new SearchEngine().search(annotationsPattern, searchParticipants, scope, requestor, new SubProgressMonitor(pm, 2));
+			new SearchEngine().search(annotationsPattern, searchParticipants, scope, requestor, subMon.newChild(2));
 
 			// find all classes in the region
 			for (IType curr : candidates) {
@@ -170,9 +166,9 @@ public class JUnit4TestFinder implements ITestFinder {
 			}
 
 			//JUnit 4.3 can also run JUnit-3.8-style public static Test suite() methods:
-			CoreTestSearchEngine.findSuiteMethods(element, result, new SubProgressMonitor(pm, 1));
+			CoreTestSearchEngine.findSuiteMethods(element, result, subMon.newChild(1));
 		} finally {
-			pm.done();
+			subMon.done();
 		}
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ChangeNonStaticToStaticTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ChangeNonStaticToStaticTest.java
@@ -24,8 +24,9 @@ import org.junit.Test;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 
+import org.eclipse.core.tests.harness.FussyProgressMonitor;
+
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Preferences;
 
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -94,12 +95,16 @@ public class ChangeNonStaticToStaticTest extends QuickFixTest {
 	}
 
 	private void assertRefactoringResultAsExpected(CleanUpRefactoring refactoring, String[] expected) throws CoreException {
-		refactoring.checkAllConditions(new NullProgressMonitor());
+		FussyProgressMonitor testMonitor= new FussyProgressMonitor();
+		refactoring.checkAllConditions(testMonitor);
+		testMonitor.assertUsedUp();
 		CompositeChange change= (CompositeChange)refactoring.createChange(null);
 		Change[] children= change.getChildren();
 		String[] previews= new String[children.length];
 		for (int i= 0; i < children.length; i++) {
-			previews[i]= ((TextEditBasedChange)children[i]).getPreviewContent(null);
+			FussyProgressMonitor testMonitor2= new FussyProgressMonitor();
+			previews[i]= ((TextEditBasedChange)children[i]).getPreviewContent(testMonitor2);
+			testMonitor2.assertUsedUp();
 		}
 
 		assertEqualStringsIgnoreOrder(previews, expected);

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
@@ -27,8 +27,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.ProgressMonitorWrapper;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 import org.eclipse.core.resources.IFile;
@@ -203,7 +203,7 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 		}
 	}
 
-	private final static class CleanUpRefactoringProgressMonitor extends SubProgressMonitor {
+	private final static class CleanUpRefactoringProgressMonitor extends ProgressMonitorWrapper {
 
 		private double fRealWork;
 		private int fFlushCount;
@@ -211,7 +211,7 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 		private final int fIndex;
 
 		private CleanUpRefactoringProgressMonitor(IProgressMonitor monitor, int ticks, int size, int index) {
-			super(monitor, ticks);
+			super(Progress.subMonitor(monitor, ticks));
 			fFlushCount= 0;
 			fSize= size;
 			fIndex= index;
@@ -494,7 +494,7 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 		}
 	}
 
-	private static final RefactoringTickProvider CLEAN_UP_REFACTORING_TICK_PROVIDER= new RefactoringTickProvider(0, 1, 0, 0);
+	private static final RefactoringTickProvider CLEAN_UP_REFACTORING_TICK_PROVIDER= new RefactoringTickProvider(1, 1, 0, 0);
 
 	/**
 	 * A clean up is considered slow if its execution lasts longer then the value of


### PR DESCRIPTION
To get rid of SubProgressMonitor deprecation warnings

There is still 1 usage (and warning) of SubProgressMonitor in CleanUpRefactoring.CleanUpRefactoringProgressMonitor
