### PR TITLE
Fix StringBuffer/StringBuilder to text block when concat string appended

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -284,7 +284,16 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        buf4.append(\"     * foo\\n\");\n" //
     	        + "        buf4.append(\"     */\");\n" //
     	        + "        String expected= buf4.toString();\n" //
-				+ "    }\n" //
+    	        + "        StringBuilder buf5= new StringBuilder();\n" //
+    	        + "        buf5.append(\n" //
+    	        + "                \"package pack1;\\n\" +\n" //
+    	        + "                \"\\n\" +\n" //
+    	        + "                \"import java.util.*;\\n\" +\n" //
+    	        + "                \"\\n\" +\n" //
+    	        + "                \"public class C {\\n\" +\n" //
+    	        + "                \"}\");\n" //
+    	        + "        System.out.println(buf5.toString());\n" //
+    	        + "    }\n" //
 				+ "}";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -353,6 +362,14 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                 * foo\n" //
     	        + "                 */\\\n" //
     	        + "            \"\"\";\n" //
+    	        + "        String str3 = \"\"\"\n" //
+    	        + "            package pack1;\n" //
+    	        + "            \n" //
+    	        + "            import java.util.*;\n" //
+    	        + "            \n" //
+    	        + "            public class C {\n" //
+    	        + "            }\"\"\";\n" //
+    	        + "        System.out.println(str3);\n" //
     	        + "    }\n" //
 				+ "}";
 


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore to recognize when appending a concatenated string via StringBuffer/StringBuilder append() and treat each StringLiteral as if they were appended separately
- fix error handling when append is invalid (e.g. uses a variable name)
- fix string name allocation to recognize body declaration boundaries and reset excluded name list
- add new test to CleanUpTest15
- fixes #1238

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes StringBuffer/StringBuilder to text block clean-up to work properly when a string concatenation is being appended and also
fixes the code to cleanly bail when conditions aren't correct.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new test scenario.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
