### PR TITLE
Do not offer string concat to text block if a variable is used

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -107,6 +107,10 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					|| visited.extendedOperands().isEmpty()) {
 				return false;
 			}
+			if (visited.getLocationInParent() == InfixExpression.LEFT_OPERAND_PROPERTY ||
+					visited.getLocationInParent() == InfixExpression.RIGHT_OPERAND_PROPERTY) {
+				return false;
+			}
 			ITypeBinding typeBinding= visited.resolveTypeBinding();
 			if (typeBinding == null || !typeBinding.getQualifiedName().equals(JAVA_STRING)) {
 				return false;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -961,5 +961,42 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 
 		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
 	}
+
+	@Test
+	public void testNoConcatToTextBlock10() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void inconsistentNLS() {\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String y = \"something\";\n");
+		buf.append("        String x = \"\" +\n");
+        buf.append("            \"public void foo() {\\n\" +\n");
+        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" +\n");
+        buf.append("                  y + \n");
+        buf.append("            \"}\\n\"; //$NON-NLS-1$ // comment 2\n");
+        buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+
+		int index= buf.indexOf("x");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 1);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		assertProposalDoesNotExist(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+	}
 }
 


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore.StringConcatFinder when visiting an InfixExpression, ensure it is not considered part of another InfixExpression implying that all items are not StringLiterals
- add new test to AssistQuickFixTest15
- fixes #1284

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Makes quick assist consistent with clean-up with regards to not converting a string concatenation if it involves a non-StringLiteral.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
