### PR TITLE
Add 'Open Call Hierarchy' hyperlink for type elements too. Fixes #1231

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OpenCallHierarchyHyperlinkDetector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OpenCallHierarchyHyperlinkDetector.java
@@ -36,7 +36,7 @@ public class OpenCallHierarchyHyperlinkDetector extends JavaElementHyperlinkDete
 
 	@Override
 	protected void addHyperlinks(List<IHyperlink> hyperlinksCollector, IRegion wordRegion, SelectionDispatchAction openAction, IJavaElement element, boolean qualify, JavaEditor editor) {
-		if ((element.getElementType() == IJavaElement.METHOD || element.getElementType() == IJavaElement.FIELD) && (element instanceof IMember imember)) {
+		if (CallHierarchy.isPossibleInputElement(element) && (element instanceof IMember imember)) {
 			hyperlinksCollector.add(new OpenCallHierarchyHyperlink(wordRegion, openAction.getSite().getWorkbenchWindow(), imember));
 		}
 	}


### PR DESCRIPTION
## What it does
Adds 'Open Call Hierarchy' item to the list of "hyperlinks" (actions offered on CTRL + mouse hover) for Java types (classes/enums/records) as well.

## How to test
CTRL + mouse hover over various elements in opened editor, 'Open Call Hierarchy' should be offered for elements for which call hierarchy can be actually shown.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
