### PR TITLE
Add lock object to fDocument in DocumentAdapter.initialize()

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/DocumentAdapter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/DocumentAdapter.java
@@ -303,6 +303,9 @@ public class DocumentAdapter implements IBuffer, IDocumentListener, ITextEditCap
 				fTextFileBuffer= manager.getTextFileBuffer(fPath, fLocationKind);
 			}
 			fDocument= fTextFileBuffer.getDocument();
+			if (fDocument instanceof ISynchronizable sDocument && sDocument.getLockObject() == null) {
+				sDocument.setLockObject(new Object());
+			}
 		} catch (CoreException x) {
 			fDocument= manager.createEmptyDocument(fPath, fLocationKind);
 			if (fDocument instanceof ISynchronizable)


### PR DESCRIPTION
This change adds a lock object to `Document` use in `DocumentAdapter`, in order to prevent concurrent text buffer access. See: https://github.com/eclipse-platform/eclipse.platform.ui/issues/1059


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
