### PR TITLE
Avoid "overlapping text edits" in "Make Static" refactoring #1045

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/ChangeCalculator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/ChangeCalculator.java
@@ -459,14 +459,16 @@ public class ChangeCalculator {
 				ASTNode[] invocations= targetProvider.getInvocations(body, null);
 				for (ASTNode invocationASTNode : invocations) {
 					MethodInvocation invocation= (MethodInvocation) invocationASTNode;
-					textEdits.add(createMethodInvocationChange(invocation));				}
+					textEdits.add(createMethodInvocationChange(invocation));
+				}
 			}
 
 			if (fFinalConditionsChecker.getStatus().hasFatalError()) {
 				return;
 			}
 
-			addEditsToChangeManager(textEdits, affectedICompilationUnit);		}
+			addEditsToChangeManager(textEdits, affectedICompilationUnit);
+		}
 		return;
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testCallsAroundRefactoredMethod/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testCallsAroundRefactoredMethod/in/Foo.java
@@ -1,0 +1,16 @@
+public class Foo {
+
+	public void callerAbove() {
+		Foo instance= new Foo();
+		instance.enclosedMethod();
+	}
+
+	public void enclosedMethod() {
+	}
+
+	public void callerBelow() {
+		Foo instance= new Foo();
+		instance.enclosedMethod();
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testCallsAroundRefactoredMethod/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testCallsAroundRefactoredMethod/out/Foo.java
@@ -1,0 +1,16 @@
+public class Foo {
+
+	public void callerAbove() {
+		Foo instance= new Foo();
+		Foo.enclosedMethod();
+	}
+
+	public static void enclosedMethod() {
+	}
+
+	public void callerBelow() {
+		Foo instance= new Foo();
+		Foo.enclosedMethod();
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Vector Informatik GmbH and others.
+ * Copyright (c) 2023, 2024 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License 2.0 which accompanies this distribution, and is available at
@@ -573,6 +573,15 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testJavaDocWithGenerics() throws Exception {
 		//New TypeParameter needs to be added to JavaDoc
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 12, 25, 12, 28);
+		assertHasNoCommonErrors(status);
+	}
+
+	/**
+	 * See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1045
+	 */
+	@Test
+	public void testCallsAroundRefactoredMethod() throws Exception {
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 8, 17, 8, 31);
 		assertHasNoCommonErrors(status);
 	}
 


### PR DESCRIPTION
## What it does
The "Make Static" refactoring currently produces overlapping text edits in case there are changes in the source code file containing the refactored method before and after that method. The reason is that the calls to the refactored method are wrapped into a single MultiTextEdit whose scope is then overlapping with the TextEdit for the refactored method itself.

With this fix, the changes to callers of the refactored method are treated as individual TextEdits rather than one MultiTextEdit, so that none of the generated text edits have pairwise overlaps. An according regression test for the behavior is added.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1045

## How to test
Take any class, in which you want to refactor an instance method to a static method which has callers in that class above and below the method to be refactored. Before this change, the refactoring will fail with an "overlapping text edit". Afterwards it will succeed.
You can, for example, use the method `org.eclipse.jdt.internal.codeassist.CompletionEngine#checkCancel()`, as described in #1045, or the scenario of the regression test added with this PR.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)