### PR TITLE
Remove locals moved via extract method if they aren't used elsewhere

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test501.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test501.java
@@ -2,8 +2,6 @@ package locals_out;
 
 public class A_test501 {
 	public void foo() {
-		int x= 10;
-		
 		extracted();
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test502.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test502.java
@@ -2,9 +2,6 @@ package locals_out;
 
 public class A_test502 {
 	public void foo() {
-		int x= 0;
-		int y= 0;
-
 		extracted();		
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test509.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test509.java
@@ -3,8 +3,6 @@ package locals_out;
 public class A_test509 {
 	public void foo() {
 		int x= 0;
-		int y= 0;
-
 		extracted(x);		
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test518.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test518.java
@@ -2,8 +2,6 @@ package locals_out;
 
 public class A_test518 {
 	public void foo() {
-		int i;
-		
 		extracted();
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1357_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1357_1.java
@@ -1,0 +1,21 @@
+package validSelection_in;
+
+public class A_testIssue1357_1 {
+
+    public synchronized int calculate() {
+        int result;
+        /*]*/switch (value) {
+        case 1:
+            result = value * 2;
+            break;
+        case 2:
+            result = value * 3;
+            break;
+        default:
+            result = value * 4;
+            break;
+        }
+        return result;/*[*/
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1357_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1357_2.java
@@ -1,0 +1,21 @@
+package validSelection_in;
+
+public class A_testIssue1357_2 {
+
+    public synchronized int calculate() {
+        int result;
+        /*]*/switch (value) {
+        case 1:
+            result = value * 2;
+            break;
+        case 2:
+            result = value * 3;
+            break;
+        default:
+            result = value * 4;
+            break;
+        }/*[*/
+        return result;
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1357_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1357_1.java
@@ -1,0 +1,25 @@
+package validSelection_out;
+
+public class A_testIssue1357_1 {
+
+    public synchronized int calculate() {
+        return extracted();/*[*/
+    }
+
+	protected int extracted() {
+		int result;
+		switch (value) {
+        case 1:
+            result = value * 2;
+            break;
+        case 2:
+            result = value * 3;
+            break;
+        default:
+            result = value * 4;
+            break;
+        }
+        return result;
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1357_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1357_2.java
@@ -1,0 +1,27 @@
+package validSelection_out;
+
+public class A_testIssue1357_2 {
+
+    public synchronized int calculate() {
+        int result;
+        /*]*/result = extracted();/*[*/
+        return result;
+    }
+
+	protected int extracted() {
+		int result;
+		switch (value) {
+        case 1:
+            result = value * 2;
+            break;
+        case 2:
+            result = value * 3;
+            break;
+        default:
+            result = value * 4;
+            break;
+        }
+		return result;
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/wiki_out/A_test2001.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/wiki_out/A_test2001.java
@@ -5,7 +5,6 @@ public class A_test2001 {
 	int field= 0;
 
 	void fun() {
-		int i;
 		extracted();
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -2700,4 +2700,14 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	public void testIssue1356_2() throws Exception {
 		invalidSelectionTest();
 	}
+
+	@Test
+	public void testIssue1357_1() throws Exception {
+		validSelectionTestChecked();
+	}
+
+	@Test
+	public void testIssue1357_2() throws Exception {
+		validSelectionTestChecked();
+	}
 }


### PR DESCRIPTION
- modify ExtractMethodRefactoring.createMethodBody() to check all locals that needed to be created in new method to see if the old declaration is still needed (i.e. referenced outside of the selected statements) and if not, remove the original declaration
- modify all ExtractMethodTests where the locals are left behind and not used elsewhere
- add new tests to ExtractMethodTests
- fixes #1357

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or modified tests or new tests.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
