### PR TITLE
Touch bundles affected by changed compiler generation for switch

### DIFF
--- a/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 530709 - Comparator errors in jdt debug and jdt ui in I20180204-2000
 Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686

--- a/org.eclipse.jdt.junit/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit/forceQualifierUpdate.txt
@@ -13,3 +13,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/439 
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686
