### PR TITLE
HierarchicalASTVisitor update after JDT core API change

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -7,15 +7,15 @@ Bundle-Version: 1.21.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.ltk.core.refactoring;bundle-version="[3.6.0,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.36.0,4.0.0)",
- org.eclipse.core.expressions;bundle-version="[3.4.100,4.0.0)",
- org.eclipse.text;bundle-version="[3.12.0,4.0.0)",
- org.eclipse.jdt.launching;bundle-version="3.19.400",
- org.eclipse.core.filesystem;bundle-version="1.7.200",
- org.eclipse.core.filebuffers;bundle-version="3.6.300",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.0,4.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.20.0,4.0.0)",
+ org.eclipse.ltk.core.refactoring;bundle-version="[3.14.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.38.0,4.0.0)",
+ org.eclipse.core.expressions;bundle-version="[3.9.0,4.0.0)",
+ org.eclipse.text;bundle-version="[3.14.0,4.0.0)",
+ org.eclipse.jdt.launching;bundle-version="3.21.0",
+ org.eclipse.core.filesystem;bundle-version="1.10.0",
+ org.eclipse.core.filebuffers;bundle-version="3.8.0",
  org.eclipse.search.core;bundle-version="3.16.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.jdt.core.manipulation,

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
@@ -668,6 +668,16 @@ public abstract class HierarchicalASTVisitor extends ASTVisitor {
 	}
 
 	@Override
+	public boolean visit(EitherOrMultiPattern node) {
+		return visit((Pattern) node);
+	}
+
+	@Override
+	public void endVisit(EitherOrMultiPattern node) {
+		endVisit((Pattern) node);
+	}
+
+	@Override
 	public boolean visit(ParenthesizedExpression node) {
 		return visit((Expression)node);
 	}


### PR DESCRIPTION
Fixes test fail `HierarchicalASTVisitor must be updated to reflect a change in the ASTNode hierarchy. No method visit(EitherOrMultiPattern) was found in HierarchicalASTVisitor.`

See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2011
