### PR TITLE
Bug 572440 - combine declaration and overridden assignment

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -17737,6 +17737,342 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testOverriddenAssignment2() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
+		String input= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public boolean removeUselessInitialization() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedVar;\n" //
+				+ "        reassignedVar = \"\\n\".equals(File.pathSeparator);//$NON-NLS-1\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long removeInitForLong() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        long reassignedVar;\n" //
+				+ "        System.out.println();\n" //
+				+ "        reassignedVar = System.currentTimeMillis();\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String removeInitForString() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        String reassignedVar;\n" //
+				+ "        System.out.println();\n" //
+				+ "        reassignedVar = File.pathSeparator;\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public boolean removePassiveInitialization(int i) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedPassiveVar;\n" //
+				+ "        reassignedPassiveVar = \"\\n\".equals(File.pathSeparator);\n" //
+				+ "        return reassignedPassiveVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long moveDeclOnlyIfEnabled() {\n" //
+				+ "        // comment 1\n" //
+				+ "        long time;\n" //
+				+ "        // comment 2\n" //
+				+ "        String separator = \"\";\n" //
+				+ "        separator = System.lineSeparator();\n" //
+				+ "        // comment 3\n" //
+				+ "        time = System.currentTimeMillis();\n" //
+				+ "        return time;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public void complexMoves(String str) {\n" //
+				+ "        // t is a String\n" //
+				+ "        String t;\n" //
+				+ "        // s is a String\n" //
+				+ "        String s;\n" //
+				+ "        // No move for multiple declarations\n" //
+				+ "        String v = \"ppp\", w; //$NON-NLS-1$\n" //
+				+ "        // No move for multiple statements on line\n" //
+				+ "        String k = \"rrr\"; String l = \"sss\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "        int j = 7;\n" //
+				+ "        // this comment will get lost\n" //
+				+ "        s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
+				+ "            \"xyz\" +\n" //
+				+ "            \"ghi\"; //$NON-NLS-1$\n" //
+				+ "        j = 4 +\n" //
+				+ "        	       // some comment\n" //
+				+ "        	       5 +\n" //
+				+ "        	       6;\n" //
+				+ "        t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
+				+ "        w = \"aaa\"; //$NON-NLS-1$\n" //
+				+ "        k = \"ttt\"; //$NON-NLS-1$\n" //
+				+ "        l = \"uuu\"; //$NON-NLS-1$\n" //
+				+ "        // No move when parent statement other than block is on same line\n" //
+				+ "        if (\"TRUE\".equals(str)) { var x= \"bar\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "           x = v;\n" //
+				+ "           System.out.println(x);\n" //
+				+ "        }\n" //
+				+ "        System.out.println(j);\n" //
+				+ "        System.out.println(k);\n" //
+				+ "        System.out.println(l);\n" //
+				+ "        System.out.println(s);\n" //
+				+ "        System.out.println(t);\n" //
+				+ "        System.out.println(w);\n" //
+				+ "    }\n" //
+				+ "}\n";
+		ICompilationUnit cu= pack.createCompilationUnit("E.java", input, false, null);
+
+		enable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT);
+		disable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL);
+		disable(CleanUpConstants.REMOVE_REDUNDANT_SEMICOLONS);
+
+		String output= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class E {\n" //
+				+ "    public boolean removeUselessInitialization() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedVar = \"\\n\".equals(File.pathSeparator);//$NON-NLS-1\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long removeInitForLong() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        long reassignedVar;\n" //
+				+ "        System.out.println();\n" //
+				+ "        reassignedVar = System.currentTimeMillis();\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String removeInitForString() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        String reassignedVar = File.pathSeparator;\n" //
+				+ "        System.out.println();\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public boolean removePassiveInitialization(int i) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedPassiveVar = \"\\n\".equals(File.pathSeparator);\n" //
+				+ "        return reassignedPassiveVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long moveDeclOnlyIfEnabled() {\n" //
+				+ "        // comment 1\n" //
+				+ "        long time;\n" //
+				+ "        // comment 2\n" //
+				+ "        String separator = System.lineSeparator();\n" //
+				+ "        // comment 3\n" //
+				+ "        time = System.currentTimeMillis();\n" //
+				+ "        return time;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public void complexMoves(String str) {\n" //
+				+ "        // t is a String\n" //
+				+ "        String t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
+				+ "        // s is a String\n" //
+				+ "        String s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
+				+ "                    \"xyz\" +\n" //
+				+ "                    \"ghi\"; //$NON-NLS-1$\n" //
+				+ "        // No move for multiple declarations\n" //
+				+ "        String v = \"ppp\", w; //$NON-NLS-1$\n" //
+				+ "        // No move for multiple statements on line\n" //
+				+ "        String k = \"rrr\"; String l = \"sss\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "        int j = 4 +\n" //
+				+ "                \t       // some comment\n" //
+				+ "                \t       5 +\n" //
+				+ "                \t       6;\n" //
+				+ "        w = \"aaa\"; //$NON-NLS-1$\n" //
+				+ "        k = \"ttt\"; //$NON-NLS-1$\n" //
+				+ "        l = \"uuu\"; //$NON-NLS-1$\n" //
+				+ "        // No move when parent statement other than block is on same line\n" //
+				+ "        if (\"TRUE\".equals(str)) { var x= \"bar\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "           x = v;\n" //
+				+ "           System.out.println(x);\n" //
+				+ "        }\n" //
+				+ "        System.out.println(j);\n" //
+				+ "        System.out.println(k);\n" //
+				+ "        System.out.println(l);\n" //
+				+ "        System.out.println(s);\n" //
+				+ "        System.out.println(t);\n" //
+				+ "        System.out.println(w);\n" //
+				+ "    }\n" //
+				+ "}\n";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { output },
+				new HashSet<>(Arrays.asList(MultiFixMessages.OverriddenAssignmentCleanUp_description)));
+
+		input= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class F {\n" //
+				+ "    public boolean removeUselessInitialization() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedVar;\n" //
+				+ "        reassignedVar = \"\\n\".equals(File.pathSeparator);//$NON-NLS-1\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long removeInitForLong() {\n" //
+				+ "        // This comment will be lost\n" //
+				+ "        long reassignedVar;\n" //
+				+ "        System.out.println();\n" //
+				+ "        // Keep this comment\n" //
+				+ "        reassignedVar = System.currentTimeMillis();\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String removeInitForString() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        String reassignedVar;\n" //
+				+ "        System.out.println();\n" //
+				+ "        reassignedVar = File.pathSeparator;\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public boolean removePassiveInitialization(int i) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedPassiveVar;\n" //
+				+ "        reassignedPassiveVar = \"\\n\".equals(File.pathSeparator);\n" //
+				+ "        return reassignedPassiveVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long moveDeclOnlyIfEnabled() {\n" //
+				+ "        // comment 1\n" //
+				+ "        long time;\n" //
+				+ "        // comment 2\n" //
+				+ "        String separator;\n" //
+				+ "        separator = System.lineSeparator();\n" //
+				+ "        System.out.println(separator);\n" //
+				+ "        // comment 3\n" //
+				+ "        time = System.currentTimeMillis();\n" //
+				+ "        return time;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public void complexMoves(String str) {\n" //
+				+ "        // t is a String\n" //
+				+ "        String t;\n" //
+				+ "        // s is a String\n" //
+				+ "        String s;\n" //
+				+ "        // No move for multiple declarations\n" //
+				+ "        String v = \"ppp\", w; //$NON-NLS-1$\n" //
+				+ "        // No move for multiple statements on line\n" //
+				+ "        String k = \"rrr\"; String l = \"sss\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "        int j = 7;\n" //
+				+ "        // this comment will get lost\n" //
+				+ "        s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
+				+ "            \"xyz\" +\n" //
+				+ "            \"ghi\"; //$NON-NLS-1$\n" //
+				+ "        j = 4 +\n" //
+				+ "        	       // some comment\n" //
+				+ "        	       5 +\n" //
+				+ "        	       6;\n" //
+				+ "        t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
+				+ "        w = \"aaa\"; //$NON-NLS-1$\n" //
+				+ "        k = \"ttt\"; //$NON-NLS-1$\n" //
+				+ "        l = \"uuu\"; //$NON-NLS-1$\n" //
+				+ "        // No move when parent statement other than block is on same line\n" //
+				+ "        if (\"TRUE\".equals(str)) { var x= \"bar\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "           x = v;\n" //
+				+ "           System.out.println(x);\n" //
+				+ "        }\n" //
+				+ "        System.out.println(j);\n" //
+				+ "        System.out.println(k);\n" //
+				+ "        System.out.println(l);\n" //
+				+ "        System.out.println(s);\n" //
+				+ "        System.out.println(t);\n" //
+				+ "        System.out.println(w);\n" //
+				+ "    }\n" //
+				+ "}\n";
+		cu= pack.createCompilationUnit("F.java", input, false, null);
+
+		enable(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL);
+		enable(CleanUpConstants.REMOVE_REDUNDANT_SEMICOLONS);
+
+		output= "" //
+				+ "package test1;\n" //
+				+ "\n" //
+				+ "import java.io.File;\n" //
+				+ "\n" //
+				+ "public class F {\n" //
+				+ "    public boolean removeUselessInitialization() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedVar = \"\\n\".equals(File.pathSeparator);//$NON-NLS-1\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long removeInitForLong() {\n" //
+				+ "        System.out.println();\n" //
+				+ "        // Keep this comment\n" //
+				+ "        long reassignedVar = System.currentTimeMillis();\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public String removeInitForString() {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        String reassignedVar = File.pathSeparator;\n" //
+				+ "        System.out.println();\n" //
+				+ "        return reassignedVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public boolean removePassiveInitialization(int i) {\n" //
+				+ "        // Keep this comment\n" //
+				+ "        boolean reassignedPassiveVar = \"\\n\".equals(File.pathSeparator);\n" //
+				+ "        return reassignedPassiveVar;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public long moveDeclOnlyIfEnabled() {\n" //
+				+ "        \n" //
+				+ "        // comment 2\n" //
+				+ "        String separator = System.lineSeparator();\n" //
+				+ "        System.out.println(separator);\n" //
+				+ "        // comment 3\n" //
+				+ "        long time = System.currentTimeMillis();\n" //
+				+ "        return time;\n" //
+				+ "    }\n" //
+				+ "\n" //
+				+ "    public void complexMoves(String str) {\n" //
+				+ "        // t is a String\n" //
+				+ "        String t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
+				+ "        // s is a String\n" //
+				+ "        String s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
+				+ "                    \"xyz\" +\n" //
+				+ "                    \"ghi\"; //$NON-NLS-1$\n" //
+				+ "        // No move for multiple declarations\n" //
+				+ "        String v = \"ppp\", w; //$NON-NLS-1$\n" //
+				+ "        // No move for multiple statements on line\n" //
+				+ "        String k = \"rrr\"; String l = \"sss\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "        int j = 4 +\n" //
+				+ "                \t       // some comment\n" //
+				+ "                \t       5 +\n" //
+				+ "                \t       6;\n" //
+				+ "        w = \"aaa\"; //$NON-NLS-1$\n" //
+				+ "        k = \"ttt\"; //$NON-NLS-1$\n" //
+				+ "        l = \"uuu\"; //$NON-NLS-1$\n" //
+				+ "        // No move when parent statement other than block is on same line\n" //
+				+ "        if (\"TRUE\".equals(str)) { var x= \"bar\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
+				+ "           x = v;\n" //
+				+ "           System.out.println(x);\n" //
+				+ "        }\n" //
+				+ "        System.out.println(j);\n" //
+				+ "        System.out.println(k);\n" //
+				+ "        System.out.println(l);\n" //
+				+ "        System.out.println(s);\n" //
+				+ "        System.out.println(t);\n" //
+				+ "        System.out.println(w);\n" //
+				+ "    }\n" //
+				+ "}\n";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { output },
+				new HashSet<>(Arrays.asList(MultiFixMessages.OverriddenAssignmentCleanUp_description)));
+	}
+
+	@Test
 	public void testDoNotMoveAssignment() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String input= "" //

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -17755,7 +17755,6 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    public long removeInitForLong() {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        long reassignedVar;\n" //
-				+ "        System.out.println();\n" //
 				+ "        reassignedVar = System.currentTimeMillis();\n" //
 				+ "        return reassignedVar;\n" //
 				+ "    }\n" //
@@ -17763,7 +17762,6 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    public String removeInitForString() {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        String reassignedVar;\n" //
-				+ "        System.out.println();\n" //
 				+ "        reassignedVar = File.pathSeparator;\n" //
 				+ "        return reassignedVar;\n" //
 				+ "    }\n" //
@@ -17775,7 +17773,7 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "        return reassignedPassiveVar;\n" //
 				+ "    }\n" //
 				+ "\n" //
-				+ "    public long moveDeclOnlyIfEnabled() {\n" //
+				+ "    public long moveDeclOnlyIfInitialized() {\n" //
 				+ "        // comment 1\n" //
 				+ "        long time;\n" //
 				+ "        // comment 2\n" //
@@ -17789,22 +17787,22 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    public void complexMoves(String str) {\n" //
 				+ "        // t is a String\n" //
 				+ "        String t;\n" //
+				+ "        t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
 				+ "        // s is a String\n" //
 				+ "        String s;\n" //
+				+ "        // this comment will get lost\n" //
+				+ "        s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
+				+ "            \"xyz\" +\n" //
+				+ "            \"ghi\"; //$NON-NLS-1$\n" //
 				+ "        // No move for multiple declarations\n" //
 				+ "        String v = \"ppp\", w; //$NON-NLS-1$\n" //
 				+ "        // No move for multiple statements on line\n" //
 				+ "        String k = \"rrr\"; String l = \"sss\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
 				+ "        int j = 7;\n" //
-				+ "        // this comment will get lost\n" //
-				+ "        s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
-				+ "            \"xyz\" +\n" //
-				+ "            \"ghi\"; //$NON-NLS-1$\n" //
 				+ "        j = 4 +\n" //
 				+ "        	       // some comment\n" //
 				+ "        	       5 +\n" //
 				+ "        	       6;\n" //
-				+ "        t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
 				+ "        w = \"aaa\"; //$NON-NLS-1$\n" //
 				+ "        k = \"ttt\"; //$NON-NLS-1$\n" //
 				+ "        l = \"uuu\"; //$NON-NLS-1$\n" //
@@ -17841,16 +17839,13 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "\n" //
 				+ "    public long removeInitForLong() {\n" //
 				+ "        // Keep this comment\n" //
-				+ "        long reassignedVar;\n" //
-				+ "        System.out.println();\n" //
-				+ "        reassignedVar = System.currentTimeMillis();\n" //
+				+ "        long reassignedVar = System.currentTimeMillis();\n" //
 				+ "        return reassignedVar;\n" //
 				+ "    }\n" //
 				+ "\n" //
 				+ "    public String removeInitForString() {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        String reassignedVar = File.pathSeparator;\n" //
-				+ "        System.out.println();\n" //
 				+ "        return reassignedVar;\n" //
 				+ "    }\n" //
 				+ "\n" //
@@ -17860,7 +17855,7 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "        return reassignedPassiveVar;\n" //
 				+ "    }\n" //
 				+ "\n" //
-				+ "    public long moveDeclOnlyIfEnabled() {\n" //
+				+ "    public long moveDeclOnlyIfInitialized() {\n" //
 				+ "        // comment 1\n" //
 				+ "        long time;\n" //
 				+ "        // comment 2\n" //
@@ -17873,6 +17868,7 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    public void complexMoves(String str) {\n" //
 				+ "        // t is a String\n" //
 				+ "        String t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
+				+ "        \n" //
 				+ "        // s is a String\n" //
 				+ "        String s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
 				+ "                    \"xyz\" +\n" //
@@ -17919,10 +17915,9 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    }\n" //
 				+ "\n" //
 				+ "    public long removeInitForLong() {\n" //
-				+ "        // This comment will be lost\n" //
-				+ "        long reassignedVar;\n" //
-				+ "        System.out.println();\n" //
 				+ "        // Keep this comment\n" //
+				+ "        long reassignedVar;\n" //
+				+ "        // This comment will be lost\n" //
 				+ "        reassignedVar = System.currentTimeMillis();\n" //
 				+ "        return reassignedVar;\n" //
 				+ "    }\n" //
@@ -17930,7 +17925,6 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    public String removeInitForString() {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        String reassignedVar;\n" //
-				+ "        System.out.println();\n" //
 				+ "        reassignedVar = File.pathSeparator;\n" //
 				+ "        return reassignedVar;\n" //
 				+ "    }\n" //
@@ -17942,7 +17936,7 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "        return reassignedPassiveVar;\n" //
 				+ "    }\n" //
 				+ "\n" //
-				+ "    public long moveDeclOnlyIfEnabled() {\n" //
+				+ "    public long moveDeclOnlyIfInitialized() {\n" //
 				+ "        // comment 1\n" //
 				+ "        long time;\n" //
 				+ "        // comment 2\n" //
@@ -17957,22 +17951,22 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    public void complexMoves(String str) {\n" //
 				+ "        // t is a String\n" //
 				+ "        String t;\n" //
+				+ "        t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
 				+ "        // s is a String\n" //
 				+ "        String s;\n" //
+				+ "        // this comment will get lost\n" //
+				+ "        s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
+				+ "            \"xyz\" +\n" //
+				+ "            \"ghi\"; //$NON-NLS-1$\n" //
 				+ "        // No move for multiple declarations\n" //
 				+ "        String v = \"ppp\", w; //$NON-NLS-1$\n" //
 				+ "        // No move for multiple statements on line\n" //
 				+ "        String k = \"rrr\"; String l = \"sss\"; //$NON-NLS-1$ //$NON-NLS-2$\n" //
 				+ "        int j = 7;\n" //
-				+ "        // this comment will get lost\n" //
-				+ "        s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
-				+ "            \"xyz\" +\n" //
-				+ "            \"ghi\"; //$NON-NLS-1$\n" //
 				+ "        j = 4 +\n" //
 				+ "        	       // some comment\n" //
 				+ "        	       5 +\n" //
 				+ "        	       6;\n" //
-				+ "        t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
 				+ "        w = \"aaa\"; //$NON-NLS-1$\n" //
 				+ "        k = \"ttt\"; //$NON-NLS-1$\n" //
 				+ "        l = \"uuu\"; //$NON-NLS-1$\n" //
@@ -18007,7 +18001,6 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    }\n" //
 				+ "\n" //
 				+ "    public long removeInitForLong() {\n" //
-				+ "        System.out.println();\n" //
 				+ "        // Keep this comment\n" //
 				+ "        long reassignedVar = System.currentTimeMillis();\n" //
 				+ "        return reassignedVar;\n" //
@@ -18016,7 +18009,6 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "    public String removeInitForString() {\n" //
 				+ "        // Keep this comment\n" //
 				+ "        String reassignedVar = File.pathSeparator;\n" //
-				+ "        System.out.println();\n" //
 				+ "        return reassignedVar;\n" //
 				+ "    }\n" //
 				+ "\n" //
@@ -18026,19 +18018,21 @@ public class CleanUpTest extends CleanUpTestCase {
 				+ "        return reassignedPassiveVar;\n" //
 				+ "    }\n" //
 				+ "\n" //
-				+ "    public long moveDeclOnlyIfEnabled() {\n" //
-				+ "        \n" //
+				+ "    public long moveDeclOnlyIfInitialized() {\n" //
+				+ "        // comment 1\n" //
+				+ "        long time;\n" //
 				+ "        // comment 2\n" //
 				+ "        String separator = System.lineSeparator();\n" //
 				+ "        System.out.println(separator);\n" //
 				+ "        // comment 3\n" //
-				+ "        long time = System.currentTimeMillis();\n" //
+				+ "        time = System.currentTimeMillis();\n" //
 				+ "        return time;\n" //
 				+ "    }\n" //
 				+ "\n" //
 				+ "    public void complexMoves(String str) {\n" //
 				+ "        // t is a String\n" //
 				+ "        String t = /* abc */ \"pqr\"; //$NON-NLS-1$\n" //
+				+ "        \n" //
 				+ "        // s is a String\n" //
 				+ "        String s = /* abc */ \"def\" +	//$NON-NLS-1$\n" //
 				+ "                    \"xyz\" +\n" //

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
@@ -159,13 +159,11 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 								shouldMoveDown &= varDefinitionsUsesVisitor.getWrites().isEmpty();
 							}
 
-							stmtToInspect= ASTNodes.getNextSibling(stmtToInspect);
-
-//							if (fragment.getInitializer() == null) {
-//								stmtToInspect= null;
-//							} else {
-//								stmtToInspect= ASTNodes.getNextSibling(stmtToInspect);
-//							}
+							if (fragment.getInitializer() == null) {
+								stmtToInspect= null;
+							} else {
+								stmtToInspect= ASTNodes.getNextSibling(stmtToInspect);
+							}
 						}
 
 						if (overridingAssignment != null && doesNotShareLines(node) && doesNotShareLines(overridingAssignment)) {
@@ -300,7 +298,7 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 				moveUp(cuRewrite, group);
 			} else if (canMoveDown && moveDown) {
 				moveDown(cuRewrite, group);
-			} else if (fragment.getInitializer() != null) {
+			} else {
 				removeInitializer(cuRewrite, group);
 			}
 		}
@@ -377,17 +375,8 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 			Expression rhs= overridingAssignment.getRightHandSide();
 			String rhsText= cu.getBuffer().getText(rhs.getStartPosition(), extendedEnd(cuRewrite.getRoot(), overridingAssignment.getParent()) - rhs.getStartPosition());
 
-			String targetText= null;
-			if (fragment.getInitializer() == null) {
-				String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), declaration.getLength() - 1);
-				Hashtable<String, String> options= JavaCore.getOptions();
-				String spaceBeforeAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_BEFORE_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
-				String spaceAfterAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_AFTER_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
-				targetText= declarationText + spaceBeforeAssignment + "=" + spaceAfterAssignment + rhsText; //$NON-NLS-1$
-			} else {
-				String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
-				targetText= declarationText + rhsText;
-			}
+			String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
+			String targetText= declarationText + rhsText;
 			ASTRewrite astRewrite= cuRewrite.getASTRewrite();
 			ASTNode replacementNode= astRewrite.createStringPlaceholder(targetText, ASTNode.VARIABLE_DECLARATION_STATEMENT);
 			overridingAssignment.getParent().setProperty(IGNORE_LEADING_COMMENT, Boolean.TRUE);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,6 +15,7 @@ package org.eclipse.jdt.internal.ui.fix;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.text.edits.TextEditGroup;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -41,6 +43,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.InterruptibleVisitor;
@@ -124,8 +127,8 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 				VariableDeclarationFragment fragment= ASTNodes.getUniqueFragment(node);
 
 				if (fragment != null
-						&& fragment.getInitializer() != null
-						&& ASTNodes.isPassiveWithoutFallingThrough(fragment.getInitializer())) {
+						&& (fragment.getInitializer() == null
+						|| ASTNodes.isPassiveWithoutFallingThrough(fragment.getInitializer()))) {
 					SimpleName varName= fragment.getName();
 					IVariableBinding variable= fragment.resolveBinding();
 					if (variable != null) {
@@ -157,6 +160,12 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 							}
 
 							stmtToInspect= ASTNodes.getNextSibling(stmtToInspect);
+
+//							if (fragment.getInitializer() == null) {
+//								stmtToInspect= null;
+//							} else {
+//								stmtToInspect= ASTNodes.getNextSibling(stmtToInspect);
+//							}
 						}
 
 						if (overridingAssignment != null && doesNotShareLines(node) && doesNotShareLines(overridingAssignment)) {
@@ -291,7 +300,7 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 				moveUp(cuRewrite, group);
 			} else if (canMoveDown && moveDown) {
 				moveDown(cuRewrite, group);
-			} else {
+			} else if (fragment.getInitializer() != null) {
 				removeInitializer(cuRewrite, group);
 			}
 		}
@@ -344,9 +353,17 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 			Expression rhs= overridingAssignment.getRightHandSide();
 			String rhsText= cu.getBuffer().getText(extendedStart(cuRewrite.getRoot(), rhs), extendedEnd(cuRewrite.getRoot(), overridingAssignment.getParent()) - extendedStart(cuRewrite.getRoot(), rhs));
 
-			String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
-			String targetText= declarationText + rhsText;
-
+			String targetText= null;
+			if (fragment.getInitializer() == null) {
+				String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), declaration.getLength() - 1);
+				Hashtable<String, String> options= JavaCore.getOptions();
+				String spaceBeforeAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_BEFORE_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
+				String spaceAfterAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_AFTER_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
+				targetText= declarationText + spaceBeforeAssignment + "=" + spaceAfterAssignment + rhsText; //$NON-NLS-1$
+			} else {
+				String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
+				targetText= declarationText + rhsText;
+			}
 			ASTRewrite astRewrite= cuRewrite.getASTRewrite();
 			ASTNode replacementNode= astRewrite.createStringPlaceholder(targetText, ASTNode.VARIABLE_DECLARATION_STATEMENT);
 			declaration.setProperty(IGNORE_LEADING_COMMENT, Boolean.TRUE);
@@ -360,10 +377,17 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 			Expression rhs= overridingAssignment.getRightHandSide();
 			String rhsText= cu.getBuffer().getText(rhs.getStartPosition(), extendedEnd(cuRewrite.getRoot(), overridingAssignment.getParent()) - rhs.getStartPosition());
 
-			String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
-
-			String targetText= declarationText + rhsText;
-
+			String targetText= null;
+			if (fragment.getInitializer() == null) {
+				String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), declaration.getLength() - 1);
+				Hashtable<String, String> options= JavaCore.getOptions();
+				String spaceBeforeAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_BEFORE_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
+				String spaceAfterAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_AFTER_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
+				targetText= declarationText + spaceBeforeAssignment + "=" + spaceAfterAssignment + rhsText; //$NON-NLS-1$
+			} else {
+				String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
+				targetText= declarationText + rhsText;
+			}
 			ASTRewrite astRewrite= cuRewrite.getASTRewrite();
 			ASTNode replacementNode= astRewrite.createStringPlaceholder(targetText, ASTNode.VARIABLE_DECLARATION_STATEMENT);
 			overridingAssignment.getParent().setProperty(IGNORE_LEADING_COMMENT, Boolean.TRUE);


### PR DESCRIPTION
- treat variable declarations that have no initializer the same as ones that do for the first declaration that gets overridden
- add new test to CleanUpTest
- fixes #1330

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test or bug or issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
