### PR TITLE
Refactor OverriddenAssignmentCleanUp to jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/OverriddenAssignmentCleanUpCore.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Fabrice TIERCELIN - initial API and implementation
+ *     Red Hat Inc. - refactor to jdt.core.manipulation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.fix;
+
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.internal.corext.fix.OverriddenAssignmentFixCore;
+
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+/**
+ * A fix that removes passive assignment when the variable is reassigned before being read.
+ */
+public class OverriddenAssignmentCleanUpCore extends AbstractCleanUp {
+
+	public OverriddenAssignmentCleanUpCore() {
+	}
+
+	public OverriddenAssignmentCleanUpCore(Map<String, String> options) {
+		super(options);
+	}
+
+	@Override
+	public CleanUpRequirements getRequirements() {
+		return new CleanUpRequirements(requireAST(), false, false, null);
+	}
+
+	public boolean requireAST() {
+		return isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT);
+	}
+
+	@Override
+	public String[] getStepDescriptions() {
+		if (isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT)) {
+			return new String[] { MultiFixMessages.OverriddenAssignmentCleanUp_description };
+		}
+
+		return new String[0];
+	}
+
+	@Override
+	public String getPreview() {
+		StringBuilder bld= new StringBuilder();
+
+		if (isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT)) {
+			if (isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL)) {
+				bld.append("String separator = System.lineSeparator();\n"); //$NON-NLS-1$
+				bld.append("long time = System.currentTimeMillis();\n"); //$NON-NLS-1$
+			} else {
+				bld.append("long time;\n"); //$NON-NLS-1$
+				bld.append("String separator = System.lineSeparator();\n"); //$NON-NLS-1$
+				bld.append("time = System.currentTimeMillis();\n"); //$NON-NLS-1$
+			}
+		} else {
+			bld.append("long time = 0;\n"); //$NON-NLS-1$
+			bld.append("String separator = \"\";\n"); //$NON-NLS-1$
+			bld.append("separator = System.lineSeparator();\n"); //$NON-NLS-1$
+			bld.append("time = System.currentTimeMillis();\n"); //$NON-NLS-1$
+		}
+
+
+		return bld.toString();
+	}
+
+	@Override
+	public ICleanUpFix createFix(final CleanUpContext context) throws CoreException {
+		CompilationUnit compilationUnit= context.getAST();
+
+		if (compilationUnit == null || !isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT)) {
+			return null;
+		}
+
+		return OverriddenAssignmentFixCore.createCleanUp(compilationUnit, isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL));
+	}
+
+}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/OverriddenAssignmentFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/OverriddenAssignmentFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
+ * Copyright (c) 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,14 +10,13 @@
  *
  * Contributors:
  *     Fabrice TIERCELIN - initial API and implementation
+ *     Red Hat Inc. - code extracted from OverriddenAssignmentCleanUp
  *******************************************************************************/
-package org.eclipse.jdt.internal.ui.fix;
+package org.eclipse.jdt.internal.corext.fix;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Hashtable;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
 
@@ -48,178 +47,15 @@ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.InterruptibleVisitor;
 import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
-import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
-import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
-import org.eclipse.jdt.ui.cleanup.CleanUpContext;
-import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
-/**
- * A fix that removes passive assignment when the variable is reassigned before being read.
- */
-public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
+import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+
+public class OverriddenAssignmentFixCore extends CompilationUnitRewriteOperationsFixCore {
+
 	private static final String IGNORE_LEADING_COMMENT= "ignoreLeadingComment"; //$NON-NLS-1$
-
-	public OverriddenAssignmentCleanUp() {
-		this(Collections.emptyMap());
-	}
-
-	public OverriddenAssignmentCleanUp(Map<String, String> options) {
-		super(options);
-	}
-
-	@Override
-	public CleanUpRequirements getRequirements() {
-		boolean requireAST= isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT);
-		return new CleanUpRequirements(requireAST, false, false, null);
-	}
-
-	@Override
-	public String[] getStepDescriptions() {
-		if (isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT)) {
-			return new String[] { MultiFixMessages.OverriddenAssignmentCleanUp_description };
-		}
-
-		return new String[0];
-	}
-
-	@Override
-	public String getPreview() {
-		StringBuilder bld= new StringBuilder();
-
-		if (isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT)) {
-			if (isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL)) {
-				bld.append("String separator = System.lineSeparator();\n"); //$NON-NLS-1$
-				bld.append("long time = System.currentTimeMillis();\n"); //$NON-NLS-1$
-			} else {
-				bld.append("long time;\n"); //$NON-NLS-1$
-				bld.append("String separator = System.lineSeparator();\n"); //$NON-NLS-1$
-				bld.append("time = System.currentTimeMillis();\n"); //$NON-NLS-1$
-			}
-		} else {
-			bld.append("long time = 0;\n"); //$NON-NLS-1$
-			bld.append("String separator = \"\";\n"); //$NON-NLS-1$
-			bld.append("separator = System.lineSeparator();\n"); //$NON-NLS-1$
-			bld.append("time = System.currentTimeMillis();\n"); //$NON-NLS-1$
-		}
-
-
-		return bld.toString();
-	}
-
-	@Override
-	public ICleanUpFix createFix(CleanUpContext context) throws CoreException {
-		if (!isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT)) {
-			return null;
-		}
-
-		CompilationUnit unit= context.getAST();
-
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
-
-		unit.accept(new ASTVisitor() {
-			@Override
-			public boolean visit(final VariableDeclarationStatement node) {
-				VariableDeclarationFragment fragment= ASTNodes.getUniqueFragment(node);
-
-				if (fragment != null
-						&& (fragment.getInitializer() == null
-						|| ASTNodes.isPassiveWithoutFallingThrough(fragment.getInitializer()))) {
-					SimpleName varName= fragment.getName();
-					IVariableBinding variable= fragment.resolveBinding();
-					if (variable != null) {
-						Statement stmtToInspect= ASTNodes.getNextSibling(node);
-						Statement firstSibling= stmtToInspect;
-						Assignment overridingAssignment= null;
-
-						boolean shouldMoveDown= true;
-						while (stmtToInspect != null) {
-							VarDefinitionsUsesVisitor varDefinitionsUsesVisitor= new VarDefinitionsUsesVisitor(variable, stmtToInspect, true);
-							if (!varDefinitionsUsesVisitor.getReads().isEmpty()) {
-								return true;
-							}
-
-
-							Assignment assignment= ASTNodes.asExpression(stmtToInspect, Assignment.class);
-
-							if (assignment != null && ASTNodes.isSameVariable(varName, assignment.getLeftHandSide())) {
-								if (!ASTNodes.hasOperator(assignment, Assignment.Operator.ASSIGN)) {
-									return true;
-								}
-
-								overridingAssignment= assignment;
-								break;
-							} else {
-								// it's not an assignment, but it writes to the variable: for example assignments
-								// inside an if statement.
-								shouldMoveDown &= varDefinitionsUsesVisitor.getWrites().isEmpty();
-							}
-
-							if (fragment.getInitializer() == null) {
-								stmtToInspect= null;
-							} else {
-								stmtToInspect= ASTNodes.getNextSibling(stmtToInspect);
-							}
-						}
-
-						if (overridingAssignment != null && doesNotShareLines(node) && doesNotShareLines(overridingAssignment)) {
-							rewriteOperations.add(new OverriddenAssignmentOperation(node, fragment, overridingAssignment, firstSibling == stmtToInspect,
-									shouldMoveDown && isEnabled(CleanUpConstants.OVERRIDDEN_ASSIGNMENT_MOVE_DECL)));
-							return false;
-						}
-					}
-				}
-
-				return true;
-			}
-
-			/**
-			 * Check that statement containing ASTNode does not share lines with other statements
-			 *
-			 * @param node ASTNode
-			 * @return true if node's statement does not share lines with other statements otherwise false
-			 */
-			private boolean doesNotShareLines(ASTNode node) {
-				Statement stmt= null;
-				if (node instanceof Statement) {
-					stmt= (Statement)node;
-				} else {
-					stmt= ASTNodes.getFirstAncestorOrNull(node, Statement.class);
-				}
-				if (stmt == null) {
-					return false;
-				}
-				int stmtStartLine= unit.getLineNumber(stmt.getStartPosition());
-				int stmtEndLine= unit.getLineNumber(stmt.getStartPosition() + stmt.getLength());
-				Statement prevStmt= ASTNodes.getPreviousSibling(stmt);
-				if (prevStmt == null) {
-					ASTNode parent= stmt.getParent();
-					while (parent != null && parent instanceof Block) {
-						parent= parent.getParent();
-					}
-					if (parent instanceof Statement) {
-						prevStmt= (Statement)parent;
-					}
-				}
-				Statement nextStmt= ASTNodes.getNextStatement(stmt);
-				int prevEndLine= prevStmt == null ? -1 : unit.getLineNumber(prevStmt.getStartPosition() + prevStmt.getLength());
-				int nextStartLine= nextStmt == null ? Integer.MAX_VALUE : unit.getLineNumber(nextStmt.getStartPosition());
-
-				return (stmtStartLine > prevEndLine) && (stmtEndLine < nextStartLine);
-			}
-		});
-
-		if (rewriteOperations.isEmpty()) {
-			return null;
-		}
-
-		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.OverriddenAssignmentCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
-	}
 
 	private static class OverriddenAssignmentOperation extends CompilationUnitRewriteOperation {
 		private final VariableDeclarationStatement declaration;
@@ -237,7 +73,7 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 		}
 
 		@Override
-		public void rewriteASTInternal(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
 			rewrite.setTargetSourceRangeComputer(new TargetSourceRangeComputer() {
 				@Override
@@ -334,7 +170,6 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 
 			return !visitor.preventsMoveUp;
 		}
-
 		private void removeInitializer(CompilationUnitRewrite cuRewrite, TextEditGroup group) throws JavaModelException {
 			ICompilationUnit cu= cuRewrite.getCu();
 			int nameEnd= fragment.getName().getStartPosition() + fragment.getName().getLength();
@@ -392,4 +227,113 @@ public class OverriddenAssignmentCleanUp extends AbstractCleanUp {
 			return cu.getExtendedStartPosition(node);
 		}
 	}
+
+	public static ICleanUpFix createCleanUp(final CompilationUnit unit, boolean canMoveDecl) {
+
+		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+
+		unit.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(final VariableDeclarationStatement node) {
+				VariableDeclarationFragment fragment= ASTNodes.getUniqueFragment(node);
+
+				if (fragment != null
+						&& (fragment.getInitializer() == null
+						|| ASTNodes.isPassiveWithoutFallingThrough(fragment.getInitializer()))) {
+					SimpleName varName= fragment.getName();
+					IVariableBinding variable= fragment.resolveBinding();
+					if (variable != null) {
+						Statement stmtToInspect= ASTNodes.getNextSibling(node);
+						Statement firstSibling= stmtToInspect;
+						Assignment overridingAssignment= null;
+
+						boolean shouldMoveDown= true;
+						while (stmtToInspect != null) {
+							VarDefinitionsUsesVisitor varDefinitionsUsesVisitor= new VarDefinitionsUsesVisitor(variable, stmtToInspect, true);
+							if (!varDefinitionsUsesVisitor.getReads().isEmpty()) {
+								return true;
+							}
+
+
+							Assignment assignment= ASTNodes.asExpression(stmtToInspect, Assignment.class);
+
+							if (assignment != null && ASTNodes.isSameVariable(varName, assignment.getLeftHandSide())) {
+								if (!ASTNodes.hasOperator(assignment, Assignment.Operator.ASSIGN)) {
+									return true;
+								}
+
+								overridingAssignment= assignment;
+								break;
+							} else {
+								// it's not an assignment, but it writes to the variable: for example assignments
+								// inside an if statement.
+								shouldMoveDown &= varDefinitionsUsesVisitor.getWrites().isEmpty();
+							}
+
+							if (fragment.getInitializer() == null) {
+								stmtToInspect= null;
+							} else {
+								stmtToInspect= ASTNodes.getNextSibling(stmtToInspect);
+							}
+						}
+
+						if (overridingAssignment != null && doesNotShareLines(node) && doesNotShareLines(overridingAssignment)) {
+							rewriteOperations.add(new OverriddenAssignmentOperation(node, fragment, overridingAssignment, firstSibling == stmtToInspect,
+									shouldMoveDown && canMoveDecl));
+							return false;
+						}
+					}
+				}
+
+				return true;
+			}
+
+			/**
+			 * Check that statement containing ASTNode does not share lines with other statements
+			 *
+			 * @param node ASTNode
+			 * @return true if node's statement does not share lines with other statements otherwise false
+			 */
+			private boolean doesNotShareLines(ASTNode node) {
+				Statement stmt= null;
+				if (node instanceof Statement) {
+					stmt= (Statement)node;
+				} else {
+					stmt= ASTNodes.getFirstAncestorOrNull(node, Statement.class);
+				}
+				if (stmt == null) {
+					return false;
+				}
+				int stmtStartLine= unit.getLineNumber(stmt.getStartPosition());
+				int stmtEndLine= unit.getLineNumber(stmt.getStartPosition() + stmt.getLength());
+				Statement prevStmt= ASTNodes.getPreviousSibling(stmt);
+				if (prevStmt == null) {
+					ASTNode parent= stmt.getParent();
+					while (parent != null && parent instanceof Block) {
+						parent= parent.getParent();
+					}
+					if (parent instanceof Statement) {
+						prevStmt= (Statement)parent;
+					}
+				}
+				Statement nextStmt= ASTNodes.getNextStatement(stmt);
+				int prevEndLine= prevStmt == null ? -1 : unit.getLineNumber(prevStmt.getStartPosition() + prevStmt.getLength());
+				int nextStartLine= nextStmt == null ? Integer.MAX_VALUE : unit.getLineNumber(nextStmt.getStartPosition());
+
+				return (stmtStartLine > prevEndLine) && (stmtEndLine < nextStartLine);
+			}
+		});
+
+		if (rewriteOperations.isEmpty()) {
+			return null;
+		}
+
+		return new CompilationUnitRewriteOperationsFixCore(MultiFixMessages.OverriddenAssignmentCleanUp_description, unit,
+				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+	}
+
+	protected OverriddenAssignmentFixCore(final String name, final CompilationUnit compilationUnit, final CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation[] fixRewriteOperations) {
+		super(name, compilationUnit, fixRewriteOperations);
+	}
+
 }

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7377,7 +7377,7 @@
             runAfter="org.eclipse.jdt.ui.boolean_value_rather_than_comparison">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.OverriddenAssignmentCleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.OverriddenAssignmentCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.overridden_assignment"
             runAfter="org.eclipse.jdt.ui.cleanup.double_negation">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/UnnecessaryCodeTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/UnnecessaryCodeTabPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,7 @@ import org.eclipse.jdt.internal.ui.fix.EmbeddedIfCleanUp;
 import org.eclipse.jdt.internal.ui.fix.EvaluateNullableCleanUp;
 import org.eclipse.jdt.internal.ui.fix.MapCloningCleanUp;
 import org.eclipse.jdt.internal.ui.fix.MapMethodCleanUp;
-import org.eclipse.jdt.internal.ui.fix.OverriddenAssignmentCleanUp;
+import org.eclipse.jdt.internal.ui.fix.OverriddenAssignmentCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PushDownNegationCleanUp;
 import org.eclipse.jdt.internal.ui.fix.RedundantComparatorCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.RedundantComparisonStatementCleanUp;
@@ -70,7 +70,7 @@ public final class UnnecessaryCodeTabPage extends AbstractCleanUpTabPage {
 				new MapMethodCleanUp(values),
 				new CollectionCloningCleanUp(values),
 				new MapCloningCleanUp(values),
-				new OverriddenAssignmentCleanUp(values),
+				new OverriddenAssignmentCleanUpCore(values),
 				new RedundantModifiersCleanUp(values),
 				new EmbeddedIfCleanUp(values),
 				new RedundantSemicolonsCleanUp(values),


### PR DESCRIPTION
- create new OverriddenAssignmentCleanUpCore and OverriddenAssignmentFixCore classes in jdt.core.manipulation
- modify OverriddenAssignmentCleanUp to use core class
- remove old OverriddenAssignmentCleanUp
- fixes #1370

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Refactors OverriddenAssignmentCleanUp to jdt.core.manipulation.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Perform an overridden assignment cleanup on code that applies.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
