### PR TITLE
Fix regression in StringBuffer to text block cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -298,6 +298,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			buf.append("\"\"\"\n"); //$NON-NLS-1$
 			boolean newLine= false;
 			boolean allWhiteSpaceStart= true;
+			boolean allEmpty= true;
 			for (String part : parts) {
 				if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
 					if (!newLine) {
@@ -307,10 +308,11 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				}
 				newLine= part.endsWith(System.lineSeparator());
 				allWhiteSpaceStart= allWhiteSpaceStart && (part.isEmpty() || Character.isWhitespace(part.charAt(0)));
+				allEmpty= allEmpty && part.isEmpty();
 				buf.append(fIndent).append(part);
 			}
 
-			if (newLine) {
+			if (newLine || allEmpty) {
 				buf.append(fIndent);
 			} else if (allWhiteSpaceStart) {
 				buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
@@ -450,7 +452,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 		private static final String TO_STRING= "toString"; //$NON-NLS-1$
 		private BodyDeclaration fLastBodyDecl;
 		private final Set<String> fExcludedNames;
-		private final Set<SimpleName> fRemovedDeclarations= new HashSet<>();
+		private final Set<IBinding> fRemovedDeclarations= new HashSet<>();
 
 		public StringBufferFinder(List<CompilationUnitRewriteOperation> operations, Set<String> excludedNames) {
 			super(true);
@@ -646,10 +648,10 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			List<MethodInvocation> toStringList= new ArrayList<>(checkValidityVisitor.getToStringList());
 			BodyDeclaration bodyDecl= ASTNodes.getFirstAncestorOrNull(node, BodyDeclaration.class);
 			if (statements.get(0) instanceof VariableDeclarationStatement) {
-				fRemovedDeclarations.add(originalVarName);
+				fRemovedDeclarations.add(originalVarName.resolveBinding());
 			}
 			ChangeStringBufferToTextBlock operation= new ChangeStringBufferToTextBlock(toStringList, statements, literals,
-					fRemovedDeclarations.contains(originalVarName) ? assignmentToConvert : null, fExcludedNames, fLastBodyDecl, nonNLS);
+					fRemovedDeclarations.contains(originalVarName.resolveBinding()) ? assignmentToConvert : null, fExcludedNames, fLastBodyDecl, nonNLS);
 			fLastBodyDecl= bodyDecl;
 			fOperations.add(operation);
 			conversions.put(assignmentToConvert, operation);
@@ -707,6 +709,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				return false;
 			}
 			originalVarName= node.getName();
+			statementList.clear();
 			statementList.add(varDeclStmt);
 			return true;
 		}
@@ -821,6 +824,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			buf.append("\"\"\"\n"); //$NON-NLS-1$
 			boolean newLine= false;
 			boolean allWhiteSpaceStart= true;
+			boolean allEmpty= true;
 			for (String part : parts) {
 				if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
 					if (!newLine) {
@@ -830,10 +834,11 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				}
 				newLine= part.endsWith(System.lineSeparator());
 				allWhiteSpaceStart= allWhiteSpaceStart && (part.isEmpty() || Character.isWhitespace(part.charAt(0)));
+				allEmpty= allEmpty && part.isEmpty();
 				buf.append(fIndent).append(part);
 			}
 
-			if (newLine) {
+			if (newLine || allEmpty) {
 				buf.append(fIndent);
 			} else if (allWhiteSpaceStart) {
 				buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -353,10 +353,15 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                \"ghi\\n\" +\n" //
     	        + "                \"jki\\n\");\n" //
     	        + "        System.out.println(buf7.toString());\n" //
+    	        + "        buf7 = new StringBuilder();\n" //
+    	        + "        buf7.append(\"abc\" + x2 + \"def\");\n" //
+    	        + "        StringBuilder buf8 = new StringBuilder(\"\");\n" //
+    	        + "        System.out.println(buf8.toString());\n" //
     	        + "    }\n" //
 				+ "}";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+		assertNoCompilationError(cu1);
 
 		enable(CleanUpConstants.STRINGCONCAT_TO_TEXTBLOCK);
 		enable(CleanUpConstants.STRINGCONCAT_STRINGBUFFER_STRINGBUILDER);
@@ -452,6 +457,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            jki\n" //
     	        + "            \"\"\";\n" //
     	        + "        System.out.println(str5);\n" //
+    	        + "        StringBuilder buf7 = new StringBuilder();\n" //
+    	        + "        buf7.append(\"abc\" + x2 + \"def\");\n" //
+    	        + "        String str6 = \"\"\"\n" //
+    	        + "            \"\"\";\n" //
+    	        + "        System.out.println(str6);\n" //
     	        + "    }\n" //
 				+ "}";
 


### PR DESCRIPTION
- fix regression whereby a future constructor assignment of a variable needs to be converted to a VariableDeclarationStatement due to the original declaration is removed but the future assignment needs to be kept
- add new tests to CleanUpTest15
- fixes #1238

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes regression.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests added.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
