### PR TITLE
Add support for code completion inside text block templates #1038

### DIFF
--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -330,6 +330,7 @@
 			requiresUIThread="false">
 			<partition type="__dftl_partition_content_type"/>
 			<partition type="__java_string"/>
+			<partition type="__java_multiline_string"/>
 		</javaCompletionProposalComputer>
 	</extension>
 	<extension
@@ -342,6 +343,7 @@
 			requiresUIThread="false">
 			<partition type="__dftl_partition_content_type"/>
 			<partition type="__java_string"/>
+			<partition type="__java_multiline_string"/>
 		</javaCompletionProposalComputer>
 	</extension>
 	<extension
@@ -354,6 +356,7 @@
 			requiresUIThread="false">
 			<partition type="__dftl_partition_content_type"/>
 			<partition type="__java_string"/>
+			<partition type="__java_multiline_string"/>
 		</javaCompletionProposalComputer>
 	</extension>
 	<!-- javadoc completions -->
@@ -432,6 +435,7 @@
             requiresUIThread="false">
             <partition type="__dftl_partition_content_type"/>
 			<partition type="__java_string"/>
+			<partition type="__java_multiline_string"/>
       </javaCompletionProposalComputer>
 	</extension>
 	<extension
@@ -444,6 +448,7 @@
 			<partition type="__java_singleline_comment"/>
 			<partition type="__java_multiline_comment"/>
 			<partition type="__java_string"/>
+			<partition type="__java_multiline_string"/>
 			<partition type="__java_javadoc"/>
 		</javaCompletionProposalComputer>
 	</extension>

--- a/org.eclipse.jdt.ui/schema/javaCompletionProposalComputer.exsd
+++ b/org.eclipse.jdt.ui/schema/javaCompletionProposalComputer.exsd
@@ -151,6 +151,8 @@ If &quot;true&quot;, the completion proposal will run in UI Thread, freezing the
                   </enumeration>
                   <enumeration value="__java_character">
                   </enumeration>
+                  <enumeration value="__java_multiline_string">
+                  </enumeration>
                </restriction>
             </simpleType>
          </attribute>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/CompletionProposalComputerDescriptor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/CompletionProposalComputerDescriptor.java
@@ -101,6 +101,7 @@ final class CompletionProposalComputerDescriptor {
 		partitions.add(IJavaPartitions.JAVA_MULTI_LINE_COMMENT);
 		partitions.add(IJavaPartitions.JAVA_SINGLE_LINE_COMMENT);
 		partitions.add(IJavaPartitions.JAVA_STRING);
+		partitions.add(IJavaPartitions.JAVA_MULTI_LINE_STRING);
 		partitions.add(IJavaPartitions.JAVA_CHARACTER);
 
 		PARTITION_SET= Collections.unmodifiableSet(partitions);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds support for code completion within text blocks
This works in tandem with the JDT Core PR - https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1803.

This change adds the text block related jdt ui partition to the relevant code completion extensions. 
Fixes #1038 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Create a Java15 compliant or above project.
2. Create class C1 and main function in it.
3. Add the below code in the function
4. press `Ctrl` + `Space`, positioning the cursor in the text block after `System.`  
```
String abc= STR."""
	\{System.}
	""";
```
The expected behavior is that the code completion suggestions should pop up at this stage.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
