### PR TITLE
Improve Javadoc generated by "Make Static" refactoring #1043

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeSignatureProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/ChangeSignatureProcessor.java
@@ -14,7 +14,6 @@
 package org.eclipse.jdt.internal.corext.refactoring.structure;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -2338,7 +2337,7 @@ public class ChangeSignatureProcessor extends RefactoringProcessor implements ID
 					}
 				} else if (isTopOfRipple && Signature.SIG_VOID.equals(fMethod.getReturnType())){
 					TagElement returnNode= createReturnTag();
-					TagElement previousTag= findTagElementToInsertAfter(tags, TagElement.TAG_RETURN);
+					TagElement previousTag= JavadocUtil.findTagElementToInsertAfter(tags, TagElement.TAG_RETURN);
 					insertTag(returnNode, previousTag, tagsRewrite);
 					tags= tagsRewrite.getRewrittenList();
 				}
@@ -2378,7 +2377,7 @@ public class ChangeSignatureProcessor extends RefactoringProcessor implements ID
 
 				if (! isOrderSameAsInitial()) {
 					// reshuffle (sort in declaration sequence) & add (only add to top of ripple):
-					TagElement previousTag= findTagElementToInsertAfter(tags, TagElement.TAG_PARAM);
+					TagElement previousTag= JavadocUtil.findTagElementToInsertAfter(tags, TagElement.TAG_PARAM);
 					boolean first= true; // workaround for bug 92111: preserve first tag if possible
 					// reshuffle:
 					for (ParameterInfo info : fParameterInfos) {
@@ -2455,7 +2454,7 @@ public class ChangeSignatureProcessor extends RefactoringProcessor implements ID
 				}
 				// reshuffle:
 				tags= tagsRewrite.getRewrittenList();
-				TagElement previousTag= findTagElementToInsertAfter(tags, TagElement.TAG_THROWS);
+				TagElement previousTag= JavadocUtil.findTagElementToInsertAfter(tags, TagElement.TAG_THROWS);
 				for (ExceptionInfo info : fExceptionInfos) {
 					if (info.isAdded()) {
 						if (!isTopOfRipple)
@@ -2531,40 +2530,6 @@ public class ChangeSignatureProcessor extends RefactoringProcessor implements ID
 			else
 				tagsRewrite.insertAfter(tag, previousTag, fDescription);
 		}
-
-		/**
-		 * @param tags existing tags
-		 * @param tagName name of tag to add
-		 * @return the <code>TagElement</code> just before a new <code>TagElement</code> with name
-		 *         <code>tagName</code>, or <code>null</code>.
-		 */
-		private TagElement findTagElementToInsertAfter(List<TagElement> tags, String tagName) {
-			List<String> tagOrder= Arrays.asList(
-					TagElement.TAG_AUTHOR,
-					TagElement.TAG_VERSION,
-					TagElement.TAG_PARAM,
-					TagElement.TAG_RETURN,
-					TagElement.TAG_THROWS,
-					TagElement.TAG_EXCEPTION,
-					TagElement.TAG_SEE,
-					TagElement.TAG_SINCE,
-					TagElement.TAG_SERIAL,
-					TagElement.TAG_SERIALFIELD,
-					TagElement.TAG_SERIALDATA,
-					TagElement.TAG_DEPRECATED,
-					TagElement.TAG_VALUE
-			);
-			int goalOrdinal= tagOrder.indexOf(tagName);
-			if (goalOrdinal == -1) // unknown tag -> to end
-				return (tags.isEmpty()) ? null : (TagElement) tags.get(tags.size());
-			for (int i= 0; i < tags.size(); i++) {
-				int tagOrdinal= tagOrder.indexOf(tags.get(i).getTagName());
-				if (tagOrdinal >= goalOrdinal)
-					return (i == 0) ? null : (TagElement) tags.get(i - 1);
-			}
-			return (tags.isEmpty()) ? null : (TagElement) tags.get(tags.size() - 1);
-		}
-
 
 		@Override
 		protected SingleVariableDeclaration createNewParamgument(ParameterInfo info, List<ParameterInfo> parameterInfos, List<SingleVariableDeclaration> nodes) {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocInsertBetweenExistingTags/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocInsertBetweenExistingTags/in/Foo.java
@@ -1,0 +1,15 @@
+class Foo<A> {
+
+	int j;
+
+	/**
+	 * Some documentation ...
+	 * 
+	 * @author someone
+	 * @see Object#equals(Object)
+	 * @throws IllegalArgumentException
+	 */
+	private void bar() throws IllegalArgumentException {
+		this.j= 0;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocInsertBetweenExistingTags/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocInsertBetweenExistingTags/out/Foo.java
@@ -1,0 +1,17 @@
+class Foo<A> {
+
+	int j;
+
+	/**
+	 * Some documentation ...
+	 * 
+	 * @author someone
+	 * @param foo
+	 * @param <A>
+	 * @see Object#equals(Object)
+	 * @throws IllegalArgumentException
+	 */
+	private static <A> void bar(Foo<A> foo) throws IllegalArgumentException {
+		foo.j= 0;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocShuffledTagsWithGenerics/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocShuffledTagsWithGenerics/in/Foo.java
@@ -1,0 +1,22 @@
+class Foo<A, B extends Runnable> {
+
+	int j;
+
+	/**
+	 * Some documentation ...
+	 * 
+	 * @author someone
+	 * @param value1
+	 * @return empty string
+	 * @param value2
+	 * @param value3
+	 * @see Object#equals(Object)
+	 * @param <T>
+	 * @param <Z>
+	 * @throws IllegalArgumentException
+	 */
+	private <T, Z> String bar(T value1, T value2, Z value3) throws IllegalArgumentException {
+		this.j= 0;
+		return "";
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocShuffledTagsWithGenerics/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testJavaDocShuffledTagsWithGenerics/out/Foo.java
@@ -1,0 +1,25 @@
+class Foo<A, B extends Runnable> {
+
+	int j;
+
+	/**
+	 * Some documentation ...
+	 * 
+	 * @author someone
+	 * @param foo
+	 * @param value1
+	 * @return empty string
+	 * @param value2
+	 * @param value3
+	 * @see Object#equals(Object)
+	 * @param <T>
+	 * @param <Z>
+	 * @param <A>
+	 * @param <B>
+	 * @throws IllegalArgumentException
+	 */
+	private static <T, Z, A, B extends Runnable> String bar(Foo<A, B> foo, T value1, T value2, Z value3) throws IllegalArgumentException {
+		foo.j= 0;
+		return "";
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
@@ -577,6 +577,26 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	}
 
 	/**
+	 * See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1043
+	 */
+	@Test
+	public void testJavaDocInsertBetweenExistingTags() throws Exception {
+		//If javadoc already contains tags, insert the new parameter information at reasonable positions
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 12, 18, 12, 21);
+		assertHasNoCommonErrors(status);
+	}
+
+	/**
+	 * See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1043
+	 */
+	@Test
+	public void testJavaDocShuffledTagsWithGenerics() throws Exception {
+		//If javadoc already has several tags in usual order, insert the new parameter information at reasonable positions
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 18, 27, 18, 30);
+		assertHasNoCommonErrors(status);
+	}
+
+	/**
 	 * See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1045
 	 */
 	@Test


### PR DESCRIPTION
## What it does

This change improves the Javadoc generation behavior of the "Make Static" refactoring and aligns it with other refactorings such as "Change Method Signature". It ensures that generated parameter tags are inserted at proper positions within an existing Javadoc comment.
<s>This change improves the Javadoc generation behavior of the "Make Static" refactoring and aligns it with other refactorings such as "Change Method Signature". This includes (1) adding a "TODO" to added parameter tags and (2) inserting parameter tags at proper positions within an existing Javadoc comment.</s>
The tag for the parameter itself is added as the first parameter tag, following any author or version tags. The tags for potential type parameters are added as the last parameter tags, preceding any other tags than author or version.


The reused functionality from `ChangeMethodSignatureRefactoringContribution` is factored out to the `JavadocUtil` class.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1043

## How to test

The behavior can be reproduced by applying the "Make Static" refactoring to any method that when refactored requires a `this` parameter and has Javadoc into which the documentation for the added parameter has to be inserted. To see different flavors of the behavior, it's easiest to consider the regression test cases provided with this PR.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
