### PR TITLE
Do not remove comments for string concat to text block

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -149,7 +149,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                + \"     * foo\\n\" //\n" //
     	        + "                + \"     */\"; //\n" //
     	        + "    }\n" //
-    	        + "}\n";
+      	        + "    public void testNoEndNewlineWithSpace() {\n" //
+    	        + "        String x= \"\"\n" //
+    	        + "                + \"/** bar\\n\" //\n" //
+    	        + "                + \" * foo\\n\" //\n" //
+    	        + "                + \" */ \"; //\n" //
+    	        + "    }\n" //
+  	        + "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
 
@@ -266,7 +272,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                 */\\\n" //
     	        + "            \"\"\"; //\n" //
     	        + "    }\n" //
-    	        + "}\n";
+     	        + "    public void testNoEndNewlineWithSpace() {\n" //
+    	        + "        String x= \"\"\"\n" //
+    	        + "            /** bar\n" //
+    	        + "             * foo\n" //
+    	        + "             */\\s\"\"\"; //\n" //
+    	        + "    }\n" //
+   	        + "}\n";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}
@@ -657,6 +669,14 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "            \"ghijkl\" + //$NON-NLS-1$\n" //
     	        + "            \"mnop\"};\n" //
     	        + "    }\n" //
+    	        + "\n" //
+   	            + "    public void testCommentsThatWillBeLost() {\n" //
+				+ "        String x = \"\" +\n" //
+    	        + "            \"abcdef\" +\n" //
+    	        + "            \"ghijkl\" + // a comment\n" //
+    	        + "            \"mnop\";\n" //
+    	        + "    }\n" //
+    	        + "\n" //
 				+ "}\n";
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
 


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore to not convert to text block if any of the concatenated elements have non-empty line comments or block comments
- also fix the last line of a text block when formed from a concatenation that ends in a space or tab-character as it still requires escaping
- add new tests to CleanUpTest15
- fixes #1273

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Does not perform string concat to text block clean-up if lines in the concat have block comments or non-empty line comments.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
