### PR TITLE
Escape specifiers when converting to MessageFormat or String.format

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
@@ -255,9 +255,12 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 						}
 					}
 					String value= ((StringLiteral) operand).getEscapedValue();
+					value= value.replace("'", "''"); //$NON-NLS-1$ //$NON-NLS-2$
+					value= value.replace("{", "'{'"); //$NON-NLS-1$ //$NON-NLS-2$
+					value= value.replace("}", "'}'"); //$NON-NLS-1$ //$NON-NLS-2$
+					value= value.replace("'{''}'", "'{}'"); //$NON-NLS-1$ //$NON-NLS-2$
 					fLiterals.add(value);
 					value= value.substring(1, value.length() - 1);
-					value= value.replace("'", "''"); //$NON-NLS-1$ //$NON-NLS-2$
 					formatString.append(value);
 				} else {
 					fLiterals.add("\"{" + Integer.toString(i) + "}\""); //$NON-NLS-1$ //$NON-NLS-2$

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
@@ -247,6 +247,7 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 						}
 					}
 					String value= ((StringLiteral) operand).getEscapedValue();
+					value= value.replace("%", "%%"); //$NON-NLS-1$ //$NON-NLS-2$
 					fLiterals.add(value);
 					value= value.substring(1, value.length() - 1);
 					formatString.append(value);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -1023,10 +1023,10 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf.append("        // comment 1\n");
 		buf.append("        String copyright=\n");
 		buf.append("                \"/***********\\n\" +\n");
-		buf.append("                \" * simple   \\n\" +\n");
+		buf.append("                \" * simple {} \\n\" +\n");
 		buf.append("                \" * copyright\\n\" +\n");
 		buf.append("                statement +\n");
-		buf.append("                \" * notice\\n\" +\n");
+		buf.append("                \" * notice {0}\\n\" +\n");
 		buf.append("                \"***********/\\n\"; // comment 2\n");
 		buf.append("    }\n");
 		buf.append("}\n");
@@ -1048,10 +1048,10 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf.append("        String copyright=\n");
 		buf.append("                MessageFormat.format(\"\"\"\n");
 		buf.append("		                /***********\n");
-		buf.append("		                 * simple  \\s\n");
+		buf.append("		                 * simple '{}'\\s\n");
 		buf.append("		                 * copyright\n");
 		buf.append("		                {0}\\\n");
-		buf.append("		                 * notice\n");
+		buf.append("		                 * notice '{'0'}'\n");
 		buf.append("		                ***********/\n");
 		buf.append("		                \"\"\", statement); // comment 2\n");
 		buf.append("    }\n");
@@ -1263,7 +1263,7 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf.append("        String copyright=\n");
 		buf.append("                \"/***********\\n\" +\n");
 		buf.append("                \" * simple   \\n\" +\n");
-		buf.append("                \" * copyright\\n\" +\n");
+		buf.append("                \" * copyright %\\n\" +\n");
 		buf.append("                statement +\n");
 		buf.append("                \" * notice\\n\" +\n");
 		buf.append("                \"***********/\\n\"; // comment 2\n");
@@ -1285,7 +1285,7 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf.append("                String.format(\"\"\"\n");
 		buf.append("		                /***********\n");
 		buf.append("		                 * simple  \\s\n");
-		buf.append("		                 * copyright\n");
+		buf.append("		                 * copyright %%\n");
 		buf.append("		                %s\\\n");
 		buf.append("		                 * notice\n");
 		buf.append("		                ***********/\n");


### PR DESCRIPTION
- for MessageFormat, put parentheses in single quotes and look for open/closed parentheses one after another
- for String.format, escape % as %%
- modify tests in AssistQuickFixTest15
- fixes #1366

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Escapes certain characters when converting string concat to MessageFormat or String.format as part of a quick assist.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
