### PR TITLE
Fix move of method with private method call when classes in same CU

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
@@ -1272,7 +1272,15 @@ public final class MemberVisibilityAdjustor {
 		}
 		final ICompilationUnit typeUnit= referencing.getCompilationUnit();
 		if (referencedUnit != null && referencedUnit.equals(typeUnit)) {
-			if (referenced.getDeclaringType().getDeclaringType() == null)
+			IType referencedType= referenced.getDeclaringType();
+			while (referencedType.getDeclaringType() != null) {
+				referencedType= referencedType.getDeclaringType();
+			}
+			IType referencingType= referencing;
+			while (referencingType.getDeclaringType() != null) {
+				referencingType= referencingType.getDeclaringType();
+			}
+			if (!referencedType.getFullyQualifiedName().equals(referencingType.getFullyQualifiedName()))
 				keyword= null;
 			else
 				keyword= ModifierKeyword.PRIVATE_KEYWORD;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1272,7 +1272,7 @@ public final class MemberVisibilityAdjustor {
 		}
 		final ICompilationUnit typeUnit= referencing.getCompilationUnit();
 		if (referencedUnit != null && referencedUnit.equals(typeUnit)) {
-			if (referenced.getDeclaringType().getDeclaringType() != null)
+			if (referenced.getDeclaringType().getDeclaringType() == null)
 				keyword= null;
 			else
 				keyword= ModifierKeyword.PRIVATE_KEYWORD;

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test70/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test70/in/A.java
@@ -1,0 +1,17 @@
+class B {
+    public void f() {
+
+    }
+}
+
+class A {
+    B b;
+    
+    public void m() {
+        n();
+    }
+    
+    private void n() {
+        
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test70/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test70/out/A.java
@@ -1,0 +1,17 @@
+class B {
+    public void f() {
+
+    }
+
+	public void m(A a) {
+	    a.n();
+	}
+}
+
+class A {
+    B b;
+    
+    void n() {
+        
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -648,6 +648,12 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 	@Test
 	public void test69() throws Exception {
 		helper1(new String[] { "p1.A", "p2.B"}, "p1.A", 11, 17, 11, 23, FIELD, "b", true, true);
+	}
+
+	// Issue 1300
+	@Test
+	public void test70() throws Exception {
+		helper1(new String[] { "A" }, "A", 10, 17, 10, 18, FIELD, "b", true, true);
 	}
 
 	// Move mA1 to field fB, do not inline delegator


### PR DESCRIPTION
- fix MemberVisibilityAdjustor.thresholdTypeToMethod() so that when two classes are in same compilation unit but are separate, use a threshold of default (null) instead of private
- add new test to MoveInstanceMethodTests
- fixes #1300

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
