### PR TITLE
suppress "illegally extends CleanUpOptions"

### DIFF
--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -105,11 +105,27 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="ui/org/eclipse/jdt/internal/ui/preferences/cleanup/ContributedCleanUpTabPage.java" type="org.eclipse.jdt.internal.ui.preferences.cleanup.ContributedCleanUpTabPage">
+        <filter id="571519004">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.internal.ui.preferences.cleanup.ContributedCleanUpTabPage.setWorkingValues(Map&lt;String,String&gt;)"/>
+                <message_argument value="CleanUpOptions"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java" type="org.eclipse.jdt.internal.ui.text.JavaOutlineInformationControl$OutlineTreeViewer">
         <filter id="571473929">
             <message_arguments>
                 <message_argument value="TreeViewer"/>
                 <message_argument value="OutlineTreeViewer"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="ui/org/eclipse/jdt/internal/ui/util/CleanUpCoreWrapper.java" type="org.eclipse.jdt.internal.ui.util.CleanUpCoreWrapper">
+        <filter id="571519004">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.internal.ui.util.CleanUpCoreWrapper.wrapOptions(CleanUpOptionsCore)"/>
+                <message_argument value="CleanUpOptions"/>
             </message_arguments>
         </filter>
     </resource>
@@ -189,9 +205,9 @@
         <filter id="576720909">
             <message_arguments>
                 <message_argument value="IInvocationContextCore"/>
-		<message_argument value="IInvocationContext"/>
+                <message_argument value="IInvocationContext"/>
             </message_arguments>
-	</filter>
+        </filter>
     </resource>
     <resource path="ui/org/eclipse/jdt/ui/text/java/correction/ASTRewriteCorrectionProposal.java" type="org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposal">
         <filter id="643850349">


### PR DESCRIPTION
CleanUpOptions @noextend is not intended to be subclassed by CLIENTS.
