### PR TITLE
Mandate a package name in NewClassWizard when project is a module

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -112,6 +112,7 @@ public final class NewWizardMessages extends NLS {
 	public static String NewTypeWizardPage_enclosing_button;
 	public static String NewTypeWizardPage_error_InvalidPackageName;
 	public static String NewTypeWizardPage_error_ClashOutputLocation;
+	public static String NewTypeWizardPage_error_PackageNameEmptyForModule;
 	public static String NewTypeWizardPage_warning_DiscouragedPackageName;
 	public static String NewTypeWizardPage_warning_DefaultPackageDiscouraged;
 	public static String NewTypeWizardPage_warning_NotJDKCompliant;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -86,6 +86,7 @@ NewTypeWizardPage_enclosing_button=Bro&wse...
 
 NewTypeWizardPage_error_InvalidPackageName=Package name is not valid. {0}
 NewTypeWizardPage_error_ClashOutputLocation=Package clashes with project output folder.
+NewTypeWizardPage_error_PackageNameEmptyForModule=A package name must be specified for a module.
 NewTypeWizardPage_error_uri_location_unkown=Cannot locate resource {0}
 NewTypeWizardPage_warning_DiscouragedPackageName=This package name is discouraged. {0}
 NewTypeWizardPage_warning_DefaultPackageDiscouraged=The use of the default package is discouraged.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1900,7 +1900,15 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 				// continue
 			}
 		} else {
-			status.setWarning(NewWizardMessages.NewTypeWizardPage_warning_DefaultPackageDiscouraged);
+			try {
+				if (project != null && project.getModuleDescription() != null) {
+					status.setError(NewWizardMessages.NewTypeWizardPage_error_PackageNameEmptyForModule);
+				} else {
+					status.setWarning(NewWizardMessages.NewTypeWizardPage_warning_DefaultPackageDiscouraged);
+				}
+			} catch (JavaModelException e) {
+				status.setWarning(NewWizardMessages.NewTypeWizardPage_warning_DefaultPackageDiscouraged);
+			}
 		}
 
 		if (project != null && root != null) {


### PR DESCRIPTION
- fixes #1328

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds an error message when Java project has module descriptor and user attempts to create a class in the default package.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Create a Java project with module-info.java file.  Attempt to create a new class using wizard where package is not specified.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
