### PR TITLE
Correct enumeration of tests when running tests from a folder (#920)

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.13.100.qualifier
+Bundle-Version: 3.13.200.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.15.300.qualifier
+Bundle-Version: 3.15.400.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.15.300-SNAPSHOT</version>
+  <version>3.15.400-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/AdvancedJUnitLaunchConfigurationDelegateTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/AdvancedJUnitLaunchConfigurationDelegateTest.java
@@ -1,0 +1,200 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Erik Brangs and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Erik Brangs - initial implementation
+ *******************************************************************************/
+package org.eclipse.jdt.junit.launcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.Launch;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+
+public class AdvancedJUnitLaunchConfigurationDelegateTest {
+
+	private IJavaProject fJavaProject;
+
+	@After
+	public void deleteProject() throws CoreException {
+		if (fJavaProject != null) {
+			JavaProjectHelper.delete(fJavaProject);
+		}
+	}
+
+	@Test
+	public void runTestsInSourceFolderHandlesMultipleSourceFoldersCorrectly() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-TestProject-MultipleSourceFolders";
+		fJavaProject= JavaProjectHelper.createJavaProject(projectName, "bin");
+		String firstTestSrcFolder= "test-src1";
+		IPackageFragmentRoot testSrc1= JavaProjectHelper.addSourceContainer(fJavaProject, firstTestSrcFolder);
+		IPackageFragmentRoot testSrc2= JavaProjectHelper.addSourceContainer(fJavaProject, "test-src2");
+		String testPackage= "p1";
+		IPackageFragment packageTestSrc1= testSrc1.createPackageFragment(testPackage, true, null);
+		String contentsTestSrc1Test= """
+				public class FirstTest {
+				@org.junit.jupiter.api.Test
+				public void myTest() { }
+				}
+				""";
+		packageTestSrc1.createCompilationUnit("FirstTest.java", contentsTestSrc1Test, true, null);
+		IPackageFragment packageTestSrc2= testSrc2.createPackageFragment(testPackage, true, null);
+		String contentsTestSrc2Test= """
+				public class ShouldNotBeRunTest {
+				@org.junit.jupiter.api.Test
+				public void shouldNotRunTest() { }
+				}
+				""";
+
+		packageTestSrc2.createCompilationUnit("ShouldNotBeRunTest.java", contentsTestSrc2Test, true, null);
+
+		List<String> fileLines= showCommandLineAndExtractContentOfTestNameFile(projectName, fJavaProject, testSrc1);
+		String lineForFirstTest= "p1.FirstTest";
+		assertThat(fileLines).contains(lineForFirstTest).size().isEqualTo(1);
+	}
+
+	@Test
+	public void runTestsInSourceFolderHandlesMultiplePackagesInASourceFolderCorrectly() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-TestProject-MultiplePackagesInOneFolder";
+		fJavaProject= JavaProjectHelper.createJavaProject(projectName, "bin");
+		String firstTestSrcFolder= "test-src1";
+		IPackageFragmentRoot testSrc1= JavaProjectHelper.addSourceContainer(fJavaProject, firstTestSrcFolder);
+		String testPackage= "p1";
+		IPackageFragment packageTestSrc1= testSrc1.createPackageFragment(testPackage, true, null);
+		String contentsTestSrc1Test= """
+				public class FirstTest {
+				@org.junit.jupiter.api.Test
+				public void myTest() { }
+				}
+				""";
+		String secondTestPackage= "p2";
+		packageTestSrc1.createCompilationUnit("FirstTest.java", contentsTestSrc1Test, true, null);
+		IPackageFragment packageTestSrc2= testSrc1.createPackageFragment(secondTestPackage, true, null);
+		String contentsTestSrc2Test= """
+				public class SecondTest {
+				@org.junit.jupiter.api.Test
+				public void mySecondTest() { }
+				}
+				""";
+		packageTestSrc2.createCompilationUnit("SecondTest.java", contentsTestSrc2Test, true, null);
+
+		List<String> fileLines= showCommandLineAndExtractContentOfTestNameFile(projectName, fJavaProject, testSrc1);
+		String lineForFirstTest= "p1.FirstTest";
+		String lineForSecondTest= "p2.SecondTest";
+		assertThat(fileLines).contains(lineForFirstTest, lineForSecondTest).size().isEqualTo(2);
+	}
+
+	@Test
+	public void runTestsInSourceFolderHandlesMultipleSourceFilesInPackagesInASourceFolderCorrectly() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-TestProject-MultipleSourceFilesInOnePackage";
+		fJavaProject= JavaProjectHelper.createJavaProject(projectName, "bin");
+		String firstTestSrcFolder= "test-src1";
+		IPackageFragmentRoot testSrc1= JavaProjectHelper.addSourceContainer(fJavaProject, firstTestSrcFolder);
+		String testPackage= "p1";
+		IPackageFragment packageTestSrc1= testSrc1.createPackageFragment(testPackage, true, null);
+		String contentsTestSrc1Test= """
+				public class FirstTest {
+				@org.junit.jupiter.api.Test
+				public void myTest() { }
+				}
+				""";
+		packageTestSrc1.createCompilationUnit("FirstTest.java", contentsTestSrc1Test, true, null);
+		String contentsTestSrc2Test= """
+				public class SecondTest {
+				@org.junit.jupiter.api.Test
+				public void mySecondTest() { }
+				}
+				""";
+		packageTestSrc1.createCompilationUnit("SecondTest.java", contentsTestSrc2Test, true, null);
+
+		List<String> fileLines= showCommandLineAndExtractContentOfTestNameFile(projectName, fJavaProject, testSrc1);
+		String lineForFirstTest= "p1.FirstTest";
+		String lineForSecondTest= "p1.SecondTest";
+		assertThat(fileLines).contains(lineForFirstTest, lineForSecondTest).size().isEqualTo(2);
+	}
+
+	@Test
+	public void runTestsInSourceFolderOnlyUsesTopLevelClasses() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-TestProject-OnlyTopLevelClasses";
+		fJavaProject= JavaProjectHelper.createJavaProject(projectName, "bin");
+		String firstTestSrcFolder= "test-src1";
+		IPackageFragmentRoot testSrc1= JavaProjectHelper.addSourceContainer(fJavaProject, firstTestSrcFolder);
+		String testPackage= "p1";
+		IPackageFragment packageTestSrc1= testSrc1.createPackageFragment(testPackage, true, null);
+		String contentsTestSrc1Test= """
+				public class FirstTest {
+				@org.junit.jupiter.api.Test
+				public void myTest() { }
+				}
+
+				@org.junit.jupiter.api.Nest
+				class NestedTestClass {
+					@org.junit.jupiter.api.Test
+					public void myNestedTest() { }
+					}
+				}
+				""";
+		packageTestSrc1.createCompilationUnit("FirstTest.java", contentsTestSrc1Test, true, null);
+
+		List<String> fileLines= showCommandLineAndExtractContentOfTestNameFile(projectName, fJavaProject, testSrc1);
+		String lineForFirstTest= "p1.FirstTest";
+		assertThat(fileLines).contains(lineForFirstTest).size().isEqualTo(1);
+	}
+
+	private List<String> showCommandLineAndExtractContentOfTestNameFile(String projectName, IJavaProject javaProject, IPackageFragmentRoot testSrc1)
+			throws CoreException, JavaModelException, IOException {
+		JavaProjectHelper.addRTJar18(javaProject);
+		IClasspathEntry cpe= JavaCore.newContainerEntry(JUnitCore.JUNIT5_CONTAINER_PATH);
+		JavaProjectHelper.addToClasspath(javaProject, cpe);
+		JavaProjectHelper.set18CompilerOptions(javaProject);
+		AdvancedJUnitLaunchConfigurationDelegate delegate= new AdvancedJUnitLaunchConfigurationDelegate();
+		MockLaunchConfig configuration= new MockLaunchConfig();
+		configuration.setProjectName(projectName);
+		String testRunnerKind= TestKindRegistry.JUNIT5_TEST_KIND_ID;
+		configuration.setTestRunnerKind(testRunnerKind);
+		String containerHandle= testSrc1.getHandleIdentifier();
+		configuration.setContainerHandle(containerHandle);
+		String mode= ILaunchManager.DEBUG_MODE;
+		ILaunch launch= new Launch(configuration, mode, null);
+		IProgressMonitor progressMonitor= null;
+		String showCommandLine= delegate.showCommandLine(configuration, mode, launch, progressMonitor);
+		String firstSearchStr= "-testNameFile";
+		int indexTestNameFile= showCommandLine.indexOf(firstSearchStr);
+		assertThat(indexTestNameFile).overridingErrorMessage("-testNameFile argument not found").isGreaterThan(-1);
+		String filePath= showCommandLine.substring(indexTestNameFile + firstSearchStr.length() + 1);
+		List<String> fileLines= Files.readAllLines(Paths.get(filePath));
+		return fileLines;
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/JUnitLauncherTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/JUnitLauncherTests.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Erik Brangs and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Erik Brangs - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.junit.launcher;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+AdvancedJUnitLaunchConfigurationDelegateTest.class,
+})
+public class JUnitLauncherTests {
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/MockLaunchConfig.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/MockLaunchConfig.java
@@ -1,0 +1,264 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Erik Brangs and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Erik Brangs - initial implementation
+ *******************************************************************************/
+package org.eclipse.jdt.junit.launcher;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchDelegate;
+
+import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
+
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+
+class MockLaunchConfig implements ILaunchConfiguration {
+
+	private String fProjectName;
+	private String fTestRunnerKind;
+	private String fMainTypeName;
+	private String fContainerHandle;
+
+	public void setProjectName(String projectName) {
+		fProjectName= projectName;
+	}
+
+	public void setTestRunnerKind(String testRunnerKind) {
+		fTestRunnerKind= testRunnerKind;
+	}
+
+	public void setContainerHandle(String containerHandle) {
+		fContainerHandle= containerHandle;
+	}
+
+
+	@Override
+	public String getAttribute(String attributeName, String defaultValue) throws CoreException {
+		if (IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME.equals(attributeName)) {
+			return fProjectName;
+		} else if (JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND.equals(attributeName)) {
+			return fTestRunnerKind;
+		} else if (IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME.equals(attributeName)) {
+			return fMainTypeName;
+		} else if (JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER.equals(attributeName)) {
+			return fContainerHandle;
+		}
+		return defaultValue;
+	}
+
+	@Override
+	public List<String> getAttribute(String attributeName, List<String> defaultValue) throws CoreException {
+		return defaultValue;
+	}
+
+	@Override
+	public boolean getAttribute(String attributeName, boolean defaultValue) throws CoreException {
+		return defaultValue;
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+	@Override
+	public boolean contentsEqual(ILaunchConfiguration configuration) {
+		return false;
+	}
+
+	@Override
+	public ILaunchConfigurationWorkingCopy copy(String name) throws CoreException {
+		return null;
+	}
+
+	@Override
+	public void delete() throws CoreException {
+	}
+
+	@Override
+	public void delete(int flag) throws CoreException {
+	}
+
+	@Override
+	public boolean exists() {
+		return false;
+	}
+
+	@Override
+	public int getAttribute(String attributeName, int defaultValue) throws CoreException {
+		return 0;
+	}
+
+	@Override
+	public Set<String> getAttribute(String attributeName, Set<String> defaultValue) throws CoreException {
+		return null;
+	}
+
+	@Override
+	public Map<String, String> getAttribute(String attributeName, Map<String, String> defaultValue) throws CoreException {
+		return null;
+	}
+
+	@Override
+	public Map<String, Object> getAttributes() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public String getCategory() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public IFile getFile() {
+		return null;
+	}
+
+	@SuppressWarnings("deprecation")
+	@Override
+	public IPath getLocation() {
+		return null;
+	}
+
+	@Override
+	public IResource[] getMappedResources() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public String getMemento() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public String getName() {
+		return null;
+	}
+
+	@Override
+	public Set<String> getModes() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public ILaunchDelegate getPreferredDelegate(Set<String> modes) throws CoreException {
+		return null;
+	}
+
+	@Override
+	public ILaunchConfigurationType getType() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public ILaunchConfigurationWorkingCopy getWorkingCopy() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public boolean hasAttribute(String attributeName) throws CoreException {
+		return false;
+	}
+
+	@Override
+	public boolean isLocal() {
+		return false;
+	}
+
+	@Override
+	public boolean isMigrationCandidate() throws CoreException {
+		return false;
+	}
+
+	@Override
+	public boolean isWorkingCopy() {
+		return false;
+	}
+
+	@Override
+	public ILaunch launch(String mode, IProgressMonitor monitor) throws CoreException {
+		return null;
+	}
+
+	@Override
+	public ILaunch launch(String mode, IProgressMonitor monitor, boolean build) throws CoreException {
+		return null;
+	}
+
+	@Override
+	public ILaunch launch(String mode, IProgressMonitor monitor, boolean build, boolean register) throws CoreException {
+		return null;
+	}
+
+	@Override
+	public void migrate() throws CoreException {
+	}
+
+	@Override
+	public boolean supportsMode(String mode) throws CoreException {
+		return false;
+	}
+
+	@Override
+	public boolean isReadOnly() {
+		return false;
+	}
+
+	@Override
+	public ILaunchConfiguration getPrototype() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public boolean isAttributeModified(String attribute) throws CoreException {
+		return false;
+	}
+
+	@Override
+	public boolean isPrototype() {
+		return false;
+	}
+
+	@Override
+	public Collection<ILaunchConfiguration> getPrototypeChildren() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public int getKind() throws CoreException {
+		return 0;
+	}
+
+	@Override
+	public Set<String> getPrototypeVisibleAttributes() throws CoreException {
+		return null;
+	}
+
+	@Override
+	public void setPrototypeAttributeVisibility(String attribute, boolean visible) throws CoreException {
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import org.eclipse.jdt.junit.launcher.JUnitLauncherTests;
 import org.eclipse.jdt.junit.tests.JUnitJUnitTests;
 import org.eclipse.jdt.testplugin.TestOptions;
 
@@ -73,6 +74,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 	RefactoringTests.class,
 
 	SearchTest.class,
+	JUnitLauncherTests.class,
 	JUnitJUnitTests.class,
 
 	BuildpathTestSuite.class,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Currently, when running tests from a source folder with JUnit 5, all tests that share a package with those packages in the selected source folder will be run (see #920). This attempts to fix this by enumerating all tests as suggested in #920.

I don't know if JDT uses a mocking framework so I mocked the needed classes by hand.

## How to test
I've added a test case. I'm not sure if that is sufficient.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

Edit: I've added a few more tests so I've set the checkmark for through testing.