### PR TITLE
Fix string concat to String.format to use text block when possible

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
@@ -15,11 +15,14 @@ package org.eclipse.jdt.internal.corext.fix;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jface.text.BadLocationException;
 
+import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
@@ -34,6 +37,7 @@ import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -49,6 +53,11 @@ import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
 public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperationsFixCore {
+
+	/**
+	 * Should match the last NLS comment before end of the line
+	 */
+	static final Pattern comment= Pattern.compile("([ ]*\\/\\/\\$NON-NLS-[0-9]\\$) *$"); //$NON-NLS-1$
 
 	public ConvertToStringFormatFixCore(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperation operation) {
 		super(name, compilationUnit, operation);
@@ -172,6 +181,30 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 		}
 	}
 
+	private static String indentOf(ICompilationUnit cu, Expression exp) {
+		CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
+		int startLine= cUnit.getLineNumber(exp.getStartPosition());
+		int startLinePos= cUnit.getPosition(startLine, 0);
+		int endOfLine= cUnit.getPosition(startLine + 1, 0);
+		String indent= ""; //$NON-NLS-1$
+		IBuffer buffer;
+		try {
+			buffer= cu.getBuffer();
+			String line= buffer.getText(startLinePos, endOfLine - startLinePos);
+			for (int i= 0; i < line.length(); ++i) {
+				char ch= line.charAt(i);
+				if (Character.isSpaceChar(ch)) {
+					indent+= ch;
+				} else {
+					break;
+				}
+			}
+		} catch (JavaModelException e) {
+			// ignore
+		}
+		return indent;
+	}
+
 	private static class ConvertToStringFormatProposalOperation extends CompilationUnitRewriteOperation {
 		private InfixExpression infixExpression;
 
@@ -181,8 +214,11 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 
 		@Override
 		public void rewriteAST(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel) throws CoreException {
+			final List<String> fLiterals= new ArrayList<>();
+			String fIndent= ""; //$NON-NLS-1$
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
 			ICompilationUnit cu= cuRewrite.getCu();
+			boolean is15OrHigher= JavaModelUtil.is15OrHigher(cu.getJavaProject());
 			CompilationUnit root= cuRewrite.getRoot();
 			String cuContents= cuRewrite.getCu().getBuffer().getContents();
 
@@ -193,8 +229,13 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 			List<String> formatArguments= new ArrayList<>();
 			StringBuilder formatString= new StringBuilder();
 			int tagsCount= 0;
+			boolean firstStringLiteral= true;
 			for (Expression operand : operands) {
 				if (operand instanceof StringLiteral) {
+					if (firstStringLiteral) {
+						fIndent= indentOf(cu, operand);
+						firstStringLiteral= false;
+					}
 					NLSLine nlsLine= scanCurrentLine(cu, operand);
 					if (nlsLine != null) {
 						for (NLSElement element : nlsLine.getElements()) {
@@ -206,10 +247,12 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 						}
 					}
 					String value= ((StringLiteral) operand).getEscapedValue();
+					fLiterals.add(value);
 					value= value.substring(1, value.length() - 1);
 					formatString.append(value);
 				} else {
 					ITypeBinding binding= operand.resolveTypeBinding();
+					fLiterals.add("\"%" + stringFormatConversion(binding) + "\""); //$NON-NLS-1$ //$NON-NLS-2$
 					formatString.append("%").append(stringFormatConversion(binding)); //$NON-NLS-1$
 					int origStart= root.getExtendedStartPosition(operand);
 					int origLength= root.getExtendedLength(operand);
@@ -220,14 +263,112 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 
 			StringBuilder buffer= new StringBuilder();
 			buffer.append("String.format("); //$NON-NLS-1$
-			buffer.append("\"" + formatString.toString().replaceAll("\"", "\\\"") + "\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+			if (is15OrHigher) {
+				StringBuilder buf= new StringBuilder();
+
+				List<String> parts= new ArrayList<>();
+				fLiterals.stream().forEach((t) -> { parts.addAll(StringConcatToTextBlockFixCore.unescapeBlock(t.substring(1, t.length() - 1))); });
+
+
+				buf.append("\"\"\"\n"); //$NON-NLS-1$
+				boolean newLine= false;
+				boolean allWhiteSpaceStart= true;
+				boolean allEmpty= true;
+				for (String part : parts) {
+					if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
+						if (!newLine) {
+							// no line terminator in this part: merge the line by emitting a line continuation escape
+							buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
+						}
+					}
+					newLine= part.endsWith(System.lineSeparator());
+					allWhiteSpaceStart= allWhiteSpaceStart && (part.isEmpty() || Character.isWhitespace(part.charAt(0)));
+					allEmpty= allEmpty && part.isEmpty();
+					buf.append(fIndent).append(part);
+				}
+
+				if (newLine || allEmpty) {
+					buf.append(fIndent);
+				} else if (allWhiteSpaceStart) {
+					buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
+					buf.append(fIndent);
+				} else {
+					// Replace trailing un-escaped quotes with escaped quotes before adding text block end
+					int readIndex= buf.length() - 1;
+					int count= 0;
+					while (readIndex >= 0 && buf.charAt(readIndex) == '"' && count <= 3) {
+						--readIndex;
+						++count;
+					}
+					if (readIndex >= 0 && buf.charAt(readIndex) == '\\') {
+						--count;
+					}
+					for (int i1= count; i1 > 0; --i1) {
+						buf.deleteCharAt(buf.length() - 1);
+					}
+					for (int i1= count; i1 > 0; --i1) {
+						buf.append("\\\""); //$NON-NLS-1$
+					}
+				}
+				buf.append("\"\"\""); //$NON-NLS-1$
+				buffer.append(buf.toString());
+			} else {
+				buffer.append("\"" + formatString.toString().replaceAll("\"", "\\\"") + "\""); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			}
+
 			for (String formatArgument : formatArguments) {
 				buffer.append(", " + formatArgument); //$NON-NLS-1$
 			}
 			buffer.append(")"); //$NON-NLS-1$
 
 			if (tagsCount > 1) {
-				ASTNodes.replaceAndRemoveNLSByCount(rewrite, infixExpression, buffer.toString(), tagsCount - 1, null, cuRewrite);
+				if (is15OrHigher) {
+					Expression lastOperand= operands.get(operands.size() - 1);
+					NLSLine nlsLine= scanCurrentLine(cu, lastOperand);
+					tagsCount= 0;
+					if (nlsLine != null) {
+						for (NLSElement element : nlsLine.getElements()) {
+							if (element.hasTag()) {
+								++tagsCount;
+							}
+						}
+					}
+					if (!(lastOperand instanceof StringLiteral) || tagsCount > 1) {
+						// if last operand is not a StringLiteral, we have to replace the statement
+						// and add a non-NLS marker because we can't add one via expression replacement
+						ASTNode statement= ASTNodes.getFirstAncestorOrNull(infixExpression, Statement.class);
+						if (statement == null) {
+							return;
+						}
+						CompilationUnit cUnit= (CompilationUnit)infixExpression.getRoot();
+						int extendedStart= cUnit.getExtendedStartPosition(statement);
+						int extendedLength= cUnit.getExtendedLength(statement);
+						String completeStatement= cu.getBuffer().getText(extendedStart, extendedLength);
+						if (tagsCount > 1) {
+							// remove all non-NLS comments and then replace with just one
+							Matcher commentMatcher= comment.matcher(completeStatement);
+							while (tagsCount-- > 0) {
+								completeStatement= commentMatcher.replaceFirst(""); //$NON-NLS-1$
+								commentMatcher= comment.matcher(completeStatement);
+							}
+							extendedLength= completeStatement.length();
+						}
+						StringBuilder newBuffer= new StringBuilder();
+						newBuffer= newBuffer.append(completeStatement.substring(0, infixExpression.getStartPosition() - extendedStart));
+						newBuffer= newBuffer.append(buffer.toString());
+						int infixExpressionEnd= infixExpression.getStartPosition() + infixExpression.getLength();
+						newBuffer= newBuffer.append(cu.getBuffer().getText(infixExpressionEnd, extendedStart + extendedLength - infixExpressionEnd));
+						newBuffer= newBuffer.append(" //$NON-NLS-1$"); //$NON-NLS-1$
+						Statement newStatement= (Statement)rewrite.createStringPlaceholder(newBuffer.toString(), statement.getNodeType());
+						rewrite.replace(statement, newStatement, null);
+					} else {
+						MethodInvocation formatInvocation= (MethodInvocation)rewrite.createStringPlaceholder(buffer.toString(), ASTNode.METHOD_INVOCATION);
+						rewrite.replace(infixExpression, formatInvocation, null);
+					}
+				} else {
+					ASTNodes.replaceAndRemoveNLSByCount(rewrite, infixExpression, buffer.toString(), tagsCount - 1, null, cuRewrite);
+				}
 			} else {
 				MethodInvocation formatInvocation= (MethodInvocation)rewrite.createStringPlaceholder(buffer.toString(), ASTNode.METHOD_INVOCATION);
 				rewrite.replace(infixExpression, formatInvocation, null);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -1240,5 +1240,231 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		assertExpectedExistInProposals(proposals, new String[] { expected });
 	}
 
-}
+	@Test
+	public void testConcatToStringFormatTextBlock1() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String copyright=\n");
+		buf.append("                \"/***********\\n\" +\n");
+		buf.append("                \" * simple   \\n\" +\n");
+		buf.append("                \" * copyright\\n\" +\n");
+		buf.append("                statement +\n");
+		buf.append("                \" * notice\\n\" +\n");
+		buf.append("                \"***********/\\n\"; // comment 2\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		int index= buf.indexOf("simple");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String copyright=\n");
+		buf.append("                String.format(\"\"\"\n");
+		buf.append("		                /***********\n");
+		buf.append("		                 * simple  \\s\n");
+		buf.append("		                 * copyright\n");
+		buf.append("		                %s\\\n");
+		buf.append("		                 * notice\n");
+		buf.append("		                ***********/\n");
+		buf.append("		                \"\"\", statement); // comment 2\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, CorrectionMessages.QuickAssistProcessor_convert_to_string_format);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testConcatToStringFormatTextBlock2() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String copyright=\n");
+		buf.append("                \"/***********\\n\" + //$NON-NLS-1$\n");
+		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
+		buf.append("                statement +\n");
+		buf.append("                \" * copyright\\n\"; //$NON-NLS-1$\n");
+		buf.append("        System.out.println(copyright);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		int index= buf.indexOf("simple");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String copyright=\n");
+		buf.append("                String.format(\"\"\"\n");
+		buf.append("\t\t                /***********\n");
+		buf.append("\t\t                 * simple  \\s\n");
+		buf.append("\t\t                %s\\\n");
+		buf.append("\t\t                 * copyright\n");
+		buf.append("\t\t                \"\"\", statement); //$NON-NLS-1$\n");
+		buf.append("        System.out.println(copyright);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, CorrectionMessages.QuickAssistProcessor_convert_to_string_format);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testConcatToStringFormatTextBlock3() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String copyright=\n");
+		buf.append("                \"/***********\\n\" + //$NON-NLS-1$\n");
+		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
+		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
+		buf.append("                statement;\n");
+		buf.append("        System.out.println(copyright);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		int index= buf.indexOf("simple");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("\t\t        String copyright=\n");
+		buf.append("\t\t                String.format(\"\"\"\n");
+		buf.append("\t\t                /***********\n");
+		buf.append("\t\t                 * simple  \\s\n");
+		buf.append("\t\t                 * copyright\n");
+		buf.append("\t\t                %s\"\"\", statement); //$NON-NLS-1$\n");
+		buf.append("        System.out.println(copyright);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, CorrectionMessages.QuickAssistProcessor_convert_to_string_format);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testConcatToStringFormatTextBlock4() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("        String copyright=\n");
+		buf.append("                \"/***********\\n\" + //$NON-NLS-1$\n");
+		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
+		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
+		buf.append("                statement + \" * notice\\n\" + \"***********/\\n\"; //comment 2 //$NON-NLS-1$ //$NON-NLS-2$\n");
+		buf.append("        System.out.println(copyright);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		int index= buf.indexOf("simple");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo() {\n");
+		buf.append("        String statement= \" * statement\\n\";\n");
+		buf.append("        // comment 1\n");
+		buf.append("\t\t        String copyright=\n");
+		buf.append("\t\t                String.format(\"\"\"\n");
+		buf.append("\t\t                /***********\n");
+		buf.append("\t\t                 * simple  \\s\n");
+		buf.append("\t\t                 * copyright\n");
+		buf.append("\t\t                %s\\\n");
+		buf.append("\t\t                 * notice\n");
+		buf.append("\t\t                ***********/\n");
+		buf.append("\t\t                \"\"\", statement); //comment 2 //$NON-NLS-1$\n");
+		buf.append("        System.out.println(copyright);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, CorrectionMessages.QuickAssistProcessor_convert_to_string_format);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+}


### PR DESCRIPTION
- change ConvertToStringFormatFixCore to use a text block for JVM 15 and above
- add new tests to AssistQuickFixTest15
- fixes #1311

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes string concat to String.format quick fix to use a text block if JVM 15 or above.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
