### PR TITLE
Don't create pattern instanceof expression for non-conditional infix

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.InfixExpression.Operator;
 import org.eclipse.jdt.core.dom.InstanceofExpression;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
@@ -129,6 +130,13 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 
 				if (currentNode.getParent() == null) {
 					return true;
+				}
+
+				if (currentNode instanceof InfixExpression infixExp) {
+					if (infixExp.getOperator() != Operator.CONDITIONAL_AND &&
+							infixExp.getOperator() != Operator.CONDITIONAL_OR) {
+						return true;
+					}
 				}
 
 				IfStatement ifStatement= (IfStatement) currentNode.getParent();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -160,17 +160,6 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "        return 0;\n" //
 				+ "    }\n" //
 				+ "\n" //
-				+ "\n" //
-				+ "    public long matchPatternInAndExpression(Object object, boolean isValid) {\n" //
-				+ "        if (object instanceof Date & isValid) {\n" //
-				+ "            // Keep this comment\n" //
-				+ "            Date date = (Date) object;\n" //
-				+ "            return date.getTime();\n" //
-				+ "        }\n" //
-				+ "\n" //
-				+ "        return 0;\n" //
-				+ "    }\n" //
-				+ "\n" //
 				+ "    public long matchPatternInElse(Object object) {\n" //
 				+ "        if (!(object instanceof Date)) {\n" //
 				+ "            return 0;\n" //
@@ -182,15 +171,6 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long matchPatternInConditionalOrExpression(Object object, boolean isValid) {\n" //
 				+ "        if (!(object instanceof Date) || isValid) {\n" //
-				+ "            return 0;\n" //
-				+ "        } else {\n" //
-				+ "            Date date = (Date) object;\n" //
-				+ "            return date.getTime();\n" //
-				+ "        }\n" //
-				+ "    }\n" //
-				+ "\n" //
-				+ "    public long matchPatternInOrExpression(Object object, boolean isValid) {\n" //
-				+ "        if (isValid | !(object instanceof Date)) {\n" //
 				+ "            return 0;\n" //
 				+ "        } else {\n" //
 				+ "            Date date = (Date) object;\n" //
@@ -254,16 +234,6 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "        return 0;\n" //
 				+ "    }\n" //
 				+ "\n" //
-				+ "\n" //
-				+ "    public long matchPatternInAndExpression(Object object, boolean isValid) {\n" //
-				+ "        if (object instanceof Date date & isValid) {\n" //
-				+ "            // Keep this comment\n" //
-				+ "            return date.getTime();\n" //
-				+ "        }\n" //
-				+ "\n" //
-				+ "        return 0;\n" //
-				+ "    }\n" //
-				+ "\n" //
 				+ "    public long matchPatternInElse(Object object) {\n" //
 				+ "        if (!(object instanceof Date date)) {\n" //
 				+ "            return 0;\n" //
@@ -274,14 +244,6 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long matchPatternInConditionalOrExpression(Object object, boolean isValid) {\n" //
 				+ "        if (!(object instanceof Date date) || isValid) {\n" //
-				+ "            return 0;\n" //
-				+ "        } else {\n" //
-				+ "            return date.getTime();\n" //
-				+ "        }\n" //
-				+ "    }\n" //
-				+ "\n" //
-				+ "    public long matchPatternInOrExpression(Object object, boolean isValid) {\n" //
-				+ "        if (isValid | !(object instanceof Date date)) {\n" //
 				+ "            return 0;\n" //
 				+ "        } else {\n" //
 				+ "            return date.getTime();\n" //
@@ -478,7 +440,25 @@ public class CleanUpTest16 extends CleanUpTestCase {
 				+ "        Integer i = (Integer) bah;\n" //
 				+ "        System.out.println(i);\n" //
 				+ "    }\n" //
-				+ "}\n";
+				+ "\n" //
+				+ "    public void doNotMatchBitWiseAnd(boolean useStrikethroughForCompleted, Object data) {\n" //
+				+ "        if (data instanceof Long & useStrikethroughForCompleted) {\n" //
+				+ "            Long task = (Long)data;\n" //
+				+ "            if (task.intValue() == 0) {\n" //
+				+ "                int i = 0;\n" //
+				+ "            }\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public void doNotMatchBitWiseOr(boolean useStrikethroughForCompleted, Object data) {\n" //
+				+ "        if (data instanceof Long | useStrikethroughForCompleted) {\n" //
+				+ "            Long task = (Long)data;\n" //
+				+ "            if (task.intValue() == 0) {\n" //
+				+ "                int i = 0;\n" //
+				+ "            }\n" //
+				+ "        }\n" //
+				+ "    }\n" //
+			+ "}\n";
 		ICompilationUnit cu= pack.createCompilationUnit("E.java", sample, false, null);
 
 		enable(CleanUpConstants.USE_PATTERN_MATCHING_FOR_INSTANCEOF);


### PR DESCRIPTION
- modify PatternMatchingForInstanceofFixCore to recognize when an instanceof expression is used in an infix expression but not with conditional and (&&) or conditional or (||)
- modify tests in CleanUpTest16
- fixes #1218

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Prevents the pattern matching instanceof cleanup from changing the code when the instanceof expression is used in an infix expression that doesn't use the conditional-and or conditional-or.  Such a sequence is invalid.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or test changes in CleanUpTest16

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
