### PR TITLE
Add missing synchronization for ChangeCorrectionProposalCore

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/ChangeCorrectionProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/ChangeCorrectionProposalCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -161,7 +161,9 @@ public class ChangeCorrectionProposalCore implements IAdaptable {
 	 * @return The current change, or null if not initialized yet
 	 */
 	public Change getCurrentChange() {
-		return fChange;
+		synchronized (this) {
+			return fChange;
+		}
 	}
 
 


### PR DESCRIPTION
- add missing synchronization for getCurrentChange() which accesses fChange which is created in a synchronized method
- potential fix for #1136

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Potentially fixes a BadLocation error thrown by an Extract to local variable refactoring.  There appears to be a timing
issue as debugging and stopping fixes the problem.  There is a method in ChangeCorrectionProposalCore to return the
current change if calculated or null.  The creation of the change is protected by a synchronized method but this one does
not use any synchronization.  Exporting the jdt.core.manipulation plug-in and overriding in the I20240126 build seems to
fix the problem.  In some cases, a UI freeze occurs which might be used to determine the cause of the timing issue.  There
is extra calculation done for extracting and replacing all instances of the variable that may be causing this delay.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and try multiple times as the error doesn't always occur.  The most reliable way is to quickly choose
Extract to local and hit enter before the preview is shown.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
