### PR TITLE
Enable prototype support for Generic Test view - JUnit

### DIFF
--- a/org.eclipse.jdt.ui.unittest.junit/plugin.xml
+++ b/org.eclipse.jdt.ui.unittest.junit/plugin.xml
@@ -37,6 +37,7 @@
             delegateDescription="%JUnitLaunchDelegate.description"
             delegateName="%JUnitLaunchDelegate.name"
             allowCommandLine="true"
+            allowPrototypes="true"
             delegate="org.eclipse.jdt.ui.unittest.junit.launcher.AdvancedJUnitLaunchConfigurationDelegate"
             modes="run, debug"
             id="org.eclipse.jdt.ui.unittest.junit.launchConfiguration"

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/internal/launcher/JUnitTabGroup.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/internal/launcher/JUnitTabGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.debug.ui.PrototypeTab;
 import org.eclipse.debug.ui.sourcelookup.SourceLookupTab;
 
 import org.eclipse.jdt.internal.junit.launcher.AssertionVMArg;
@@ -45,7 +46,7 @@ public class JUnitTabGroup extends AbstractLaunchConfigurationTabGroup {
 		ILaunchConfigurationTab[] tabs = new ILaunchConfigurationTab[] { new JUnitLaunchConfigurationTab(),
 				new JavaArgumentsTab(), new JavaJRETab(true),
 				isModularConfiguration ? new JavaDependenciesTab() : new JavaClasspathTab(), new SourceLookupTab(),
-				new EnvironmentTab(), new CommonTab() };
+				new EnvironmentTab(), new CommonTab(), new PrototypeTab() };
 		setTabs(tabs);
 	}
 


### PR DESCRIPTION
## What it does
Enables the the prototype support for Generic Test view - JUnit.
Majority of the tabs are already providing labels support for the prototype tab.

## How to test
Create a prototype of type "JUnit Test (generic Test view)" and link existing JUnit test launch of same type, link them and  see that e.g. VM args from template are appiled to the test launch.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
