### PR TITLE
Fix string concat to text block handling of redundant constructors

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -309,6 +309,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "        buf3.append(\"\\n\");\n" //
 				+ "        // comment 6\n" //
 				+ "        k = buf3.toString();\n" //
+				+ "        buf3= new StringBuilder();\n" //
+				+ "        buf3.append(4);\n" //
 				+ "\n" //
 				+ "        String x = \"abc\\n\" +\n"
 				+ "            \"def\\n\" +\n" //
@@ -325,6 +327,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        buf4.append(\"     */\");\n" //
     	        + "        String expected= buf4.toString();\n" //
     	        + "        StringBuilder buf5= new StringBuilder();\n" //
+    	        + "        buf5.append(3);\n" //
+    	        + "        buf5= new StringBuilder();\n" //
     	        + "        buf5.append(\n" //
     	        + "                \"package pack1;\\n\" +\n" //
     	        + "                \"\\n\" +\n" //
@@ -333,6 +337,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                \"public class C {\\n\" +\n" //
     	        + "                \"}\");\n" //
     	        + "        System.out.println(buf5.toString());\n" //
+    	        + "        buf5= new StringBuilder();\n" //
+    	        + "        buf5.append(7);\n" //
     	        + "        String str3= \"abc\";\n" //
     	        + "    }\n" //
 				+ "}";
@@ -382,6 +388,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "            }\n" //
 				+ "            \n" //
 				+ "            \"\"\";\n" //
+				+ "        StringBuilder buf3 = new StringBuilder();\n" //
+				+ "        buf3.append(4);\n" //
 				+ "\n" //
 				+ "        String x = \"\"\"\n" //
 				+ "            abc\n" //
@@ -403,6 +411,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                 * foo\n" //
     	        + "                 */\\\n" //
     	        + "            \"\"\";\n" //
+    	        + "        StringBuilder buf5= new StringBuilder();\n" //
+    	        + "        buf5.append(3);\n" //
     	        + "        String str4 = \"\"\"\n" //
     	        + "            package pack1;\n" //
     	        + "            \n" //
@@ -411,6 +421,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            public class C {\n" //
     	        + "            }\"\"\";\n" //
     	        + "        System.out.println(str4);\n" //
+    	        + "        buf5= new StringBuilder();\n" //
+    	        + "        buf5.append(7);\n" //
     	        + "        String str3= \"abc\";\n" //
     	        + "    }\n" //
 				+ "}";


### PR DESCRIPTION
- fix StringBuffer/StringBuilder to text block support when original code has one or more redundant constructors preceding the first append
- fix StringBuffer/StringBuilder look-ahead to next constructor statement logic so it doesn't change next constructor to VariableDeclarationStatement if the initial declaration never gets removed (i.e. first concenatation was invalid for conversion)
- add new test scenarios to CleanUpTest15
- fixes #1238

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes more edge-case scenarios discovered by converting test suite to use text blocks.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test scenarios.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
