### PR TITLE
Don't allow extracting a final field assignment to a new method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -573,6 +573,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String ExtractMethodAnalyzer_cannot_extract_yield;
 
+	public static String ExtractMethodAnalyzer_cannot_extract_final_field_assignment;
+
 	public static String ExtractMethodAnalyzer_compile_errors;
 
 	public static String ExtractMethodAnalyzer_compile_errors_no_parent_binding;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -135,6 +135,7 @@ ExtractMethodAnalyzer_cannot_extract_method_name_reference=Cannot extract a sing
 ExtractMethodAnalyzer_cannot_extract_part_of_qualified_name=Cannot extract part of a qualified name
 ExtractMethodAnalyzer_cannot_extract_name_in_declaration=Cannot extract the name part of a declaration.
 ExtractMethodAnalyzer_cannot_extract_return=Cannot extract a single return statement that returns no value.
+ExtractMethodAnalyzer_cannot_extract_final_field_assignment=Cannot extract any statement that initializes a final field.
 ExtractMethodAnalyzer_cannot_extract_yield=Cannot extract yield statement.
 ExtractMethodAnalyzer_compile_errors_no_parent_binding=The selection cannot be analyzed because of compilation errors in the enclosing type. To perform the operation you will need to fix the errors.
 ExtractMethodAnalyzer_ambiguous_return_value=Ambiguous return value: Expression, access to local or return statement extracted.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1356_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1356_1.java
@@ -1,0 +1,18 @@
+package invalidSelection;
+
+public class A_testIssue1356_1 {
+
+	private final int value;
+	
+	public A_testIssue1356_1(int value) {
+		/*]*/this.value= value;/*[*/
+	}
+
+	public void foo(int a) {
+        if (this.value < 3) {
+            return;
+        }
+        System.out.println(a);
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1356_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1356_2.java
@@ -1,0 +1,18 @@
+package invalidSelection;
+
+public class A_testIssue1356_2 {
+
+	private final int fValue;
+	
+	public A_testIssue1356_2(int someValue) {
+		/*]*/fValue= someValue;/*[*/
+	}
+
+	public void foo(int a) {
+        if (this.fValue < 3) {
+            return;
+        }
+        System.out.println(a);
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -2690,4 +2690,14 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	public void testIssue1355() throws Exception {
 		invalidSelectionTest();
 	}
+
+	@Test
+	public void testIssue1356_1() throws Exception {
+		invalidSelectionTest();
+	}
+
+	@Test
+	public void testIssue1356_2() throws Exception {
+		invalidSelectionTest();
+	}
 }


### PR DESCRIPTION
- fix ExtractMethodAnalyzer to add a new check if selected statements to extract contain a final field assignment and fail if this is true
- add new tests to ExtractMethodTests
- fixes #1356

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Does not allow final field initialization statements to be moved as part of an extract method refactoring.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
