### PR TITLE
Revert workaround for #945, as it causes problems in the JUnit view

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestSuiteElement.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestSuiteElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,6 @@
 package org.eclipse.jdt.internal.junit.model;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.junit.model.ITestElement;
@@ -48,8 +47,7 @@ public class TestSuiteElement extends TestElement implements ITestSuiteElement {
 
 	@Override
 	public ITestElement[] getChildren() {
-		TestElement[] elements= fChildren.toArray(new TestElement[fChildren.size()]); // copy list to avoid concurrency problems
-		return Arrays.stream(elements).filter(e -> !isSingleDynamicTest(e)).toArray(ITestElement[]::new);
+		return fChildren.toArray(new ITestElement[fChildren.size()]);
 	}
 
 	public void addChild(TestElement child) {
@@ -156,44 +154,4 @@ public class TestSuiteElement extends TestElement implements ITestSuiteElement {
 		return "TestSuite: " + getTestName() + " : " + super.toString() + " (" + fChildren.size() + ")";   //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	}
 
-	@Override
-	public String getTrace() {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child != null) {
-			return child.getTrace();
-		}
-		return super.getTrace();
-	}
-
-	private static boolean isSingleDynamicTest(TestElement element) {
-		if (element instanceof TestCaseElement) {
-			TestCaseElement testCase = (TestCaseElement) element;
-			TestSuiteElement suite = testCase.getParent();
-			if (testCase.isDynamicTest() && suite.fChildren.size() == 1) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * If this test suite is a {@code @TestTemplate} test case with a single child, return that child.
-	 * @return The single dynamic test case child or {@code null} if the suite has no children or multiple or non-dynamid children.
-	 */
-	public TestCaseElement getSingleDynamicChild() {
-		try {
-			if (fChildren.size() == 1) {
-				TestElement child= fChildren.get(0);
-				if (child instanceof TestCaseElement) {
-					TestCaseElement testCase= (TestCaseElement) child;
-					if (testCase.isDynamicTest()) {
-						return testCase;
-					}
-				}
-			}
-		} catch (IndexOutOfBoundsException e) {
-			// don't care, children changed concurrently
-		}
-		return null;
-	}
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -452,14 +452,6 @@ public class TestViewer {
 			// a group of parameterized tests
 			return new OpenTestAction(fTestRunnerPart, (TestCaseElement) children[0], null);
 		}
-		if (children.length == 0) {
-			// check if we have applied the workaround for: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/945
-			TestCaseElement child= testSuite.getSingleDynamicChild();
-			if (child != null) {
-				// a parameterized test that ran only one test
-				return new OpenTestAction(fTestRunnerPart, child, null);
-			}
-		}
 
 		int index= testName.indexOf('(');
 		// test factory method


### PR DESCRIPTION
We revert the changes from:

#946
#1022

Since there are other regressions we see, such as showing the string comparison dialog not working.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
