### PR TITLE
Fix string to text block indentation when last line has no newline

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -294,6 +294,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 
 			buf.append("\"\"\"\n"); //$NON-NLS-1$
 			boolean newLine= false;
+			boolean allWhiteSpaceStart= true;
 			for (String part : parts) {
 				if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
 					if (!newLine) {
@@ -302,27 +303,32 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					}
 				}
 				newLine= part.endsWith(System.lineSeparator());
+				allWhiteSpaceStart= allWhiteSpaceStart && (part.isEmpty() || Character.isWhitespace(part.charAt(0)));
 				buf.append(fIndent).append(part);
 			}
 
 			if (newLine) {
 				buf.append(fIndent);
-			}
-			// Replace trailing un-escaped quotes with escaped quotes before adding text block end
-			int i= buf.length() - 1;
-			int count= 0;
-			while (i >= 0 && buf.charAt(i) == '"' && count <= 3) {
-				--i;
-				++count;
-			}
-			if (i >= 0 && buf.charAt(i) == '\\') {
-				--count;
-			}
-			for (i= count; i > 0; --i) {
-				buf.deleteCharAt(buf.length() - 1);
-			}
-			for (i= count; i > 0; --i) {
-				buf.append("\\\""); //$NON-NLS-1$
+			} else if (allWhiteSpaceStart) {
+				buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
+				buf.append(fIndent);
+			} else {
+				// Replace trailing un-escaped quotes with escaped quotes before adding text block end
+				int i= buf.length() - 1;
+				int count= 0;
+				while (i >= 0 && buf.charAt(i) == '"' && count <= 3) {
+					--i;
+					++count;
+				}
+				if (i >= 0 && buf.charAt(i) == '\\') {
+					--count;
+				}
+				for (i= count; i > 0; --i) {
+					buf.deleteCharAt(buf.length() - 1);
+				}
+				for (i= count; i > 0; --i) {
+					buf.append("\\\""); //$NON-NLS-1$
+				}
 			}
 			buf.append("\"\"\""); //$NON-NLS-1$
 			if (!isTagged) {
@@ -730,6 +736,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 
 			buf.append("\"\"\"\n"); //$NON-NLS-1$
 			boolean newLine= false;
+			boolean allWhiteSpaceStart= true;
 			for (String part : parts) {
 				if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
 					if (!newLine) {
@@ -738,28 +745,32 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					}
 				}
 				newLine= part.endsWith(System.lineSeparator());
+				allWhiteSpaceStart= allWhiteSpaceStart && (part.isEmpty() || Character.isWhitespace(part.charAt(0)));
 				buf.append(fIndent).append(part);
 			}
 
 			if (newLine) {
 				buf.append(fIndent);
-			}
-
-			// Replace trailing un-escaped quotes with escaped quotes before adding text block end
-			int readIndex= buf.length() - 1;
-			int count= 0;
-			while (readIndex >= 0 && buf.charAt(readIndex) == '"' && count <= 3) {
-				--readIndex;
-				++count;
-			}
-			if (readIndex >= 0 && buf.charAt(readIndex) == '\\') {
-				--count;
-			}
-			for (int i= count; i > 0; --i) {
-				buf.deleteCharAt(buf.length() - 1);
-			}
-			for (int i= count; i > 0; --i) {
-				buf.append("\\\""); //$NON-NLS-1$
+			} else if (allWhiteSpaceStart) {
+				buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
+				buf.append(fIndent);
+			} else {
+				// Replace trailing un-escaped quotes with escaped quotes before adding text block end
+				int readIndex= buf.length() - 1;
+				int count= 0;
+				while (readIndex >= 0 && buf.charAt(readIndex) == '"' && count <= 3) {
+					--readIndex;
+					++count;
+				}
+				if (readIndex >= 0 && buf.charAt(readIndex) == '\\') {
+					--count;
+				}
+				for (int i= count; i > 0; --i) {
+					buf.deleteCharAt(buf.length() - 1);
+				}
+				for (int i= count; i > 0; --i) {
+					buf.append("\\\""); //$NON-NLS-1$
+				}
 			}
 			buf.append("\"\"\""); //$NON-NLS-1$
 			MethodInvocation firstToStringCall= fToStringList.get(0);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -586,6 +586,61 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 	}
 
 	@Test
+	public void testConcatToTextBlock11() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1240
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		Hashtable<String, String> hashtable= JavaCore.getOptions();
+		hashtable.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
+		JavaCore.setOptions(hashtable);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String x =\"\\tif (true) {\\n\" +\n");
+		buf.append("                \"\\t\\tstuff();\\n\" +\n");
+		buf.append("                \"\\t} else\\n\" +\n");
+		buf.append("                \"\\t\\tnoStuff\";\n");
+		buf.append("        System.out.println(x);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("x");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String x =\"\"\"\n");
+		buf.append("            \tif (true) {\n");
+		buf.append("            \t\tstuff();\n");
+		buf.append("            \t} else\n");
+		buf.append("            \t\tnoStuff\\\n");
+		buf.append("            \"\"\";\n");
+		buf.append("        System.out.println(x);\n");		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
 	public void testNoConcatToTextBlock1() throws Exception {
 		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
 		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -124,6 +124,12 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                \"4\\n\" +\n" //
     	        + "                \"\\\"\\\"\\\"\\\"\";\n" //
     	        + "    }\n" //
+    	        + "    public void testNoEndNewlineIndented() {\n" //
+    	        + "        String x= \"\"\n" //
+    	        + "                + \"    /** bar\\n\" //\n" //
+    	        + "                + \"     * foo\\n\" //\n" //
+    	        + "                + \"     */\"; //\n" //
+    	        + "    }\n" //
     	        + "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -201,7 +207,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            \tif (true) {\n" //
     	        + "            \t\tstuff();\n" //
     	        + "            \t} else\n" //
-    	        + "            \t\tnoStuff\"\"\";\n" //
+    	        + "            \t\tnoStuff\\\n" //
+    	        + "            \"\"\";\n" //
     	        + "    }\n" //
     	        + "    public void testEndEscapedQuotes() {\n" //
     	        + "        String a =\n" //
@@ -211,6 +218,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            3\n" //
     	        + "            4\n" //
     	        + "            \\\"\"\"\\\"\"\"\";\n" //
+    	        + "    }\n" //
+    	        + "    public void testNoEndNewlineIndented() {\n" //
+    	        + "        String x= \"\"\"\n" //
+    	        + "                /** bar\n" //
+    	        + "                 * foo\n" //
+    	        + "                 */\\\n" //
+    	        + "            \"\"\"; //\n" //
     	        + "    }\n" //
     	        + "}\n";
 
@@ -265,6 +279,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                \"3\\n\" +\n" //
     	        + "                \"4\\n\" +\n" //
     	        + "                \"\\\"\\\"\\\"\");\n" //
+    	        + "        StringBuilder buf4= new StringBuilder();\n" //
+    	        + "        buf4.append(\"    /** bar\\n\");\n" //
+    	        + "        buf4.append(\"     * foo\\n\");\n" //
+    	        + "        buf4.append(\"     */\");\n" //
+    	        + "        String expected= buf4.toString();\n" //
 				+ "    }\n" //
 				+ "}";
 
@@ -329,6 +348,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            3\n" //
     	        + "            4\n" //
     	        + "            \\\"\\\"\\\"\"\"\");\n" //
+    	        + "        String expected= \"\"\"\n" //
+    	        + "                /** bar\n" //
+    	        + "                 * foo\n" //
+    	        + "                 */\\\n" //
+    	        + "            \"\"\";\n" //
     	        + "    }\n" //
 				+ "}";
 


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore to handle case where all lines start with white-space and the last line doesn't end in newline so that the text block end-quotes get put on a separate line and the last text is a continuation character so that proper indentation occurs
- add new tests to CleanUpTest15 and AssistQuickFixTest15
- fixes #1240

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes indentation when all lines of text block start with white-space and last line doesn't end with new-line.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
