### PR TITLE
Fix text block conversion when ending in quotes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -308,6 +308,22 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			if (newLine) {
 				buf.append(fIndent);
 			}
+			// Replace trailing un-escaped quotes with escaped quotes before adding text block end
+			int i= buf.length() - 1;
+			int count= 0;
+			while (i >= 0 && buf.charAt(i) == '"' && count <= 3) {
+				--i;
+				++count;
+			}
+			if (i >= 0 && buf.charAt(i) == '\\') {
+				--count;
+			}
+			for (i= count; i > 0; --i) {
+				buf.deleteCharAt(buf.length() - 1);
+			}
+			for (i= count; i > 0; --i) {
+				buf.append("\\\""); //$NON-NLS-1$
+			}
 			buf.append("\"\"\""); //$NON-NLS-1$
 			if (!isTagged) {
 				TextBlock textBlock= (TextBlock) rewrite.createStringPlaceholder(buf.toString(), ASTNode.TEXT_BLOCK);
@@ -370,7 +386,6 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				for (int j = 0; j < quoteCount % 3; j++) {
 					transformed.append("\""); //$NON-NLS-1$
 				}
-
 				readIndex= bsIndex + 2 * quoteCount;
 			} else if (escapedText.startsWith("\\t", bsIndex)) { //$NON-NLS-1$ "\t"
 				transformed.append(escapedText.substring(readIndex, bsIndex));
@@ -728,6 +743,23 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 
 			if (newLine) {
 				buf.append(fIndent);
+			}
+
+			// Replace trailing un-escaped quotes with escaped quotes before adding text block end
+			int readIndex= buf.length() - 1;
+			int count= 0;
+			while (readIndex >= 0 && buf.charAt(readIndex) == '"' && count <= 3) {
+				--readIndex;
+				++count;
+			}
+			if (readIndex >= 0 && buf.charAt(readIndex) == '\\') {
+				--count;
+			}
+			for (int i= count; i > 0; --i) {
+				buf.deleteCharAt(buf.length() - 1);
+			}
+			for (int i= count; i > 0; --i) {
+				buf.append("\\\""); //$NON-NLS-1$
 			}
 			buf.append("\"\"\""); //$NON-NLS-1$
 			MethodInvocation firstToStringCall= fToStringList.get(0);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -116,7 +116,15 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                \"\\t} else\\n\" +\n" //
     	        + "                \"\\t\\tnoStuff\";\n" //
     	        + "    }\n" //
-				+ "}\n";
+    	        + "    public void testEndEscapedQuotes() {\n" //
+    	        + "        String a =\n" //
+    	        + "                \"1\\n\" +\n" //
+    	        + "                \"2\\n\" +\n" //
+    	        + "                \"3\\n\" +\n" //
+    	        + "                \"4\\n\" +\n" //
+    	        + "                \"\\\"\\\"\\\"\\\"\";\n" //
+    	        + "    }\n" //
+    	        + "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
 
@@ -195,6 +203,15 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            \t} else\n" //
     	        + "            \t\tnoStuff\"\"\";\n" //
     	        + "    }\n" //
+    	        + "    public void testEndEscapedQuotes() {\n" //
+    	        + "        String a =\n" //
+    	        + "                \"\"\"\n" //
+    	        + "            1\n" //
+    	        + "            2\n" //
+    	        + "            3\n" //
+    	        + "            4\n" //
+    	        + "            \\\"\"\"\\\"\"\"\";\n" //
+    	        + "    }\n" //
     	        + "}\n";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
@@ -243,6 +260,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "            \"def\\n\" +\n" //
 				+ "            \"ghi\\n\";\n" //
     	        + "        new StringBuffer(\"abc\\n\" + \"def\\n\" + \"ghi\");\n" //
+    	        + "        new StringBuffer(\"1\\n\" +\n" //
+    	        + "                \"2\\n\" +\n" //
+    	        + "                \"3\\n\" +\n" //
+    	        + "                \"4\\n\" +\n" //
+    	        + "                \"\\\"\\\"\\\"\");\n" //
 				+ "    }\n" //
 				+ "}";
 
@@ -301,7 +323,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            abc\n" //
     	        + "            def\n" //
     	        + "            ghi\"\"\");\n" //
-				+ "    }\n" //
+    	        + "        new StringBuffer(\"\"\"\n" //
+    	        + "            1\n" //
+    	        + "            2\n" //
+    	        + "            3\n" //
+    	        + "            4\n" //
+    	        + "            \\\"\\\"\\\"\"\"\");\n" //
+    	        + "    }\n" //
 				+ "}";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore to look at resultant buffer before adding final block quotes and if last 1 or 2 characters are un-escaped quotes, replace them with escaped quotes
- add new scenarios to CleanUpTest15
- fixes #1238

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes conversion to text block when the string ends in quotes.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test changes.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
