### PR TITLE
Move some core code into ReorgCorrectionBaseSubProcessor

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ReorgCorrectionsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ReorgCorrectionsBaseSubProcessor.java
@@ -49,7 +49,6 @@ import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.Type;
-import org.eclipse.jdt.core.manipulation.ICleanUpFixCore;
 import org.eclipse.jdt.core.manipulation.TypeKinds;
 
 import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
@@ -186,16 +185,7 @@ public abstract class ReorgCorrectionsBaseSubProcessor<T> {
 
 		final ICompilationUnit cu= context.getCompilationUnit();
 		String name= CorrectionMessages.ReorgCorrectionsSubProcessor_organizeimports_description;
-		ICleanUpFixCore removeAllUnusedImportsFix = UnusedCodeFixCore.createCleanUp(context.getASTRoot(), false, false, false, false, false, true, false, false);
-		Change cleanupChange= null;
-		if( removeAllUnusedImportsFix != null ) {
-			try {
-				cleanupChange= removeAllUnusedImportsFix.createChange(null);
-			} catch(CoreException ce) {
-				// ignore
-			}
-		}
-		T proposal= createOrganizeImportsProposal(name, cleanupChange, cu, IProposalRelevance.ORGANIZE_IMPORTS);
+		T proposal= createOrganizeImportsProposal(name, null, cu, IProposalRelevance.ORGANIZE_IMPORTS);
 		if (proposal != null)
 			proposals.add(proposal);
 	}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Code that really should have belonged in ReorgCorrectionBaseSubProcessor when it was created was left in the UI extension, due to an uncertainty over how to handle delegation to other subprocessors. 

Since the time of its creation, other subprocessors have solved that issue by having abstract methods that get the other subprocessors in question, and this behavior can be used in the ReorgCorrectionBaseSubProcessor as well. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
