### PR TITLE
Only allow moving an interface member to another interface

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -2075,6 +2075,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String ReorgPolicyFactory_cannot_modify;
 
+	public static String ReorgPolicyFactory_cannot_move_interface_member;
+
 	public static String ReorgPolicyFactory_cannot_move_package_to_parent;
 
 	public static String ReorgPolicyFactory_cannot_move_source_to_parent;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -1119,6 +1119,7 @@ ReorgPolicyFactory_copy_elements_plural=Copy elements
 ReorgPolicyFactory_copy_elements_header_singular=Copy element ''{0}'' to ''{1}''
 ReorgPolicyFactory_copy_elements_header_plural=Copy {0} elements to ''{1}''
 ReorgPolicyFactory_copy_description_singular=Copy element
+ReorgPolicyFactory_cannot_move_interface_member=Interface member cannot be moved to selected destination.
 ReorgPolicyFactory_cannot_move_source_to_parent=A source folder cannot be moved to its own parent.
 ReorgPolicyFactory_cannot_move_package_to_parent=A package cannot be moved to its own parent.
 ReorgPolicyFactory_move_description_plural=Move elements

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2366,6 +2366,11 @@ public final class ReorgPolicyFactory {
 						return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ReorgPolicyFactory_cannot);
 					}
 					parent= parent.getParent();
+				}
+				if (element instanceof IMember member && member.getParent() instanceof IType parentType && parentType.isInterface()) {
+					if (!(destination instanceof IType destType) || !destType.isInterface()) {
+						return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ReorgPolicyFactory_cannot_move_interface_member);
+					}
 				}
 			}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail22/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail22/in/A.java
@@ -1,0 +1,4 @@
+package p;
+public interface A{
+	int m();
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail22/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail22/in/B.java
@@ -1,0 +1,3 @@
+package p;
+class B{
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
@@ -691,9 +691,12 @@ public class MoveMembersTests extends GenericRefactoringTest {
 				RefactoringStatus.FATAL, "p.B");
 	}
 
+	// Issue 1299
 	@Test
 	public void testFail22() throws Exception{
-		//free slot
+		fieldMethodTypeHelper_failing(new String[0],
+				new String[]{"m"}, new String[][]{new String[0]}, new String[0],
+				RefactoringStatus.FATAL, "p.B");
 	}
 
 	@Test


### PR DESCRIPTION
- fix ReorgPolicyFactory.MoveSubCuElementsPolicy.validateDestination() to restrict moving an interface member to anything other than another interface
- add new test to MoveMemberTests
- fixes #1299

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
