### PR TITLE
Fix StringBuffer to text block clean-up when constructed with String

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -340,6 +340,19 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        buf5= new StringBuilder();\n" //
     	        + "        buf5.append(7);\n" //
     	        + "        String str3= \"abc\";\n" //
+    	        + "        String x2= \"\" +\n" //
+    	        + "                \"abc\\n\" +\n" //
+    	        + "                \"def\\n\" +\n" //
+    	        + "                \"ghi\\n\" +\n" //
+    	        + "                \"jki\\n\";\n" //
+    	        + "        StringBuilder buf6 = new StringBuilder(x2);\n" //
+    	        + "        System.out.println(buf6.toString());\n" //
+    	        + "        StringBuilder buf7 = new StringBuilder(\"\" +\n" //
+    	        + "                \"abc\\n\" +\n" //
+    	        + "                \"def\\n\" +\n" //
+    	        + "                \"ghi\\n\" +\n" //
+    	        + "                \"jki\\n\");\n" //
+    	        + "        System.out.println(buf7.toString());\n" //
     	        + "    }\n" //
 				+ "}";
 
@@ -424,6 +437,21 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        buf5= new StringBuilder();\n" //
     	        + "        buf5.append(7);\n" //
     	        + "        String str3= \"abc\";\n" //
+    	        + "        String x2= \"\"\"\n" //
+    	        + "            abc\n" //
+    	        + "            def\n" //
+    	        + "            ghi\n" //
+    	        + "            jki\n" //
+    	        + "            \"\"\";\n" //
+    	        + "        StringBuilder buf6 = new StringBuilder(x2);\n" //
+    	        + "        System.out.println(buf6.toString());\n" //
+    	        + "        String str5 = \"\"\"\n" //
+    	        + "            abc\n" //
+    	        + "            def\n" //
+    	        + "            ghi\n" //
+    	        + "            jki\n" //
+    	        + "            \"\"\";\n" //
+    	        + "        System.out.println(str5);\n" //
     	        + "    }\n" //
 				+ "}";
 


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore.StringBufferFinder() to fail if a StringBuffer/StringBuilder constructor is used and isn't passed a StringLiteral or a NumberLiteral or an InfixExpression of StringLiterals concatenated
- add new tests to CleanUpTest15

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes StringBuffer to text block when a non-String-literal is passed to constructor.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
