### PR TITLE
Fix ExtractConstantRefactorings to handle NLS tags

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Assignment;
@@ -31,9 +34,15 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSUtil;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
 public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperationsFixCore {
@@ -83,6 +92,8 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 		collectInfixPlusOperands(oldInfixExpression, operands);
 
 		boolean foundNoneLiteralOperand= false;
+		boolean seenTag= false;
+		boolean seenNoTag= false;
 		// we need to loop through all to exclude any null binding scenarios.
 		for (Expression operand : operands) {
 			if (!(operand instanceof StringLiteral)) {
@@ -93,6 +104,32 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 					}
 				}
 				foundNoneLiteralOperand= true;
+			} else {
+				// ensure either all string literals are nls-tagged or none are
+				ICompilationUnit cu= (ICompilationUnit)compilationUnit.getJavaElement();
+				try {
+					NLSLine nlsLine= NLSUtil.scanCurrentLine(cu, operand.getStartPosition());
+					if (nlsLine != null) {
+						for (NLSElement element : nlsLine.getElements()) {
+							if (element.getPosition().getOffset() == operand.getStartPosition()) {
+								if (element.hasTag()) {
+									if (seenNoTag) {
+										return null;
+									}
+									seenTag= true;
+								} else {
+									if (seenTag) {
+										return null;
+									}
+									seenNoTag= true;
+								}
+								break;
+							}
+						}
+					}
+				} catch (JavaModelException e) {
+					return null;
+				}
 			}
 		}
 		if (!foundNoneLiteralOperand) {
@@ -129,40 +166,56 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 		@Override
 		public void rewriteAST(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
-			AST ast= cuRewrite.getAST();
+			ICompilationUnit cu= cuRewrite.getCu();
+			CompilationUnit root= cuRewrite.getRoot();
+			String cuContents= cuRewrite.getCu().getBuffer().getContents();
 
 			// collect operands
 			List<Expression> operands= new ArrayList<>();
 			collectInfixPlusOperands(infixExpression, operands);
 
-			List<Expression> formatArguments= new ArrayList<>();
+			List<String> formatArguments= new ArrayList<>();
 			StringBuilder formatString= new StringBuilder();
+			int tagsCount= 0;
 			for (Expression operand : operands) {
 				if (operand instanceof StringLiteral) {
+					NLSLine nlsLine= NLSUtil.scanCurrentLine(cu, operand.getStartPosition());
+					if (nlsLine != null) {
+						for (NLSElement element : nlsLine.getElements()) {
+							if (element.getPosition().getOffset() == operand.getStartPosition()) {
+								if (element.hasTag()) {
+									++tagsCount;
+								}
+							}
+						}
+					}
 					String value= ((StringLiteral) operand).getEscapedValue();
 					value= value.substring(1, value.length() - 1);
 					formatString.append(value);
 				} else {
 					ITypeBinding binding= operand.resolveTypeBinding();
 					formatString.append("%").append(stringFormatConversion(binding)); //$NON-NLS-1$
-					formatArguments.add((Expression) rewrite.createCopyTarget(operand));
+					int origStart= root.getExtendedStartPosition(operand);
+					int origLength= root.getExtendedLength(operand);
+					String argument= cuContents.substring(origStart, origStart + origLength);
+					formatArguments.add(argument);
 				}
 			}
 
+			StringBuilder buffer= new StringBuilder();
+			buffer.append("String.format("); //$NON-NLS-1$
+			buffer.append("\"" + formatString.toString().replaceAll("\"", "\\\"") + "\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			for (String formatArgument : formatArguments) {
+				buffer.append(", " + formatArgument); //$NON-NLS-1$
+			}
+			buffer.append(")"); //$NON-NLS-1$
 
-			MethodInvocation formatInvocation= ast.newMethodInvocation();
-			formatInvocation.setExpression(ast.newName("String")); //$NON-NLS-1$
-			formatInvocation.setName(ast.newSimpleName("format")); //$NON-NLS-1$
-
-			List<Expression> arguments= formatInvocation.arguments();
-
-			StringLiteral formatStringArgument= ast.newStringLiteral();
-			formatStringArgument.setEscapedValue("\"" + formatString.append("\"").toString()); //$NON-NLS-1$ //$NON-NLS-2$
-			arguments.add(formatStringArgument);
-
-			arguments.addAll(formatArguments);
-
-			rewrite.replace(infixExpression, formatInvocation, null);
+			if (tagsCount > 1) {
+				ASTNodes.replaceAndRemoveNLSByCount(rewrite, infixExpression, buffer.toString(), tagsCount - 1, null, cuRewrite);
+			} else {
+				MethodInvocation formatInvocation= (MethodInvocation)rewrite.createStringPlaceholder(buffer.toString(), ASTNode.METHOD_INVOCATION);
+				rewrite.replace(infixExpression, formatInvocation, null);
+			}
 		}
 
 		private char stringFormatConversion(ITypeBinding type) {


### PR DESCRIPTION
- fixes #1040
- don't perform convert to MessageFormat.format() or String.format() unless all string literals have NLS tags or none do
- add new tests to AssistQuickFixTest

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes extract string concatenation refactorings to StringBuffer/StringBuilder, MessageFormat, and to String.format() to handle the cases where String literals have NON-NLS tags specified.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests in AssistQuickFixTest

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
