### PR TITLE
Fix exception in use comparator cleanup

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2005,6 +2005,8 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "import java.util.List;\n" //
 				+ "import java.util.Locale;\n" //
 				+ "import java.util.TreeSet;\n" //
+				+ "import java.util.Map.Entry;\n" //
+				+ "import java.util.stream.Stream;\n" //
 				+ "\n" //
 				+ "public class E {\n" //
 				+ "    private Comparator<Date> refactorField = new Comparator<Date>() {\n" //
@@ -2406,6 +2408,10 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "        return listToSort;\n" //
 				+ "    }\n" //
 				+ "\n" //
+				+ "    void wildcardMethod() {\n" //
+				+ "        Stream.<Entry<String, String>>of().sorted((entry1, entry2) -> entry1.getKey().compareTo(entry2.getKey()));\n"//
+				+ "    }\n" //
+				+ "\n" //
 				+ "    public class FooBar {\n" //
 				+ "        public String value;\n" //
 				+ "    }\n" //
@@ -2424,6 +2430,8 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "import java.util.List;\n" //
 				+ "import java.util.Locale;\n" //
 				+ "import java.util.TreeSet;\n" //
+				+ "import java.util.Map.Entry;\n" //
+				+ "import java.util.stream.Stream;\n" //
 				+ "\n" //
 				+ "public class E {\n" //
 				+ "    private Comparator<Date> refactorField = Comparator.comparing(Date::toString);\n" //
@@ -2616,6 +2624,10 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				+ "        Collections.sort(listToSort, comparator);\n" //
 				+ "\n" //
 				+ "        return listToSort;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    void wildcardMethod() {\n" //
+				+ "        Stream.<Entry<String, String>>of().sorted(Comparator.comparing(Entry<String, String>::getKey));\n" //
 				+ "    }\n" //
 				+ "\n" //
 				+ "    public class FooBar {\n" //

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -550,10 +550,15 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 		}
 
 		private TypeMethodReference buildMethod(final ITypeBinding type, final MethodInvocation method, final ASTRewrite rewrite, final AST ast, final ImportRewrite importRewrite) {
-			String comparedClassNameText= importRewrite.addImport((type.getBound() != null && !type.isUpperbound()) ? type.getBound() : type.getErasure());
-
 			TypeMethodReference typeMethodRef= ast.newTypeMethodReference();
-			typeMethodRef.setType(ast.newSimpleType(ASTNodeFactory.newName(ast, comparedClassNameText)));
+			if (type.isWildcardType()) {
+				ITypeBinding bound= type.getBound();
+				Type boundType= importRewrite.addImport(bound, ast, importRewrite.getDefaultImportRewriteContext(), TypeLocation.TYPE_BOUND);
+				typeMethodRef.setType(boundType);
+			} else {
+				String comparedClassNameText= importRewrite.addImport(type.getErasure());
+				typeMethodRef.setType(ast.newSimpleType(ASTNodeFactory.newName(ast, comparedClassNameText)));
+			}
 			typeMethodRef.setName(ASTNodes.createMoveTarget(rewrite, method.getName()));
 			return typeMethodRef;
 		}


### PR DESCRIPTION
- fixes #915
- add wildcard support to ComparingOnCriteriaOperation.buildMethod() similar to what was added to buildField()
- add to existing test case in CleanUpTest1d8 for comparator cleanup

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes comparator cleanup when involving a wildcard type and creating a method reference.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new test scenario added.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
