### PR TITLE
Fix inline method to handle a synchronized input method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,9 +31,13 @@ public final class RefactoringCoreMessages extends NLS {
 
 	private static final String BUNDLE_NAME= "org.eclipse.jdt.internal.corext.refactoring.refactoring";//$NON-NLS-1$
 
+	public static String CallInliner_cannot_synchronize_error;
+
 	public static String CallInliner_cast_analysis_error;
 
 	public static String CallInliner_constructors;
+
+	public static String CallInliner_create_sync_block_error;
 
 	public static String CallInliner_execution_flow;
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -80,8 +80,10 @@ import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SwitchExpression;
 import org.eclipse.jdt.core.dom.SwitchStatement;
+import org.eclipse.jdt.core.dom.SynchronizedStatement;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeLiteral;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.WhileStatement;
@@ -637,12 +639,19 @@ public class CallInliner {
 							(Expression)fRewrite.createStringPlaceholder(block, ASTNode.METHOD_INVOCATION));
 					} else {
 						node= fRewrite.getAST().newExpressionStatement(
-							(Expression)fRewrite.createStringPlaceholder(block, ASTNode.METHOD_INVOCATION));
+								(Expression)fRewrite.createStringPlaceholder(block, ASTNode.METHOD_INVOCATION));
+					}
+					if (fSourceProvider.isSynchronized()) {
+						node= createSyncBlock(node, status);
 					}
 				} else {
 					node= null;
 				}
 			} else if (fTargetNode instanceof Expression) {
+				if (fSourceProvider.isSynchronized()) {
+					status.addWarning(RefactoringCoreMessages.CallInliner_cannot_synchronize_error,
+							JavaStatusContext.create(fCUnit, fInvocation));
+				}
 				node= fRewrite.createStringPlaceholder(block, ASTNode.METHOD_INVOCATION);
 
 				// fixes bug #24941
@@ -677,8 +686,14 @@ public class CallInliner {
 				} else {
 					node= fRewrite.createStringPlaceholder(block, ASTNode.YIELD_STATEMENT);
 				}
+				if (fSourceProvider.isSynchronized()) {
+					node= createSyncBlock(node, status);
+				}
 			} else {
 				node= fRewrite.createStringPlaceholder(block, ASTNode.RETURN_STATEMENT);
+				if (fSourceProvider.isSynchronized()) {
+					node= createSyncBlock(node, status);
+				}
 			}
 
 			// Now replace the target node with the source node
@@ -696,6 +711,34 @@ public class CallInliner {
 				}
 			}
 		}
+	}
+
+	private ASTNode createSyncBlock(ASTNode node, RefactoringStatus status) {
+		AST ast= fRewrite.getAST();
+		SynchronizedStatement sync=
+				ast.newSynchronizedStatement();
+		Expression exp= Invocations.getExpression(fInvocation);
+		if (exp != null) {
+			sync.setExpression((Expression)fRewrite.createCopyTarget(exp));
+		} else if (fSourceProvider.isStatic()) {
+			TypeLiteral literal= ast.newTypeLiteral();
+			ITypeBinding binding= ASTNodes.getEnclosingType(fSourceProvider.getDeclaration());
+			if (binding == null) {
+				status.addError(RefactoringCoreMessages.CallInliner_cast_analysis_error,
+						JavaStatusContext.create(fCUnit, fInvocation));
+				return null;
+			}
+			Type type= fImportRewrite.addImport(binding, ast);
+			literal.setType(type);
+			sync.setExpression(literal);
+		} else {
+			sync.setExpression(ast.newThisExpression());
+		}
+		Block newBlock= ast.newBlock();
+		sync.setBody(newBlock);
+		newBlock.statements().add(node);
+		node= sync;
+		return node;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -69,6 +69,7 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.ForStatement;
 import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IExtendedModifier;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
@@ -294,6 +295,26 @@ public class SourceProvider {
 
 	public MethodDeclaration getDeclaration() {
 		return fDeclaration;
+	}
+
+	public boolean isSynchronized() {
+		List<IExtendedModifier> modifierList= fDeclaration.modifiers();
+		for (IExtendedModifier modifier : modifierList) {
+			if (modifier instanceof Modifier m && m.isSynchronized()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public boolean isStatic() {
+		List<IExtendedModifier> modifierList= fDeclaration.modifiers();
+		for (IExtendedModifier modifier : modifierList) {
+			if (modifier instanceof Modifier m && m.isStatic()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public String getMethodName() {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -216,6 +216,8 @@ CallInliner_field_initialize_write_parameter=Cannot inline field initializer bec
 CallInliner_field_initialize_self_reference=Cannot inline method. Method references the field to be initialized.
 CallInliner_constructors=Cannot inline a constructor invocation that is used as a class instance creation.
 CallInliner_cast_analysis_error=Cannot analyze call context to determine if implicit cast is needed.
+CallInliner_create_sync_block_error=Cannot get type binding to create static class reference.
+CallInliner_cannot_synchronize_error=Source method is synchronized and it is not possible to synchronize inlined content.
 
 TargetProvider_inaccurate_match=Inaccurate references to method found. References will be ignored.
 TargetProvider_method_declaration_not_unique=Cannot uniquely resolve method to be inlined.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1360_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1360_1.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_1360_1 {
+    private boolean flag = false;
+    public synchronized void originalMethod() throws InterruptedException {
+        // Some logic here
+        flag = true;
+        notify();
+    }
+    public void callerMethod() throws InterruptedException {
+        /*]*/originalMethod();/*[*/
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1360_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1360_2.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_1360_2 {
+    public static boolean flag = false;
+    public synchronized static void originalMethod() {
+        // Some logic here
+        flag = true;
+        System.out.println("here");
+    }
+    public static void callerMethod() {
+        /*]*/originalMethod();/*[*/
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1360_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1360_3.java
@@ -1,0 +1,15 @@
+package bugs_in;
+
+public class Test_issue_1360_3 {
+    private boolean flag = false;
+    public synchronized void originalMethod() throws InterruptedException {
+        // Some logic here
+        flag = true;
+        notify();
+    }
+    public void callerMethod() throws InterruptedException {
+    	Test_issue_1360_3 e = new Test_issue_1360_3();
+        /*]*/e.originalMethod();/*[*/
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1360_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1360_1.java
@@ -1,0 +1,18 @@
+package bugs_in;
+
+public class Test_issue_1360_1 {
+    private boolean flag = false;
+    public synchronized void originalMethod() throws InterruptedException {
+        // Some logic here
+        flag = true;
+        notify();
+    }
+    public void callerMethod() throws InterruptedException {
+        /*]*/synchronized (this) {
+			// Some logic here
+			flag = true;
+			notify();
+		}/*[*/
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1360_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1360_2.java
@@ -1,0 +1,18 @@
+package bugs_in;
+
+public class Test_issue_1360_2 {
+    public static boolean flag = false;
+    public synchronized static void originalMethod() {
+        // Some logic here
+        flag = true;
+        System.out.println("here");
+    }
+    public static void callerMethod() {
+        /*]*/synchronized (Test_issue_1360_2.class) {
+			// Some logic here
+			flag = true;
+			System.out.println("here");
+		}/*[*/
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1360_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1360_3.java
@@ -1,0 +1,19 @@
+package bugs_in;
+
+public class Test_issue_1360_3 {
+    private boolean flag = false;
+    public synchronized void originalMethod() throws InterruptedException {
+        // Some logic here
+        flag = true;
+        notify();
+    }
+    public void callerMethod() throws InterruptedException {
+    	Test_issue_1360_3 e = new Test_issue_1360_3();
+        /*]*/synchronized (e) {
+			// Some logic here
+			e.flag = true;
+			e.notify();
+		}/*[*/
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression5.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression5.java
@@ -1,0 +1,15 @@
+package simple18_in;
+
+public class TestSwitchExpression1 {
+    public synchronized String format (String... input) {
+        return "";
+    }
+    public String foo() {
+        int value = 0;
+        String message = switch (value) {
+            case 0 -> /*]*/format("")/*[*/;
+            default -> "";
+        };
+        return message;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression6.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression6.java
@@ -1,0 +1,15 @@
+package simple18_in;
+
+public class TestSwitchExpression1 {
+    public synchronized static String format (String... input) {
+        return "";
+    }
+    public static String foo() {
+        int value = 0;
+        String message = switch (value) {
+            case 0 -> /*]*/format("")/*[*/;
+            default -> "";
+        };
+        return message;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression7.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression7.java
@@ -1,0 +1,18 @@
+package simple18_in;
+
+public class TestSwitchExpression1 {
+	class Inner {
+        public synchronized String format (String... input) {
+            return "";
+        }
+	}
+    public String foo() {
+        int value = 0;
+        Inner inner = new Inner();
+        String message = switch (value) {
+            case 0 -> /*]*/inner.format("")/*[*/;
+            default -> "";
+        };
+        return message;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression5.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression5.java
@@ -1,0 +1,20 @@
+package simple18_in;
+
+public class TestSwitchExpression1 {
+    public synchronized String format (String... input) {
+        return "";
+    }
+    public String foo() {
+        int value = 0;
+        String message = switch (value) {
+            case 0 -> /*]*/{
+	String[] input = {""};
+	synchronized (this) {
+		yield "";
+	}
+}
+            default -> "";
+        };
+        return message;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression6.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression6.java
@@ -1,0 +1,20 @@
+package simple18_in;
+
+public class TestSwitchExpression1 {
+    public synchronized static String format (String... input) {
+        return "";
+    }
+    public static String foo() {
+        int value = 0;
+        String message = switch (value) {
+            case 0 -> /*]*/{
+	String[] input = {""};
+	synchronized (TestSwitchExpression1.class) {
+		yield "";
+	}
+}
+            default -> "";
+        };
+        return message;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression7.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression7.java
@@ -1,0 +1,23 @@
+package simple18_in;
+
+public class TestSwitchExpression1 {
+	class Inner {
+        public synchronized String format (String... input) {
+            return "";
+        }
+	}
+    public String foo() {
+        int value = 0;
+        Inner inner = new Inner();
+        String message = switch (value) {
+            case 0 -> /*]*/{
+	String[] input = {""};
+	synchronized (inner) {
+		yield "";
+	}
+}
+            default -> "";
+        };
+        return message;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/warning_in/TestSync1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/warning_in/TestSync1.java
@@ -1,0 +1,13 @@
+package warning_in;
+
+public class TestSync1 {
+	public synchronized String format (String... input) {
+		return "";
+	}
+	public String foo() {
+		if (/*]*/format("abc")/*[*/ == "abc") {
+			return "def";
+		}
+		return null;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AbstractJunit4SelectionTestCase.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AbstractJunit4SelectionTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -58,7 +58,7 @@ public abstract class AbstractJunit4SelectionTestCase extends AbstractJunit4CUTe
 	public static final String SQUARE_BRACKET_CLOSE=   "/*]*/";
 	public static final int    SQUARE_BRACKET_CLOSE_LENGTH= SQUARE_BRACKET_CLOSE.length();
 
-	enum TestMode { VALID_SELECTION, INVALID_SELECTION, COMPARE_WITH_OUTPUT }
+	enum TestMode { VALID_SELECTION, INVALID_SELECTION, COMPARE_WITH_OUTPUT, WARNING_FOR_SELECTION }
 
 	private final boolean fIgnoreSelectionMarker;
 	private int[] fSelection;
@@ -110,6 +110,9 @@ public abstract class AbstractJunit4SelectionTestCase extends AbstractJunit4CUTe
 				break;
 			case INVALID_SELECTION:
 				assertFalse(checkPreconditions(refactoring, pm).isOK());
+				break;
+			case WARNING_FOR_SELECTION:
+				assertTrue(checkPreconditions(refactoring, pm).hasWarning());
 				break;
 			case COMPARE_WITH_OUTPUT:
 				IUndoManager undoManager= RefactoringCore.getUndoManager();

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -107,6 +107,10 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 				if (!status.isOK())
 					return;
 				break;
+			case WARNING_FOR_SELECTION:
+				if (!status.hasWarning())
+					return;
+				break;
 			case COMPARE_WITH_OUTPUT:
 			default:
 				break;

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTestSetup.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTestSetup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -53,6 +53,7 @@ public class InlineMethodTestSetup extends RefactoringTestSetup {
 	private IPackageFragment fGeneric;
 	private IPackageFragment fBinary;
 	private IPackageFragment fOperator;
+	private IPackageFragment fWarning;
 
 	@Override
 	public void before() throws Exception {
@@ -74,6 +75,7 @@ public class InlineMethodTestSetup extends RefactoringTestSetup {
 		fGeneric= root.createPackageFragment("generic_in", true, null);
 		fBinary= root.createPackageFragment("binary_in", true, null);
 		fOperator= root.createPackageFragment("operator_in", true, null);
+		fWarning= root.createPackageFragment("warning_in", true, null);
 
 		IJavaProject javaProject= getProject();
 		IProject project= javaProject.getProject();
@@ -228,5 +230,9 @@ public class InlineMethodTestSetup extends RefactoringTestSetup {
 
 	public IPackageFragment getOperatorPackage() {
 		return fOperator;
+	}
+
+	public IPackageFragment getWarningPackage() {
+		return fWarning;
 	}
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -34,7 +34,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.eclipse.core.runtime.CoreException;
+
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IMethod;
@@ -43,11 +47,10 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InfixExpression.Operator;
+
 import org.eclipse.jdt.internal.core.manipulation.dom.OperatorPrecedence;
 import org.eclipse.jdt.internal.corext.refactoring.code.InlineMethodRefactoring;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
-import org.junit.Rule;
-import org.junit.Test;
 
 public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	private static final boolean BUG_82166= true;
@@ -222,6 +225,17 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	@Test
 	public void test_314407() throws Exception {
 		performInvalidTest();
+	}
+
+	/* *********************** Warning Tests ****************************** */
+
+	private void performWarningTest() throws Exception {
+		performTestInlineCall(fgTestSetup.getWarningPackage(), getName(), TestMode.WARNING_FOR_SELECTION, "warning_out");
+	}
+
+	@Test
+	public void testSync1() throws Exception {
+		performWarningTest();
 	}
 
 	/* *********************** Simple Tests ******************************* */
@@ -425,6 +439,21 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 
 	@Test
 	public void test_462038() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_1360_1() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_1360_2() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_1360_3() throws Exception {
 		performBugTest();
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests16.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests16.java
@@ -84,4 +84,19 @@ public class InlineMethodTests16 extends InlineMethodTests {
 	public void testSwitchExpression4() throws Exception {
 		performSimpleTest();
 	}
+
+	@Test
+	public void testSwitchExpression5() throws Exception {
+		performSimpleTest();
+	}
+
+	@Test
+	public void testSwitchExpression6() throws Exception {
+		performSimpleTest();
+	}
+
+	@Test
+	public void testSwitchExpression7() throws Exception {
+		performSimpleTest();
+	}
 }


### PR DESCRIPTION
- modify CallInliner to add logic to add a synchronized block if the method to inline is synchronized
- issue warning if synchronized block cannot be substituted for expression call
- add new tests to InlineMethodTests and InlineMethodTests16
- fixes #1360

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds support for synchronized methods being inlined.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
