### PR TITLE
Correct "Make Static" refactoring behavior for anonymous classes #1083

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/InstanceUsageRewriter.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/InstanceUsageRewriter.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.internal.corext.refactoring.code.makestatic;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
@@ -115,10 +116,10 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 	@Override
 	public boolean visit(SimpleName node) {
 		IBinding binding= node.resolveBinding();
-		if (binding instanceof IVariableBinding) {
-			modifyFieldUsage(node, binding);
-		} else if (binding instanceof IMethodBinding) {
-			modifyInstanceMethodUsage(node, binding);
+		if (binding instanceof IVariableBinding variableBinding) {
+			modifyFieldUsage(node, variableBinding);
+		} else if (binding instanceof IMethodBinding methodBinding) {
+			modifyInstanceMethodUsage(node, methodBinding);
 		}
 		return super.visit(node);
 	}
@@ -145,7 +146,7 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 		if (qualifier != null) {
 			IBinding qualifierBinding= qualifier.resolveBinding();
 			ITypeBinding typeBinding= (ITypeBinding) qualifierBinding;
-			if (isInsideAnonymousClass(typeBinding)) {
+			if (isAccessToAnonymousClass(node, typeBinding)) {
 				return super.visit(node);
 			}
 		} else {
@@ -198,12 +199,8 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 		return super.visit(node);
 	}
 
-	private void modifyFieldUsage(SimpleName node, IBinding binding) {
-		IVariableBinding variableBinding= (IVariableBinding) binding;
-
-		//Check if we are inside a anonymous class
-		ITypeBinding declaringClass= variableBinding.getDeclaringClass();
-		if (isInsideAnonymousClass(declaringClass)) {
+	private void modifyFieldUsage(SimpleName node, IVariableBinding variableBinding) {
+		if (isAccessToAnonymousClass(node, variableBinding.getDeclaringClass())) {
 			return;
 		}
 
@@ -221,11 +218,8 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 		}
 	}
 
-	private void modifyInstanceMethodUsage(SimpleName node, IBinding binding) {
-		IMethodBinding methodBinding= (IMethodBinding) binding;
-		ITypeBinding declaringClass= methodBinding.getDeclaringClass();
-		//Check if we are inside a anonymous class
-		if (isInsideAnonymousClass(declaringClass)) {
+	private void modifyInstanceMethodUsage(SimpleName node, IMethodBinding methodBinding) {
+		if (isAccessToAnonymousClass(node, methodBinding.getDeclaringClass())) {
 			return;
 		}
 
@@ -236,15 +230,29 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 		}
 	}
 
-	private boolean isInsideAnonymousClass(ITypeBinding declaringClass) {
-		if (declaringClass != null) {
-			boolean isLocal= declaringClass.isLocal();
-			boolean isAnonymous= declaringClass.isAnonymous();
-			boolean isMember= declaringClass.isMember();
-			boolean isNested= declaringClass.isNested();
-			boolean isTopLevel= declaringClass.isTopLevel();
-			if (!isTopLevel || isNested || isAnonymous || isLocal || isMember) {
-				return true;
+	private boolean isAccessToAnonymousClass(ASTNode node, ITypeBinding declaringClass) {
+		IMethodBinding refactoredMethod = fTargetMethodDeclaration.resolveBinding();
+		if (refactoredMethod == null) {
+			// If we cannot resolve the binding of the refactored method for some reason, better keep this member access
+			// as is and, in the worst case, risk a compile error than changing semantics by erroneously modifying the access.
+			return true;
+		}
+		ITypeBinding typeOfRefactoredMethod = refactoredMethod.getDeclaringClass();
+		ASTNode currentNode = node;
+		while (currentNode != null) {
+			currentNode = currentNode.getParent();
+			// Stop when reaching class declaration with method to be refactored
+			if (currentNode instanceof AbstractTypeDeclaration typeDeclaration) {
+				if (typeOfRefactoredMethod.equals(typeDeclaration.resolveBinding())) {
+					return false;
+				}
+			}
+			// If containing anonymous class specializes declaring class of called method, method is invoked on this anonymous class
+			if (currentNode instanceof AnonymousClassDeclaration typeDeclaration) {
+				ITypeBinding anonymousClass = typeDeclaration.resolveBinding();
+				if (anonymousClass != null && anonymousClass.isAssignmentCompatible(declaringClass)) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/in/Foo.java
@@ -1,0 +1,13 @@
+public class Foo {
+	int j = 0;
+	
+	void toBeRefactored() {
+		this.j = 1;
+		new Other() {
+			@Override
+			void toImplement() {
+				toCall();
+			}
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/in/Other.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/in/Other.java
@@ -1,0 +1,5 @@
+public abstract class Other {
+	abstract void toImplement();
+	void toCall() {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/out/Foo.java
@@ -1,0 +1,13 @@
+public class Foo {
+	int j = 0;
+	
+	static void toBeRefactored(Foo foo) {
+		foo.j = 1;
+		new Other() {
+			@Override
+			void toImplement() {
+				toCall();
+			}
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/out/Other.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClass/out/Other.java
@@ -1,0 +1,5 @@
+public abstract class Other {
+	abstract void toImplement();
+	void toCall() {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClassExtendingRefactoredClass/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClassExtendingRefactoredClass/in/Foo.java
@@ -1,0 +1,15 @@
+public class Foo {
+	
+	void toBeRefactored() {
+		new Foo() {
+			void toImplement() {
+				toCall();
+			}
+		};
+	}
+	
+	void toCall() { }
+	
+	void toImplement() { }
+	
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClassExtendingRefactoredClass/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInAnonymousClassExtendingRefactoredClass/out/Foo.java
@@ -1,0 +1,15 @@
+public class Foo {
+	
+	static void toBeRefactored() {
+		new Foo() {
+			void toImplement() {
+				toCall();
+			}
+		};
+	}
+	
+	void toCall() { }
+	
+	void toImplement() { }
+	
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/in/Foo.java
@@ -1,0 +1,19 @@
+public class Foo {
+	int j = 0;
+	
+	void toBeRefactored() {
+		this.j = 1;
+		new Other() {
+			@Override
+			void toImplement() {
+				new Object() {
+					@Override
+					public boolean equals(Object obj) {
+						toCall();
+						return false;
+					}
+				};
+			}
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/in/Other.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/in/Other.java
@@ -1,0 +1,5 @@
+public abstract class Other {
+	abstract void toImplement();
+	void toCall() {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/out/Foo.java
@@ -1,0 +1,19 @@
+public class Foo {
+	int j = 0;
+	
+	static void toBeRefactored(Foo foo) {
+		foo.j = 1;
+		new Other() {
+			@Override
+			void toImplement() {
+				new Object() {
+					@Override
+					public boolean equals(Object obj) {
+						toCall();
+						return false;
+					}
+				};
+			}
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/out/Other.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testMethodCallInNestedAnonymousClass/out/Other.java
@@ -1,0 +1,5 @@
+public abstract class Other {
+	abstract void toImplement();
+	void toCall() {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
@@ -395,6 +395,27 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void testMethodCallInAnonymousClassExtendingRefactoredClass() throws Exception {
+		//Method of anonymous class invokes another method of anonymous class -> Refactoring should ignore this invocation
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 3, 10, 3, 24);
+		assertHasNoCommonErrors(status);
+	}
+
+	@Test
+	public void testMethodCallInAnonymousClass() throws Exception {
+		//Method of anonymous class invokes another method of anonymous class -> Refactoring should ignore this invocation
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo", "p.Other" }, 4, 10, 4, 24);
+		assertHasNoCommonErrors(status);
+	}
+
+	@Test
+	public void testMethodCallInNestedAnonymousClass() throws Exception {
+		//Method of anonymous class invokes another method of anonymous class -> Refactoring should ignore this invocation
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo", "p.Other" }, 4, 10, 4, 24);
+		assertHasNoCommonErrors(status);
+	}
+
+	@Test
 	public void testVariousInstanceCases() throws Exception {
 		//Various cases of instance access in many different forms
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 14, 17, 14, 20);


### PR DESCRIPTION
## What it does

The "Make Static" refactoring erroneously interprets a method call within an anonymous class inside the refactored method as a call on `this` and thus changes the method invocation to be performed on the added input parameter of the method. This is (1) semantically incorrect and (2) leads to compile errors if the type of the added parameter does not provide the method.

With this fix, the identification of whether a method invocation is performed on the `this` object of the method to be refactored and not some instance of an anonymous inner class inside that method is corrected. For three different scenarios (anonymous class extending outer class, anonymous class extending other class, and nested anonymous classes), regression tests are added.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1083

## How to test
As explained in #1083, the issue can be seen when applying the refactoring to `org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest#findReferences(String)`. Without this fix, a faulty method call will be introduced, whereas the refactoring produces a correct result with this fix. Different other scenarios, in which the issue occurs, can be seen in the regression tests added with this PR.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
