### PR TITLE
Fix version-ranges to have exclusive upper-bounds

### DIFF
--- a/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
@@ -22,7 +22,7 @@ Require-Bundle:
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.jdt.debug.ui;bundle-version="[3.3.0,4.0.0)",
- org.eclipse.jdt.junit.core;bundle-version="[3.11.200,4.0.0]",
+ org.eclipse.jdt.junit.core;bundle-version="[3.11.200,4.0.0)",
  org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.2.200,4.0.0)",
  org.eclipse.jdt.core.manipulation;bundle-version="1.9.0",


### PR DESCRIPTION
## What it does
Fix version-ranges to have exclusive upper-bounds



## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
