### PR TITLE
Make order of elements in saved JAR description file deterministic #1024

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarPackageWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/JarPackageWizardPage.java
@@ -14,9 +14,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.jarpackager;
 
+import static java.util.Arrays.sort;
+import static java.util.Comparator.comparing;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
 
 import org.eclipse.swt.SWT;
@@ -663,7 +667,9 @@ class JarPackageWizardPage extends AbstractJarDestinationWizardPage {
 	Object[] getSelectedElementsWithoutContainedChildren() {
 		Set<Object> closure= removeContainedChildren(fInputGroup.getWhiteCheckedTreeItems());
 		closure.addAll(getExportedNonContainers());
-		return closure.toArray();
+		Object[] sortedElements = closure.toArray();
+		sort(sortedElements, comparing(Objects::toString));
+		return sortedElements;
 	}
 
 	private Set<Object> removeContainedChildren(Set<Object> elements) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
When exporting JAR description files from the JarPackageWizard, the elements to be exported into the JAR file are currently stored in a non-deterministic order. This makes it particularly difficult to merge the description files in case they are put under version control. For a detailed description, see #1024.

This change makes a JAR description file exported from the JarPackageWizard always list the exported elements in the same order by sorting them according to their names. It also adds an according regression test.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1024

## How to test
The behavior can be tested by creating and updating a *.jardesc file from the JAR export wizard. Before this change, the order of elements in the *.jardesc file will vary upon each export, while after this change the order will be deterministic.

The added test case `WizardTests#testJarPackageWizard_sameElementOrderInJarDescriptionExports` simulates these multiple exports and can also be used for verification.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
