### PR TITLE
Fix string concat to text block so it does not escape single quotes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -432,6 +432,10 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				transformed.append(escapedText.substring(readIndex, bsIndex));
 				transformed.append("\t"); //$NON-NLS-1$
 				readIndex= bsIndex + (escapedText.startsWith("\\t", bsIndex) ? 2 : 7); //$NON-NLS-1$
+			} else if (escapedText.startsWith("\\'", bsIndex) || escapedText.startsWith("\\u005c'", bsIndex)) { //$NON-NLS-1$ //$NON-NLS-2$
+				transformed.append(escapedText.substring(readIndex, bsIndex));
+				transformed.append("'"); //$NON-NLS-1$
+				readIndex= bsIndex + (escapedText.startsWith("\\'", bsIndex) ? 2 : 7); //$NON-NLS-1$
 			} else {
 				transformed.append(escapedText.substring(readIndex, bsIndex));
 				transformed.append("\\").append(escapedText.charAt(bsIndex + 1)); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -155,7 +155,18 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "                + \" * foo\\n\" //\n" //
     	        + "                + \" */ \"; //\n" //
     	        + "    }\n" //
-  	        + "}\n";
+      	        + "    public void testEscapedSingleQuote() {\n" //
+    	        + "        String x= \"\"\n" //
+    	        + "                + \"public class Test {\\n\"\n" //
+    	        + "                + \"  static String C = \\\"\\\\n\\\";\\n\"\n" //
+    	        + "                + \"  \\n\"\n" //
+    	        + "                + \"  public static void main(String[] args) {\\n\"\n" //
+    	        + "                + \"      System.out.print(C.length());\\n\"\n" //
+    	        + "                + \"      System.out.print(C.charAt(0) == \\'\\\\n\\');\\n\"\n" //
+    	        + "                + \"  }\\n\"\n" //
+    	        + "                + \"}\";\n" //
+    	        + "    }\n" //
+    	        + "}\n";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
 
@@ -278,7 +289,18 @@ public class CleanUpTest15 extends CleanUpTestCase {
     	        + "             * foo\n" //
     	        + "             */\\s\"\"\"; //\n" //
     	        + "    }\n" //
-   	        + "}\n";
+    	        + "    public void testEscapedSingleQuote() {\n" //
+    	        + "        String x= \"\"\"\n" //
+    	        + "            public class Test {\n" //
+    	        + "              static String C = \"\\\\n\";\n" //
+    	        + "             \\s\n" //
+    	        + "              public static void main(String[] args) {\n" //
+    	        + "                  System.out.print(C.length());\n" //
+    	        + "                  System.out.print(C.charAt(0) == '\\\\n');\n" //
+    	        + "              }\n" //
+    	        + "            }\"\"\";\n" //
+    	        + "    }\n" //
+    	        + "}\n";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}


### PR DESCRIPTION
- add new test to CleanUpTest15
- fixes #1240

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes string concat to text block so that escaped single quotes are represented by single quotes.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test or see issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
