### PR TITLE
Fix trailing tab logic for converting to Text Block

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -405,12 +405,12 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			if (unescaped.charAt(whitespaceStart) == ' ') {
 				whitespaceStart--;
 				trailingWhitespace.append("\\s"); //$NON-NLS-1$
+				continue;
 			} else if (unescaped.charAt(whitespaceStart) == '\t') {
 				whitespaceStart--;
 				trailingWhitespace.append("\\t"); //$NON-NLS-1$
-			} else {
-				break;
 			}
+			break;
 		}
 
 		return unescaped.substring(0, whitespaceStart + 1) + trailingWhitespace;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -110,6 +110,12 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "    public void testConcatInConstructor() {\n" //
     	        + "        new StringBuffer(\"abc\\n\" + \"def\\n\" + \"ghi\");\n" //
     	        + "    }\n" //
+    	        + "    public void testTabStart() {\n" //
+    	        + "        String x =\"\\tif (true) {\\n\" +\n" //
+    	        + "                \"\\t\\tstuff();\\n\" +\n" //
+    	        + "                \"\\t} else\\n\" +\n" //
+    	        + "                \"\\t\\tnoStuff\";\n" //
+    	        + "    }\n" //
 				+ "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -182,7 +188,14 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            def\n" //
     	        + "            ghi\"\"\");\n" //
     	        + "    }\n" //
-				+ "}\n";
+    	        + "    public void testTabStart() {\n" //
+    	        + "        String x =\"\"\"\n" //
+    	        + "            \tif (true) {\n" //
+    	        + "            \t\tstuff();\n" //
+    	        + "            \t} else\n" //
+    	        + "            \t\tnoStuff\"\"\";\n" //
+    	        + "    }\n" //
+    	        + "}\n";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore.escapeTrailingWhitespace() method
- add new test to CleanUpTest15
- fixes #1240

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes problems with converting to text block when text ends with tab and has other white-space prior to that.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
