### PR TITLE
Javadoc sections misaligned

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
@@ -74,17 +74,17 @@ import org.eclipse.jdt.internal.ui.viewsupport.CoreJavaElementLinks;
  * Helper to get the content of a Javadoc comment as HTML.
  */
 public class CoreJavadocAccessImpl implements IJavadocAccess {
-	protected static final String BLOCK_TAG_START= "<ul>"; //$NON-NLS-1$
+	protected static final String BLOCK_TAG_START= "<dl>"; //$NON-NLS-1$
 
-	protected static final String BLOCK_TAG_END= "</ul>"; //$NON-NLS-1$
+	protected static final String BLOCK_TAG_END= "</dl>"; //$NON-NLS-1$
 
 	protected static final String BlOCK_TAG_TITLE_START= "<dt>"; //$NON-NLS-1$
 
 	protected static final String BlOCK_TAG_TITLE_END= "</dt>"; //$NON-NLS-1$
 
-	protected static final String BlOCK_TAG_ENTRY_START= "<li>"; //$NON-NLS-1$
+	protected static final String BlOCK_TAG_ENTRY_START= "<dd>"; //$NON-NLS-1$
 
-	protected static final String BlOCK_TAG_ENTRY_END= "</li>"; //$NON-NLS-1$
+	protected static final String BlOCK_TAG_ENTRY_END= "</dd>"; //$NON-NLS-1$
 
 	protected static final String PARAM_NAME_START= "<b>"; //$NON-NLS-1$
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/browser/BrowserTextAccessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/browser/BrowserTextAccessor.java
@@ -24,7 +24,7 @@ import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.jface.internal.text.html.BrowserInformationControl;
 
 /**
- * Provides access to the text of the {@link Browser} internally created & used by {@link BrowserInformationControl}.
+ * Provides access to the text of the {@link Browser} internally created &amp; used by {@link BrowserInformationControl}.
  */
 public class BrowserTextAccessor {
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/javadoc/SignatureStylingMenuToolbarAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/javadoc/SignatureStylingMenuToolbarAction.java
@@ -39,7 +39,7 @@ import org.eclipse.jdt.internal.ui.viewsupport.browser.BrowserTextAccessor;
 import org.eclipse.jdt.internal.ui.viewsupport.browser.BrowserTextAccessor.IBrowserContentChangeListener;
 
 /**
- * Toolbar item action for building & presenting javadoc styling menu.
+ * Toolbar item action for building &amp; presenting javadoc styling menu.
  */
 public class SignatureStylingMenuToolbarAction extends Action implements IMenuCreator, IBrowserContentChangeListener, IStylingConfigurationListener {
 	private final Action[] noStylingActions= { new NoStylingEnhancementsAction() };


### PR DESCRIPTION
Regression from cbc03c25f6059c774d8766bd7b02489c9df53acf / https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/941 

The code moved from JavadocContentAccess2 to CoreJavadocAccessImpl changed dt/dd tags to ul/li tag pairs, and that broke javadoc alignment.

This commit restores original tag pairs used for javadoc formatting.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1346
