### PR TITLE
Fix ExtractConstantRefactoring to recognize no type is available

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -454,6 +454,8 @@ public final class RefactoringCoreMessages extends NLS {
 	public static String ExtractConstantRefactoring_descriptor_description_short;
 
 	public static String ExtractConstantRefactoring_name;
+
+	public static String ExtractConstantRefactoring_no_type;
 
 	public static String ExtractConstantRefactoring_no_void;
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -355,6 +355,7 @@ ExtractConstantRefactoring_declare_constant=Add constant declaration
 ExtractConstantRefactoring_default_visibility=(package)
 ExtractConstantRefactoring_replace=Replace expression with constant reference
 ExtractConstantRefactoring_another_variable=A variable with name ''{0}'' is already defined in the visible scope.
+ExtractConstantRefactoring_no_type=No type to extract constant into.
 ExtractConstantRefactoring_no_void=Cannot extract an expression of type \'void\'.
 ExtractConstantRefactoring_null_literals=Cannot extract single null literals.
 ExtractConstantRefactoring_not_load_time_constant=Cannot extract this expression - it is not a valid static constant.

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractConstantRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractConstantRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -305,6 +305,12 @@ public class ExtractConstantRefactoring extends Refactoring {
 
 			if (isLiteralNodeSelected())
 				fReplaceAllOccurrences= false;
+
+			AbstractTypeDeclaration typeDeclaration= ASTNodes.getParent(getSelectedExpression().getAssociatedNode(), AbstractTypeDeclaration.class);
+			if (typeDeclaration == null) {
+				result.merge(RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ExtractConstantRefactoring_no_type));
+				return result;
+			}
 
 			if (isInTypeDeclarationAnnotation(getSelectedExpression().getAssociatedNode())) {
 				fVisibility= JdtFlags.VISIBILITY_STRING_PACKAGE;

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractConstantTests1d7.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractConstantTests1d7.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 IBM Corporation and others.
+ * Copyright (c) 2011, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,11 +13,23 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.refactoring;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.ISourceRange;
+
+import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
+import org.eclipse.jdt.internal.corext.refactoring.code.ExtractConstantRefactoring;
+
 import org.eclipse.jdt.ui.tests.CustomBaseRunner;
 import org.eclipse.jdt.ui.tests.IgnoreInheritedTests;
+import org.eclipse.jdt.ui.tests.refactoring.infra.TextRangeUtil;
 import org.eclipse.jdt.ui.tests.refactoring.rules.Java1d7Setup;
 
 /**
@@ -37,6 +49,21 @@ public class ExtractConstantTests1d7 extends ExtractConstantTests {
 		return fileName.append(getSimpleTestFileName(canExtract, input)).toString();
 	}
 
+	private void failHelper2(int startLine, int startColumn, int endLine, int endColumn, boolean replaceAll, boolean allowLoadtime, String constantName, String errorMsg, boolean checkMsg) throws Exception{
+		ICompilationUnit cu= createCU(getPackageP(), "package-info.java", getFileContents(getTestFileName(false, true)));
+		ISourceRange selection= TextRangeUtil.getSelection(cu, startLine, startColumn, endLine, endColumn);
+		ExtractConstantRefactoring ref= new ExtractConstantRefactoring(cu, selection.getOffset(), selection.getLength());
+		ref.setReplaceAllOccurrences(replaceAll);
+		ref.setConstantName(constantName);
+		RefactoringStatus result= performRefactoring(ref);
+
+		if(!allowLoadtime && !ref.selectionAllStaticFinal())
+			return;
+
+		assertNotNull("precondition was supposed to fail", result);
+		if(checkMsg)
+			assertTrue(errorMsg.equals(result.getEntryMatchingSeverity(RefactoringStatus.FATAL).getMessage()));
+	}
 	//--- TESTS
 
 	// -- testing failing preconditions
@@ -44,5 +71,10 @@ public class ExtractConstantTests1d7 extends ExtractConstantTests {
 	@Test
 	public void testFail0() throws Exception{
 		failHelper1(10, 14, 10, 56, true, true, "CONSTANT");
+	}
+
+	@Test
+	public void testFailNoType() throws Exception{
+		failHelper2(2, 41, 2, 48, true, true, "CONSTANT", RefactoringCoreMessages.ExtractConstantRefactoring_no_type, true);
 	}
 }


### PR DESCRIPTION
- fixes #1023
- add new test to ExtractConstantTests1d7.java

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the ExtractConstantRefactoring code to recognize when there isn't a target type to extract a constant to and fail gracefully.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test or original issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
