### PR TITLE
Don't set preference key of other bundle on shutdown

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
@@ -539,8 +539,6 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 			// must add here to guarantee that it is the first in the listener list
 
 			OpenTypeHistory.shutdown();
-
-			JavaManipulation.setPreferenceNodeId(null);
 		} finally {
 			super.stop(context);
 		}


### PR DESCRIPTION
The other bundle might not be shutdown yet and would still want that key.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1093
