### PR TITLE
Add chained append support to text block clean-up

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -88,6 +88,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 	private final static String JAVA_STRINGBUFFER= "java.lang.StringBuffer"; //$NON-NLS-1$
 	private final static String JAVA_STRINGBUILDER= "java.lang.StringBuilder"; //$NON-NLS-1$
 	private final static String NLSComment= "$NON-NLS-1$"; //$NON-NLS-1$
+	private final static String NLSCommentPrefix= "$NON-NLS-"; //$NON-NLS-1$
 
 	public static final class StringConcatFinder extends ASTVisitor {
 
@@ -554,17 +555,34 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			ICompilationUnit icu= (ICompilationUnit) cu.getJavaElement();
 			if (args.size() == 1 && args.get(0) instanceof StringLiteral) {
 				fLiterals.add((StringLiteral)args.get(0));
-				nonNLS= hasNLSMarker(statement, icu);
 			} else if (args.size() > 0) {
 				if (args.get(0) instanceof InfixExpression infix) {
-					if (!processInfixExpression(statement, infix)) {
-						statementList.remove(statement);
-						return false;
+					if (!processInfixExpression(infix)) {
+						return failure();
 					}
 				} else if (!(args.get(0) instanceof NumberLiteral)) {
 					statementList.remove(statement);
 					return false;
 				}
+			}
+			ASTNode parent= node.getParent();
+			while (parent != statement) {
+				if (parent instanceof MethodInvocation methodCall) {
+					if (!methodCall.getName().getFullyQualifiedName().equals(APPEND)) {
+						return failure();
+					}
+					Expression arg= (Expression) methodCall.arguments().get(0);
+					if (arg instanceof StringLiteral) {
+						fLiterals.add((StringLiteral)arg);
+					} else if (arg instanceof InfixExpression infix) {
+						if (!processInfixExpression(infix)) {
+							return failure();
+						}
+					} else {
+						return failure();
+					}
+				}
+				parent= parent.getParent();
 			}
 			Block block= (Block) statement.getParent();
 			List<Statement> stmtList= block.statements();
@@ -583,22 +601,15 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 								method.getName().getFullyQualifiedName().equals(APPEND)) {
 							Expression arg= (Expression) method.arguments().get(0);
 							if (arg instanceof StringLiteral) {
-								if (nonNLS != hasNLSMarker(s, icu)) {
-									nonNLS= !nonNLS;
-									if (i - startIndex > 1 || args.size() == 1) {
-										return false;
-									}
-								}
 								fLiterals.add((StringLiteral)arg);
 								statementList.add(s);
 							} else if (arg instanceof InfixExpression infix) {
-								if (!processInfixExpression(s, infix)) {
-									return false;
+								if (!processInfixExpression(infix)) {
+									return failure();
 								}
+								statementList.add(s);
 							} else {
-								statementList.clear();
-								fLiterals.clear();
-								return false;
+								return failure();
 							}
 						} else {
 							break;
@@ -612,9 +623,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 							ignoredConstructorStatements.add(s);
 							statementList.add(s);
 							if (!cicArgs.isEmpty() || !fLiterals.isEmpty()) {
-								statementList.clear();
-								fLiterals.clear();
-								return false;
+								return failure();
 							}
 						}
 					} else {
@@ -629,7 +638,20 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			int lastStatementEnd= endStatement.getStartPosition() + endStatement.getLength();
 			IBinding varBinding= null;
 			if (originalVarName == null || (varBinding= originalVarName.resolveBinding()) == null) {
-				return false;
+				return failure();
+			}
+			// verify NLS markers are consistent for all string literals
+			if (!fLiterals.isEmpty()) {
+				try {
+					nonNLS= hasNLSMarker(fLiterals.get(0), icu);
+					for (int j= 1; j < fLiterals.size(); ++j) {
+						if (nonNLS != hasNLSMarker(fLiterals.get(j), icu)) {
+							return failure();
+						}
+					}
+				} catch (AbortSearchException e) {
+					return failure();
+				}
 			}
 			CheckValidityVisitor checkValidityVisitor= new CheckValidityVisitor(lastStatementEnd, varBinding);
 			try {
@@ -638,9 +660,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				// do nothing
 			}
 			if (!checkValidityVisitor.isValid() || checkValidityVisitor.getToStringList().size() == 0) {
-				statementList.clear();
-				fLiterals.clear();
-				return false;
+				return failure();
 			}
 			ExpressionStatement assignmentToConvert= checkValidityVisitor.getNextAssignment();
 			List<Statement> statements= new ArrayList<>(statementList);
@@ -660,7 +680,13 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			return true;
 		}
 
-		private boolean processInfixExpression(Statement s, InfixExpression infix) {
+		private boolean failure() {
+			statementList.clear();
+			fLiterals.clear();
+			return false;
+		}
+
+		private boolean processInfixExpression(InfixExpression infix) {
 			if (infix.getOperator() == Operator.PLUS) {
 				Expression left= infix.getLeftOperand();
 				Expression right= infix.getRightOperand();
@@ -671,8 +697,6 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 						if (extendedOp instanceof StringLiteral) {
 							extendedLiterals.add((StringLiteral)extendedOp);
 						} else {
-							statementList.clear();
-							fLiterals.clear();
 							return false;
 						}
 
@@ -680,12 +704,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					fLiterals.add((StringLiteral)left);
 					fLiterals.add((StringLiteral)right);
 					fLiterals.addAll(extendedLiterals);
-					if (!statementList.contains(s)) {
-						statementList.add(s);
-					}
 				} else {
-					statementList.clear();
-					fLiterals.clear();
 					return false;
 				}
 			}
@@ -734,17 +753,27 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 
 	}
 
-	private static boolean hasNLSMarker(Statement statement, ICompilationUnit cu) {
+	private static boolean hasNLSMarker(ASTNode node, ICompilationUnit cu) throws AbortSearchException {
 		boolean hasNLS= false;
-		List<Comment> commentList= ASTNodes.getTrailingComments(statement);
+		List<Comment> commentList= ASTNodes.getTrailingComments(node);
+		if (commentList.isEmpty()) {
+			ASTNode n= node;
+			while (!(n instanceof Statement) && commentList.isEmpty()) {
+				n= n.getParent();
+				commentList= ASTNodes.getTrailingComments(n);
+			}
+		}
 		if (commentList.size() > 0) {
 			if (commentList.get(0) instanceof LineComment) {
 				LineComment lineComment= (LineComment) commentList.get(0);
 				try {
 					String comment= cu.getBuffer().getText(lineComment.getStartPosition() + 2, lineComment.getLength() - 2).trim();
-					hasNLS= comment.equals(NLSComment);
+					hasNLS= comment.startsWith(NLSComment);
+					if (comment.substring(NLSComment.length()).contains(NLSCommentPrefix)) {
+						throw new AbortSearchException();
+					}
 				} catch (IndexOutOfBoundsException | JavaModelException e) {
-					return false;
+					throw new AbortSearchException();
 				}
 			}
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -870,12 +870,12 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf= new StringBuilder();
 		buf.append("package test;\n");
 		buf.append("public class Cls {\n");
-		buf.append("    public void combinedAppend() {\n");
+		buf.append("    public void combinedAppendWithNLS() {\n");
 		buf.append("        StringBuffer buf3= new StringBuffer();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
-		buf.append("        buf3.append(\"    return null;\\n\");\n");
-		buf.append("        buf3.append(\"}\\n\");\n");
-		buf.append("        buf3.append(\"\\n\").append(\"extra append\\n\");\n");
+		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
+		buf.append("        buf3.append(\"    return null;\\n\"); //$NON-NLS-1$\n");
+		buf.append("        buf3.append(\"}\\n\"); //$NON-NLS-1$\n");
+		buf.append("        buf3.append(\"\\n\").append(\"extra append\\n\"); //$NON-NLS-1$ //$NON-NLS-2$\n");
 		buf.append("        String k = buf3.toString();\n");
 		buf.append("        \n");
 		buf.append("    }\n");

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -357,6 +357,8 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        buf7.append(\"abc\" + x2 + \"def\");\n" //
     	        + "        StringBuilder buf8 = new StringBuilder(\"\");\n" //
     	        + "        System.out.println(buf8.toString());\n" //
+    	        + "        StringBuilder buf9 = new StringBuilder(\"abc\\n\").append(\"def\\n\").append(\"ghi\");\n" //
+    	        + "        System.out.println(buf9.toString());\n" //
     	        + "    }\n" //
 				+ "}";
 
@@ -462,6 +464,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        String str6 = \"\"\"\n" //
     	        + "            \"\"\";\n" //
     	        + "        System.out.println(str6);\n" //
+    	        + "        String str7 = \"\"\"\n" //
+    	        + "            abc\n" //
+    	        + "            def\n" //
+    	        + "            ghi\"\"\";\n" //
+    	        + "        System.out.println(str7);\n" //
     	        + "    }\n" //
 				+ "}";
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -358,6 +358,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        StringBuilder buf8 = new StringBuilder(\"\");\n" //
     	        + "        System.out.println(buf8.toString());\n" //
     	        + "        StringBuilder buf9 = new StringBuilder(\"abc\\n\").append(\"def\\n\").append(\"ghi\");\n" //
+    	        + "        buf9.append(\"jkl\\n\").append(\"mno\");\n" //
     	        + "        System.out.println(buf9.toString());\n" //
     	        + "    }\n" //
 				+ "}";
@@ -467,7 +468,9 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "        String str7 = \"\"\"\n" //
     	        + "            abc\n" //
     	        + "            def\n" //
-    	        + "            ghi\"\"\";\n" //
+    	        + "            ghi\\\n" //
+    	        + "            jkl\n" //
+    	        + "            mno\"\"\";\n" //
     	        + "        System.out.println(str7);\n" //
     	        + "    }\n" //
 				+ "}";
@@ -693,11 +696,11 @@ public class CleanUpTest15 extends CleanUpTestCase {
 				+ "        String x = buf.toString();\n" //
     	        + "    }\n" //
     	        + "\n" //
-   	            + "    public void testSerialCallsNotSupported() {\n" //
+   	            + "    public void testSerialNLSCallsNotSupported() {\n" //
 				+ "        StringBuffer buf = new StringBuffer();\n" //
-    	        + "        buf.append(\"abcdef\\n\");\n" //
-    	        + "        buf.append(\"123456\\n\");\n" //
-    	        + "        buf.append(\"ghijkl\\n\").append(\"mnopqrst\\n\");\n" //
+    	        + "        buf.append(\"abcdef\\n\"); //$NON-NLS-1$\n" //
+    	        + "        buf.append(\"123456\\n\"); //$NON-NLS-1$\n" //
+    	        + "        buf.append(\"ghijkl\\n\").append(\"mnopqrst\\n\"); //$NON-NLS-1$ //$NON-NLS-2$\n" //
 				+ "        String x = buf.toString();\n" //
     	        + "    }\n" //
     	        + "\n" //


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds support to text block clean-up for using chained StringBuffer/StringBuilder append() calls.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
