### PR TITLE
Fix name collision in string concat to text block cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -4130,6 +4130,25 @@ public class ASTNodes {
 	}
 
 	/**
+	 * Returns a list of all variable names used in the block containing the given node.
+	 *
+	 * @param node the AST node
+	 * @return a list of local variable names in the block of the given node
+	 * @see ScopeAnalyzer#getUsedVariableNames(int, int)
+	 */
+	public static List<String> getAllLocalVariablesInBlock(ASTNode node) {
+		List<String> variableNames= new ArrayList<>();
+		CompilationUnit root= (CompilationUnit) node.getRoot();
+		Block block= ASTNodes.getFirstAncestorOrNull(node, Block.class);
+		if (block != null) {
+			Collection<String> names= new ScopeAnalyzer(root).
+					getUsedVariableNames(block.getStartPosition(), block.getLength());
+			variableNames.addAll(names);
+		}
+		return variableNames;
+	}
+
+	/**
 	 * Checks whether the given <code>exprStatement</code> has a semicolon at the end.
 	 *
 	 * @param exprStatement the {@link ExpressionStatement} to check the semicolon

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -428,7 +428,6 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			if (unescaped.charAt(whitespaceStart) == ' ') {
 				whitespaceStart--;
 				trailingWhitespace.append("\\s"); //$NON-NLS-1$
-				continue;
 			} else if (unescaped.charAt(whitespaceStart) == '\t') {
 				whitespaceStart--;
 				trailingWhitespace.append("\\t"); //$NON-NLS-1$
@@ -834,7 +833,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				ImportRewrite importRewriter= cuRewrite.getImportRewrite();
 				ITypeBinding binding= firstToStringCall.resolveTypeBinding();
 				if (binding != null) {
-					Set<String> excludedNames= new HashSet<>(ASTNodes.getVisibleLocalVariablesInScope(fToStringList.get(fToStringList.size() - 1)));
+					Set<String> excludedNames= new HashSet<>(ASTNodes.getAllLocalVariablesInBlock(fStatements.get(0)));
 					excludedNames.addAll(fExcludedNames);
 					String newVarName= DEFAULT_NAME;
 					if (excludedNames.contains(DEFAULT_NAME)) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -293,6 +293,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                \"public class C {\\n\" +\n" //
     	        + "                \"}\");\n" //
     	        + "        System.out.println(buf5.toString());\n" //
+    	        + "        String str3= \"abc\";\n" //
     	        + "    }\n" //
 				+ "}";
 
@@ -362,14 +363,15 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                 * foo\n" //
     	        + "                 */\\\n" //
     	        + "            \"\"\";\n" //
-    	        + "        String str3 = \"\"\"\n" //
+    	        + "        String str4 = \"\"\"\n" //
     	        + "            package pack1;\n" //
     	        + "            \n" //
     	        + "            import java.util.*;\n" //
     	        + "            \n" //
     	        + "            public class C {\n" //
     	        + "            }\"\"\";\n" //
-    	        + "        System.out.println(str3);\n" //
+    	        + "        System.out.println(str4);\n" //
+    	        + "        String str3= \"abc\";\n" //
     	        + "    }\n" //
 				+ "}";
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -160,7 +160,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "    public void testTrailingSpacesAndInnerNewlines() {\n" //
 				+ "        String x = \"\"\"\n" //
     	        + "            public\\s\n"
-    	        + "            void foo() {\\s\\s\n" //
+    	        + "            void foo() { \\s\n" //
     	        + "                System.out.println\\\\(\"abc\");\n" //
     	        + "            }\n" //
     	        + "            \"\"\";\n" //


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fix issue with string concat to text block whereby name collision occurs with other local variable.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test scenario added.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
