### PR TITLE
Place setAddFinal in the correct proposal.

### DIFF
--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/AssignToVariableAssistProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/AssignToVariableAssistProposalCore.java
@@ -113,7 +113,7 @@ public class AssignToVariableAssistProposalCore extends LinkedCorrectionProposal
 	private final List<String> fParamNames;
 
 	private VariableDeclarationFragment fExistingFragment;
-	private boolean fAddFinal;
+	private final boolean fAddFinal;
 
 	public AssignToVariableAssistProposalCore(ICompilationUnit cu, int variableKind, ExpressionStatement node, ITypeBinding typeBinding, int relevance, boolean addFinal) {
 		super("", cu, null, relevance); //$NON-NLS-1$
@@ -368,10 +368,6 @@ public class AssignToVariableAssistProposalCore extends LinkedCorrectionProposal
 			}
 		}
 		return false;
-	}
-
-	public void setAddFinal (boolean addFinal) {
-		this.fAddFinal= addFinal;
 	}
 
 	private ASTRewrite doAddField(ASTRewrite rewrite, ASTNode nodeToAssign, ITypeBinding typeBinding, int index) {

--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/NewVariableCorrectionProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/NewVariableCorrectionProposalCore.java
@@ -90,7 +90,7 @@ public class NewVariableCorrectionProposalCore extends LinkedCorrectionProposalC
 	final private int  fVariableKind;
 	final private SimpleName fOriginalNode;
 	final private ITypeBinding fSenderBinding;
-	final private boolean fAddFinal;
+	private boolean fAddFinal;
 
 	public NewVariableCorrectionProposalCore(String label, ICompilationUnit cu, int variableKind, SimpleName node, ITypeBinding senderBinding, int relevance, boolean addFinal) {
 		super(label, cu, null, relevance);
@@ -103,7 +103,7 @@ public class NewVariableCorrectionProposalCore extends LinkedCorrectionProposalC
 		fVariableKind= variableKind;
 		fOriginalNode= node;
 		fSenderBinding= senderBinding;
-		fAddFinal = addFinal;
+		fAddFinal= addFinal;
 	}
 
 	@Override
@@ -624,6 +624,10 @@ public class NewVariableCorrectionProposalCore extends LinkedCorrectionProposalC
 	 */
 	public int getVariableKind() {
 		return fVariableKind;
+	}
+
+	public void setAddFinal(boolean addFinal) {
+		fAddFinal= addFinal;
 	}
 
 }


### PR DESCRIPTION
- Remove setAddFinal from AssignToVariableAssistProposalCore and place it in NewVariableCorrectionProposalCore

This reverts commit 14c5480d51e36a79b37142f89e71de440b08fc9e.

See https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1324 for the change this is addressing.