### PR TITLE
Fix `jar-in-jar-loader` multi-release support

### DIFF
--- a/org.eclipse.jdt.ui/jar in jar loader/org/eclipse/jdt/internal/jarinjarloader/JIJConstants.java
+++ b/org.eclipse.jdt.ui/jar in jar loader/org/eclipse/jdt/internal/jarinjarloader/JIJConstants.java
@@ -35,7 +35,8 @@ final class JIJConstants {
 	static final String PATH_SEPARATOR                       = "/";  //$NON-NLS-1$
 	static final String CURRENT_DIR                          = "./";  //$NON-NLS-1$
 	static final String UTF8_ENCODING                        = "UTF-8";  //$NON-NLS-1$
-	static final String RUNTIME                              = "#runtime";  //$NON-NLS-1$
+	static final String RUNTIME_WITH_HASH                    = "#runtime";  //$NON-NLS-1$
+	static final String RUNTIME                              = "runtime";  //$NON-NLS-1$
 
 	private JIJConstants() {
 	}

--- a/org.eclipse.jdt.ui/jar in jar loader/org/eclipse/jdt/internal/jarinjarloader/RsrcURLStreamHandler.java
+++ b/org.eclipse.jdt.ui/jar in jar loader/org/eclipse/jdt/internal/jarinjarloader/RsrcURLStreamHandler.java
@@ -45,17 +45,19 @@ public class RsrcURLStreamHandler extends java.net.URLStreamHandler {
 	@Override
     protected void parseURL(URL url, String spec, int start, int limit) {
     	String file;
+    	String ref = null;
     	if (spec.startsWith(JIJConstants.INTERNAL_URL_PROTOCOL_WITH_COLON))
     		file = spec.substring(5);
     	else if (JIJConstants.CURRENT_DIR.equals(url.getFile()))
     		file = spec;
     	else if (url.getFile().endsWith(JIJConstants.PATH_SEPARATOR))
     		file = url.getFile() + spec;
-		else if (JIJConstants.RUNTIME.equals(spec))
+    	else if (JIJConstants.RUNTIME_WITH_HASH.equals(spec)) {
     		file = url.getFile();
-    	else
+    		ref = JIJConstants.RUNTIME;
+    	} else
     		file = spec;
-    	setURL(url, JIJConstants.INTERNAL_URL_PROTOCOL, "", -1, null, null, file, null, null);	 //$NON-NLS-1$
+    	setURL(url, JIJConstants.INTERNAL_URL_PROTOCOL, "", -1, null, null, file, null, ref);	 //$NON-NLS-1$
     }
 
 }


### PR DESCRIPTION
## What it does

In order to open a JAR file in multi-release mode the URL of the file must be suffixed with `#runtime`.

Currently the `rsrc:` URL handler strips this fragment, which breaks multi-release JARs retrieved through the `rsrc:` protocol.

This PR copies the `#runtime` fragment from the `rsrc:` URL to the URL of the underlying resource.

Closes #1057.

## How to test

A minimal reproducible example is available at [copernik-eu/bug-reproducibility/eclipse-jar-in-jar](https://github.com/copernik-eu/bug-reproducibility/tree/main/eclipse-jar-in-jar).

I can provide a JUnit test if you point to the right module, where to put it.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
