### PR TITLE
Fix type parameters coloring corner cases (#1073 #1074)

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaElementLabelComposerCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/JavaElementLabelComposerCore.java
@@ -904,10 +904,19 @@ public class JavaElementLabelComposerCore {
 				if (i > 0) {
 					fBuffer.append(JavaElementLabelsCore.COMMA_STRING);
 				}
-				fBuffer.append(Signature.getTypeVariable(typeParamSigs[i]));
+				appendTypeParameteSignatureLabel(Signature.getTypeVariable(typeParamSigs[i]));
 			}
 			appendGT();
 		}
+	}
+
+	/**
+	 * Appends label for single type parameter from a signature.
+	 *
+	 * @param typeVariableName the type variable name
+	 */
+	protected void appendTypeParameteSignatureLabel(String typeVariableName) {
+		fBuffer.append(typeVariableName);
 	}
 
 	/**
@@ -916,7 +925,7 @@ public class JavaElementLabelComposerCore {
 	protected void appendLT() {
 		fBuffer.append(getLT());
 	}
-	
+
 	/**
 	 * Returns the string for rendering the '<code>&lt;</code>' character.
 	 *
@@ -932,7 +941,7 @@ public class JavaElementLabelComposerCore {
 	protected void appendGT() {
 		fBuffer.append(getGT());
 	}
-	
+
 	/**
 	 * Returns the string for rendering the '<code>&gt;</code>' character.
 	 *

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/JavaElementLinks.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/JavaElementLinks.java
@@ -451,7 +451,7 @@ public class JavaElementLinks {
 
 		@Override
 		protected void appendTypeParameterWithBounds(ITypeParameter typeParameter, long flags) throws JavaModelException {
-			if (noEnhancements) {
+			if (noEnhancements || nextNestingLevel == 1) {
 				super.appendTypeParameterWithBounds(typeParameter, flags);
 			} else {
 				fBuffer.append("<span class='"); //$NON-NLS-1$
@@ -494,6 +494,11 @@ public class JavaElementLinks {
 			} else {
 				super.appendTypeArgumentSignaturesLabel(enclosingElement, typeArgsSig, flags);
 			}
+		}
+
+		@Override
+		protected void appendTypeParameteSignatureLabel(String typeVariableName) {
+			super.appendTypeParameteSignatureLabel(wrapWithTypeClass(typeVariableName, typeVariableName));
 		}
 	}
 


### PR DESCRIPTION
## What it does
Fixing 2 (lets call them) corner cases when types parameters coloring was not working as expected.

- Missing coloring (for classes/interfaces from other compilation unit) ![missing_types_coloring](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/36334098/bbd54a06-7119-4c07-ba06-dc7727f54c4e)
- Unwanted coloring of type label(s) outside of generic signature (diamond brackets) ![unwanted_types_coloring](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/36334098/cc198d2a-af2d-4a52-b65e-898347b7822a)

After fix
- ![missing_types_coloring_fix](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/36334098/dcac0c90-1597-4666-b94c-d631a16d368e)
- ![unwanted_types_coloring_fix](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/36334098/b84490e4-3aaa-4757-87fc-51951d8d7590)


## How to test
- have Javadoc (in hover or view) displayed for e.g. java.util.function.Function<T, R> reference used inside compilation unit other than Function class itself (editor displaying some other class)
- have Javadoc (in hover or view) displayed for any type parameter of any class with generics e.g. for "T" of java.util.function.Function<T, R> while in editor displaying compilation unit of that class

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
