### PR TITLE
fix ImporterTest.testImportRawJavaProject()

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/ImporterTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/ImporterTest.java
@@ -59,7 +59,7 @@ public class ImporterTest{
 			project = ResourcesPlugin.getWorkspace().getRoot().getProject(expandedZip.getName());
 			Assert.assertTrue("Project wasn't created", project.exists());
 			Assert.assertTrue("Project doesn't have Java nature", project.hasNature(JavaCore.NATURE_ID));
-			IJavaProject javaProject = (IJavaProject) project.getNature(JavaCore.NATURE_ID);
+			IJavaProject javaProject = JavaCore.create(project);
 			project.build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
 			Assert.assertNotNull("Couldn't resolve type from Java project", javaProject.findType("junit.framework.TestCase"));
 			Assert.assertNotNull("Couldn't resolve JRE type from Java project", javaProject.findType("java.util.List"));

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ActionUtil.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ActionUtil.java
@@ -19,7 +19,6 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.resources.IResource;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -37,11 +36,11 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.refactoring.util.ResourceUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 /*
  * http://dev.eclipse.org/bugs/show_bug.cgi?id=19104
@@ -102,9 +101,8 @@ public class ActionUtil {
 			IProject resourceProject= project.getProject();
 			if (resourceProject == null)
 				return false;
-			IProjectNature nature= resourceProject.getNature(JavaCore.NATURE_ID);
 			// We have a Java project
-			if (nature != null)
+			if (resourceProject.hasNature(JavaCore.NATURE_ID))
 				return true;
 		} catch (CoreException e) {
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/model/JavaModelLabelProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/model/JavaModelLabelProvider.java
@@ -140,7 +140,7 @@ public final class JavaModelLabelProvider extends AppearanceAwareLabelProvider {
 	 */
 	private static boolean isInJavaProject(IFolder folder) {
 		try {
-			return folder.getProject().getNature(JavaCore.NATURE_ID) != null;
+			return folder.getProject().hasNature(JavaCore.NATURE_ID);
 		} catch (CoreException e) {
 			return false;
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/GotoResourceAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/GotoResourceAction.java
@@ -76,7 +76,7 @@ public class GotoResourceAction extends Action {
 			private boolean select(IResource resource) {
 				IProject project= resource.getProject();
 				try {
-					if (project.getNature(JavaCore.NATURE_ID) != null)
+					if (project.hasNature(JavaCore.NATURE_ID))
 						return fJavaModel.contains(resource);
 				} catch (CoreException e) {
 					// do nothing. Consider resource;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/importer/JDTProjectNatureImportConfigurator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/importer/JDTProjectNatureImportConfigurator.java
@@ -82,7 +82,7 @@ public class JDTProjectNatureImportConfigurator implements ProjectConfigurator {
 	public Set<IFolder> getFoldersToIgnore(IProject project, IProgressMonitor monitor) {
 		Set<IFolder> res = new HashSet<>();
 		try {
-			IJavaProject javaProject = (IJavaProject)project.getNature(JavaCore.NATURE_ID);
+			IJavaProject javaProject = JavaCore.create(project);
 			if (javaProject == null) { // project already has .classpath and .project but Java nature isn't set
 				return Collections.emptySet();
 			}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/importer/ProjectWithJavaResourcesImportConfigurator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/importer/ProjectWithJavaResourcesImportConfigurator.java
@@ -100,16 +100,16 @@ public class ProjectWithJavaResourcesImportConfigurator implements ProjectConfig
 			SubMonitor subMonitor = SubMonitor.convert(monitor, 6);
 			IProjectDescription description = project.getDescription();
 			List<String> natures = Arrays.asList(description.getNatureIds());
-			IJavaProject javaNature = null;
+			IJavaProject javaProject = null;
 			if (!natures.contains(JavaCore.NATURE_ID)) {
 				List<String> newNatures = new ArrayList<>(natures);
 				newNatures.add(JavaCore.NATURE_ID);
 				description.setNatureIds(newNatures.toArray(new String[newNatures.size()]));
 				project.setDescription(description, subMonitor.split(1));
-				javaNature = JavaCore.create(project);
-				javaNature.open(subMonitor.split(1));
+				javaProject = JavaCore.create(project);
+				javaProject.open(subMonitor.split(1));
 			} else {
-				javaNature = (IJavaProject)project.getNature(JavaCore.NATURE_ID);
+				javaProject = JavaCore.create(project);
 				subMonitor.worked(2);
 			}
 			if (!project.getFile(CLASSPATH).exists()) {
@@ -119,7 +119,7 @@ public class ProjectWithJavaResourcesImportConfigurator implements ProjectConfig
 				if (entries.length == 0) {
 					entries = PreferenceConstants.getDefaultJRELibrary();
 				}
-				javaNature.setRawClasspath(entries, subMonitor.split(1));
+				javaProject.setRawClasspath(entries, subMonitor.split(1));
 				if (outputLocation == null) {
 					IFolder binFolder = project.getFolder(BIN);
 					if (!binFolder.exists()) {
@@ -131,7 +131,7 @@ public class ProjectWithJavaResourcesImportConfigurator implements ProjectConfig
 				} else {
 					subMonitor.worked(1);
 				}
-				javaNature.setOutputLocation(outputLocation, subMonitor.split(1));
+				javaProject.setOutputLocation(outputLocation, subMonitor.split(1));
 			} else {
 				subMonitor.worked(4);
 			}
@@ -153,7 +153,7 @@ public class ProjectWithJavaResourcesImportConfigurator implements ProjectConfig
 	public Set<IFolder> getFoldersToIgnore(IProject project, IProgressMonitor monitor) {
 		Set<IFolder> res = new HashSet<>();
 		try {
-			IJavaProject javaProject = (IJavaProject)project.getNature(JavaCore.NATURE_ID);
+			IJavaProject javaProject = JavaCore.create(project);
 			if (javaProject == null) {
 				return res;
 			}


### PR DESCRIPTION
to use public API instead of type cast.
Failing since I20240130-1800

Java nature and java project are now implemented as separate instances https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1916
