### PR TITLE
Refactor MultiCatchCleanUp to jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiCatchCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiCatchCleanUpCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     Fabrice TIERCELIN - initial API and implementation
+ *     Red Hat Inc. - refactored to jdt.core.manipulation from jdt.ui
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.fix;
 
@@ -52,8 +53,8 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ASTSemanticMatcher;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -70,16 +71,16 @@ import org.eclipse.jdt.ui.text.java.IProblemLocation;
  * <li>The <code>catch</code> blocks must be able to move.</li>
  * </ul>
  */
-public class MultiCatchCleanUp extends AbstractMultiFix {
+public class MultiCatchCleanUpCore extends AbstractMultiFix {
 	private enum MergeDirection {
 		NONE, UP, DOWN;
 	}
 
-	public MultiCatchCleanUp() {
+	public MultiCatchCleanUpCore() {
 		this(Collections.emptyMap());
 	}
 
-	public MultiCatchCleanUp(final Map<String, String> options) {
+	public MultiCatchCleanUpCore(final Map<String, String> options) {
 		super(options);
 	}
 
@@ -420,7 +421,7 @@ public class MultiCatchCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.MultiCatchCleanUp_description, unit,
+		return new CompilationUnitRewriteOperationsFixCore(MultiFixMessages.MultiCatchCleanUp_description, unit,
 				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
 	}
 
@@ -444,7 +445,7 @@ public class MultiCatchCleanUp extends AbstractMultiFix {
 		}
 
 		@Override
-		public void rewriteASTInternal(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
 			AST ast= cuRewrite.getRoot().getAST();
 			TextEditGroup group= createTextEditGroup(MultiFixMessages.MultiCatchCleanUp_description, cuRewrite);

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7512,7 +7512,7 @@
             runAfter="org.eclipse.jdt.ui.cleanup.join">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.MultiCatchCleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.MultiCatchCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.multi_catch"
             runAfter="org.eclipse.jdt.ui.cleanup.try_with_resource">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/JavaFeatureTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/JavaFeatureTabPage.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.internal.ui.fix.ConvertLoopCleanUp;
 import org.eclipse.jdt.internal.ui.fix.HashCleanUp;
 import org.eclipse.jdt.internal.ui.fix.JoinCleanUp;
 import org.eclipse.jdt.internal.ui.fix.LambdaExpressionsCleanUpCore;
-import org.eclipse.jdt.internal.ui.fix.MultiCatchCleanUp;
+import org.eclipse.jdt.internal.ui.fix.MultiCatchCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.ObjectsEqualsCleanUp;
 import org.eclipse.jdt.internal.ui.fix.PatternMatchingForInstanceofCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.StringConcatToTextBlockCleanUpCore;
@@ -52,7 +52,7 @@ public final class JavaFeatureTabPage extends AbstractCleanUpTabPage {
 				new JoinCleanUp(values),
 				new TryWithResourceCleanUp(values),
 				new StringConcatToTextBlockCleanUpCore(values),
-				new MultiCatchCleanUp(values),
+				new MultiCatchCleanUpCore(values),
 				new TypeParametersCleanUp(values),
 				new HashCleanUp(values),
 				new ObjectsEqualsCleanUp(values),


### PR DESCRIPTION
- fixes #1382

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Clean up code that is eligible for a multi-catch cleanup.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
