### PR TITLE
Don't use text block for MessageFormat/String.format if one line concat

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
@@ -237,13 +237,20 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 			StringBuilder formatString= new StringBuilder();
 			int i= 0;
 			int tagsCount= 0;
-			boolean firstStringLiteral= true;
+			boolean isFirstStringLiteral= true;
+			boolean isFirstArgument= true;
+			Expression firstStringLiteral= operands.get(0);
+			Expression lastStringLiteral= firstStringLiteral;
+			Expression firstArgumentExpression= operands.get(0);
+			Expression lastArgumentExpression= firstArgumentExpression;
 			for (Expression operand : operands) {
 				if (operand instanceof StringLiteral) {
-					if (firstStringLiteral) {
+					if (isFirstStringLiteral) {
 						fIndent= indentOf(cu, operand);
-						firstStringLiteral= false;
+						isFirstStringLiteral= false;
+						firstStringLiteral= operand;
 					}
+					lastStringLiteral= operand;
 					NLSLine nlsLine= scanCurrentLine(cu, operand);
 					if (nlsLine != null) {
 						for (NLSElement element : nlsLine.getElements()) {
@@ -263,6 +270,11 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 					value= value.substring(1, value.length() - 1);
 					formatString.append(value);
 				} else {
+					if (isFirstArgument) {
+						firstArgumentExpression= operand;
+						isFirstArgument= false;
+					}
+					lastArgumentExpression= operand;
 					fLiterals.add("\"{" + Integer.toString(i) + "}\""); //$NON-NLS-1$ //$NON-NLS-2$
 					formatString.append("{").append(i).append("}"); //$NON-NLS-1$ //$NON-NLS-2$
 
@@ -298,7 +310,13 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 			StringBuilder buffer= new StringBuilder();
 			buffer.append("MessageFormat.format("); //$NON-NLS-1$
 
-			if (is15OrHigher) {
+			int minOffset= firstStringLiteral.getStartPosition() < firstArgumentExpression.getStartPosition() ? firstStringLiteral.getStartPosition() : firstArgumentExpression.getStartPosition();
+			int maxOffset= lastStringLiteral.getStartPosition() > lastArgumentExpression.getStartPosition() ?
+					lastStringLiteral.getStartPosition() + lastStringLiteral.getLength() : lastArgumentExpression.getStartPosition() + lastArgumentExpression.getLength();
+
+			boolean isSingleLine= root.getLineNumber(maxOffset) == root.getLineNumber(minOffset);
+
+			if (is15OrHigher && !isSingleLine) {
 				StringBuilder buf= new StringBuilder();
 
 				List<String> parts= new ArrayList<>();
@@ -419,5 +437,6 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 				rewrite.replace(infixExpression, formatInvocation, null);
 			}
 		}
+
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -1241,6 +1241,51 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 	}
 
 	@Test
+	public void testConcatToMessageFormatTextBlock5() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo(String name, String id) {\n");
+		buf.append("        String title = \"Name: \" + name + \" ID: \" + id;\n");
+		buf.append("        System.out.println(title);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		int index= buf.indexOf("title");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("\n");
+		buf.append("import java.text.MessageFormat;\n");
+		buf.append("\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo(String name, String id) {\n");
+		buf.append("        String title = MessageFormat.format(\"Name: {0} ID: {1}\", name, id);\n");
+		buf.append("        System.out.println(title);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, CorrectionMessages.QuickAssistProcessor_convert_to_string_format);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
 	public void testConcatToStringFormatTextBlock1() throws Exception {
 		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
 		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
@@ -1459,6 +1504,48 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		buf.append("\t\t                ***********/\n");
 		buf.append("\t\t                \"\"\", statement); //comment 2 //$NON-NLS-1$\n");
 		buf.append("        System.out.println(copyright);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		String expected= buf.toString();
+
+		assertProposalExists(proposals, CorrectionMessages.QuickAssistProcessor_convert_to_string_format);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testConcatToStringFormatTextBlock5() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		StringBuilder buf= new StringBuilder();
+		buf.append("module test {\n");
+		buf.append("}\n");
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", buf.toString(), false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo(String name, String id) {\n");
+		buf.append("        String title = \"Name: \" + name + \" ID: \" + id;\n");
+		buf.append("        System.out.println(title);\n");
+		buf.append("    }\n");
+		buf.append("}\n");
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		int index= buf.indexOf("title");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		buf= new StringBuilder();
+		buf.append("package test;\n");
+		buf.append("public class Cls {\n");
+		buf.append("    public void foo(String name, String id) {\n");
+		buf.append("        String title = String.format(\"Name: %s ID: %s\", name, id);\n");
+		buf.append("        System.out.println(title);\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		String expected= buf.toString();


### PR DESCRIPTION
- for a single line concat, don't use a text block when converting a string concat to MessageFormat or String.format in ConvertToMessageFormatFixCore and ConvertToStringFormatFixCore
- add new tests to AssistQuickFixTest15
- fixes #1384

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
