### PR TITLE
Fix StringConcatToTextBlockFixCore escape logic when string is size 1

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -424,15 +424,12 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 		}
 		int whitespaceStart= unescaped.length()-1;
 		StringBuilder trailingWhitespace= new StringBuilder();
-		while (whitespaceStart > 0) {
-			if (unescaped.charAt(whitespaceStart) == ' ') {
-				whitespaceStart--;
-				trailingWhitespace.append("\\s"); //$NON-NLS-1$
-			} else if (unescaped.charAt(whitespaceStart) == '\t') {
-				whitespaceStart--;
-				trailingWhitespace.append("\\t"); //$NON-NLS-1$
-			}
-			break;
+		if (unescaped.charAt(whitespaceStart) == ' ') {
+			--whitespaceStart;
+			trailingWhitespace.append("\\s"); //$NON-NLS-1$
+		} else if (unescaped.charAt(whitespaceStart) == '\t') {
+			--whitespaceStart;
+			trailingWhitespace.append("\\t"); //$NON-NLS-1$
 		}
 
 		return unescaped.substring(0, whitespaceStart + 1) + trailingWhitespace;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -62,6 +62,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "            \"   }\\n\" + //$NON-NLS-1$\n" //
 				+ "            \"}\"; //$NON-NLS-1$\n" //
 				+ "\n" //
+				+ "    private static final String CU_POSTFIX= \" {\\n\" +\n" //
+				+ "            \"	\\n\" +\n" //
+				+ "            \"}\\n\" +\n" //
+				+ "            \"}\\n\";\n" //
+				+ "\n" //
 				+ "    public void testSimple() {\n" //
 				+ "        // comment 1\n" //
 				+ "        String x = \"\" + //$NON-NLS-1$\n" //
@@ -147,6 +152,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "               System.out.println(\"abc\");\n" //
 				+ "           }\n" //
 				+ "        }\"\"\"; //$NON-NLS-1$\n" //
+				+ "\n" //
+				+ "    private static final String CU_POSTFIX= \"\"\"\n" //
+				+ "         {\n" //
+				+ "        \\t\n" //
+				+ "        }\n" //
+				+ "        }\n" //
+				+ "        \"\"\";\n" //
 				+ "\n" //
 				+ "    public void testSimple() {\n" //
 				+ "        // comment 1\n" //

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -54,6 +54,20 @@ public class CleanUpTest15 extends CleanUpTestCase {
 		String sample= "" //
 				+ "package test1;\n" //
 				+ "\n" //
+			    + "/**\n" //
+			    + " * Performs:\u005cn" //
+			    + " * <pre>{@code\n" //
+			    + " *    for (String s : strings) {\u005cn" //
+			    + " *        if (s.equals(value)) {\n" //
+			    + " *            return \\u0030;\n" //
+			    + " *        }\n" //
+			    + " *        if (s.startsWith(value)) {\n" //
+			    + " *            return 1;\n" //
+			    + " *        }\n" //
+			    + " *    }\n" //
+			    + " *    return -1;\n" //
+			    + " * }</pre>\n" //
+			    + " */\n" //
 				+ "public class E {\n" //
 				+ "    static String str = \"\" + //$NON-NLS-1$\n" //
 				+ "            \"public class B { \\n\" + //$NON-NLS-1$\n" //
@@ -144,6 +158,20 @@ public class CleanUpTest15 extends CleanUpTestCase {
 		String expected1= "" //
 				+ "package test1;\n" //
 				+ "\n" //
+				+ "/**\n" //
+				+ " * Performs:\n" //
+				+ " * <pre>{@code\n" //
+				+ " *    for (String s : strings) {\n" //
+				+ " *        if (s.equals(value)) {\n" //
+				+ " *            return \\u0030;\n" //
+				+ " *        }\n" //
+				+ " *        if (s.startsWith(value)) {\n" //
+				+ " *            return 1;\n" //
+				+ " *        }\n" //
+				+ " *    }\n" //
+				+ " *    return -1;\n" //
+				+ " * }</pre>\n" //
+				+ " */\n" //
 				+ "public class E {\n" //
 				+ "    static String str = \"\"\"\n" //
 				+ "        public class B {\\s\n" //


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore.escapeTrailingWhitespace()
- add new test to CleanupTest15
- fixes #1240

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes another white-space issue with string concat to text block conversion of test suite.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test scenario added.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
