### PR TITLE
Do not log locking CSS fragments cache for read was interrupted #1294

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/JavaElementLinks.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/JavaElementLinks.java
@@ -562,8 +562,8 @@ public class JavaElementLinks {
 						CSS_FRAGMENTS_CACHE_LOCK.unlock();
 					}
 				}
-			} catch (InterruptedException e1) {
-				JavaPlugin.logErrorMessage("Interrupted while waiting for CSS fragments cache lock, cache reset unsuccessful"); //$NON-NLS-1$
+			} catch (InterruptedException e) {
+				JavaPlugin.log(new RuntimeException("Interrupted while waiting for CSS fragments cache lock, cache reset unsuccessful", e)); //$NON-NLS-1$
 			}
 		}
 	}
@@ -866,7 +866,8 @@ public class JavaElementLinks {
 		try {
 			locked= CSS_FRAGMENTS_CACHE_LOCK.tryLock(100, TimeUnit.MILLISECONDS);
 		} catch (InterruptedException e) {
-			JavaPlugin.logErrorMessage("Interrupted while waiting for CSS fragments cache lock, proceeding without using cache"); //$NON-NLS-1$
+			Thread.currentThread().interrupt();
+			return css;
 		}
 		try {
 			if (locked) {


### PR DESCRIPTION
## What it does
Removes unnecessary log message when interrupted while JavaElementLinks code was waiting for CSS fragments lock (performed for purposes of applying new Javadoc styling enhancements #1074 ).

## How to test
I was not able to reproduce the reported issue so I can't give exact steps/flow to test the fix. Issue description is however right in saying:
> while editing or navigating inside Java file, mouse hover request may be cancelled because of some user actions that make the request obsolete.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
