### PR TITLE
NPE in StubUtility when generating javadoc for method declaration with no return type

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/StubUtility.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/StubUtility.java
@@ -713,7 +713,12 @@ public class StubUtility {
 		context.setVariable(CodeTemplateContextType.ENCLOSING_TYPE, typeName);
 		context.setVariable(CodeTemplateContextType.ENCLOSING_METHOD, decl.getName().getIdentifier());
 		if (!decl.isConstructor()) {
-			context.setVariable(CodeTemplateContextType.RETURN_TYPE, ASTNodes.asString(getReturnType(decl)));
+			ASTNode retType= getReturnType(decl);
+			if (retType != null) {
+				context.setVariable(CodeTemplateContextType.RETURN_TYPE, ASTNodes.asString(retType));
+			} else {
+				context.setVariable(CodeTemplateContextType.RETURN_TYPE, "void"); //$NON-NLS-1$
+			}
 		}
 		if (needsTarget) {
 			if (delegate)
@@ -756,7 +761,12 @@ public class StubUtility {
 
 		String returnType= null;
 		if (!decl.isConstructor()) {
-			returnType= ASTNodes.asString(getReturnType(decl));
+			ASTNode retType= getReturnType(decl);
+			if (retType != null) {
+				returnType= ASTNodes.asString(retType);
+			} else {
+				returnType= "void"; //$NON-NLS-1$
+			}
 		}
 		int[] tagOffsets= position.getOffsets();
 		for (int i= tagOffsets.length - 1; i >= 0; i--) { // from last to first


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
When StubUtility.getMethodComment(etc) is called and passes in an incorrect MethodDeclaration that lacks a return type (for example, when the user has left out the return type incorrectly), the method fails with NPE and blows away the stack. 

This issue is currently replicatable via jdt.ls test suite. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
