### PR TITLE
Don't show children for JUnit 5 @TestTemplate tests that ran only once

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -452,6 +452,14 @@ public class TestViewer {
 			// a group of parameterized tests
 			return new OpenTestAction(fTestRunnerPart, (TestCaseElement) children[0], null);
 		}
+		if (children.length == 0) {
+			// check if we have applied the workaround for: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/945
+			TestCaseElement child= testSuite.getSingleDynamicChild();
+			if (child != null) {
+				// a parameterized test that ran only one test
+				return new OpenTestAction(fTestRunnerPart, child, null);
+			}
+		}
 
 		int index= testName.indexOf('(');
 		// test factory method


### PR DESCRIPTION
Don't show children for JUnit 5 `@TestTemplate` tests that ran only once

When running JUnit 5 `@TestTemplate` tests, extra test suites are shown in the JUnit view to represent the tests in the template. Those suites introduce unnecessary noise when the template contains only one test - e.g. when repeating tests that failed.

This change adjusts TestSuiteElement.getChildren(), pruning each TestSuiteElement that has a single TestCaseElement child that is also a dynamic test.

```
import static org.junit.jupiter.api.Assertions.assertEquals;

import org.junit.Assume;
import org.junit.jupiter.api.MethodOrderer.MethodName;
import org.junit.jupiter.api.RepeatedTest;
import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.TestMethodOrder;

@TestMethodOrder(MethodName.class)
public class TestTemplatesJunit5 {

	@Test
	public void testOkNoRepeats() throws Exception {
		Thread.sleep(500);
	}
	
	@RepeatedTest(value = 1)
	public void testOkOneRepeat() throws Exception {
		Thread.sleep(500);
	}

	@RepeatedTest(value = 2)
	public void testOkTwoRepeats() throws Exception {
		Thread.sleep(500);
	}
	
	@Test
	public void testWithErrorNoRepeats() throws Exception {
		doStupidThings(null);
	}
	
	@RepeatedTest(value = 1)
	public void testErrorOneRepeat() throws Exception {
		doStupidThings(null);
	}
	
	@RepeatedTest(value = 2)
	public void testErrorTwoRepeats() throws Exception {
		doStupidThings(null);
	}

	@Test
	public void testFailNoRepeats() throws Exception {
		assertEquals("expected", "observed");
	}
	
	@RepeatedTest(value = 1)
	public void testFailOneRepeat() throws Exception {
		assertEquals("expected", "observed");
	}

	@RepeatedTest(value = 2)
	public void testFailTwoRepeats() throws Exception {
		assertEquals("expected", "observed");
	}


	@RepeatedTest(value = 0)
	public void testWrongRepeat() throws Exception {
		Thread.sleep(500);
	}
	
	@Test
	public void testAssume() throws Exception {
		Assume.assumeFalse(true);
	}
	
	@RepeatedTest(value = 1)
	public void testAssumeOneRepeat() throws Exception {
		Assume.assumeFalse(true);
	}
	
	@RepeatedTest(value = 2)
	public void testAssumeTwoRepeats() throws Exception {
		Assume.assumeFalse(true);
	}
	
	private void doStupidThings(String arg) {
		arg.toString();
	}
	
}
```

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/945
