### PR TITLE
Do not use runReadOnly during TypeHierarchyViewPart.updateViewers #1408

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyLifeCycle.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyLifeCycle.java
@@ -280,10 +280,8 @@ public class TypeHierarchyLifeCycle implements ITypeHierarchyChangedListener, IE
 				}
 				if (pm.isCanceled())
 					return;
-				JavaCore.runReadOnly(() -> {
-					fTypeHierarchyViewPart.setViewersInput();
-					fTypeHierarchyViewPart.updateViewers();
-				});
+				fTypeHierarchyViewPart.setViewersInput();
+				fTypeHierarchyViewPart.updateViewers();
 			});
 		}
 	}


### PR DESCRIPTION
partial revert of fc6a25a6a1d46627eae34f4aeab98cafb71a5f70

The used firePostSelectionChanged may run events that try to edit java model.

fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1408

Since "Increase JavaModelCache #1929" its not a performance impact anymore anyway, since the jdt.core typically keeps a cached JavaModel of the TypeHierarchy after computing it anyway and does not need to compute it in ui again.

