### PR TITLE
Fix SourceViewerInformationControl not updating String input. Fixes #1125

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/SourceViewerInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/SourceViewerInformationControl.java
@@ -376,6 +376,7 @@ public class SourceViewerInformationControl
 	@Override
 	public void setInput(Object input) {
 		String content= null;
+		boolean doSetInformation= true;
 		if (input instanceof String) {
 			content= (String) input;
 		} else if (input instanceof JavaSourceInformationInput) {
@@ -388,13 +389,14 @@ public class SourceViewerInformationControl
 					fSemanticHighlightingManager.getReconciler().refresh(); // triggers semantic coloring job
 				} else {
 					setContentFrom(fSemanticHighlightingViewer);
+					doSetInformation= false;
 				}
 			}
 		}
 
-		if (fViewer.getDocument() == null) {
+		if (doSetInformation) {
 			setInformation(content);
-		} // else document already set to content of fSemanticHighlightingViewer
+		}
 
 		if (fShell != null && !fShell.isDisposed()) {
 			Display display= fShell.getDisplay();


### PR DESCRIPTION
## What it does
Fixes SourceViewerInformationControl not setting new String input content over existing one, causing e.g. code completion proposal preview not being updated with different content if user choses other proposal.

## How to test

> In any Java file, type for and hit Ctrl+Space to get template proposals.
The list with multiple "for" templates is shown (and also some classes starting with "for"), but selecting any of the template proposals doesn't update proposal preview on the right side.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
