### PR TITLE
Cleanup in all -BaseSubProcessor classes and extenders

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/JavadocTagsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/JavadocTagsBaseSubProcessor.java
@@ -65,6 +65,13 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 	}
 	public void addMissingJavadocTagProposals(IInvocationContextCore context, IProblemLocationCore problem, Collection<T> proposals) {
 		ASTNode node= problem.getCoveringNode(context.getASTRoot());
+		addMissingJavadocTagProposals(context, node, proposals);
+	}
+
+	/*
+	 * This entry point is requested by jdt.ls
+	 */
+	public void addMissingJavadocTagProposals(IInvocationContextCore context, ASTNode node, Collection<T> proposals) {
 		ASTNode parentDeclaration= null;
 		if (node == null) {
 			return;
@@ -132,14 +139,6 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 				proposals.add(addAllMissing);
 		}
 	}
-
-	protected abstract T addAllMissingJavadocTagsProposal(String label2, ICompilationUnit compilationUnit, ASTNode parentDeclaration, int addAllMissingTags);
-
-	protected abstract T addMissingJavadocTagProposal(String label, ICompilationUnit compilationUnit, ASTNode parentDeclaration, ASTNode node, int addMissingTag);
-
-	protected abstract T addAllMissingModuleJavadocTagsProposal(String label2, ICompilationUnit compilationUnit, ModuleDeclaration moduleDecl, ASTNode node, int addAllMissingTags);
-
-	protected abstract T addMissingModuleJavadocTagProposal(String label, ICompilationUnit compilationUnit, ModuleDeclaration moduleDecl, ASTNode node, int addMissingTag);
 
 	public void addUnusedAndUndocumentedParameterOrExceptionProposals(IInvocationContextCore context, IProblemLocationCore problem, Collection<T> proposals) {
 		ICompilationUnit cu= context.getCompilationUnit();
@@ -393,6 +392,10 @@ public abstract class JavadocTagsBaseSubProcessor<T> {
 			proposals.add(proposal);
 	}
 
-	protected abstract T createInvalidQualificationProposal(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int qualifyInnerTypeName);
+	protected abstract T addAllMissingJavadocTagsProposal(String label, ICompilationUnit compilationUnit, ASTNode parentDeclaration, int relevance);
+	protected abstract T addMissingJavadocTagProposal(String label, ICompilationUnit compilationUnit, ASTNode parentDeclaration, ASTNode node, int relevance);
+	protected abstract T addAllMissingModuleJavadocTagsProposal(String label, ICompilationUnit compilationUnit, ModuleDeclaration moduleDecl, ASTNode node, int relevance);
+	protected abstract T addMissingModuleJavadocTagProposal(String label, ICompilationUnit compilationUnit, ModuleDeclaration moduleDecl, ASTNode node, int relevance);
+	protected abstract T createInvalidQualificationProposal(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int relevance);
 
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ReorgCorrectionsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ReorgCorrectionsBaseSubProcessor.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.IStatus;
 
 import org.eclipse.core.resources.IProject;
 
+import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
@@ -302,27 +303,27 @@ public abstract class ReorgCorrectionsBaseSubProcessor<T> {
 		return false;
 	}
 
-	public abstract T createRenameCUProposal(String label, RenameCompilationUnitChange change, int renameCu);
+	public abstract T createRenameCUProposal(String label, RenameCompilationUnitChange change, int relevance);
 
-	public abstract T createCorrectMainTypeNameProposal(ICompilationUnit cu, IInvocationContextCore context, String currTypeName, String newTypeName, int renameType);
+	public abstract T createCorrectMainTypeNameProposal(ICompilationUnit cu, IInvocationContextCore context, String currTypeName, String newTypeName, int relevance);
 
 	protected abstract T createCorrectPackageDeclarationProposal(ICompilationUnit cu, IProblemLocationCore problem, int relevance);
 
-	protected abstract T createMoveToNewPackageProposal(String label, CompositeChange composite, int moveCuToPackage);
+	protected abstract T createMoveToNewPackageProposal(String label, CompositeChange composite, int relevance);
 
-	protected abstract T createOrganizeImportsProposal(String name, Object object, ICompilationUnit cu, int organizeImports);
+	protected abstract T createOrganizeImportsProposal(String name, Change change, ICompilationUnit cu, int relevance);
 
-	protected abstract T createRemoveUnusedImportProposal(IProposableFix fix, UnusedCodeCleanUp unusedCodeCleanUp, int removeUnusedImport, IInvocationContextCore context);
+	protected abstract T createRemoveUnusedImportProposal(IProposableFix fix, UnusedCodeCleanUp unusedCodeCleanUp, int relevance, IInvocationContextCore context);
 
 	public abstract T createProjectSetupFixProposal(IInvocationContextCore context, IProblemLocationCore problem, String missingType, Collection<T> proposals);
 
 	/* answers false if the problem location is not an import declaration, and hence no proposal have been added. */
 	public abstract boolean addImportNotFoundProposals(IInvocationContextCore context, IProblemLocationCore problem, Collection<T> proposals) throws CoreException;
 
-	protected abstract T createChangeToRequiredCompilerComplianceProposal(String label1, IJavaProject project, boolean b, String requiredVersion, int changeProjectCompliance);
+	protected abstract T createChangeToRequiredCompilerComplianceProposal(String label1, IJavaProject project, boolean changeOnWorkspace, String requiredVersion, int relevance);
 
-	protected abstract T createChangeToRequiredCompilerComplianceProposal(String label2, IJavaProject project, boolean b, String requiredVersion, boolean enablePreviews,
-			int changeWorkspaceCompliance);
+	protected abstract T createChangeToRequiredCompilerComplianceProposal(String label2, IJavaProject project, boolean changeOnWorkspace, String requiredVersion, boolean enablePreviews,
+			int relevance);
 
 	protected abstract T createOpenBuildPathCorrectionProposal(IProject project, String label, int relevance, IBinding referencedElement);
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ReturnTypeBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ReturnTypeBaseSubProcessor.java
@@ -412,8 +412,8 @@ public abstract class ReturnTypeBaseSubProcessor<T> {
 	}
 
 	protected abstract TypeMismatchBaseSubProcessor<T> getTypeMismatchSubProcessor();
-	protected abstract T linkedCorrectionProposal1ToT(LinkedCorrectionProposalCore proposal, int uid);
-	protected abstract T rewriteCorrectionProposalToT(ASTRewriteCorrectionProposalCore p, int uid);
+	protected abstract T linkedCorrectionProposal1ToT(LinkedCorrectionProposalCore core, int uid);
+	protected abstract T rewriteCorrectionProposalToT(ASTRewriteCorrectionProposalCore core, int uid);
 	protected abstract T replaceCorrectionProposalToT(ReplaceCorrectionProposalCore core, int uid);
 	protected abstract T missingReturnTypeProposalToT(MissingReturnTypeCorrectionProposalCore core, int uid);
 	protected abstract T missingReturnTypeInLambdaProposalToT(MissingReturnTypeInLambdaCorrectionProposalCore core, int uid);

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/SerialVersionBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/SerialVersionBaseSubProcessor.java
@@ -53,6 +53,6 @@ public abstract class SerialVersionBaseSubProcessor<T> {
 		}
 	}
 
-	protected abstract T createSerialVersionProposal(IProposableFix iProposableFix, int missingSerialVersion, IInvocationContextCore context, boolean b);
+	protected abstract T createSerialVersionProposal(IProposableFix iProposableFix, int relevance, IInvocationContextCore context, boolean isDefault);
 
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchBaseSubProcessor.java
@@ -528,11 +528,11 @@ public abstract class TypeMismatchBaseSubProcessor<T> {
 			proposals.add(p2);
 	}
 
-	protected abstract T createInsertNullCheckProposal(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int insertNullCheck);
+	protected abstract T createInsertNullCheckProposal(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int relevance);
 
-	protected abstract T createChangeReturnTypeProposal(String label, ICompilationUnit cu, ASTRewrite rewrite, int changeMethodReturnType, ITypeBinding currBinding, AST ast, CompilationUnit astRoot, MethodDeclaration methodDeclaration, BodyDeclaration decl);
+	protected abstract T createChangeReturnTypeProposal(String label, ICompilationUnit cu, ASTRewrite rewrite, int relevance, ITypeBinding currBinding, AST ast, CompilationUnit astRoot, MethodDeclaration methodDeclaration, BodyDeclaration decl);
 
-	protected abstract T createOptionalProposal(String label0, ICompilationUnit cu, Expression nodeToCast, int relevance, int optionalType);
+	protected abstract T createOptionalProposal(String label, ICompilationUnit cu, Expression nodeToCast, int relevance, int optionalType);
 
 	protected abstract T createImplementInterfaceProposal(ICompilationUnit nodeCu, ITypeBinding typeDecl, CompilationUnit astRoot, ITypeBinding castTypeBinding, int relevance);
 
@@ -541,16 +541,16 @@ public abstract class TypeMismatchBaseSubProcessor<T> {
 
 	protected abstract T createCastCorrectionProposal(String label, ICompilationUnit cu, Expression nodeToCast, ITypeBinding castTypeBinding, int relevance);
 
-	protected abstract T createChangeReturnTypeOfOverridden(ICompilationUnit targetCu, IMethodBinding overriddenDecl, CompilationUnit astRoot, ITypeBinding returnType, boolean b,
-			int changeReturnTypeOfOverridden, ITypeBinding overridenDeclType);
+	protected abstract T createChangeReturnTypeOfOverridden(ICompilationUnit targetCu, IMethodBinding overriddenDecl, CompilationUnit astRoot, ITypeBinding returnType, boolean offerSuperTypeProposals,
+			int relevance, ITypeBinding overridenDeclType);
 
-	protected abstract T createChangeIncompatibleReturnTypeProposal(ICompilationUnit cu, IMethodBinding methodDecl, CompilationUnit astRoot, ITypeBinding overriddenReturnType, boolean b,
-			int changeReturnType);
+	protected abstract T createChangeIncompatibleReturnTypeProposal(ICompilationUnit cu, IMethodBinding methodDecl, CompilationUnit astRoot, ITypeBinding overriddenReturnType, boolean offerSuperTypeProposals,
+			int relevance);
 
-	protected abstract T createChangeMethodSignatureProposal(String label, ICompilationUnit cu, CompilationUnit astRoot, IMethodBinding methodDeclBinding, Object object, ChangeDescription[] changes,
-			int removeExceptions);
+	protected abstract T createChangeMethodSignatureProposal(String label, ICompilationUnit cu, CompilationUnit astRoot, IMethodBinding methodDeclBinding, ChangeDescription[] paramChanges,
+			ChangeDescription[] changes, int relevance);
 
-	protected abstract T createNewVariableCorrectionProposal(String label, ICompilationUnit cu, int local, SimpleName simpleName, Object object, int relevance);
+	protected abstract T createNewVariableCorrectionProposal(String label, ICompilationUnit cu, int local, SimpleName simpleName, ITypeBinding senderBinding, int relevance);
 
 	protected abstract T createIncompatibleForEachTypeProposal(String label, ICompilationUnit cu, ASTRewrite rewrite, int incompatibleForeachType, CompilationUnit astRoot, AST ast, ITypeBinding expectedBinding, ASTNode selectedNode, SingleVariableDeclaration parameter);
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnInitializedFinalFieldBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnInitializedFinalFieldBaseSubProcessor.java
@@ -94,7 +94,7 @@ public abstract class UnInitializedFinalFieldBaseSubProcessor<T> {
 		}
 	}
 
-	protected abstract T createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, SimpleName node, IVariableBinding targetBinding, int createConstructor);
-	protected abstract T createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int createConstructor, int updateAtConstructor);
-	protected abstract T conditionallyCreateInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int createConstructor, int updateAtConstructor);
+	protected abstract T createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, SimpleName node, IVariableBinding targetBinding, int relevance);
+	protected abstract T createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int relevance, int updateType);
+	protected abstract T conditionallyCreateInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int relevance, int updateType);
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
@@ -2375,17 +2375,17 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 	protected abstract T renameNodeCorrectionProposalToT(RenameNodeCorrectionProposalCore core, int uid);
 	protected abstract T compositeProposalToT(ChangeCorrectionProposalCore compositeProposal, int uid);
 	protected abstract int getQualifiedTypeNameHistoryBoost(String qualifiedName, int min, int max);
-	protected abstract T linkedProposalToT(LinkedCorrectionProposalCore proposal, int uid);
-	protected abstract T changeCorrectionProposalToT(ChangeCorrectionProposalCore proposal, int uid);
-	protected abstract T qualifyTypeProposalToT(QualifyTypeProposalCore proposal, int uid);
-	protected abstract T addTypeParametersToT(AddTypeParameterProposalCore proposal, int uid);
-	protected abstract T addModuleRequiresProposalToT(AddModuleRequiresCorrectionProposalCore proposal, int uid);
-	protected abstract T replaceCorrectionProposalToT(ReplaceCorrectionProposalCore proposal, int uid);
-	protected abstract T castCorrectionProposalToT(CastCorrectionProposalCore c, int uid);
-	protected abstract T addArgumentCorrectionProposalToT(AddArgumentCorrectionProposalCore proposal, int uid);
-	protected abstract T changeMethodSignatureProposalToT(ChangeMethodSignatureProposalCore proposal, int uid);
+	protected abstract T linkedProposalToT(LinkedCorrectionProposalCore core, int uid);
+	protected abstract T changeCorrectionProposalToT(ChangeCorrectionProposalCore core, int uid);
+	protected abstract T qualifyTypeProposalToT(QualifyTypeProposalCore core, int uid);
+	protected abstract T addTypeParametersToT(AddTypeParameterProposalCore core, int uid);
+	protected abstract T addModuleRequiresProposalToT(AddModuleRequiresCorrectionProposalCore core, int uid);
+	protected abstract T replaceCorrectionProposalToT(ReplaceCorrectionProposalCore core, int uid);
+	protected abstract T castCorrectionProposalToT(CastCorrectionProposalCore core, int uid);
+	protected abstract T addArgumentCorrectionProposalToT(AddArgumentCorrectionProposalCore core, int uid);
+	protected abstract T changeMethodSignatureProposalToT(ChangeMethodSignatureProposalCore core, int uid);
 	protected abstract T newMethodProposalToT(NewMethodCorrectionProposalCore core, int uid);
-	protected abstract T rewriteProposalToT(ASTRewriteCorrectionProposalCore proposal, int uid);
+	protected abstract T rewriteProposalToT(ASTRewriteCorrectionProposalCore core, int uid);
 	protected abstract T newAnnotationProposalToT(NewAnnotationMemberProposalCore core, int uid);
 	protected abstract T renameNodeProposalToT(RenameNodeCorrectionProposalCore core, int uid);
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/VarargsWarningsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/VarargsWarningsBaseSubProcessor.java
@@ -122,7 +122,7 @@ public abstract class VarargsWarningsBaseSubProcessor<T> {
 			proposals.add(proposal);
 	}
 
-	protected abstract T createAddSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, MethodDeclaration methodDeclaration, Object object, int addSafevarargs);
-	protected abstract T createAddSafeVarargsToDeclarationProposal1(String label, ICompilationUnit targetCu, Object object, IMethodBinding methodDeclaration, int addSafevarargs);
+	protected abstract T createAddSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, MethodDeclaration methodDeclaration, IMethodBinding methodBinding, int relevance);
+	protected abstract T createAddSafeVarargsToDeclarationProposal1(String label, ICompilationUnit targetCu, Object object, IMethodBinding methodDeclaration, int relevance);
 	protected abstract T createRemoveSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int removeSafevarargs);
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ReorgCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ReorgCorrectionsSubProcessor.java
@@ -50,6 +50,7 @@ import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.progress.IProgressService;
 
+import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
 
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
@@ -541,13 +542,13 @@ public class ReorgCorrectionsSubProcessor extends ReorgCorrectionsBaseSubProcess
 	}
 
 	@Override
-	public ICommandAccess createRenameCUProposal(String label, RenameCompilationUnitChange change, int renameCu) {
-		return new ChangeCorrectionProposal(label, change, IProposalRelevance.RENAME_CU, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_RENAME));
+	public ICommandAccess createRenameCUProposal(String label, RenameCompilationUnitChange change, int relevance) {
+		return new ChangeCorrectionProposal(label, change, relevance, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_RENAME));
 	}
 
 	@Override
-	public ICommandAccess createCorrectMainTypeNameProposal(ICompilationUnit cu, IInvocationContextCore context, String currTypeName, String newTypeName, int renameType) {
-		return new CorrectMainTypeNameProposal(cu, context, currTypeName, newTypeName, IProposalRelevance.RENAME_TYPE);
+	public ICommandAccess createCorrectMainTypeNameProposal(ICompilationUnit cu, IInvocationContextCore context, String currTypeName, String newTypeName, int relevance) {
+		return new CorrectMainTypeNameProposal(cu, context, currTypeName, newTypeName, relevance);
 	}
 
 	@Override
@@ -556,13 +557,13 @@ public class ReorgCorrectionsSubProcessor extends ReorgCorrectionsBaseSubProcess
 	}
 
 	@Override
-	protected ICommandAccess createMoveToNewPackageProposal(String label, CompositeChange composite, int moveCuToPackage) {
-		return new ChangeCorrectionProposal(label, composite, IProposalRelevance.MOVE_CU_TO_PACKAGE, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_MOVE));
+	protected ICommandAccess createMoveToNewPackageProposal(String label, CompositeChange composite, int relevance) {
+		return new ChangeCorrectionProposal(label, composite, relevance, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_MOVE));
 	}
 
 	@Override
-	protected ICommandAccess createOrganizeImportsProposal(String name, Object object, ICompilationUnit cu, int organizeImports) {
-		ChangeCorrectionProposal proposal= new ChangeCorrectionProposal(name, null, IProposalRelevance.ORGANIZE_IMPORTS, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE)) {
+	protected ICommandAccess createOrganizeImportsProposal(String name, Change change, ICompilationUnit cu, int relevance) {
+		ChangeCorrectionProposal proposal= new ChangeCorrectionProposal(name, change, relevance, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE)) {
 			@Override
 			public void apply(IDocument document) {
 				IEditorInput input= new FileEditorInput((IFile) cu.getResource());
@@ -581,9 +582,9 @@ public class ReorgCorrectionsSubProcessor extends ReorgCorrectionsBaseSubProcess
 	}
 
 	@Override
-	protected ICommandAccess createRemoveUnusedImportProposal(IProposableFix fix, UnusedCodeCleanUp unusedCodeCleanUp, int removeUnusedImport, IInvocationContextCore context) {
+	protected ICommandAccess createRemoveUnusedImportProposal(IProposableFix fix, UnusedCodeCleanUp unusedCodeCleanUp, int relevance, IInvocationContextCore context) {
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_DELETE_IMPORT);
-		FixCorrectionProposal proposal= new FixCorrectionProposal(fix, unusedCodeCleanUp, IProposalRelevance.REMOVE_UNUSED_IMPORT, image, context);
+		FixCorrectionProposal proposal= new FixCorrectionProposal(fix, unusedCodeCleanUp, relevance, image, context);
 		return proposal;
 	}
 
@@ -598,19 +599,18 @@ public class ReorgCorrectionsSubProcessor extends ReorgCorrectionsBaseSubProcess
 	}
 
 	@Override
-	protected ICommandAccess createChangeToRequiredCompilerComplianceProposal(String label1, IJavaProject project, boolean b, String requiredVersion, int changeProjectCompliance) {
-		return new ChangeToRequiredCompilerCompliance(label1, project, b, requiredVersion, changeProjectCompliance);
+	protected ICommandAccess createChangeToRequiredCompilerComplianceProposal(String label1, IJavaProject project, boolean changeOnWorkspace, String requiredVersion, int relevance) {
+		return new ChangeToRequiredCompilerCompliance(label1, project, changeOnWorkspace, requiredVersion, relevance);
 	}
 
 	@Override
-	protected ICommandAccess createChangeToRequiredCompilerComplianceProposal(String label2, IJavaProject project, boolean b, String requiredVersion, boolean enablePreviews,
-			int changeWorkspaceCompliance) {
-		return new ChangeToRequiredCompilerCompliance(label2, project, b, requiredVersion, enablePreviews, changeWorkspaceCompliance);
+	protected ICommandAccess createChangeToRequiredCompilerComplianceProposal(String label2, IJavaProject project, boolean changeOnWorkspace, String requiredVersion, boolean enablePreviews,
+			int relevance) {
+		return new ChangeToRequiredCompilerCompliance(label2, project, changeOnWorkspace, requiredVersion, enablePreviews, relevance);
 	}
 
 	@Override
 	protected ICommandAccess createOpenBuildPathCorrectionProposal(IProject project, String label, int relevance, IBinding referencedElement) {
-		// TODO Auto-generated method stub
 		return new OpenBuildPathCorrectionProposal(project, label, IProposalRelevance.CONFIGURE_BUILD_PATH, null);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchSubProcessor.java
@@ -55,7 +55,6 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.ChangeMethodSignatu
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ImplementInterfaceProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.LinkedCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewVariableCorrectionProposal;
-import org.eclipse.jdt.internal.ui.text.correction.proposals.NewVariableCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.OptionalCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.TypeChangeCorrectionProposal;
 
@@ -95,15 +94,15 @@ public class TypeMismatchSubProcessor extends TypeMismatchBaseSubProcessor<IComm
 	}
 
 	@Override
-	protected ICommandAccess createInsertNullCheckProposal(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int insertNullCheck) {
+	protected ICommandAccess createInsertNullCheckProposal(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int relevance) {
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-		return new ASTRewriteCorrectionProposal(label, compilationUnit, rewrite, IProposalRelevance.INSERT_NULL_CHECK, image);
+		return new ASTRewriteCorrectionProposal(label, compilationUnit, rewrite, relevance, image);
 	}
 
 	@Override
-	protected ICommandAccess createChangeReturnTypeProposal(String label, ICompilationUnit cu, ASTRewrite rewrite, int changeMethodReturnType, ITypeBinding currBinding, AST ast, CompilationUnit astRoot, MethodDeclaration methodDeclaration, BodyDeclaration decl) {
+	protected ICommandAccess createChangeReturnTypeProposal(String label, ICompilationUnit cu, ASTRewrite rewrite, int relevance, ITypeBinding currBinding, AST ast, CompilationUnit astRoot, MethodDeclaration methodDeclaration, BodyDeclaration decl) {
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-		LinkedCorrectionProposal proposal= new LinkedCorrectionProposal(label, cu, rewrite, IProposalRelevance.CHANGE_METHOD_RETURN_TYPE, image);
+		LinkedCorrectionProposal proposal= new LinkedCorrectionProposal(label, cu, rewrite, relevance, image);
 		ImportRewrite imports= proposal.createImportRewrite(astRoot);
 		ImportRewriteContext importRewriteContext= new ContextSensitiveImportRewriteContext(decl, imports);
 
@@ -143,9 +142,9 @@ public class TypeMismatchSubProcessor extends TypeMismatchBaseSubProcessor<IComm
 	}
 
 	@Override
-	protected ICommandAccess createChangeReturnTypeOfOverridden(ICompilationUnit targetCu, IMethodBinding overriddenDecl, CompilationUnit astRoot, ITypeBinding returnType, boolean b,
-			int changeReturnTypeOfOverridden, ITypeBinding overridenDeclType) {
-		TypeChangeCorrectionProposal proposal= new TypeChangeCorrectionProposal(targetCu, overriddenDecl, astRoot, returnType, false, IProposalRelevance.CHANGE_RETURN_TYPE_OF_OVERRIDDEN);
+	protected ICommandAccess createChangeReturnTypeOfOverridden(ICompilationUnit targetCu, IMethodBinding overriddenDecl, CompilationUnit astRoot, ITypeBinding returnType, boolean offerSuperTypeProposals,
+			int relevance, ITypeBinding overridenDeclType) {
+		TypeChangeCorrectionProposal proposal= new TypeChangeCorrectionProposal(targetCu, overriddenDecl, astRoot, returnType, offerSuperTypeProposals, relevance);
 		if (overridenDeclType.isInterface()) {
 			proposal.setDisplayName(Messages.format(CorrectionMessages.TypeMismatchSubProcessor_changereturnofimplemented_description, BasicElementLabels.getJavaElementName(overriddenDecl.getName())));
 		} else {
@@ -155,29 +154,29 @@ public class TypeMismatchSubProcessor extends TypeMismatchBaseSubProcessor<IComm
 	}
 
 	@Override
-	protected ICommandAccess createChangeIncompatibleReturnTypeProposal(ICompilationUnit cu, IMethodBinding methodDecl, CompilationUnit astRoot, ITypeBinding overriddenReturnType, boolean b,
-			int changeReturnType) {
-		return new TypeChangeCorrectionProposal(cu, methodDecl, astRoot, overriddenReturnType, false, IProposalRelevance.CHANGE_RETURN_TYPE);
+	protected ICommandAccess createChangeIncompatibleReturnTypeProposal(ICompilationUnit cu, IMethodBinding methodDecl, CompilationUnit astRoot, ITypeBinding overriddenReturnType, boolean offerSuperTypeProposals,
+			int relevance) {
+		return new TypeChangeCorrectionProposal(cu, methodDecl, astRoot, overriddenReturnType, offerSuperTypeProposals, relevance);
 	}
 
 	@Override
-	protected ICommandAccess createChangeMethodSignatureProposal(String label, ICompilationUnit cu, CompilationUnit astRoot, IMethodBinding methodDeclBinding, Object object,
-			ChangeDescription[] changes, int removeExceptions) {
+	protected ICommandAccess createChangeMethodSignatureProposal(String label, ICompilationUnit cu, CompilationUnit astRoot, IMethodBinding methodDeclBinding, ChangeDescription[] paramChanges,
+			ChangeDescription[] changes, int relevance) {
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_REMOVE);
-		return new ChangeMethodSignatureProposal(label, cu, astRoot, methodDeclBinding, null, changes, IProposalRelevance.REMOVE_EXCEPTIONS, image);
+		return new ChangeMethodSignatureProposal(label, cu, astRoot, methodDeclBinding, null, changes, relevance, image);
 	}
 
 	@Override
-	protected ICommandAccess createNewVariableCorrectionProposal(String label, ICompilationUnit cu, int local, SimpleName simpleName, Object object, int relevance) {
+	protected ICommandAccess createNewVariableCorrectionProposal(String label, ICompilationUnit cu, int local, SimpleName simpleName, ITypeBinding senderBinding, int relevance) {
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_LOCAL);
-		return new NewVariableCorrectionProposal(label, cu, NewVariableCorrectionProposalCore.LOCAL, simpleName, null, relevance, image);
+		return new NewVariableCorrectionProposal(label, cu, local, simpleName, null, relevance, image);
 	}
 
 	@Override
-	protected ICommandAccess createIncompatibleForEachTypeProposal(String label, ICompilationUnit cu, ASTRewrite rewrite, int incompatibleForeachType, CompilationUnit astRoot, AST ast,
+	protected ICommandAccess createIncompatibleForEachTypeProposal(String label, ICompilationUnit cu, ASTRewrite rewrite, int relevance, CompilationUnit astRoot, AST ast,
 			ITypeBinding expectedBinding, ASTNode selectedNode, SingleVariableDeclaration parameter) {
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-		ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, cu, rewrite, IProposalRelevance.INCOMPATIBLE_FOREACH_TYPE, image);
+		ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, cu, rewrite, relevance, image);
 		ImportRewrite importRewrite= proposal.createImportRewrite(astRoot);
 		ImportRewriteContext importRewriteContext= new ContextSensitiveImportRewriteContext(ASTResolving.findParentBodyDeclaration(selectedNode), importRewrite);
 		Type newType= importRewrite.addImport(expectedBinding, ast, importRewriteContext, TypeLocation.LOCAL_VARIABLE);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnInitializedFinalFieldSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/UnInitializedFinalFieldSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,6 @@ import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.correction.ICommandAccess;
 
 import org.eclipse.jdt.internal.ui.text.correction.proposals.InitializeFinalFieldProposal;
-import org.eclipse.jdt.internal.ui.text.correction.proposals.InitializeFinalFieldProposalCore;
 
 public class UnInitializedFinalFieldSubProcessor extends UnInitializedFinalFieldBaseSubProcessor<ICommandAccess>{
 
@@ -41,18 +40,18 @@ public class UnInitializedFinalFieldSubProcessor extends UnInitializedFinalField
 	}
 
 	@Override
-	protected ICommandAccess createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, SimpleName node, IVariableBinding targetBinding, int createConstructor) {
-		return new InitializeFinalFieldProposal(problem, targetCU, node, targetBinding, IProposalRelevance.CREATE_CONSTRUCTOR);
+	protected ICommandAccess createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, SimpleName node, IVariableBinding targetBinding, int relevance) {
+		return new InitializeFinalFieldProposal(problem, targetCU, node, targetBinding, relevance);
 	}
 
 	@Override
-	protected ICommandAccess createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int createConstructor, int updateAtConstructor) {
-		return new InitializeFinalFieldProposal(problem, targetCU, node, IProposalRelevance.CREATE_CONSTRUCTOR, InitializeFinalFieldProposalCore.UPDATE_AT_CONSTRUCTOR);
+	protected ICommandAccess createInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int relevance, int updateType) {
+		return new InitializeFinalFieldProposal(problem, targetCU, node, relevance, updateType);
 	}
 
 	@Override
-	protected ICommandAccess conditionallyCreateInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int createConstructor, int updateAtConstructor) {
-		InitializeFinalFieldProposal initializeFinalFieldProposal= new InitializeFinalFieldProposal(problem, targetCU, node, IProposalRelevance.CREATE_CONSTRUCTOR, InitializeFinalFieldProposalCore.UPDATE_CONSTRUCTOR_NEW_PARAMETER);
+	protected ICommandAccess conditionallyCreateInitializeFinalFieldProposal(IProblemLocationCore problem, ICompilationUnit targetCU, MethodDeclaration node, int relevance, int updateType) {
+		InitializeFinalFieldProposal initializeFinalFieldProposal= new InitializeFinalFieldProposal(problem, targetCU, node, relevance, updateType);
 		try {
 			if(initializeFinalFieldProposal.hasProposal()) {
 				return initializeFinalFieldProposal;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/VarargsWarningsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/VarargsWarningsSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2023 IBM Corporation and others.
+ * Copyright (c) 2011, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -57,16 +57,18 @@ public class VarargsWarningsSubProcessor extends VarargsWarningsBaseSubProcessor
 	}
 
 	@Override
-	protected ICommandAccess createAddSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, MethodDeclaration methodDeclaration, Object object, int addSafevarargs) {
-		return new AddSafeVarargsProposal(label, compilationUnit, methodDeclaration, null, IProposalRelevance.ADD_SAFEVARARGS);
+	protected ICommandAccess createAddSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, MethodDeclaration methodDeclaration, IMethodBinding methodBinding, int relevance) {
+		return new AddSafeVarargsProposal(label, compilationUnit, methodDeclaration, methodBinding, relevance);
 	}
+
 	@Override
-	protected ICommandAccess createAddSafeVarargsToDeclarationProposal1(String label, ICompilationUnit targetCu, Object object, IMethodBinding methodDeclaration, int addSafevarargs) {
-		return new AddSafeVarargsProposal(label, targetCu, null, methodDeclaration, IProposalRelevance.ADD_SAFEVARARGS);
+	protected ICommandAccess createAddSafeVarargsToDeclarationProposal1(String label, ICompilationUnit targetCu, Object object, IMethodBinding methodDeclaration, int relevance) {
+		return new AddSafeVarargsProposal(label, targetCu, null, methodDeclaration, relevance);
 	}
+
 	@Override
-	protected ICommandAccess createRemoveSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int removeSafevarargs) {
+	protected ICommandAccess createRemoveSafeVarargsProposal1(String label, ICompilationUnit compilationUnit, ASTRewrite rewrite, int relevance) {
 		Image image= PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_TOOL_DELETE);
-		return new ASTRewriteCorrectionProposal(label, compilationUnit, rewrite, IProposalRelevance.REMOVE_SAFEVARARGS, image);
+		return new ASTRewriteCorrectionProposal(label, compilationUnit, rewrite, relevance, image);
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->
The recent pushdown of many SubProcessor / quickfix processors could benefit from more clarity and uniformity in some of the variable names. Several of the abstract methods have parameters like `boolean b` or `Object object`, and several of the extenders are choosing to ignore those parameters and instead pass in their own hard-coded values when constructing the proposals. 

This should be cleaned up ASAP before consumers get a chance to extend or interact with these (admittedly, internal) classes. 

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
