### PR TITLE
Fix inline method to check access modifiers of inlined code

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -2526,15 +2526,15 @@ public class ASTNodes {
 	 * @param node the node
 	 * @return the top-level AbstractTypeDeclaration node for the file that node is in
 	 */
-	public static ASTNode getTopLevelTypeDeclaration(ASTNode node) {
-		ASTNode result= null;
+	public static AbstractTypeDeclaration getTopLevelTypeDeclaration(ASTNode node) {
+		AbstractTypeDeclaration result= null;
 		if (node instanceof AbstractTypeDeclaration) {
-			result= node;
+			result= (AbstractTypeDeclaration) node;
 		}
 		ASTNode parent= node.getParent();
 		while (parent != null) {
 			if (parent instanceof AbstractTypeDeclaration) {
-				result= parent;
+				result= (AbstractTypeDeclaration) parent;
 			}
 			parent= parent.getParent();
 		}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -2521,6 +2521,27 @@ public class ASTNodes {
 	}
 
 	/**
+	 * Returns the top-level AbstractTypeDeclaration that is the parent of the node.
+	 *
+	 * @param node the node
+	 * @return the top-level AbstractTypeDeclaration node for the file that node is in
+	 */
+	public static ASTNode getTopLevelTypeDeclaration(ASTNode node) {
+		ASTNode result= null;
+		if (node instanceof AbstractTypeDeclaration) {
+			result= node;
+		}
+		ASTNode parent= node.getParent();
+		while (parent != null) {
+			if (parent instanceof AbstractTypeDeclaration) {
+				result= parent;
+			}
+			parent= parent.getParent();
+		}
+		return result;
+	}
+
+	/**
 	 * Returns the closest ancestor of <code>node</code> whose type is <code>nodeType</code>, or <code>null</code> if none.
 	 * <p>
 	 * <b>Warning:</b> This method does not stop at any boundaries like parentheses, statements, body declarations, etc.

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -57,6 +57,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String CallInliner_super_into_this_expression;
 
+	public static String CallInliner_unexpected_model_exception;
+
 	public static String Change_does_not_exist;
 
 	public static String ChangeSignatureRefactoring_add_constructor;
@@ -854,6 +856,12 @@ public final class RefactoringCoreMessages extends NLS {
 	public static String InlineMethodRefactoring_SourceAnalyzer_abstract_methods;
 
 	public static String InlineMethodRefactoring_SourceAnalyzer_declaration_has_errors;
+
+	public static String InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_package_private;
+
+	public static String InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_private;
+
+	public static String InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_protected;
 
 	public static String InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_has_errors;
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -47,6 +47,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.RefactoringStatusEntry;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -265,6 +266,7 @@ public class CallInliner {
 			JavaManipulationPlugin.log(exception);
 		}
 		checkInvocationContext(result, severity);
+		checkAccessCompatibility(result, severity);
 
 		return result;
 	}
@@ -314,6 +316,17 @@ public class CallInliner {
 					RefactoringCoreMessages.CallInliner_super_into_this_expression,
 					JavaStatusContext.create(fCUnit, fInvocation)));
 			}
+		}
+	}
+
+	private void checkAccessCompatibility(RefactoringStatus result, int severity) {
+		try {
+			result.merge(fSourceProvider.checkAccessCompatible(fTargetNode));
+		} catch (JavaModelException e) {
+			result.addEntry(new RefactoringStatusEntry(
+					severity,
+					RefactoringCoreMessages.CallInliner_unexpected_model_exception,
+					JavaStatusContext.create(fCUnit, fInvocation)));
 		}
 	}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -361,6 +361,26 @@ class SourceAnalyzer  {
 		}
 	}
 
+	private class AccessAnalyzer extends ASTVisitor {
+		public boolean accessesPrivate;
+		public boolean accessesProtected;
+		public boolean accessesPackagePrivate;
+		@Override
+		public boolean visit(SimpleName node) {
+			IBinding binding= node.resolveBinding();
+			if (binding != null) {
+				int modifiers= binding.getModifiers();
+				boolean isPublic= Modifier.isPublic(modifiers);
+				boolean isPrivate= Modifier.isPrivate(modifiers);
+				boolean isProtected= Modifier.isProtected(modifiers);
+				accessesPrivate= accessesPrivate || isPrivate;
+				accessesProtected= accessesProtected || isProtected;
+				accessesPackagePrivate= accessesPackagePrivate || (!isPublic && !isPrivate && !isProtected);
+			}
+			return true;
+		}
+	}
+
 	private ITypeRoot fTypeRoot;
 	private MethodDeclaration fDeclaration;
 	private Map<IVariableBinding, ParameterData> fParameters;
@@ -380,6 +400,10 @@ class SourceAnalyzer  {
 	private Map<ITypeBinding, NameData> fMethodTypeParameterMapping;
 
 	private boolean fInterruptedExecutionFlow;
+
+	private boolean fAccessesPrivate;
+	private boolean fAccessesProtected;
+	private boolean fAccessesPackagePrivate;
 
 	public SourceAnalyzer(ITypeRoot typeRoot, MethodDeclaration declaration) {
 		super();
@@ -420,6 +444,11 @@ class SourceAnalyzer  {
 			result.addFatalError(RefactoringCoreMessages.InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_has_errors, JavaStatusContext.create(fTypeRoot));
 			return result;
 		}
+		AccessAnalyzer accessAnalyzer= new AccessAnalyzer();
+		fDeclaration.accept(accessAnalyzer);
+		fAccessesPrivate= accessAnalyzer.accessesPrivate;
+		fAccessesProtected= accessAnalyzer.accessesProtected;
+		fAccessesPackagePrivate= accessAnalyzer.accessesPackagePrivate;
 		ActivationAnalyzer analyzer= new ActivationAnalyzer();
 		fDeclaration.accept(analyzer);
 		result.merge(analyzer.status);
@@ -534,6 +563,22 @@ class SourceAnalyzer  {
 	private ASTNode[] getStatements() {
 		List<Statement> statements= fDeclaration.getBody().statements();
 		return statements.toArray(new ASTNode[statements.size()]);
+	}
+
+	public boolean accessesPrivate() {
+		return fAccessesPrivate;
+	}
+
+	public boolean accessesProtected() {
+		return fAccessesProtected;
+	}
+
+	public boolean accessesPackagePrivate() {
+		return fAccessesPackagePrivate;
+	}
+
+	public boolean onlyAccessesPublic() {
+		return !fAccessesPrivate && !fAccessesProtected && !fAccessesPackagePrivate;
 	}
 
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -373,6 +373,21 @@ class SourceAnalyzer  {
 				boolean isPublic= Modifier.isPublic(modifiers);
 				boolean isPrivate= Modifier.isPrivate(modifiers);
 				boolean isProtected= Modifier.isProtected(modifiers);
+				if (!isPublic) {
+					if (binding instanceof IVariableBinding varBinding) {
+						ITypeBinding declClass= varBinding.getDeclaringClass();
+						if (!varBinding.isField() || declClass == null || declClass.isLocal()) {
+							return true;
+						}
+					} else if (binding instanceof IMethodBinding methodBinding) {
+						ITypeBinding declClass= methodBinding.getDeclaringClass();
+						if (declClass == null || declClass.isLocal()) {
+							return true;
+						}
+					} else {
+						return true;
+					}
+				}
 				accessesPrivate= accessesPrivate || isPrivate;
 				accessesProtected= accessesProtected || isProtected;
 				accessesPackagePrivate= accessesPackagePrivate || (!isPublic && !isPrivate && !isProtected);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -197,6 +197,9 @@ InlineMethodRefactoring_checking_implements_error= Method to be inlined implemen
 
 InlineMethodRefactoring_SourceAnalyzer_recursive_call=Method declaration contains recursive call.
 InlineMethodRefactoring_SourceAnalyzer_native_methods=Cannot inline native methods
+InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_package_private=The method declaration references at least one package-private member that would be inaccessible after inlining.
+InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_private=The method declaration references at least one private member that would be inaccessible after inlining.
+InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_protected=The method declaration references at least one protected member that would be inaccessible after inlining.
 InlineMethodRefactoring_SourceAnalyzer_declaration_has_errors=The method declaration contains compile errors. To perform the operation you will need to fix the errors.
 InlineMethodRefactoring_SourceAnalyzer_typedeclaration_has_errors=The type declaration contains compile errors. To perform the operation you will need to fix the errors.
 InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_has_errors=The method declaration contains compile errors. To perform the operation you will need to fix the errors.
@@ -218,6 +221,7 @@ CallInliner_constructors=Cannot inline a constructor invocation that is used as 
 CallInliner_cast_analysis_error=Cannot analyze call context to determine if implicit cast is needed.
 CallInliner_create_sync_block_error=Cannot get type binding to create static class reference.
 CallInliner_cannot_synchronize_error=Source method is synchronized and it is not possible to synchronize inlined content.
+CallInliner_unexpected_model_exception=Unexpected Java model exception.
 
 TargetProvider_inaccurate_match=Inaccurate references to method found. References will be ignored.
 TargetProvider_method_declaration_not_unique=Cannot uniquely resolve method to be inlined.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1358_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1358_2.java
@@ -1,0 +1,17 @@
+package bugs_in;
+
+class MyClass {
+	static int value= 10;
+	
+	public static void staticMethod() {
+		System.out.println("Value: " + value);
+	}
+}
+
+public class Test_issue_1358_2 {
+	private int value= 20;
+
+	public void callStaticMethod() {
+		new MyClass()./*]*/staticMethod()/*[*/;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1358_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1358_3.java
@@ -1,0 +1,16 @@
+package bugs_in;
+
+public class Test_issue_1358_3 {
+	class MyClass {
+		private int value= 10;
+		
+		public void method() {
+			System.out.println("Value: " + value);
+		}
+	}
+	private int value= 20;
+
+	public void callMethod() {
+		new MyClass()./*]*/method()/*[*/;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1358_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1358_2.java
@@ -1,0 +1,17 @@
+package bugs_in;
+
+class MyClass {
+	static int value= 10;
+	
+	public static void staticMethod() {
+		System.out.println("Value: " + value);
+	}
+}
+
+public class Test_issue_1358_2 {
+	private int value= 20;
+
+	public void callStaticMethod() {
+		System.out.println("Value: " + MyClass.value);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1358_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1358_3.java
@@ -1,0 +1,16 @@
+package bugs_in;
+
+public class Test_issue_1358_3 {
+	class MyClass {
+		private int value= 10;
+		
+		public void method() {
+			System.out.println("Value: " + value);
+		}
+	}
+	private int value= 20;
+
+	public void callMethod() {
+		System.out.println("Value: " + new MyClass().value);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/Test_issue_1358_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/Test_issue_1358_1.java
@@ -1,0 +1,17 @@
+package invalid;
+
+class MyClass {
+	private static int value= 10;
+
+	public static void staticMethod() {
+		System.out.println("Value: " + value);
+	}
+}
+
+class AnotherClass {
+	private int value= 20;
+
+	public void callStaticMethod() {
+		new MyClass()./*]*/staticMethod()/*[*/;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -457,6 +457,21 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_1358_1() throws Exception {
+		performInvalidTest();
+	}
+
+	@Test
+	public void test_issue_1358_2() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_1358_3() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- add new checkAccessCompatible() method to SourceProvider that checks if code from declaration can be moved to target without causing an access violation
- add new AccessVisitor to SourceAnalyzer to log non-public accesses (private, package-private, and protected)
- add call to checkAccessCompatible() in CallInliner
- add new tests to InlineMethodTests
- fixes #1358

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes inline method to consider the various access modifiers of members being accessed by the code to be inlined and to fail if there would be access violations from performing the inline.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
