### PR TITLE
Also handle RuntimeException when performing ClasspathFixProposal

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ClasspathFixSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ClasspathFixSelectionDialog.java
@@ -109,6 +109,8 @@ public class ClasspathFixSelectionDialog extends StatusDialog {
 						throw new InterruptedException();
 					} catch (CoreException e2) {
 						throw new InvocationTargetException(e2);
+					} catch(RuntimeException e3) {
+						throw new InvocationTargetException(e3);
 					} finally {
 						monitor.done();
 					}


### PR DESCRIPTION
Currently when a RuntimeException occurs inside ClasspathFixProposal an obscure error dialog as the wizard already handles errors if they are InvocationTargetException this now wraps RuntimeException as well.
