### PR TITLE
Fix extraction of yield statements into method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InOutFlowAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InOutFlowAnalyzer.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.core.dom.YieldStatement;
 
 public class InOutFlowAnalyzer extends FlowAnalyzer {
 
-	private ASTNode firstNode= null;
+	private ASTNode[] fSelectedNodes= null;
 
 	public InOutFlowAnalyzer(FlowContext context) {
 		super(context);
@@ -43,7 +43,7 @@ public class InOutFlowAnalyzer extends FlowAnalyzer {
 	public FlowInfo perform(ASTNode[] selectedNodes) {
 		FlowContext context= getFlowContext();
 		GenericSequentialFlowInfo result= createSequential();
-		firstNode= selectedNodes[0];
+		fSelectedNodes= selectedNodes;
 		for (ASTNode node : selectedNodes) {
 			node.accept(this);
 			result.merge(getFlowInfo(node), context);
@@ -69,7 +69,7 @@ public class InOutFlowAnalyzer extends FlowAnalyzer {
 		while (parent != null && !(parent instanceof SwitchExpression)) {
 			parent= parent.getParent();
 		}
-		return (parent instanceof SwitchExpression) && parent.getStartPosition() < firstNode.getStartPosition();		// we are only traversing selected nodes.
+		return (parent instanceof SwitchExpression) && fSelectedNodes.length > 0 && parent.getStartPosition() < fSelectedNodes[0].getStartPosition();	// we are only traversing selected nodes.
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InOutFlowAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InOutFlowAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,11 +26,15 @@ import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.SwitchExpression;
 import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+import org.eclipse.jdt.core.dom.YieldStatement;
 
 public class InOutFlowAnalyzer extends FlowAnalyzer {
+
+	private ASTNode firstNode= null;
 
 	public InOutFlowAnalyzer(FlowContext context) {
 		super(context);
@@ -39,6 +43,7 @@ public class InOutFlowAnalyzer extends FlowAnalyzer {
 	public FlowInfo perform(ASTNode[] selectedNodes) {
 		FlowContext context= getFlowContext();
 		GenericSequentialFlowInfo result= createSequential();
+		firstNode= selectedNodes[0];
 		for (ASTNode node : selectedNodes) {
 			node.accept(this);
 			result.merge(getFlowInfo(node), context);
@@ -56,6 +61,15 @@ public class InOutFlowAnalyzer extends FlowAnalyzer {
 	protected boolean createReturnFlowInfo(ReturnStatement node) {
 		// we are only traversing selected nodes.
 		return true;
+	}
+
+	@Override
+	protected boolean createReturnFlowInfo(YieldStatement node) {
+		ASTNode parent= node.getParent();
+		while (parent != null && !(parent instanceof SwitchExpression)) {
+			parent= parent.getParent();
+		}
+		return (parent instanceof SwitchExpression) && parent.getStartPosition() < firstNode.getStartPosition();		// we are only traversing selected nodes.
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InputFlowAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/InputFlowAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.SwitchExpression;
 import org.eclipse.jdt.core.dom.SwitchStatement;
 import org.eclipse.jdt.core.dom.WhileStatement;
+import org.eclipse.jdt.core.dom.YieldStatement;
 
 import org.eclipse.jdt.internal.corext.dom.Selection;
 
@@ -58,6 +59,11 @@ public class InputFlowAnalyzer extends FlowAnalyzer {
 		}
 		@Override
 		protected boolean createReturnFlowInfo(ReturnStatement node) {
+			// Make sure that the whole return statement is selected or located before the selection.
+			return node.getStartPosition() + node.getLength() <= fSelection.getExclusiveEnd();
+		}
+		@Override
+		protected boolean createReturnFlowInfo(YieldStatement node) {
 			// Make sure that the whole return statement is selected or located before the selection.
 			return node.getStartPosition() + node.getLength() <= fSelection.getExclusiveEnd();
 		}
@@ -164,6 +170,13 @@ public class InputFlowAnalyzer extends FlowAnalyzer {
 
 	@Override
 	protected boolean createReturnFlowInfo(ReturnStatement node) {
+		// Make sure that the whole return statement is located after the selection. There can be cases like
+		// return i + [x + 10] * 10; In this case we must not create a return info node.
+		return node.getStartPosition() >= fSelection.getInclusiveEnd();
+	}
+
+	@Override
+	protected boolean createReturnFlowInfo(YieldStatement node) {
 		// Make sure that the whole return statement is located after the selection. There can be cases like
 		// return i + [x + 10] * 10; In this case we must not create a return info node.
 		return node.getStartPosition() >= fSelection.getInclusiveEnd();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/ReturnFlowInfo.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/flow/ReturnFlowInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,11 +16,16 @@ package org.eclipse.jdt.internal.corext.refactoring.code.flow;
 
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.YieldStatement;
 
 class ReturnFlowInfo extends FlowInfo {
 
 	public ReturnFlowInfo(ReturnStatement node) {
 		super(getReturnFlag(node));
+	}
+
+	public ReturnFlowInfo(@SuppressWarnings("unused") YieldStatement node) {
+		super(VALUE_RETURN);
 	}
 
 	public void merge(FlowInfo info) {


### PR DESCRIPTION
- add YieldStatement support to FlowAnalyzer
- add YieldStatement support to InOutFlowAnalyzer that marks an exposed yield statement (parent SwitchExpression is not part of selected nodes) the same as a return value
- add code to ExtractMethodRefactoring to change exposed yield statements that are moved to extracted method into return statements and replace the extracted code with a yield statement that calls the new method
- in the case of non-exposed yield statements, leave them alone as the whole SwitchExpression gets moved into the new method
- fixes #1286

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes extract method to handle the case where a subset of statements within a Switch Expression are moved and
they have yield statements.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
