### PR TITLE
CallHierarchy: fix error when clicking a method that is gone #1098

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.java
@@ -135,6 +135,7 @@ public final class CallHierarchyMessages extends NLS {
 	public static String OpenLocationAction_error_title;
 	public static String CallHierarchyUI_open_in_editor_error_message;
 	public static String CallHierarchyUI_open_in_editor_error_messageArgs;
+	public static String CallHierarchyUI_open_in_editor_notExists;
 	public static String CallHierarchyUI_open_operation_unavialable;
 	public static String CallHierarchyUI_error_open_view;
 	public static String CopyCallHierarchyAction_label;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
@@ -120,6 +120,7 @@ SearchUtil_workingSetConcatenation= {0}, {1}
 OpenLocationAction_error_title=Show Call Location
 CallHierarchyUI_open_in_editor_error_message=An error occurred while opening the editor.
 CallHierarchyUI_open_in_editor_error_messageArgs=An error occurred while opening the editor for ''{0}'': ''{1}''.
+CallHierarchyUI_open_in_editor_notExists=Method {0} not found.
 CallHierarchyUI_open_operation_unavialable=Operation unavailable on the current selection.\n\nSelect one or more methods, classes, fields, or initializers.
 CallHierarchyUI_error_open_view=An error occurred while opening the call hierarchy view.
 


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1098

![image](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/51790620/25797c07-aa7f-4adb-9c11-f3223544ac69)
