### PR TITLE
Fix extract local for autocloseable expression in try with resources

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -1119,7 +1119,7 @@ public class ExtractTempRefactoring extends Refactoring {
 
 	private void createAndInsertTempDeclaration() throws CoreException {
 		Expression initializer= getSelectedExpression().createCopyTarget(fCURewrite.getASTRewrite(), true);
-		VariableDeclarationStatement vds= createTempDeclaration(initializer);
+		VariableDeclarationExpression vds= createTempDeclaration(initializer);
 
 		boolean insertAtSelection;
 		if (!fReplaceAllOccurrences) {
@@ -1140,6 +1140,44 @@ public class ExtractTempRefactoring extends Refactoring {
 			fDeclareFinal= true;
 		}
 
+		if (node instanceof TryStatement tryStatement) {
+			if (getSelectedExpression().getAssociatedNode() instanceof Expression originalexp) {
+				ITypeBinding vdsBinding= originalexp.resolveTypeBinding();
+				if (vdsBinding != null) {
+					boolean isAutoCloseable= false;
+					for (ITypeBinding superType : Bindings.getAllSuperTypes(vdsBinding)) {
+						if ("java.lang.AutoCloseable".equals(superType.getQualifiedName())) { //$NON-NLS-1$
+							isAutoCloseable= true;
+							break;
+						}
+					}
+					if (isAutoCloseable) {
+						List<Expression> resources= tryStatement.resources();
+						ASTNode originalNode= getSelectedExpression().getAssociatedNode();
+						boolean resourceFound= false;
+						for (Expression resource : resources) {
+							int offset= resource.getStartPosition();
+							ASTNode parent= originalNode.getParent();
+							while (parent != null) {
+								if (parent == resource) {
+									resourceFound= true;
+									node= resource;
+									fReplaceAllOccurrences= false;
+									break;
+								} else if (parent.getStartPosition() < offset) {
+									break;
+								}
+								parent= parent.getParent();
+							}
+							if (resourceFound) {
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
 		IASTFragment[] retainOnlyReplacableMatches= retainOnlyReplacableMatches(getMatchingFragments());
 		if (retainOnlyReplacableMatches == null) {
 			return;
@@ -1153,11 +1191,18 @@ public class ExtractTempRefactoring extends Refactoring {
 				break;
 			}
 		}
-		if (node instanceof SwitchStatement || node instanceof EnhancedForStatement) {
+		AST ast= fCURewrite.getAST();
+		if (node instanceof SwitchStatement || node instanceof EnhancedForStatement || node instanceof TryStatement) {
 			/* must insert above switch statement */
 			fStartPoint= 0;
 			fEndPoint= retainOnlyReplacableMatches.length - 1;
-			insertAt(node, vds);
+			ExpressionStatement exs= ast.newExpressionStatement(vds);
+			insertAt(node, exs);
+			return;
+		} else if (node.getLocationInParent() == TryStatement.RESOURCES2_PROPERTY) {
+			fStartPoint= 0;
+			fEndPoint= retainOnlyReplacableMatches.length - 1;
+			insertResourceAt(node, vds);
 			return;
 		} else {
 			if (insertAtSelection) {
@@ -1167,18 +1212,20 @@ public class ExtractTempRefactoring extends Refactoring {
 					fSeen.add(retainOnlyReplacableMatches[selectNumber]);
 				}
 				if (realCommonASTNode != null || retainOnlyReplacableMatches.length == 0) {
-					insertAt(getSelectedExpression().getAssociatedNode(), vds);
+					ExpressionStatement exs= ast.newExpressionStatement(vds);
+					insertAt(getSelectedExpression().getAssociatedNode(), exs);
 				}
 				return;
 			}
 		}
 		ASTNode realCommonASTNode= null;
+		ExpressionStatement exs= ast.newExpressionStatement(vds);
 		realCommonASTNode= evalStartAndEnd(retainOnlyReplacableMatches, selectNumber, null);
 		if (realCommonASTNode == null && selectNumber >= 0) {
 			fSeen.add(retainOnlyReplacableMatches[selectNumber]);
 		}
 		if (realCommonASTNode != null) {
-			insertAt(realCommonASTNode, vds);
+			insertAt(realCommonASTNode, exs);
 		}
 		return;
 	}
@@ -1281,14 +1328,14 @@ public class ExtractTempRefactoring extends Refactoring {
 		return target;
 	}
 
-	private VariableDeclarationStatement createTempDeclaration(Expression initializer) throws CoreException {
+	private VariableDeclarationExpression createTempDeclaration(Expression initializer) throws CoreException {
 		AST ast= fCURewrite.getAST();
 
 		VariableDeclarationFragment vdf= ast.newVariableDeclarationFragment();
 		vdf.setName(ast.newSimpleName(fTempName));
 		vdf.setInitializer(initializer);
 
-		VariableDeclarationStatement vds= ast.newVariableDeclarationStatement(vdf);
+		VariableDeclarationExpression vds= ast.newVariableDeclarationExpression(vdf);
 		if (fDeclareFinal) {
 			if (!hasFinalModifer(vds.modifiers())) {
 				vds.modifiers().add(ast.newModifier(ModifierKeyword.FINAL_KEYWORD));
@@ -1312,12 +1359,22 @@ public class ExtractTempRefactoring extends Refactoring {
 		return vds;
 	}
 
+	private void insertResourceAt(ASTNode target, VariableDeclarationExpression exp) {
+		ASTRewrite rewrite= fCURewrite.getASTRewrite();
+		TextEditGroup groupDescription= fCURewrite.createGroupDescription(RefactoringCoreMessages.ExtractTempRefactoring_declare_local_variable);
+		StructuralPropertyDescriptor locationInParent= target.getLocationInParent();
+		ASTNode parent= target.getParent();
+		ListRewrite listRewrite= rewrite.getListRewrite(parent, (ChildListPropertyDescriptor) locationInParent);
+		listRewrite.insertBefore(exp, target, groupDescription);
+	}
+
 	private void insertAt(ASTNode target, Statement declaration) {
 		ASTRewrite rewrite= fCURewrite.getASTRewrite();
 		TextEditGroup groupDescription= fCURewrite.createGroupDescription(RefactoringCoreMessages.ExtractTempRefactoring_declare_local_variable);
 		ASTNode parent= target.getParent();
 		StructuralPropertyDescriptor locationInParent= target.getLocationInParent();
-		while (locationInParent != Block.STATEMENTS_PROPERTY && locationInParent != SwitchStatement.STATEMENTS_PROPERTY) {
+		while (locationInParent != Block.STATEMENTS_PROPERTY && locationInParent != SwitchStatement.STATEMENTS_PROPERTY
+				&& locationInParent != TryStatement.RESOURCES2_PROPERTY) {
 			if (locationInParent == IfStatement.THEN_STATEMENT_PROPERTY
 					|| locationInParent == IfStatement.ELSE_STATEMENT_PROPERTY
 					|| locationInParent == ForStatement.BODY_PROPERTY
@@ -1695,17 +1752,18 @@ public class ExtractTempRefactoring extends Refactoring {
 		evalStartAndEnd(retainOnlyReplacableMatches(getMatchingFragments()), 0, Integer.valueOf(selectedExpression.getStartPosition() + selectedExpression.getLength()));
 
 		Expression initializer= (Expression) rewrite.createMoveTarget(selectedExpression);
-		VariableDeclarationStatement tempDeclaration= createTempDeclaration(initializer);
+		VariableDeclarationExpression tempDeclarationExpression= createTempDeclaration(initializer);
 		ASTNode replacement;
 
 		ASTNode parent= selectedExpression.getParent();
 		boolean isParentLambda= parent instanceof LambdaExpression;
 		AST ast= rewrite.getAST();
+		ExpressionStatement tempDeclaration= ast.newExpressionStatement(tempDeclarationExpression);
 		if (isParentLambda) {
 			Block blockBody= ast.newBlock();
 			blockBody.statements().add(tempDeclaration);
 			if (!Bindings.isVoidType(((LambdaExpression) parent).resolveMethodBinding().getReturnType())) {
-				List<VariableDeclarationFragment> fragments= tempDeclaration.fragments();
+				List<VariableDeclarationFragment> fragments= tempDeclarationExpression.fragments();
 				SimpleName varName= fragments.get(0).getName();
 				ReturnStatement returnStatement= ast.newReturnStatement();
 				returnStatement.setExpression(ast.newSimpleName(varName.getIdentifier()));

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -1199,7 +1199,7 @@ public class ExtractTempRefactoring extends Refactoring {
 			ExpressionStatement exs= ast.newExpressionStatement(vds);
 			insertAt(node, exs);
 			return;
-		} else if (node.getLocationInParent() == TryStatement.RESOURCES2_PROPERTY) {
+		} else if (node != null && node.getLocationInParent() == TryStatement.RESOURCES2_PROPERTY) {
 			fStartPoint= 0;
 			fEndPoint= retainOnlyReplacableMatches.length - 1;
 			insertResourceAt(node, vds);


### PR DESCRIPTION
- fixes #1194
- add logic to ExtractTempRefactoring to determine if dealing with autocloseable expression taken from resource expression in try with resources in which case place the new variable declaration in the resource expressions
- add new tests to AssistQuickFixTest1d7

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes bug 401089: https://bugs.eclipse.org/bugs/show_bug.cgi?id=401089 which notes that extracting an autocloseable local from a set of resource expressions within a try-with-resources statement should put the new declaration in the resources

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
