### PR TITLE
Refactor ElseIfCleanUp to jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ElseIfFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ElseIfFixCore.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Fabrice TIERCELIN and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Fabrice TIERCELIN - initial API and implementation
+ *     Red Hat Inc. - code extracted from ElseIfCleanUp
+ *******************************************************************************/
+package org.eclipse.jdt.internal.corext.fix;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.text.edits.TextEditGroup;
+
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IfStatement;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+
+import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+
+public class ElseIfFixCore extends CompilationUnitRewriteOperationsFixCore {
+
+	private static class ElseIfOperation extends CompilationUnitRewriteOperation {
+		private final IfStatement visited;
+		private final IfStatement innerIf;
+
+		public ElseIfOperation(final IfStatement visited, final IfStatement innerIf) {
+			this.visited= visited;
+			this.innerIf= innerIf;
+		}
+
+		@Override
+		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+			ASTRewrite rewrite= cuRewrite.getASTRewrite();
+			TextEditGroup group= createTextEditGroup(MultiFixMessages.CodeStyleCleanUp_ElseIf_description, cuRewrite);
+
+			rewrite.replace(visited.getElseStatement(), ASTNodes.createMoveTarget(rewrite, innerIf), group);
+		}
+	}
+
+	public static ICleanUpFix createCleanUp(final CompilationUnit unit) {
+
+		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+
+		unit.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(final IfStatement visited) {
+				Statement elseStatement= visited.getElseStatement();
+
+				if (elseStatement instanceof Block) {
+					IfStatement innerIf= ASTNodes.as(elseStatement, IfStatement.class);
+
+					if (innerIf != null) {
+						rewriteOperations.add(new ElseIfOperation(visited, innerIf));
+						return false;
+					}
+				}
+
+				return true;
+			}
+		});
+
+		if (rewriteOperations.isEmpty()) {
+			return null;
+		}
+
+		return new CompilationUnitRewriteOperationsFixCore(MultiFixMessages.CodeStyleCleanUp_ElseIf_description, unit,
+				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+
+	}
+
+	protected ElseIfFixCore(final String name, final CompilationUnit compilationUnit, CompilationUnitRewriteOperation[] fixRewriteOperations) {
+		super(name, compilationUnit, fixRewriteOperations);
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/performance/org/eclipse/jdt/ui/tests/performance/views/CleanUpPerfTest.java
+++ b/org.eclipse.jdt.ui.tests/performance/org/eclipse/jdt/ui/tests/performance/views/CleanUpPerfTest.java
@@ -74,7 +74,7 @@ import org.eclipse.jdt.internal.ui.fix.ConstantsForSystemPropertyCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ControlStatementsCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ConvertLoopCleanUp;
 import org.eclipse.jdt.internal.ui.fix.DoubleNegationCleanUp;
-import org.eclipse.jdt.internal.ui.fix.ElseIfCleanUp;
+import org.eclipse.jdt.internal.ui.fix.ElseIfCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.EmbeddedIfCleanUp;
 import org.eclipse.jdt.internal.ui.fix.EvaluateNullableCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ExpressionsCleanUp;
@@ -721,7 +721,7 @@ public class CleanUpPerfTest extends JdtPerformanceTestCaseCommon {
 
 		storeSettings(node);
 
-		cleanUpRefactoring.addCleanUp(new ElseIfCleanUp());
+		cleanUpRefactoring.addCleanUp(new ElseIfCleanUpCore());
 
 		doCleanUp(cleanUpRefactoring);
 	}

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7132,7 +7132,7 @@
             runAfter="org.eclipse.jdt.ui.cleanup.replace_deprecated_calls">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.ElseIfCleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.ElseIfCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.else_if"
             runAfter="org.eclipse.jdt.ui.cleanup.variables">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CodeStyleTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CodeStyleTabPage.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
 import org.eclipse.jdt.internal.ui.fix.AddAllCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ControlStatementsCleanUp;
-import org.eclipse.jdt.internal.ui.fix.ElseIfCleanUp;
+import org.eclipse.jdt.internal.ui.fix.ElseIfCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.ExpressionsCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ExtractIncrementCleanUp;
 import org.eclipse.jdt.internal.ui.fix.InstanceofCleanUp;
@@ -43,7 +43,7 @@ public final class CodeStyleTabPage extends AbstractCleanUpTabPage {
 				new ControlStatementsCleanUp(values),
 				new SwitchCleanUpCore(values),
 				new AddAllCleanUp(values),
-				new ElseIfCleanUp(values),
+				new ElseIfCleanUpCore(values),
 				new ReduceIndentationCleanUp(values),
 				new ExpressionsCleanUp(values),
 				new ExtractIncrementCleanUp(values),


### PR DESCRIPTION
- create new ElseIfCleanUpCore and ElseIfFixCore classes
- modify CodeStyleTabPage, CleanUpPerfTest, and plugin.xml to refer to new core clean-up
- fixes #1373

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Refactors ElseIfCleanUp to jdt.core.manipulation for use by jdt.ls.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Set up project to do appropriate else if cleanup set by CodeStyleTabPage of the clean-up preferences dialog.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
