### PR TITLE
Fix NPE when type declaration is not found. Fix #1097

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/AddMissingMethodDeclarationFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/AddMissingMethodDeclarationFixCore.java
@@ -65,6 +65,9 @@ public class AddMissingMethodDeclarationFixCore extends CompilationUnitRewriteOp
 		}
 
 		TypeDeclaration typeDeclaration= ASTNodes.getParent(methodReferenceNode, TypeDeclaration.class);
+		if (typeDeclaration == null) {
+			return null;
+		}
 
 		if (QuickAssistProcessorUtil.isTypeReferenceToInstanceMethod(methodReferenceNode)) {
 			String methodReferenceQualifiedName= ((Name) methodReferenceNode.getExpression()).getFullyQualifiedName();


### PR DESCRIPTION
## What it does
When the type declaration ancestor of the method reference to be created cannot be found, don't suggest the AddMissingMethodDeclarationFixCore proposal.

## How to test
Use the scenario described in the issue.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
