### PR TITLE
ExceptionOccurrencesFinder: fix IndexOutOfBoundsException #1241

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/ExceptionOccurrencesFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/ExceptionOccurrencesFinder.java
@@ -285,7 +285,7 @@ public class ExceptionOccurrencesFinder extends ASTVisitor implements IOccurrenc
 			for (TagElement tag : tags) {
 				String tagName= tag.getTagName();
 				if (TagElement.TAG_EXCEPTION.equals(tagName) || TagElement.TAG_THROWS.equals(tagName)) {
-					ASTNode name= (ASTNode) tag.fragments().get(0);
+					ASTNode name= tag.fragments().isEmpty() ? null : (ASTNode) tag.fragments().get(0);
 					if (name instanceof Name) {
 						if (name != fSelectedNode && Bindings.equals(fException, ((Name) name).resolveBinding())) {
 							fResult.add(new OccurrenceLocation(name.getStartPosition(), name.getLength(), 0, fDescription));


### PR DESCRIPTION
when @throws in javadoc doesn't have anything after it.

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1241

Shows the no exception instead:
![image](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/51790620/3a031168-ef7b-432c-ad25-68ca660597ad)
