### PR TITLE
Refresh CallHierarchy on FiltersDialog validation

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyFiltersActionGroup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyFiltersActionGroup.java
@@ -21,10 +21,9 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
-import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.window.Window;
 
 import org.eclipse.ui.IActionBars;
-import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.actions.ActionGroup;
 
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
@@ -62,15 +61,15 @@ public class CallHierarchyFiltersActionGroup extends ActionGroup {
     	}
     }
 
-    private IViewPart fPart;
+    private CallHierarchyViewPart fPart;
 
     /**
      * Creates a new <code>CustomFiltersActionGroup</code>.
      *
-     * @param part      the view part that owns this action group
-     * @param viewer    the viewer to be filtered
+	 * @param part the call hierarchy view part
+	 * @param viewer the call hierarchy viewer
      */
-    public CallHierarchyFiltersActionGroup(IViewPart part, StructuredViewer viewer) {
+    public CallHierarchyFiltersActionGroup(CallHierarchyViewPart part, CallHierarchyViewer viewer) {
         Assert.isNotNull(part);
         Assert.isNotNull(viewer);
         fPart= part;
@@ -98,7 +97,9 @@ public class CallHierarchyFiltersActionGroup extends ActionGroup {
         FiltersDialog dialog= new FiltersDialog(
             fPart.getViewSite().getShell());
 
-        dialog.open();
+        if(Window.OK == dialog.open()) {
+        	fPart.refresh();
+        }
     }
 
     private void openExpandWithConstructorsDialog() {


### PR DESCRIPTION
When modifying the filters of the Callhierarchy we must click on refresh to apply the filters.

Refresh CallHierarchy on FiltersDialog validation

![callhierarchy](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/3462260/0de3790e-60af-47fc-a745-07b0f66defe9)

![callhierarchy_2](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/3462260/261aeed9-69de-4fba-bca9-3bedb3aff1c2)

![callhierarchy_3](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/3462260/c6bb9e5f-b438-403f-b2a3-83f19241a2c1)

## What it does
Refresh CallHierarchy on FiltersDialog validation ==> No need to click on refresh anymore

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
