### PR TITLE
Fix lambda method ref generation to avoid ambiguous error

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 IBM Corporation and others.
+ * Copyright (c) 2013, 2024 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -750,12 +750,12 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 									methodRef.setExpression(ast.newThisExpression());
 								}
 								methodRef.setName(ASTNodes.createMoveTarget(rewrite, methodInvocation.getName()));
-								cicReplacement= methodRef;
+								cicReplacement= castMethodRefIfNeeded(cuRewrite, ast, methodRef, classInstanceCreation);
 							} else if (methodInvocationCheck.status() == MethodRefStatus.TYPE_REF) {
 								TypeMethodReference typeMethodRef= ast.newTypeMethodReference();
 								typeMethodRef.setType(copyType(cuRewrite, ast, methodInvocation, methodInvocationCheck.classBinding()));
 								typeMethodRef.setName(ASTNodes.createMoveTarget(rewrite, methodInvocation.getName()));
-								cicReplacement= typeMethodRef;
+								cicReplacement= castMethodRefIfNeeded(cuRewrite, ast, typeMethodRef, classInstanceCreation);
 							}
 						}
 					} else if (lambdaBody instanceof ClassInstanceCreation invokedClassInstanceCreation) {
@@ -774,7 +774,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 						if (methodDeclaration.parameters().size() == arguments.size() && areSameIdentifiers(methodDeclaration, arguments)) {
 							SuperMethodReference superMethodRef= ast.newSuperMethodReference();
 							superMethodRef.setName(ASTNodes.createMoveTarget(rewrite, superMethodInvocation.getName()));
-							cicReplacement= superMethodRef;
+							cicReplacement= castMethodRefIfNeeded(cuRewrite, ast, superMethodRef, classInstanceCreation);
 						}
 					} else if (lambdaBody instanceof InstanceofExpression instanceofExpression) {
 						Expression leftOp= instanceofExpression.getLeftOperand();
@@ -784,7 +784,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 							typeLiteral.setType(copyType(cuRewrite, ast, instanceofExpression, instanceofExpression.getRightOperand().resolveBinding()));
 							instanceofMethodReference.setName(ast.newSimpleName("isInstance")); //$NON-NLS-1$
 							instanceofMethodReference.setExpression(typeLiteral);
-							cicReplacement= instanceofMethodReference;
+							cicReplacement= castMethodRefIfNeeded(cuRewrite, ast, instanceofMethodReference, classInstanceCreation);
 						}
 					}
 				}
@@ -960,6 +960,50 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 				importRemover.registerRemovedNode(classInstanceCreation);
 				importRemover.registerRetainedNode(lambdaBody);
 			}
+		}
+
+		private Expression castMethodRefIfNeeded(final CompilationUnitRewrite cuRewrite, AST ast, Expression methodRef, Expression visited) {
+			boolean needCast= false;
+			Expression replacementNode= methodRef;
+			if (visited.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
+				MethodInvocation parent= (MethodInvocation) visited.getParent();
+				List<Expression> args= parent.arguments();
+				IMethodBinding parentBinding= parent.resolveMethodBinding();
+				if (parentBinding != null) {
+					ITypeBinding parentTypeBinding= parentBinding.getDeclaringClass();
+					while (parentTypeBinding != null) {
+						IMethodBinding[] parentTypeMethods= parentTypeBinding.getDeclaredMethods();
+						for (IMethodBinding parentTypeMethod : parentTypeMethods) {
+							if (parentTypeMethod.getName().equals(parentBinding.getName()) && !parentTypeMethod.isEqualTo(parentBinding)) {
+								needCast= true;
+								break;
+							}
+						}
+						if (!needCast) {
+							parentTypeBinding= parentTypeBinding.getSuperclass();
+						} else {
+							break;
+						}
+					}
+					if (needCast) {
+						for (Expression arg : args) {
+							if (arg == visited) {
+								CastExpression cast= ast.newCastExpression();
+								cast.setExpression(methodRef);
+								ITypeBinding argTypeBinding= arg.resolveTypeBinding();
+								if (argTypeBinding == null) {
+									return replacementNode;
+								}
+								ImportRewrite importRewriter= cuRewrite.getImportRewrite();
+								Type argType= importRewriter.addImport(argTypeBinding, ast);
+								cast.setType(argType);
+								replacementNode= cast;
+							}
+						}
+					}
+				}
+			}
+			return replacementNode;
 		}
 
 		private static void collectInheritedTypes(final ITypeBinding anonymType, final Set<ITypeBinding> inheritedTypes) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -5003,6 +5003,212 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 	}
 
 	@Test
+	public void testIssue1047_1() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf1= new StringBuilder();
+		buf1.append("package test1;\n");
+		buf1.append("import java.util.function.Supplier;\n");
+		buf1.append("\n");
+		buf1.append("public class E {\n");
+		buf1.append("    void func( String ... args) {\n");
+		buf1.append("    }\n");
+		buf1.append("\n");
+		buf1.append("    private void called( Supplier<Object> r ) {\n");
+		buf1.append("    }\n");
+		buf1.append("\n");
+		buf1.append("    void called( Runnable r ) {\n");
+		buf1.append("    }\n");
+		buf1.append("\n");
+		buf1.append("    void test() {\n");
+		buf1.append("        called(() -> func());\n");
+		buf1.append("    }\n");
+		buf1.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf1.toString(), false, null);
+
+
+		int offset= buf1.toString().indexOf("func()");
+		AssistContext context= getCorrectionContext(cu, offset, 0);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("import java.util.function.Supplier;\n");
+		buf.append("\n");
+		buf.append("public class E {\n");
+		buf.append("    void func( String ... args) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    private void called( Supplier<Object> r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void called( Runnable r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void test() {\n");
+		buf.append("        called((Runnable) this::func);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected1= buf.toString();
+		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
+	public void testIssue1047_2() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf1= new StringBuilder();
+		buf1.append("package test1;\n");
+		buf1.append("import java.util.function.Supplier;\n");
+		buf1.append("\n");
+		buf1.append("public class E1 {\n");
+		buf1.append("    private void called( Supplier<Object> r ) {\n");
+		buf1.append("    }\n");
+		buf1.append("\n");
+		buf1.append("}\n");
+		pack1.createCompilationUnit("E1.java", buf1.toString(), false, null);
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E extends E1 {\n");
+		buf.append("    void func( String ... args) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void called( Runnable r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void test() {\n");
+		buf.append("        called(() -> func());\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		int offset= buf.toString().indexOf("func()");
+		AssistContext context= getCorrectionContext(cu, offset, 0);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E extends E1 {\n");
+		buf.append("    void func( String ... args) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void called( Runnable r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void test() {\n");
+		buf.append("        called((Runnable) this::func);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected1= buf.toString();
+		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
+	public void testIssue1047_3() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf1= new StringBuilder();
+		buf1.append("package test1;\n");
+		buf1.append("import java.util.function.Supplier;\n");
+		buf1.append("\n");
+		buf1.append("public class E1 {\n");
+		buf1.append("    void func( String ... args) {\n");
+		buf1.append("    }\n");
+		buf1.append("    private void called( Supplier<Object> r ) {\n");
+		buf1.append("    }\n");
+		buf1.append("\n");
+		buf1.append("}\n");
+		pack1.createCompilationUnit("E1.java", buf1.toString(), false, null);
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E extends E1 {\n");
+		buf.append("\n");
+		buf.append("    void called( Runnable r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void test() {\n");
+		buf.append("        called(() -> super.func());\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		int offset= buf.toString().indexOf("func()");
+		AssistContext context= getCorrectionContext(cu, offset, 0);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E extends E1 {\n");
+		buf.append("\n");
+		buf.append("    void called( Runnable r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void test() {\n");
+		buf.append("        called((Runnable) super::func);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected1= buf.toString();
+		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
+	public void testIssue1047_4() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuilder buf1= new StringBuilder();
+		buf1.append("package test1;\n");
+		buf1.append("import java.util.function.Supplier;\n");
+		buf1.append("\n");
+		buf1.append("public class E1 {\n");
+		buf1.append("    public static void func( String ... args) {\n");
+		buf1.append("    }\n");
+		buf1.append("    private void called( Supplier<Object> r ) {\n");
+		buf1.append("    }\n");
+		buf1.append("\n");
+		buf1.append("}\n");
+		pack1.createCompilationUnit("E1.java", buf1.toString(), false, null);
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E extends E1 {\n");
+		buf.append("\n");
+		buf.append("    void called( Runnable r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void test() {\n");
+		buf.append("        called(() -> E1.func());\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+
+		int offset= buf.toString().indexOf("func()");
+		AssistContext context= getCorrectionContext(cu, offset, 0);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		buf= new StringBuilder();
+		buf.append("package test1;\n");
+		buf.append("\n");
+		buf.append("public class E extends E1 {\n");
+		buf.append("\n");
+		buf.append("    void called( Runnable r ) {\n");
+		buf.append("    }\n");
+		buf.append("\n");
+		buf.append("    void test() {\n");
+		buf.append("        called((Runnable) E1::func);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected1= buf.toString();
+		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
 	public void testFixParenthesesInLambdaExpressionAdd() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		StringBuilder buf1= new StringBuilder();


### PR DESCRIPTION
- modify ConvertLambdaToMethodReferenceFixCore, LambdaExpressionsFixCore, and LambdaExpressionAndMethodRefFixCore when generating method refs to check if the method ref will be a method argument and if that method is overloaded, add a type cast to prevent an ambiguous error
- add new tests to CleanUpTest1d8 and AssistQuickFixTest1d8
- fixes #1047

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes lambda cleanups and assists that create method refs to add a cast when needed to avoid a compiler error saying that the call is ambiguous.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue and new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
