### PR TITLE
Fix lambda cleanup to not generate if interface method is generic

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -1292,7 +1292,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 		if (interfaces.length != 1) {
 			return false;
 		}
-		if (interfaces[0].getFunctionalInterfaceMethod() == null) {
+		if (interfaces[0].getFunctionalInterfaceMethod() == null || interfaces[0].getFunctionalInterfaceMethod().isGenericMethod()) {
 			return false;
 		}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -2262,6 +2262,41 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testDoNotConvertGenericInterface() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "public class C2 {\n" //
+				+ "\n" //
+				+ "    public interface IInteractionContext {\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public interface IAdaptable {\n" //
+				+ "        public <T> T getAdapter(Class<T> adapter);\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    @SuppressWarnings(\"unchecked\")\n" //
+				+ "    public IAdaptable asAdaptable(final IInteractionContext result) {\n" //
+				+ "        return new IAdaptable() {\n" //
+				+ "            public Object getAdapter(Class adapter) {\n" //
+				+ "                if (adapter == IInteractionContext.class) {\n" //
+				+ "                    return result;\n" //
+				+ "                }\n" //
+				+ "                return null;\n" //
+				+ "            }\n" //
+				+ "        };\n" //
+				+ "    }\n" //
+				+ "}\n"; //
+		ICompilationUnit cu= pack1.createCompilationUnit("C2.java", sample, false, null);
+
+		enable(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES);
+		enable(CleanUpConstants.USE_LAMBDA);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu });
+	}
+
+	@Test
 	public void testComparingOnCriteria() throws Exception {
 		// Given
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);


### PR DESCRIPTION
- fixes #1198
- add new test to CleanUpTest1d8

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds check to lambda cleanup to not generate lambda when interface method is generic.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test case.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
