### PR TITLE
fix endless loop in RippleMethodFinder2.UnionFind.find(IType) #1192

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RippleMethodFinder2.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RippleMethodFinder2.java
@@ -98,7 +98,8 @@ public class RippleMethodFinder2 {
 		public IType find(IType element) {
 			IType root= element;
 			IType rep= fElementToRepresentative.get(root);
-			while (rep != null && ! rep.equals(root)) {
+			Set<IType> visited=new HashSet<>();
+			while (rep != null && visited.add(root)) {
 				root= rep;
 				rep= fElementToRepresentative.get(root);
 			}


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1192
