### PR TITLE
Fix performance lag for String to text block cleanups/fixes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
@@ -112,7 +112,7 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 				NLSLine nlsLine= scanCurrentLine(cu, operand);
 				if (nlsLine != null) {
 					for (NLSElement element : nlsLine.getElements()) {
-						if (element.getPosition().getOffset() == operand.getStartPosition()) {
+						if (element.getPosition().getOffset() == compilationUnit.getColumnNumber(operand.getStartPosition())) {
 							if (element.hasTag()) {
 								if (seenNoTag) {
 									return null;
@@ -142,10 +142,11 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 	private static NLSLine scanCurrentLine(ICompilationUnit cu, Expression exp) {
 		CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
 		int startLine= cUnit.getLineNumber(exp.getStartPosition());
+		int startLinePos= cUnit.getPosition(startLine, 0);
 		int endOfLine= cUnit.getPosition(startLine + 1, 0);
 		NLSLine[] lines;
 		try {
-			lines= NLSScanner.scan(cu.getBuffer().getText(exp.getStartPosition(), endOfLine - exp.getStartPosition()));
+			lines= NLSScanner.scan(cu.getBuffer().getText(startLinePos, endOfLine - startLinePos));
 			if (lines.length > 0) {
 				return lines[0];
 			}
@@ -205,7 +206,7 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 					NLSLine nlsLine= scanCurrentLine(cu, operand);
 					if (nlsLine != null) {
 						for (NLSElement element : nlsLine.getElements()) {
-							if (element.getPosition().getOffset() == operand.getStartPosition()) {
+							if (element.getPosition().getOffset() == root.getColumnNumber(operand.getStartPosition())) {
 								if (element.hasTag()) {
 									++tagsCount;
 								}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
@@ -18,8 +18,11 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 
+import org.eclipse.jface.text.BadLocationException;
+
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Assignment;
@@ -42,7 +45,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
-import org.eclipse.jdt.internal.corext.refactoring.nls.NLSUtil;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSScanner;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
@@ -106,28 +109,24 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 			} else {
 				// ensure either all string literals are nls-tagged or none are
 				ICompilationUnit cu= (ICompilationUnit)compilationUnit.getJavaElement();
-				try {
-					NLSLine nlsLine= NLSUtil.scanCurrentLine(cu, operand.getStartPosition());
-					if (nlsLine != null) {
-						for (NLSElement element : nlsLine.getElements()) {
-							if (element.getPosition().getOffset() == operand.getStartPosition()) {
-								if (element.hasTag()) {
-									if (seenNoTag) {
-										return null;
-									}
-									seenTag= true;
-								} else {
-									if (seenTag) {
-										return null;
-									}
-									seenNoTag= true;
+				NLSLine nlsLine= scanCurrentLine(cu, operand);
+				if (nlsLine != null) {
+					for (NLSElement element : nlsLine.getElements()) {
+						if (element.getPosition().getOffset() == operand.getStartPosition()) {
+							if (element.hasTag()) {
+								if (seenNoTag) {
+									return null;
 								}
-								break;
+								seenTag= true;
+							} else {
+								if (seenTag) {
+									return null;
+								}
+								seenNoTag= true;
 							}
+							break;
 						}
 					}
-				} catch (JavaModelException e) {
-					return null;
 				}
 			}
 		}
@@ -138,6 +137,22 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 
 		return new ConvertToMessageFormatFixCore(CorrectionMessages.QuickAssistProcessor_convert_to_message_format, compilationUnit,
 				new ConvertToMessageFormatProposalOperation(oldInfixExpression));
+	}
+
+	private static NLSLine scanCurrentLine(ICompilationUnit cu, Expression exp) {
+		CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
+		int startLine= cUnit.getLineNumber(exp.getStartPosition());
+		int endOfLine= cUnit.getPosition(startLine + 1, 0);
+		NLSLine[] lines;
+		try {
+			lines= NLSScanner.scan(cu.getBuffer().getText(exp.getStartPosition(), endOfLine - exp.getStartPosition()));
+			if (lines.length > 0) {
+				return lines[0];
+			}
+		} catch (IndexOutOfBoundsException | JavaModelException | InvalidInputException | BadLocationException e) {
+			// fall-through
+		}
+		return null;
 	}
 
 	private static void collectInfixPlusOperands(Expression expression, List<Expression> collector) {
@@ -187,7 +202,7 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 			int tagsCount= 0;
 			for (Expression operand : operands) {
 				if (operand instanceof StringLiteral) {
-					NLSLine nlsLine= NLSUtil.scanCurrentLine(cu, operand.getStartPosition());
+					NLSLine nlsLine= scanCurrentLine(cu, operand);
 					if (nlsLine != null) {
 						for (NLSElement element : nlsLine.getElements()) {
 							if (element.getPosition().getOffset() == operand.getStartPosition()) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringBufferFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringBufferFixCore.java
@@ -19,8 +19,12 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 
+import org.eclipse.jface.text.BadLocationException;
+
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.NamingConventions;
+import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Assignment;
@@ -52,7 +56,7 @@ import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
-import org.eclipse.jdt.internal.corext.refactoring.nls.NLSUtil;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSScanner;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
@@ -258,7 +262,7 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 			int tagsCount= 0;
 			for (Expression operand : operands) {
 				boolean tagged= false;
-				NLSLine nlsLine= NLSUtil.scanCurrentLine(cu, operand.getStartPosition());
+				NLSLine nlsLine= scanCurrentLine(cu, operand);
 				if (nlsLine != null) {
 					for (NLSElement element : nlsLine.getElements()) {
 						if (element.getPosition().getOffset() == operand.getStartPosition()) {
@@ -318,5 +322,22 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 				linkedModel.setEndPosition(rewrite.track(bufferToString));
 			}
 		}
+
+		private static NLSLine scanCurrentLine(ICompilationUnit cu, Expression exp) {
+			CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
+			int startLine= cUnit.getLineNumber(exp.getStartPosition());
+			int endOfLine= cUnit.getPosition(startLine + 1, 0);
+			NLSLine[] lines;
+			try {
+				lines= NLSScanner.scan(cu.getBuffer().getText(exp.getStartPosition(), endOfLine - exp.getStartPosition()));
+				if (lines.length > 0) {
+					return lines[0];
+				}
+			} catch (IndexOutOfBoundsException | JavaModelException | InvalidInputException | BadLocationException e) {
+				// fall-through
+			}
+			return null;
+		}
+
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringBufferFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringBufferFixCore.java
@@ -260,12 +260,13 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 
 			Statement lastAppend= insertAfter;
 			int tagsCount= 0;
+			CompilationUnit compilationUnit= (CompilationUnit)oldInfixExpression.getRoot();
 			for (Expression operand : operands) {
 				boolean tagged= false;
 				NLSLine nlsLine= scanCurrentLine(cu, operand);
 				if (nlsLine != null) {
 					for (NLSElement element : nlsLine.getElements()) {
-						if (element.getPosition().getOffset() == operand.getStartPosition()) {
+						if (element.getPosition().getOffset() == compilationUnit.getColumnNumber(operand.getStartPosition())) {
 							if (element.hasTag()) {
 								tagged= true;
 								++tagsCount;
@@ -326,10 +327,11 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 		private static NLSLine scanCurrentLine(ICompilationUnit cu, Expression exp) {
 			CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
 			int startLine= cUnit.getLineNumber(exp.getStartPosition());
+			int startLinePos= cUnit.getPosition(startLine, 0);
 			int endOfLine= cUnit.getPosition(startLine + 1, 0);
 			NLSLine[] lines;
 			try {
-				lines= NLSScanner.scan(cu.getBuffer().getText(exp.getStartPosition(), endOfLine - exp.getStartPosition()));
+				lines= NLSScanner.scan(cu.getBuffer().getText(startLinePos, endOfLine - startLinePos));
 				if (lines.length > 0) {
 					return lines[0];
 				}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
@@ -113,7 +113,7 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 				NLSLine nlsLine= scanCurrentLine(cu, operand);
 				if (nlsLine != null) {
 					for (NLSElement element : nlsLine.getElements()) {
-						if (element.getPosition().getOffset() == operand.getStartPosition()) {
+						if (element.getPosition().getOffset() == compilationUnit.getColumnNumber(operand.getStartPosition())) {
 							if (element.hasTag()) {
 								if (seenNoTag) {
 									return null;
@@ -142,10 +142,11 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 	private static NLSLine scanCurrentLine(ICompilationUnit cu, Expression exp) {
 		CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
 		int startLine= cUnit.getLineNumber(exp.getStartPosition());
+		int startLinePos= cUnit.getPosition(startLine, 0);
 		int endOfLine= cUnit.getPosition(startLine + 1, 0);
 		NLSLine[] lines;
 		try {
-			lines= NLSScanner.scan(cu.getBuffer().getText(exp.getStartPosition(), endOfLine - exp.getStartPosition()));
+			lines= NLSScanner.scan(cu.getBuffer().getText(startLinePos, endOfLine - startLinePos));
 			if (lines.length > 0) {
 				return lines[0];
 			}
@@ -197,7 +198,7 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 					NLSLine nlsLine= scanCurrentLine(cu, operand);
 					if (nlsLine != null) {
 						for (NLSElement element : nlsLine.getElements()) {
-							if (element.getPosition().getOffset() == operand.getStartPosition()) {
+							if (element.getPosition().getOffset() == root.getColumnNumber(operand.getStartPosition())) {
 								if (element.hasTag()) {
 									++tagsCount;
 								}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -26,11 +26,15 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.text.edits.TextEditGroup;
 
+import org.eclipse.jface.text.BadLocationException;
+
+import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -66,7 +70,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
-import org.eclipse.jdt.internal.corext.refactoring.nls.NLSUtil;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSScanner;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -119,7 +123,8 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				return false;
 			}
 			StringLiteral rightLiteral= (StringLiteral)leftHand;
-			hasComments= hasComments || !ASTNodes.getTrailingComments(rightLiteral).isEmpty();
+			ICompilationUnit cu= (ICompilationUnit)cUnit.getJavaElement();
+			hasComments= hasComments || hasNLS(ASTNodes.getTrailingComments(rightLiteral), cu);
 			literal= rightLiteral.getLiteralValue();
 			if (!literal.isEmpty() && !fAllConcats && !literal.endsWith("\n")) { //$NON-NLS-1$
 				return false;
@@ -130,17 +135,17 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			}
 			int lineNo= getLineOfOffset(cUnit, leftLiteral.getStartPosition());
 			int endPosition= getLineOffset(cUnit, lineNo + 1) == -1 ? cUnit.getLength() : getLineOffset(cUnit, lineNo + 1);
-			hasComments= hasComments || !ASTNodes.getCommentsForRegion(cUnit, leftLiteral.getStartPosition(), endPosition - leftLiteral.getStartPosition()).isEmpty();
+			hasComments= hasComments || hasNLS(ASTNodes.getCommentsForRegion(cUnit, leftLiteral.getStartPosition(), endPosition - leftLiteral.getStartPosition()), cu);
 			lineNo= getLineOfOffset(cUnit, rightLiteral.getStartPosition());
 			endPosition= getLineOffset(cUnit, lineNo + 1) == -1 ? cUnit.getLength() : getLineOffset(cUnit, lineNo + 1);
-			hasComments= hasComments || !ASTNodes.getCommentsForRegion(cUnit, rightLiteral.getStartPosition(), endPosition - rightLiteral.getStartPosition()).isEmpty();
+			hasComments= hasComments || hasNLS(ASTNodes.getCommentsForRegion(cUnit, rightLiteral.getStartPosition(), endPosition - rightLiteral.getStartPosition()), cu);
 			for (int i= 0; i < extendedOperands.size(); ++i) {
 				Expression operand= extendedOperands.get(i);
 				if (operand instanceof StringLiteral) {
 					StringLiteral stringLiteral= (StringLiteral)operand;
 					lineNo= getLineOfOffset(cUnit, stringLiteral.getStartPosition());
 					endPosition= getLineOffset(cUnit, lineNo + 1) == -1 ? cUnit.getLength() : getLineOffset(cUnit, lineNo + 1);
-					hasComments= hasComments || !ASTNodes.getCommentsForRegion(cUnit, stringLiteral.getStartPosition(), endPosition - stringLiteral.getStartPosition()).isEmpty();
+					hasComments= hasComments || hasNLS(ASTNodes.getCommentsForRegion(cUnit, stringLiteral.getStartPosition(), endPosition - stringLiteral.getStartPosition()), cu);
 					String string= stringLiteral.getLiteralValue();
 					if (!string.isEmpty() && (fAllConcats || string.endsWith("\n") || i == extendedOperands.size() - 1)) { //$NON-NLS-1$
 						continue;
@@ -150,36 +155,65 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			}
 			boolean isTagged= false;
 			if (hasComments && ASTNodes.getFirstAncestorOrNull(visited, Annotation.class) == null) {
-				// we must ensure that NLS comments are consistent for all string literals in concatenation
-				ICompilationUnit cu= (ICompilationUnit)((CompilationUnit)leftHand.getRoot()).getJavaElement();
-				try {
-				   NLSLine nlsLine= NLSUtil.scanCurrentLine(cu, leftHand.getStartPosition());
-				   if (nlsLine == null) {
-					   return false;
-				   }
-				   isTagged= nlsLine.getElements()[0].hasTag();
-				   if (!isConsistent(nlsLine, isTagged)) {
-					   return false;
-				   }
-				   nlsLine= NLSUtil.scanCurrentLine(cu, rightHand.getStartPosition());
-				   if (!isConsistent(nlsLine, isTagged)) {
-					   return false;
-				   }
-				   for (int i= 0; i < extendedOperands.size(); ++i) {
-					   Expression operand= extendedOperands.get(i);
-					   nlsLine= NLSUtil.scanCurrentLine(cu, operand.getStartPosition());
-					   if (!isConsistent(nlsLine, isTagged)) {
-						   return false;
-					   }
-				   }
-				} catch (JavaModelException e) {
+				NLSLine nlsLine= scanCurrentLine(cu, leftHand);
+				if (nlsLine == null) {
 					return false;
+				}
+				isTagged= nlsLine.getElements()[0].hasTag();
+				if (!isConsistent(nlsLine, isTagged)) {
+					return false;
+				}
+				nlsLine= scanCurrentLine(cu, rightHand);
+				if (nlsLine == null || !isConsistent(nlsLine, isTagged)) {
+					return false;
+				}
+				for (int i= 0; i < extendedOperands.size(); ++i) {
+					Expression operand= extendedOperands.get(i);
+					nlsLine= scanCurrentLine(cu, operand);
+					if (nlsLine == null || !isConsistent(nlsLine, isTagged)) {
+						return false;
+					}
 				}
 			}
 			// check if we are untagged or else if tagged, make sure we have a Statement or FieldDeclaration
 			// ancestor so we can recreate with proper single NLS tag
 			if (!isTagged || ASTNodes.getFirstAncestorOrNull(visited, Statement.class, FieldDeclaration.class) != null) {
 				fOperations.add(new ChangeStringConcatToTextBlock(visited, isTagged));
+			}
+			return false;
+		}
+
+		private NLSLine scanCurrentLine(ICompilationUnit cu, Expression exp) {
+			CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
+			int startLine= cUnit.getLineNumber(exp.getStartPosition());
+			int endOfLine= cUnit.getPosition(startLine + 1, 0);
+			NLSLine[] lines;
+			try {
+				lines= NLSScanner.scan(cu.getBuffer().getText(exp.getStartPosition(), endOfLine - exp.getStartPosition()));
+				if (lines.length > 0) {
+					return lines[0];
+				}
+			} catch (IndexOutOfBoundsException | JavaModelException | InvalidInputException | BadLocationException e) {
+				// fall-through
+			}
+			return null;
+		}
+
+		private boolean hasNLS(List<Comment> trailingComments, ICompilationUnit cu) {
+			if (!trailingComments.isEmpty() && cu != null) {
+				IBuffer buffer;
+				try {
+					buffer= cu.getBuffer();
+					for (Comment comment : trailingComments) {
+						if (comment instanceof LineComment lineComment) {
+							if (buffer.getText(comment.getStartPosition(), comment.getLength()).contains("$NON-NLS")) { //$NON-NLS-1$
+								return true;
+							}
+						}
+					}
+				} catch (JavaModelException e) {
+					// fall through
+				}
 			}
 			return false;
 		}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -205,7 +205,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				try {
 					buffer= cu.getBuffer();
 					for (Comment comment : trailingComments) {
-						if (comment instanceof LineComment lineComment) {
+						if (comment instanceof LineComment) {
 							if (buffer.getText(comment.getStartPosition(), comment.getLength()).contains("$NON-NLS")) { //$NON-NLS-1$
 								return true;
 							}


### PR DESCRIPTION
- don't use NLSUtil.scanCurrentLine(cu) which scans the entire compilation unit to find one line; instead get the text of the line and use NLSScanner.scan(String)
- add code in StringConcatToTextBlockFixCore when looking for comments to also ensure that nls prefix is found before doing any NLS checking
- fixes #1237

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes performance lag in String to text block conversions via cleanup or quick assist.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue example which converts a large file (CleanUpTest.java) which also has line comments at the end of every
concatenated string.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
