### PR TITLE
Sub processor push down part1

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionBaseSubProcessor.java
@@ -1,0 +1,355 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.text.correction;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.core.resources.IFile;
+
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.Refactoring;
+import org.eclipse.ltk.core.refactoring.TextFileChange;
+
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.manipulation.ChangeCorrectionProposalCore;
+
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
+import org.eclipse.jdt.internal.corext.codemanipulation.GetterSetterUtil;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.Bindings;
+import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTesterCore;
+import org.eclipse.jdt.internal.corext.refactoring.sef.SelfEncapsulateFieldRefactoring;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.internal.corext.util.Messages;
+
+
+public abstract class GetterSetterCorrectionBaseSubProcessor<T> {
+
+	public static final String SELF_ENCAPSULATE_FIELD_COMMAND_ID= "org.eclipse.jdt.ui.correction.encapsulateField.assist"; //$NON-NLS-1$
+
+	private static class ProposalParameter {
+		public final boolean useSuper;
+		public final ICompilationUnit compilationUnit;
+		public final ASTRewrite astRewrite;
+		public final Expression accessNode;
+		public final Expression qualifier;
+		public final IVariableBinding variableBinding;
+
+		public ProposalParameter(boolean useSuper, ICompilationUnit compilationUnit, ASTRewrite rewrite, Expression accessNode, Expression qualifier, IVariableBinding variableBinding) {
+			this.useSuper= useSuper;
+			this.compilationUnit= compilationUnit;
+			this.astRewrite= rewrite;
+			this.accessNode= accessNode;
+			this.qualifier= qualifier;
+			this.variableBinding= variableBinding;
+		}
+	}
+
+	public static class SelfEncapsulateFieldProposalCore extends ChangeCorrectionProposalCore { // public for tests
+
+		private IField fField;
+
+		public SelfEncapsulateFieldProposalCore(int relevance, IField field) {
+			this(relevance, null, field);
+		}
+
+		public SelfEncapsulateFieldProposalCore(int relevance, Change change, IField field) {
+			super(getDescription(field), change, relevance);
+			fField= field;
+			setCommandId(SELF_ENCAPSULATE_FIELD_COMMAND_ID);
+		}
+
+		public IField getField() {
+			return fField;
+		}
+
+		public static SelfEncapsulateFieldRefactoring getChangeRefactoring(IField field) throws CoreException {
+			final SelfEncapsulateFieldRefactoring refactoring= new SelfEncapsulateFieldRefactoring(field);
+			refactoring.setVisibility(Flags.AccPublic);
+			refactoring.setConsiderVisibility(false);//private field references are just searched in local file
+			refactoring.checkInitialConditions(new NullProgressMonitor());
+			refactoring.checkFinalConditions(new NullProgressMonitor());
+			return refactoring;
+		}
+
+		public static Change getChange(IField field) throws CoreException {
+			Refactoring refactoring= getChangeRefactoring(field);
+			Change createdChange= refactoring.createChange(new NullProgressMonitor());
+			return createdChange;
+		}
+
+		public static TextFileChange getChange(IField field, IFile file) throws CoreException {
+			Change createdChange= getChange(field);
+			if (createdChange instanceof CompositeChange c) {
+				for (Change curr : c.getChildren()) {
+					if (curr instanceof TextFileChange tfc && (file == null || tfc.getFile().equals(file))) {
+						return tfc;
+					}
+				}
+			}
+			return null;
+		}
+
+
+		public static String getDescription(IField field) {
+			return Messages.format(CorrectionMessages.GetterSetterCorrectionSubProcessor_creategetterunsingencapsulatefield_description, BasicElementLabels.getJavaElementName(field.getElementName()));
+		}
+
+		@Override
+		public Object getAdditionalProposalInfo(IProgressMonitor monitor) {
+			return CorrectionMessages.GetterSetterCorrectionSubProcessor_additional_info;
+		}
+	}
+
+	protected GetterSetterCorrectionBaseSubProcessor() {
+	}
+
+	/**
+	 * Used by quick assist
+	 * @param context the invocation context
+	 * @param coveringNode the covering node
+	 * @param locations the problems at the corrent location
+	 * @param resultingCollections the resulting proposals
+	 * @return <code>true</code> if the quick assist is applicable at this offset
+	 */
+	public boolean addGetterSetterProposals(IInvocationContextCore context, ASTNode coveringNode, IProblemLocationCore[] locations, ArrayList<T> resultingCollections) {
+		if (locations != null) {
+			for (IProblemLocationCore location : locations) {
+				int problemId= location.getProblemId();
+				if (problemId == IProblem.UnusedPrivateField)
+					return false;
+				if (problemId == IProblem.UnqualifiedFieldAccess)
+					return false;
+			}
+		}
+		return addGetterSetterProposals(context, coveringNode, resultingCollections, IProposalRelevance.GETTER_SETTER_QUICK_ASSIST);
+	}
+
+	public void addGetterSetterProposals(IInvocationContextCore context, IProblemLocationCore location, Collection<T> proposals, int relevance) {
+		addGetterSetterProposals(context, location.getCoveringNode(context.getASTRoot()), proposals, relevance);
+	}
+
+	protected boolean addGetterSetterProposals(IInvocationContextCore context, ASTNode coveringNode, Collection<T> proposals, int relevance) {
+		if (!(coveringNode instanceof SimpleName sn)) {
+			return false;
+		}
+
+		IBinding binding= sn.resolveBinding();
+		if (!(binding instanceof IVariableBinding variableBinding))
+			return false;
+		if (!variableBinding.isField())
+			return false;
+
+		if (proposals == null)
+			return true;
+
+		T proposal= getProposal(context.getCompilationUnit(), sn, variableBinding, relevance);
+		if (proposal != null)
+			proposals.add(proposal);
+		return true;
+	}
+
+	private T getProposal(ICompilationUnit cu, SimpleName sn, IVariableBinding variableBinding, int relevance) {
+		Expression accessNode= sn;
+		Expression qualifier= null;
+		boolean useSuper= false;
+
+		ASTNode parent= sn.getParent();
+		switch (parent.getNodeType()) {
+			case ASTNode.QUALIFIED_NAME:
+				accessNode= (Expression) parent;
+				qualifier= ((QualifiedName) parent).getQualifier();
+				break;
+			case ASTNode.SUPER_FIELD_ACCESS:
+				accessNode= (Expression) parent;
+				qualifier= ((SuperFieldAccess) parent).getQualifier();
+				useSuper= true;
+				break;
+		}
+		ASTRewrite rewrite= ASTRewrite.create(sn.getAST());
+		ProposalParameter gspc= new ProposalParameter(useSuper, cu, rewrite, accessNode, qualifier, variableBinding);
+		if (ASTResolving.isWriteAccess(sn))
+			return createSetterProposal(gspc, relevance);
+		else
+			return createGetterProposal(gspc, relevance);
+	}
+
+	protected abstract T createNonNullMethodGetterProposal(String label, ICompilationUnit compilationUnit, ASTRewrite astRewrite, int relevance);
+
+	protected abstract T createFieldGetterProposal(int relevance, IField field);
+
+	/**
+	 * Proposes a getter for this field.
+	 *
+	 * @param context the proposal parameter
+	 * @param relevance relevance of this proposal
+	 * @return the proposal if available or null
+	 */
+	private T createGetterProposal(ProposalParameter context, int relevance) {
+		IMethodBinding method= findGetter(context);
+		if (method != null) {
+			Expression mi= createMethodInvocation(context, method, null);
+			context.astRewrite.replace(context.accessNode, mi, null);
+
+			String label= Messages.format(CorrectionMessages.GetterSetterCorrectionSubProcessor_replacewithgetter_description, BasicElementLabels.getJavaCodeString(ASTNodes.asString(context.accessNode)));
+			return createNonNullMethodGetterProposal(label, context.compilationUnit, context.astRewrite, relevance);
+		} else {
+			IJavaElement element= context.variableBinding.getJavaElement();
+			if (element instanceof IField field) {
+				try {
+					if (RefactoringAvailabilityTesterCore.isSelfEncapsulateAvailable(field))
+						return createFieldGetterProposal(relevance, field);
+				} catch (JavaModelException e) {
+					JavaManipulationPlugin.log(e);
+				}
+			}
+		}
+		return null;
+	}
+
+	private static IMethodBinding findGetter(ProposalParameter context) {
+		ITypeBinding returnType= context.variableBinding.getType();
+		String getterName= GetterSetterUtil.getGetterName(context.variableBinding, context.compilationUnit.getJavaProject(), null, isBoolean(context));
+		ITypeBinding declaringType= context.variableBinding.getDeclaringClass();
+		if (declaringType == null)
+			return null;
+		IMethodBinding getter= Bindings.findMethodInHierarchy(declaringType, getterName, new ITypeBinding[0]);
+		if (getter != null && getter.getReturnType().isAssignmentCompatible(returnType) && Modifier.isStatic(getter.getModifiers()) == Modifier.isStatic(context.variableBinding.getModifiers()))
+			return getter;
+		return null;
+	}
+
+	private static Expression createMethodInvocation(ProposalParameter context, IMethodBinding method, Expression argument) {
+		AST ast= context.astRewrite.getAST();
+		Expression qualifier= context.qualifier;
+		if (context.useSuper) {
+			SuperMethodInvocation invocation= ast.newSuperMethodInvocation();
+			invocation.setName(ast.newSimpleName(method.getName()));
+			if (qualifier != null)
+				invocation.setQualifier((Name) context.astRewrite.createCopyTarget(qualifier));
+			if (argument != null)
+				invocation.arguments().add(argument);
+			return invocation;
+		} else {
+			MethodInvocation invocation= ast.newMethodInvocation();
+			invocation.setName(ast.newSimpleName(method.getName()));
+			if (qualifier != null)
+				invocation.setExpression((Expression) context.astRewrite.createCopyTarget(qualifier));
+			if (argument != null)
+				invocation.arguments().add(argument);
+			return invocation;
+		}
+	}
+
+	protected abstract T createMethodSetterProposal(String label, ICompilationUnit compilationUnit, ASTRewrite astRewrite, int relevance);
+
+
+	protected abstract T createFieldSetterProposal(int relevance, IField field);
+
+	/**
+	 * Proposes a setter for this field.
+	 *
+	 * @param context the proposal parameter
+	 * @param relevance relevance of this proposal
+	 * @return the proposal if available or null
+	 */
+	private T createSetterProposal(ProposalParameter context, int relevance) {
+		boolean isBoolean= isBoolean(context);
+		String setterName= GetterSetterUtil.getSetterName(context.variableBinding, context.compilationUnit.getJavaProject(), null, isBoolean);
+		ITypeBinding declaringType= context.variableBinding.getDeclaringClass();
+		if (declaringType == null)
+			return null;
+
+		IMethodBinding method= Bindings.findMethodInHierarchy(declaringType, setterName, new ITypeBinding[] { context.variableBinding.getType() });
+		if (method != null && Bindings.isVoidType(method.getReturnType()) && (Modifier.isStatic(method.getModifiers()) == Modifier.isStatic(context.variableBinding.getModifiers()))) {
+			Expression assignedValue= getAssignedValue(context);
+			if (assignedValue == null)
+				return null; //we don't know how to handle those cases.
+			Expression mi= createMethodInvocation(context, method, assignedValue);
+			context.astRewrite.replace(context.accessNode.getParent(), mi, null);
+
+			String label= Messages.format(CorrectionMessages.GetterSetterCorrectionSubProcessor_replacewithsetter_description, BasicElementLabels.getJavaCodeString(ASTNodes.asString(context.accessNode)));
+			T proposal= createMethodSetterProposal(label, context.compilationUnit, context.astRewrite, relevance);
+			return proposal;
+		} else {
+			IJavaElement element= context.variableBinding.getJavaElement();
+			if (element instanceof IField field) {
+				try {
+					if (RefactoringAvailabilityTesterCore.isSelfEncapsulateAvailable(field))
+						return createFieldSetterProposal(relevance, field);
+				} catch (JavaModelException e) {
+					JavaManipulationPlugin.log(e);
+				}
+			}
+		}
+		return null;
+	}
+
+	private static boolean isBoolean(ProposalParameter context) {
+		AST ast= context.astRewrite.getAST();
+		boolean isBoolean= ast.resolveWellKnownType("boolean") == context.variableBinding.getType(); //$NON-NLS-1$
+		if (!isBoolean)
+			isBoolean= ast.resolveWellKnownType("java.lang.Boolean") == context.variableBinding.getType(); //$NON-NLS-1$
+		return isBoolean;
+	}
+
+	private static Expression getAssignedValue(ProposalParameter context) {
+		ASTNode parent= context.accessNode.getParent();
+		ASTRewrite astRewrite= context.astRewrite;
+		IJavaProject javaProject= context.compilationUnit.getJavaProject();
+		IMethodBinding getter= findGetter(context);
+		Expression getterExpression= null;
+		if (getter != null) {
+			getterExpression= astRewrite.getAST().newSimpleName("placeholder"); //$NON-NLS-1$
+		}
+		ITypeBinding type= context.variableBinding.getType();
+		boolean is50OrHigher= JavaModelUtil.is50OrHigher(javaProject);
+		Expression result= GetterSetterUtil.getAssignedValue(parent, astRewrite, getterExpression, type, is50OrHigher);
+		if (result != null && getterExpression != null && getterExpression.getParent() != null) {
+			getterExpression.getParent().setStructuralProperty(getterExpression.getLocationInParent(), createMethodInvocation(context, getter, null));
+		}
+		return result;
+	}
+
+
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/JavadocTagsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/JavadocTagsBaseSubProcessor.java
@@ -83,11 +83,13 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 			}
 			ModuleDeclaration moduleDecl= (ModuleDeclaration) node.getParent();
 			T proposal= addMissingModuleJavadocTagProposal(label, context.getCompilationUnit(), moduleDecl, node, IProposalRelevance.ADD_MISSING_TAG);
-			proposals.add(proposal);
+			if (proposal != null)
+				proposals.add(proposal);
 
 			String label2= CorrectionMessages.JavadocTagsSubProcessor_addjavadoc_allmissing_description;
 			T addAllMissing= addAllMissingModuleJavadocTagsProposal(label2, context.getCompilationUnit(), moduleDecl, node, IProposalRelevance.ADD_ALL_MISSING_TAGS);
-			proposals.add(addAllMissing);
+			if (addAllMissing != null)
+				proposals.add(addAllMissing);
 		} else {
 			parentDeclaration= ASTResolving.findParentBodyDeclaration(node);
 			if (parentDeclaration == null) {
@@ -121,11 +123,13 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 				return;
 			}
 			T proposal= addMissingJavadocTagProposal(label, context.getCompilationUnit(), parentDeclaration, node, IProposalRelevance.ADD_MISSING_TAG);
-			proposals.add(proposal);
+			if (proposal != null)
+				proposals.add(proposal);
 
 			String label2= CorrectionMessages.JavadocTagsSubProcessor_addjavadoc_allmissing_description;
 			T addAllMissing= addAllMissingJavadocTagsProposal(label2, context.getCompilationUnit(), parentDeclaration, IProposalRelevance.ADD_ALL_MISSING_TAGS);
-			proposals.add(addAllMissing);
+			if (addAllMissing != null)
+				proposals.add(addAllMissing);
 		}
 	}
 
@@ -174,7 +178,8 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 			label= CorrectionMessages.JavadocTagsSubProcessor_document_exception_description;
 		}
 		T proposal= addMissingJavadocTagProposal(label, context.getCompilationUnit(), bodyDecl, node, IProposalRelevance.DOCUMENT_UNUSED_ITEM);
-		proposals.add(proposal);
+		if (proposal != null)
+			proposals.add(proposal);
 	}
 
 	public void addMissingJavadocCommentProposals(IInvocationContextCore context, IProblemLocationCore problem, Collection<T> proposals) throws CoreException {
@@ -201,7 +206,9 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 					String.valueOf('\n'));
 			if (comment != null) {
 				String label= CorrectionMessages.JavadocTagsSubProcessor_addjavadoc_method_description;
-				proposals.add(addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_MODULE, declaration.getStartPosition(), comment));
+				T p = addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_MODULE, declaration.getStartPosition(), comment);
+				if (p != null)
+					proposals.add(p);
 			}
 		} else {
 			BodyDeclaration declaration= ASTResolving.findParentBodyDeclaration(node);
@@ -224,7 +231,9 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 				String string= CodeGeneration.getMethodComment(cu, binding.getName(), methodDecl, overridden, String.valueOf('\n'));
 				if (string != null) {
 					String label= CorrectionMessages.JavadocTagsSubProcessor_addjavadoc_method_description;
-					proposals.add(addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_METHOD, declaration.getStartPosition(), string));
+					T p = addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_METHOD, declaration.getStartPosition(), string);
+					if (p != null)
+						proposals.add(p);
 				}
 			} else if (declaration instanceof AbstractTypeDeclaration) {
 				String typeQualifiedName= Bindings.getTypeQualifiedName(binding);
@@ -254,7 +263,9 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 				String string= CodeGeneration.getTypeComment(cu, typeQualifiedName, typeParamNames, params, String.valueOf('\n'));
 				if (string != null) {
 					String label= CorrectionMessages.JavadocTagsSubProcessor_addjavadoc_type_description;
-					proposals.add(addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_TYPE, declaration.getStartPosition(), string));
+					T p = addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_TYPE, declaration.getStartPosition(), string);
+					if (p != null)
+						proposals.add(p);
 				}
 			} else if (declaration instanceof FieldDeclaration) {
 				String comment= "/**\n *\n */\n"; //$NON-NLS-1$
@@ -267,14 +278,18 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 				}
 				if (comment != null) {
 					String label= CorrectionMessages.JavadocTagsSubProcessor_addjavadoc_field_description;
-					proposals.add(addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_FIELD, declaration.getStartPosition(), comment));
+					T p = addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_FIELD, declaration.getStartPosition(), comment);
+					if (p != null)
+						proposals.add(p);
 				}
 			} else if (declaration instanceof EnumConstantDeclaration) {
 				EnumConstantDeclaration enumDecl= (EnumConstantDeclaration) declaration;
 				String id= enumDecl.getName().getIdentifier();
 				String comment= CodeGeneration.getFieldComment(cu, binding.getName(), id, String.valueOf('\n'));
 				String label= CorrectionMessages.JavadocTagsSubProcessor_addjavadoc_enumconst_description;
-				proposals.add(addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_ENUM, declaration.getStartPosition(), comment));
+				T p = addJavadocCommentProposal(label, cu, IProposalRelevance.ADD_JAVADOC_ENUM, declaration.getStartPosition(), comment);
+				if (p != null)
+					proposals.add(p);
 			}
 		}
 	}
@@ -293,7 +308,9 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 		rewrite.remove(node, null);
 
 		String label= CorrectionMessages.JavadocTagsSubProcessor_removetag_description;
-		proposals.add(createRemoveJavadocTagProposals(label, context.getCompilationUnit(), rewrite, IProposalRelevance.REMOVE_TAG));
+		T p = createRemoveJavadocTagProposals(label, context.getCompilationUnit(), rewrite, IProposalRelevance.REMOVE_TAG);
+		if (p != null)
+			proposals.add(p);
 	}
 
 
@@ -322,7 +339,8 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 			String label= Messages.format(CorrectionMessages.JavadocTagsSubProcessor_removeduplicatetag_description, ((TextElement) ((TagElement) node).fragments().get(0)).getText().trim());
 			T proposal= createRemoveDuplicateModuleJavadocTagProposal(label, context.getCompilationUnit(), start, length,
 					"", IProposalRelevance.REMOVE_TAG); //$NON-NLS-1$
-			proposals.add(proposal);
+			if (proposal != null)
+				proposals.add(proposal);
 		}
 	}
 
@@ -371,7 +389,8 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 
 		String label= CorrectionMessages.JavadocTagsSubProcessor_qualifylinktoinner_description;
 		T proposal= createInvalidQualificationProposal(label, context.getCompilationUnit(), rewrite, IProposalRelevance.QUALIFY_INNER_TYPE_NAME);
-		proposals.add(proposal);
+		if (proposal != null)
+			proposals.add(proposal);
 	}
 
 	protected abstract T createInvalidQualificationProposal(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int qualifyInnerTypeName);

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/SerialVersionBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/SerialVersionBaseSubProcessor.java
@@ -44,8 +44,12 @@ public abstract class SerialVersionBaseSubProcessor<T> {
 
 		IProposableFix[] fixes= PotentialProgrammingProblemsFixCore.createMissingSerialVersionFixes(context.getASTRoot(), location);
 		if (fixes != null) {
-			proposals.add(createSerialVersionProposal(fixes[0], IProposalRelevance.MISSING_SERIAL_VERSION_DEFAULT, context, true));
-			proposals.add(createSerialVersionProposal(fixes[1], IProposalRelevance.MISSING_SERIAL_VERSION, context, false));
+			T p1 = createSerialVersionProposal(fixes[0], IProposalRelevance.MISSING_SERIAL_VERSION_DEFAULT, context, true);
+			T p2 = createSerialVersionProposal(fixes[1], IProposalRelevance.MISSING_SERIAL_VERSION, context, false);
+			if (p1 != null)
+				proposals.add(p1);
+			if (p2 != null)
+				proposals.add(p2);
 		}
 	}
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnInitializedFinalFieldBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnInitializedFinalFieldBaseSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -67,11 +67,11 @@ public abstract class UnInitializedFinalFieldBaseSubProcessor<T> {
 			ICompilationUnit targetCU= ASTResolving.findCompilationUnitForBinding(cu, astRoot, targetDecl);
 
 			T p1 = createInitializeFinalFieldProposal(problem, targetCU, node, IProposalRelevance.CREATE_CONSTRUCTOR, InitializeFinalFieldProposalCore.UPDATE_AT_CONSTRUCTOR);
-			if( p1 != null )
+			if (p1 != null)
 				proposals.add(p1);
 
 			T p2= conditionallyCreateInitializeFinalFieldProposal(problem, targetCU, node, IProposalRelevance.CREATE_CONSTRUCTOR, InitializeFinalFieldProposalCore.UPDATE_CONSTRUCTOR_NEW_PARAMETER);
-			if( p2 != null ) {
+			if (p2 != null) {
 				proposals.add(p2);
 			}
 
@@ -89,7 +89,7 @@ public abstract class UnInitializedFinalFieldBaseSubProcessor<T> {
 			ICompilationUnit targetCU= ASTResolving.findCompilationUnitForBinding(cu, astRoot, targetDecl);
 
 			T p3= createInitializeFinalFieldProposal(problem, targetCU, node, targetBinding, IProposalRelevance.CREATE_CONSTRUCTOR);
-			if( p3 != null )
+			if (p3 != null)
 				proposals.add(p3);
 		}
 	}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/VarargsWarningsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/VarargsWarningsBaseSubProcessor.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc - separate core logic from UI images
+ *******************************************************************************/
+
+package org.eclipse.jdt.internal.ui.text.correction;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.MarkerAnnotation;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.internal.corext.util.Messages;
+
+public abstract class VarargsWarningsBaseSubProcessor<T> {
+	public VarargsWarningsBaseSubProcessor() {
+	}
+
+	public void createAddSafeVarargsProposals(IInvocationContextCore context, IProblemLocationCore problem, Collection<T> proposals) {
+		ASTNode coveringNode= problem.getCoveringNode(context.getASTRoot());
+
+		MethodDeclaration methodDeclaration= ASTResolving.findParentMethodDeclaration(coveringNode);
+		if (methodDeclaration == null)
+			return;
+
+		IMethodBinding methodBinding= methodDeclaration.resolveBinding();
+		if (methodBinding == null)
+			return;
+
+		int modifiers= methodBinding.getModifiers();
+		if (!Modifier.isStatic(modifiers) && !Modifier.isFinal(modifiers) && !Modifier.isPrivate(modifiers) && !methodBinding.isConstructor())
+			return;
+
+		String label= CorrectionMessages.VarargsWarningsSubProcessor_add_safevarargs_label;
+		T proposal= createAddSafeVarargsProposal1(label, context.getCompilationUnit(), methodDeclaration, null, IProposalRelevance.ADD_SAFEVARARGS);
+		if (proposal != null)
+			proposals.add(proposal);
+	}
+
+	public void createAddSafeVarargsToDeclarationProposals(IInvocationContextCore context, IProblemLocationCore problem, Collection<T> proposals) {
+		if (!JavaModelUtil.is1d7OrHigher(context.getCompilationUnit().getJavaProject()))
+			return;
+
+		ASTNode coveringNode= problem.getCoveringNode(context.getASTRoot());
+		IMethodBinding methodBinding;
+		if (coveringNode instanceof MethodInvocation) {
+			methodBinding= ((MethodInvocation) coveringNode).resolveMethodBinding();
+		} else if (coveringNode instanceof ClassInstanceCreation) {
+			methodBinding= ((ClassInstanceCreation) coveringNode).resolveConstructorBinding();
+		} else {
+			return;
+		}
+		if (methodBinding == null)
+			return;
+
+		String label= Messages.format(CorrectionMessages.VarargsWarningsSubProcessor_add_safevarargs_to_method_label, methodBinding.getName());
+
+		ITypeBinding declaringType= methodBinding.getDeclaringClass();
+		CompilationUnit astRoot= (CompilationUnit) coveringNode.getRoot();
+		if (declaringType != null && declaringType.isFromSource()) {
+			try {
+				ICompilationUnit targetCu= ASTResolving.findCompilationUnitForBinding(context.getCompilationUnit(), astRoot, declaringType);
+				if (targetCu != null) {
+					T proposal= createAddSafeVarargsToDeclarationProposal1(label, targetCu, null, methodBinding.getMethodDeclaration(), IProposalRelevance.ADD_SAFEVARARGS);
+					if (proposal != null)
+						proposals.add(proposal);
+				}
+			} catch (JavaModelException e) {
+				return;
+			}
+		}
+	}
+
+	public void createRemoveSafeVarargsProposals(IInvocationContextCore context, IProblemLocationCore problem, Collection<T> proposals) {
+		ASTNode coveringNode= problem.getCoveringNode(context.getASTRoot());
+		if (!(coveringNode instanceof MethodDeclaration methodDeclaration))
+			return;
+
+		MarkerAnnotation annotation= null;
+
+		for (ASTNode node : (List<? extends ASTNode>) methodDeclaration.modifiers()) {
+			if (node instanceof MarkerAnnotation) {
+				annotation= (MarkerAnnotation) node;
+				if ("SafeVarargs".equals(annotation.resolveAnnotationBinding().getName())) { //$NON-NLS-1$
+					break;
+				}
+			}
+		}
+
+		if (annotation == null)
+			return;
+
+		ASTRewrite rewrite= ASTRewrite.create(coveringNode.getAST());
+		rewrite.remove(annotation, null);
+
+		String label= CorrectionMessages.VarargsWarningsSubProcessor_remove_safevarargs_label;
+		T proposal= createRemoveSafeVarargsProposal1(label, context.getCompilationUnit(), rewrite, IProposalRelevance.REMOVE_SAFEVARARGS);
+		if (proposal != null)
+			proposals.add(proposal);
+	}
+
+	protected abstract T createAddSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, MethodDeclaration methodDeclaration, Object object, int addSafevarargs);
+	protected abstract T createAddSafeVarargsToDeclarationProposal1(String label, ICompilationUnit targetCu, Object object, IMethodBinding methodDeclaration, int addSafevarargs);
+	protected abstract T createRemoveSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int removeSafevarargs);
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionSubProcessor.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 
 import org.eclipse.core.resources.IFile;
 
@@ -31,43 +30,17 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
-import org.eclipse.ltk.core.refactoring.Change;
-import org.eclipse.ltk.core.refactoring.CompositeChange;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.TextFileChange;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.compiler.IProblem;
-import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.Expression;
-import org.eclipse.jdt.core.dom.IBinding;
-import org.eclipse.jdt.core.dom.IMethodBinding;
-import org.eclipse.jdt.core.dom.ITypeBinding;
-import org.eclipse.jdt.core.dom.IVariableBinding;
-import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.Modifier;
-import org.eclipse.jdt.core.dom.Name;
-import org.eclipse.jdt.core.dom.QualifiedName;
-import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.SuperFieldAccess;
-import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
-import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
-import org.eclipse.jdt.internal.corext.codemanipulation.GetterSetterUtil;
-import org.eclipse.jdt.internal.corext.dom.ASTNodes;
-import org.eclipse.jdt.internal.corext.dom.Bindings;
-import org.eclipse.jdt.internal.corext.refactoring.RefactoringAvailabilityTester;
 import org.eclipse.jdt.internal.corext.refactoring.sef.SelfEncapsulateFieldRefactoring;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
-import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposal;
@@ -82,27 +55,9 @@ import org.eclipse.jdt.internal.ui.refactoring.sef.SelfEncapsulateFieldWizard;
 import org.eclipse.jdt.internal.ui.util.ExceptionHandler;
 
 
-public class GetterSetterCorrectionSubProcessor {
+public class GetterSetterCorrectionSubProcessor extends GetterSetterCorrectionBaseSubProcessor<ICommandAccess> {
 
-	public static final String SELF_ENCAPSULATE_FIELD_ID= "org.eclipse.jdt.ui.correction.encapsulateField.assist"; //$NON-NLS-1$
-
-	private static class ProposalParameter {
-		public final boolean useSuper;
-		public final ICompilationUnit compilationUnit;
-		public final ASTRewrite astRewrite;
-		public final Expression accessNode;
-		public final Expression qualifier;
-		public final IVariableBinding variableBinding;
-
-		public ProposalParameter(boolean useSuper, ICompilationUnit compilationUnit, ASTRewrite rewrite, Expression accessNode, Expression qualifier, IVariableBinding variableBinding) {
-			this.useSuper= useSuper;
-			this.compilationUnit= compilationUnit;
-			this.astRewrite= rewrite;
-			this.accessNode= accessNode;
-			this.qualifier= qualifier;
-			this.variableBinding= variableBinding;
-		}
-	}
+	public static final String SELF_ENCAPSULATE_FIELD_ID= GetterSetterCorrectionBaseSubProcessor.SELF_ENCAPSULATE_FIELD_COMMAND_ID;
 
 	public static class SelfEncapsulateFieldProposal extends ChangeCorrectionProposal { // public for tests
 
@@ -110,7 +65,7 @@ public class GetterSetterCorrectionSubProcessor {
 		private boolean fNoDialog;
 
 		public SelfEncapsulateFieldProposal(int relevance, IField field) {
-			super(getDescription(field), null, relevance, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE));
+			super(SelfEncapsulateFieldProposalCore.getDescription(field), null, relevance, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE));
 			fField= field;
 			fNoDialog= false;
 			setCommandId(SELF_ENCAPSULATE_FIELD_ID);
@@ -124,26 +79,9 @@ public class GetterSetterCorrectionSubProcessor {
 			fNoDialog= noDialog;
 		}
 
+		// I can't find any caller for this but it is public and cannot be removed?
 		public TextFileChange getChange(IFile file) throws CoreException {
-			final SelfEncapsulateFieldRefactoring refactoring= new SelfEncapsulateFieldRefactoring(fField);
-			refactoring.setVisibility(Flags.AccPublic);
-			refactoring.setConsiderVisibility(false);//private field references are just searched in local file
-			refactoring.checkInitialConditions(new NullProgressMonitor());
-			refactoring.checkFinalConditions(new NullProgressMonitor());
-			Change createdChange= refactoring.createChange(new NullProgressMonitor());
-			if (createdChange instanceof CompositeChange) {
-				for (Change curr : ((CompositeChange) createdChange).getChildren()) {
-					if (curr instanceof TextFileChange && ((TextFileChange) curr).getFile().equals(file)) {
-						return (TextFileChange) curr;
-					}
-				}
-			}
-			return null;
-		}
-
-
-		private static String getDescription(IField field) {
-			return Messages.format(CorrectionMessages.GetterSetterCorrectionSubProcessor_creategetterunsingencapsulatefield_description, BasicElementLabels.getJavaElementName(field.getElementName()));
+			return SelfEncapsulateFieldProposalCore.getChange(fField, file);
 		}
 
 		/*
@@ -197,203 +135,39 @@ public class GetterSetterCorrectionSubProcessor {
 	 * @return <code>true</code> if the quick assist is applicable at this offset
 	 */
 	public static boolean addGetterSetterProposal(IInvocationContextCore context, ASTNode coveringNode, IProblemLocationCore[] locations, ArrayList<ICommandAccess> resultingCollections) {
-		if (locations != null) {
-			for (IProblemLocationCore location : locations) {
-				int problemId= location.getProblemId();
-				if (problemId == IProblem.UnusedPrivateField)
-					return false;
-				if (problemId == IProblem.UnqualifiedFieldAccess)
-					return false;
-			}
-		}
-		return addGetterSetterProposal(context, coveringNode, resultingCollections, IProposalRelevance.GETTER_SETTER_QUICK_ASSIST);
+		return new GetterSetterCorrectionSubProcessor().addGetterSetterProposals(context, coveringNode, locations, resultingCollections);
 	}
 
 	public static void addGetterSetterProposal(IInvocationContextCore context, IProblemLocationCore location, Collection<ICommandAccess> proposals, int relevance) {
-		addGetterSetterProposal(context, location.getCoveringNode(context.getASTRoot()), proposals, relevance);
-	}
-
-	private static boolean addGetterSetterProposal(IInvocationContextCore context, ASTNode coveringNode, Collection<ICommandAccess> proposals, int relevance) {
-		if (!(coveringNode instanceof SimpleName)) {
-			return false;
-		}
-		SimpleName sn= (SimpleName) coveringNode;
-
-		IBinding binding= sn.resolveBinding();
-		if (!(binding instanceof IVariableBinding))
-			return false;
-		IVariableBinding variableBinding= (IVariableBinding) binding;
-		if (!variableBinding.isField())
-			return false;
-
-		if (proposals == null)
-			return true;
-
-		ChangeCorrectionProposal proposal= getProposal(context.getCompilationUnit(), sn, variableBinding, relevance);
-		if (proposal != null)
-			proposals.add(proposal);
-		return true;
-	}
-
-	private static ChangeCorrectionProposal getProposal(ICompilationUnit cu, SimpleName sn, IVariableBinding variableBinding, int relevance) {
-		Expression accessNode= sn;
-		Expression qualifier= null;
-		boolean useSuper= false;
-
-		ASTNode parent= sn.getParent();
-		switch (parent.getNodeType()) {
-			case ASTNode.QUALIFIED_NAME:
-				accessNode= (Expression) parent;
-				qualifier= ((QualifiedName) parent).getQualifier();
-				break;
-			case ASTNode.SUPER_FIELD_ACCESS:
-				accessNode= (Expression) parent;
-				qualifier= ((SuperFieldAccess) parent).getQualifier();
-				useSuper= true;
-				break;
-		}
-		ASTRewrite rewrite= ASTRewrite.create(sn.getAST());
-		ProposalParameter gspc= new ProposalParameter(useSuper, cu, rewrite, accessNode, qualifier, variableBinding);
-		if (ASTResolving.isWriteAccess(sn))
-			return addSetterProposal(gspc, relevance);
-		else
-			return addGetterProposal(gspc, relevance);
-	}
-
-	/**
-	 * Proposes a getter for this field.
-	 *
-	 * @param context the proposal parameter
-	 * @param relevance relevance of this proposal
-	 * @return the proposal if available or null
-	 */
-	private static ChangeCorrectionProposal addGetterProposal(ProposalParameter context, int relevance) {
-		IMethodBinding method= findGetter(context);
-		if (method != null) {
-			Expression mi= createMethodInvocation(context, method, null);
-			context.astRewrite.replace(context.accessNode, mi, null);
-
-			String label= Messages.format(CorrectionMessages.GetterSetterCorrectionSubProcessor_replacewithgetter_description, BasicElementLabels.getJavaCodeString(ASTNodes.asString(context.accessNode)));
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-			ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, context.compilationUnit, context.astRewrite, relevance, image);
-			return proposal;
-		} else {
-			IJavaElement element= context.variableBinding.getJavaElement();
-			if (element instanceof IField) {
-				IField field= (IField) element;
-				try {
-					if (RefactoringAvailabilityTester.isSelfEncapsulateAvailable(field))
-						return new SelfEncapsulateFieldProposal(relevance, field);
-				} catch (JavaModelException e) {
-					JavaPlugin.log(e);
-				}
-			}
-		}
-		return null;
-	}
-
-	private static IMethodBinding findGetter(ProposalParameter context) {
-		ITypeBinding returnType= context.variableBinding.getType();
-		String getterName= GetterSetterUtil.getGetterName(context.variableBinding, context.compilationUnit.getJavaProject(), null, isBoolean(context));
-		ITypeBinding declaringType= context.variableBinding.getDeclaringClass();
-		if (declaringType == null)
-			return null;
-		IMethodBinding getter= Bindings.findMethodInHierarchy(declaringType, getterName, new ITypeBinding[0]);
-		if (getter != null && getter.getReturnType().isAssignmentCompatible(returnType) && Modifier.isStatic(getter.getModifiers()) == Modifier.isStatic(context.variableBinding.getModifiers()))
-			return getter;
-		return null;
-	}
-
-	private static Expression createMethodInvocation(ProposalParameter context, IMethodBinding method, Expression argument) {
-		AST ast= context.astRewrite.getAST();
-		Expression qualifier= context.qualifier;
-		if (context.useSuper) {
-			SuperMethodInvocation invocation= ast.newSuperMethodInvocation();
-			invocation.setName(ast.newSimpleName(method.getName()));
-			if (qualifier != null)
-				invocation.setQualifier((Name) context.astRewrite.createCopyTarget(qualifier));
-			if (argument != null)
-				invocation.arguments().add(argument);
-			return invocation;
-		} else {
-			MethodInvocation invocation= ast.newMethodInvocation();
-			invocation.setName(ast.newSimpleName(method.getName()));
-			if (qualifier != null)
-				invocation.setExpression((Expression) context.astRewrite.createCopyTarget(qualifier));
-			if (argument != null)
-				invocation.arguments().add(argument);
-			return invocation;
-		}
-	}
-
-	/**
-	 * Proposes a setter for this field.
-	 *
-	 * @param context the proposal parameter
-	 * @param relevance relevance of this proposal
-	 * @return the proposal if available or null
-	 */
-	private static ChangeCorrectionProposal addSetterProposal(ProposalParameter context, int relevance) {
-		boolean isBoolean= isBoolean(context);
-		String setterName= GetterSetterUtil.getSetterName(context.variableBinding, context.compilationUnit.getJavaProject(), null, isBoolean);
-		ITypeBinding declaringType= context.variableBinding.getDeclaringClass();
-		if (declaringType == null)
-			return null;
-
-		IMethodBinding method= Bindings.findMethodInHierarchy(declaringType, setterName, new ITypeBinding[] { context.variableBinding.getType() });
-		if (method != null && Bindings.isVoidType(method.getReturnType()) && (Modifier.isStatic(method.getModifiers()) == Modifier.isStatic(context.variableBinding.getModifiers()))) {
-			Expression assignedValue= getAssignedValue(context);
-			if (assignedValue == null)
-				return null; //we don't know how to handle those cases.
-			Expression mi= createMethodInvocation(context, method, assignedValue);
-			context.astRewrite.replace(context.accessNode.getParent(), mi, null);
-
-			String label= Messages.format(CorrectionMessages.GetterSetterCorrectionSubProcessor_replacewithsetter_description, BasicElementLabels.getJavaCodeString(ASTNodes.asString(context.accessNode)));
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-			ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, context.compilationUnit, context.astRewrite, relevance, image);
-			return proposal;
-		} else {
-			IJavaElement element= context.variableBinding.getJavaElement();
-			if (element instanceof IField) {
-				IField field= (IField) element;
-				try {
-					if (RefactoringAvailabilityTester.isSelfEncapsulateAvailable(field))
-						return new SelfEncapsulateFieldProposal(relevance, field);
-				} catch (JavaModelException e) {
-					JavaPlugin.log(e);
-				}
-			}
-		}
-		return null;
-	}
-
-	private static boolean isBoolean(ProposalParameter context) {
-		AST ast= context.astRewrite.getAST();
-		boolean isBoolean= ast.resolveWellKnownType("boolean") == context.variableBinding.getType(); //$NON-NLS-1$
-		if (!isBoolean)
-			isBoolean= ast.resolveWellKnownType("java.lang.Boolean") == context.variableBinding.getType(); //$NON-NLS-1$
-		return isBoolean;
-	}
-
-	private static Expression getAssignedValue(ProposalParameter context) {
-		ASTNode parent= context.accessNode.getParent();
-		ASTRewrite astRewrite= context.astRewrite;
-		IJavaProject javaProject= context.compilationUnit.getJavaProject();
-		IMethodBinding getter= findGetter(context);
-		Expression getterExpression= null;
-		if (getter != null) {
-			getterExpression= astRewrite.getAST().newSimpleName("placeholder"); //$NON-NLS-1$
-		}
-		ITypeBinding type= context.variableBinding.getType();
-		boolean is50OrHigher= JavaModelUtil.is50OrHigher(javaProject);
-		Expression result= GetterSetterUtil.getAssignedValue(parent, astRewrite, getterExpression, type, is50OrHigher);
-		if (result != null && getterExpression != null && getterExpression.getParent() != null) {
-			getterExpression.getParent().setStructuralProperty(getterExpression.getLocationInParent(), createMethodInvocation(context, getter, null));
-		}
-		return result;
+		new GetterSetterCorrectionSubProcessor().addGetterSetterProposals(context, location, proposals, relevance);
 	}
 
 	private GetterSetterCorrectionSubProcessor() {
+		super();
+	}
+
+	@Override
+	protected ICommandAccess createNonNullMethodGetterProposal(String label, ICompilationUnit compilationUnit, ASTRewrite astRewrite, int relevance) {
+		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
+		ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, compilationUnit, astRewrite, relevance, image);
+		return proposal;
+	}
+
+	@Override
+	protected ICommandAccess createFieldGetterProposal(int relevance, IField field) {
+		return new SelfEncapsulateFieldProposal(relevance, field);
+	}
+
+	@Override
+	protected ICommandAccess createMethodSetterProposal(String label, ICompilationUnit compilationUnit, ASTRewrite astRewrite, int relevance) {
+		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
+		ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, compilationUnit, astRewrite, relevance, image);
+		return proposal;
+	}
+
+	@Override
+	protected ICommandAccess createFieldSetterProposal(int relevance, IField field) {
+		return new SelfEncapsulateFieldProposal(relevance, field);
 	}
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Separate core and ui for GetterSetterCorrectionSubProcessor and VarargsWarningsSubProcessor. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Any UI entrypoint that would access the various code completions and quick fixes should be able to trigger this code. 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
