### PR TITLE
[formatter] Align arrows on column in switch statements/expressions

### DIFF
--- a/org.eclipse.jdt.ui/preview/formatter.java
+++ b/org.eclipse.jdt.ui/preview/formatter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Mateusz Matela and others.
+ * Copyright (c) 2018, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -99,6 +99,13 @@ class Example {
 			str = i + str;
 			object = Arrays.asList(str);
 			i += 2;
+		}
+		
+		switch(i){
+			case 0 -> theInt++;
+			case 22, 33 -> theInt--;
+			case 1234567890 -> theInt = 0;
+			default -> theInt = -1;
 		}
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -111,6 +111,7 @@ final class FormatterMessages extends NLS {
 	public static String FormatterModifyDialog_indentation_info_blank_lines_before_field;
 	public static String FormatterModifyDialog_indentation_info_blank_lines_before_field_delete;
 	public static String FormatterModifyDialog_indentation_info_blank_lines_to_preserve;
+	public static String FormatterModifyDialog_indentation_pref_align_arrows_in_switch_on_columns;
 	public static String FormatterModifyDialog_indentation_pref_align_assignment_statements_on_columns;
 	public static String FormatterModifyDialog_indentation_pref_align_fields_in_columns;
 	public static String FormatterModifyDialog_indentation_pref_align_variable_declarations_on_columns;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -380,6 +380,7 @@ FormatterModifyDialog_indentation_val_indentation_default=Default for wrapped li
 FormatterModifyDialog_indentation_val_indentation_preserve=Do not touch
 FormatterModifyDialog_indentation_pref_indent_size=Indentation size:
 
+FormatterModifyDialog_indentation_pref_align_arrows_in_switch_on_columns=Arrows in switch statements/expressions
 FormatterModifyDialog_indentation_pref_align_assignment_statements_on_columns=Assignment statements
 FormatterModifyDialog_indentation_pref_align_fields_in_columns=Field declarations
 FormatterModifyDialog_indentation_pref_align_variable_declarations_on_columns=Variable declarations

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterModifyDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterModifyDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -310,7 +310,7 @@ public class FormatterModifyDialog extends ModifyDialog {
 		}
 
 		public static ModifyAll<ToolBar> addModifyAll(Section section, boolean withIndent, final Images images) {
-			return new ModifyAll<ToolBar>(section, images) {
+			return new ModifyAll<>(section, images) {
 				private LineWrapPreference fPreference;
 
 				@Override
@@ -919,6 +919,8 @@ public class FormatterModifyDialog extends ModifyDialog {
 				DefaultCodeFormatterConstants.FORMATTER_ALIGN_VARIABLE_DECLARATIONS_ON_COLUMNS, CheckboxPreference.FALSE_TRUE);
 		final CheckboxPreference alignAssignmentsPref= fTree.addCheckbox(alignSection, FormatterMessages.FormatterModifyDialog_indentation_pref_align_assignment_statements_on_columns,
 				DefaultCodeFormatterConstants.FORMATTER_ALIGN_ASSIGNMENT_STATEMENTS_ON_COLUMNS, CheckboxPreference.FALSE_TRUE);
+		final CheckboxPreference alignArrowsPref= fTree.addCheckbox(alignSection, FormatterMessages.FormatterModifyDialog_indentation_pref_align_arrows_in_switch_on_columns,
+				DefaultCodeFormatterConstants.FORMATTER_ALIGN_ARROWS_IN_SWITCH_ON_COLUMNS, CheckboxPreference.FALSE_TRUE);
 
 		fTree.addGap(alignSection);
 		final CheckboxPreference useSpacesPref= fTree.addCheckbox(alignSection, FormatterMessages.FormatterModifyDialog_indentation_pref_align_with_spaces,
@@ -926,11 +928,13 @@ public class FormatterModifyDialog extends ModifyDialog {
 		Preference<?> tabCharPref= parentSection.findChildPreference(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR);
 		Predicate<String> anyAlignChecker= v -> DefaultCodeFormatterConstants.TRUE.equals(alignFieldsPref.getValue())
 				|| DefaultCodeFormatterConstants.TRUE.equals(alignVariablesPref.getValue())
-				|| DefaultCodeFormatterConstants.TRUE.equals(alignAssignmentsPref.getValue());
+				|| DefaultCodeFormatterConstants.TRUE.equals(alignAssignmentsPref.getValue())
+				|| DefaultCodeFormatterConstants.TRUE.equals(alignArrowsPref.getValue());
 		Predicate<String> spacesChecker= anyAlignChecker.and(v -> !JavaCore.SPACE.equals(tabCharPref.getValue()));
 		alignFieldsPref.addDependant(useSpacesPref, spacesChecker);
 		alignVariablesPref.addDependant(useSpacesPref, spacesChecker);
 		alignAssignmentsPref.addDependant(useSpacesPref, spacesChecker);
+		alignArrowsPref.addDependant(useSpacesPref, spacesChecker);
 		tabCharPref.addDependant(useSpacesPref, spacesChecker);
 
 		Button checkbox = new Button(alignSection.fInnerComposite, SWT.CHECK);
@@ -945,6 +949,7 @@ public class FormatterModifyDialog extends ModifyDialog {
 		alignFieldsPref.addDependant(groupingPref, anyAlignChecker);
 		alignVariablesPref.addDependant(groupingPref, anyAlignChecker);
 		alignAssignmentsPref.addDependant(groupingPref, anyAlignChecker);
+		alignArrowsPref.addDependant(groupingPref, anyAlignChecker);
 
 		groupingPref.setValueValidator(value -> {
 			String warningMessage= null;


### PR DESCRIPTION

## What it does
Adds a new setting to align arrows on column in switch statements/expressions.
UI part for https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1817

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
