### PR TITLE
Ensure "Make Static" refactoring only adds parameter if necessary #1044

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/InstanceUsageRewriter.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/InstanceUsageRewriter.java
@@ -230,11 +230,9 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 		}
 
 		if (!Modifier.isStatic(methodBinding.getModifiers())) {
-			fTargetMethodhasInstanceUsage= true;
-
 			fFinalConditionsChecker.checkIsNotRecursive(node, fTargetMethodDeclaration);
 
-			replaceMethodInvocation(node);
+			fTargetMethodhasInstanceUsage |= replaceMethodInvocation(node);
 		}
 	}
 
@@ -282,7 +280,7 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 		}
 	}
 
-	private void replaceMethodInvocation(SimpleName node) {
+	private boolean replaceMethodInvocation(SimpleName node) {
 		ASTNode parent= node.getParent();
 		SimpleName replacementExpression= fAst.newSimpleName(fParamName);
 		if (parent instanceof MethodInvocation) {
@@ -291,8 +289,10 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 
 			if (optionalExpression == null) {
 				fRewrite.set(methodInvocation, MethodInvocation.EXPRESSION_PROPERTY, replacementExpression, null);
+				return true;
 			}
 		}
+		return false;
 	}
 
 	private boolean parentIsAnonymousClass(ASTNode parentNode) {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodWithInvocationOnNewObject/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodWithInvocationOnNewObject/in/Foo.java
@@ -1,0 +1,7 @@
+public class Foo {
+
+	public void method() {
+		new Object().toString();
+	}
+	
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodWithInvocationOnNewObject/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodWithInvocationOnNewObject/out/Foo.java
@@ -1,0 +1,7 @@
+public class Foo {
+
+	public static void method() {
+		new Object().toString();
+	}
+	
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
@@ -575,4 +575,14 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 12, 25, 12, 28);
 		assertHasNoCommonErrors(status);
 	}
+
+	/**
+	 * See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1044
+	 */
+	@Test
+	public void testMethodWithInvocationOnNewObject() throws Exception {
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 3, 17, 3, 23);
+		assertHasNoCommonErrors(status);
+	}
+
 }


### PR DESCRIPTION
## What it does

The "Make Static" refactoring currently adds a "this" parameter to the method in cases in which it is actually not necessary. This is particularly the case the body of the method to be refactored contains invocations of methods on a newly instantiated object. The according logic erroneously considers such a method invocation as a reason to add a parameter.

With this fix, the identification of whether a parameter needs to be added to the method depends on whether the logic calculating an actual change to the method body is actually applied. An according regression test for the behavior is added.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1044

## How to test

It is easiest to test with either the example provided as a regression test within this PR or by applying the "Make Static" refactoring to `org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest#getCompilerTestsPluginDirectoryPath()`, as documented in the according issue #1044.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
