### PR TITLE
fix deprecated createImage(ImageDescriptor)

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
@@ -676,7 +676,7 @@ public class FilteredTypesSelectionDialog extends FilteredItemsSelectionDialog i
 			if (contributedImageDescriptor == null) {
 				return TypeNameMatchLabelProvider.getImage((TypeNameMatch) element, TypeNameMatchLabelProvider.SHOW_TYPE_ONLY);
 			} else {
-				return fImageManager.createImage(contributedImageDescriptor);
+				return fImageManager.create(contributedImageDescriptor);
 			}
 		}
 


### PR DESCRIPTION
The method createImage(ImageDescriptor) from the type ResourceManager is deprecated since version 3.31
