### PR TITLE
Fix UI freeze due to extract to local computations

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -439,7 +439,9 @@ public final class CorrectionMessages extends NLS {
 	public static String ReorgCorrectionsSubProcessor_configure_buildpath_label;
 	public static String ReorgCorrectionsSubProcessor_configure_buildpath_description;
 	public static String QuickAssistProcessor_extract_to_local_all_description;
+	public static String QuickAssistProcessor_extract_to_local_all_preview;
 	public static String QuickAssistProcessor_extract_to_local_description;
+	public static String QuickAssistProcessor_extract_to_local_preview;
 	public static String QuickAssistProcessor_extractmethod_description;
 	public static String QuickAssistProcessor_extractmethod_from_lambda_description;
 	public static String QuickAssistProcessor_move_exception_to_separate_catch_block;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -394,7 +394,9 @@ QuickAssistProcessor_split_case_labels=Split case labels
 QuickAssistProcessor_splitdeclaration_description=Split variable declaration
 QuickAssistProcessor_exceptiontothrows_description=Replace exception with throws
 QuickAssistProcessor_extract_to_local_all_description=Extract to local variable (replace all occurrences)
+QuickAssistProcessor_extract_to_local_all_preview=Extract to local variable (replace all occurrences) if possible
 QuickAssistProcessor_extract_to_local_description=Extract to local variable
+QuickAssistProcessor_extract_to_local_preview=Extract to local variable if possible
 QuickAssistProcessor_extractmethod_description=Extract to method
 QuickAssistProcessor_extractmethod_from_lambda_description=Extract lambda body to method
 QuickAssistProcessor_extract_to_constant_description=Extract to constant

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/base/RefactoringStatusCodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/base/RefactoringStatusCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,6 +24,7 @@ public class RefactoringStatusCodes {
 	public static final int EXPRESSION_NOT_RVALUE= 								64;
 	public static final int EXPRESSION_NOT_RVALUE_VOID= 						65;
 	public static final int EXTRANEOUS_TEXT= 											66;
+	public static final int EXPRESSION_MAY_CAUSE_SIDE_EFFECTS=					67;
 
 	public static final int NOT_STATIC_FINAL_SELECTED= 							128;
 	public static final int SYNTAX_ERRORS= 												129;

--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/RefactoringCorrectionProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/RefactoringCorrectionProposalCore.java
@@ -34,6 +34,7 @@ import org.eclipse.ltk.core.refactoring.TextFileChange;
 import org.eclipse.jdt.core.ICompilationUnit;
 
 import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
+import org.eclipse.jdt.internal.corext.refactoring.base.RefactoringStatusCodes;
 
 public class RefactoringCorrectionProposalCore extends LinkedCorrectionProposalCore {
 
@@ -63,10 +64,10 @@ public class RefactoringCorrectionProposalCore extends LinkedCorrectionProposalC
 	public TextChange createTextChange() throws CoreException {
 		init(fRefactoring);
 		fRefactoringStatus= fRefactoring.checkFinalConditions(new NullProgressMonitor());
-		if (fRefactoringStatus.hasFatalError() || fRefactoringStatus.hasError()) {
+		if (fRefactoringStatus.hasFatalError()) {
 			TextFileChange dummyChange= new TextFileChange("fatal error", (IFile) getCompilationUnit().getResource()); //$NON-NLS-1$
 			dummyChange.setEdit(new InsertEdit(0, "")); //$NON-NLS-1$
-			if (fRefactoringStatus.getEntryAt(0).getCode() == RefactoringStatus.INFO) {
+			if (fRefactoringStatus.getEntryAt(0).getCode() == RefactoringStatusCodes.EXPRESSION_MAY_CAUSE_SIDE_EFFECTS) {
 				JavaManipulationPlugin.log(new Status(IStatus.INFO, JavaManipulationPlugin.getPluginId(), fRefactoringStatus.getEntryAt(0).getMessage()));
 			}
 			return dummyChange;

--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/RefactoringCorrectionProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/RefactoringCorrectionProposalCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,7 +16,9 @@ package org.eclipse.jdt.internal.ui.text.correction.proposals;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
 
 import org.eclipse.core.resources.IFile;
 
@@ -30,6 +32,8 @@ import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.ltk.core.refactoring.TextFileChange;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 
 public class RefactoringCorrectionProposalCore extends LinkedCorrectionProposalCore {
 
@@ -59,9 +63,12 @@ public class RefactoringCorrectionProposalCore extends LinkedCorrectionProposalC
 	public TextChange createTextChange() throws CoreException {
 		init(fRefactoring);
 		fRefactoringStatus= fRefactoring.checkFinalConditions(new NullProgressMonitor());
-		if (fRefactoringStatus.hasFatalError()) {
+		if (fRefactoringStatus.hasFatalError() || fRefactoringStatus.hasError()) {
 			TextFileChange dummyChange= new TextFileChange("fatal error", (IFile) getCompilationUnit().getResource()); //$NON-NLS-1$
 			dummyChange.setEdit(new InsertEdit(0, "")); //$NON-NLS-1$
+			if (fRefactoringStatus.getEntryAt(0).getCode() == RefactoringStatus.INFO) {
+				JavaManipulationPlugin.log(new Status(IStatus.INFO, JavaManipulationPlugin.getPluginId(), fRefactoringStatus.getEntryAt(0).getMessage()));
+			}
 			return dummyChange;
 		}
 		Change o = fRefactoring.createChange(new NullProgressMonitor());

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -756,9 +756,11 @@ public class ExtractTempRefactoring extends Refactoring {
 					if (children.length == 1 && children[0] instanceof MultiTextEdit childEdit) {
 						if (childEdit.hasChildren() == false) {
 							fCURewrite.clearASTAndImportRewrites();
-							fLinkedProposalModel.clear();
+							if (fLinkedProposalModel != null) {
+								fLinkedProposalModel.clear();
+							}
 							fLinkedProposalModel= null;
-							result.addEntry(RefactoringStatus.ERROR, RefactoringCoreMessages.ExtractTempRefactoring_side_effects_possible, null, JavaManipulationPlugin.getPluginId(), RefactoringStatus.INFO, null);
+							result.addEntry(RefactoringStatus.FATAL, RefactoringCoreMessages.ExtractTempRefactoring_side_effects_possible, null, JavaManipulationPlugin.getPluginId(), RefactoringStatusCodes.EXPRESSION_MAY_CAUSE_SIDE_EFFECTS, null);
 						}
 					}
 				}

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -755,7 +755,10 @@ public class ExtractTempRefactoring extends Refactoring {
 					TextEdit[] children= topEdit.getChildren();
 					if (children.length == 1 && children[0] instanceof MultiTextEdit childEdit) {
 						if (childEdit.hasChildren() == false) {
-							result.addInfo(RefactoringCoreMessages.ExtractTempRefactoring_side_effects_possible);
+							fCURewrite.clearASTAndImportRewrites();
+							fLinkedProposalModel.clear();
+							fLinkedProposalModel= null;
+							result.addEntry(RefactoringStatus.ERROR, RefactoringCoreMessages.ExtractTempRefactoring_side_effects_possible, null, JavaManipulationPlugin.getPluginId(), RefactoringStatus.INFO, null);
 						}
 					}
 				}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
@@ -1358,19 +1358,19 @@ public class ExtractTempTests extends GenericRefactoringTest {
 	@Test
 	public void testFail41() throws Exception {
 		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/39
-		failHelper1(5, 28, 5, 38, true, false, "length", RefactoringStatus.INFO);
+		failHelper1(5, 28, 5, 38, true, false, "length", RefactoringStatus.FATAL);
 	}
 
 	@Test
 	public void testFail42() throws Exception {
 		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/39
-		failHelper1(5, 68, 5, 94, true, false, "intValue", RefactoringStatus.INFO);
+		failHelper1(5, 68, 5, 94, true, false, "intValue", RefactoringStatus.FATAL);
 	}
 
 	@Test
 	public void testFail43() throws Exception {
 		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1176
-		failHelper1(19, 9, 19, 88, true, false, "intValue", RefactoringStatus.INFO);
+		failHelper1(19, 9, 19, 88, true, false, "intValue", RefactoringStatus.FATAL);
 	}
 
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
@@ -2104,9 +2104,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		AssistContext context= getCorrectionContext(cu, offset, selection.length());
 		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
 
-		assertNumberOfProposals(proposals, 3);
-		assertProposalDoesNotExist(proposals, EXTRACT_TO_LOCAL);
-		assertProposalDoesNotExist(proposals, EXTRACT_TO_LOCAL_REPLACE);
+		assertNumberOfProposals(proposals, 5);
 		assertProposalDoesNotExist(proposals, EXTRACT_TO_CONSTANT);
 	}
 
@@ -3446,7 +3444,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		AssistContext context= getCorrectionContext(cu, buf.toString().indexOf(str), 0);
 		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
 
-		assertNumberOfProposals(proposals, 2);
+		assertNumberOfProposals(proposals, 4);
 		assertCorrectLabels(proposals);
 
 		buf= new StringBuilder();
@@ -3622,7 +3620,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		AssistContext context= getCorrectionContext(cu, buf.toString().indexOf(str), 0);
 		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
 
-		assertNumberOfProposals(proposals, 2);
+		assertNumberOfProposals(proposals, 4);
 		assertCorrectLabels(proposals);
 
 		buf= new StringBuilder();


### PR DESCRIPTION
- fixes #1185
- don't run checkFinalConditions() from QuickAssistProcessor to see if extract to local variable proposals are valid
- override the preview for extract to local variable and extract to local variable (replace all occurrences) so they just display a message instead of creating the change
- fix ExtractTempRefactoring.checkFinalConditions() to recognize an invalid change in which case add an error status with a code that is RefactoringStatus.INFO
- modify RefactoringCorrectionProposalCore to recognize an error refactoring status in which case create a dummy edit and if the INFO code is found, then also create a log entry to note that the extraction will not occur
- fix AssistQuickFixTest tests proposal counts

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes UI freezes in quick assist processor due to Extract to local variable proposal logic by replacing the preview with a message and also reverting the logic of #1176 to not show invalid proposals.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Hover over selections that might be extracted to local variable and note the time lag.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
