### PR TITLE
Fix false error on extraction of for loop contents

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/branch_in/A_test770.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/branch_in/A_test770.java
@@ -1,0 +1,24 @@
+package branch_in;
+
+import java.util.List;
+
+public class A_test770 {
+
+	public static void foo(List<List<String>> defs) {
+		for (List<String> def : defs) {
+			/*]*/
+			boolean isLeftRecursive= false;
+			for (String rule : def) {
+				if (!rule.isEmpty()) {
+					break;
+				}
+			}
+
+			if (!isLeftRecursive) {
+				continue;
+			}
+			/*[*/
+		}
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/branch_out/A_test770.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/branch_out/A_test770.java
@@ -1,0 +1,28 @@
+package branch_out;
+
+import java.util.List;
+
+public class A_test770 {
+
+	public static void foo(List<List<String>> defs) {
+		for (List<String> def : defs) {
+			/*]*/
+			extracted(def);
+			/*[*/
+		}
+	}
+
+	protected static void extracted(List<String> def) {
+		boolean isLeftRecursive= false;
+		for (String rule : def) {
+			if (!rule.isEmpty()) {
+				break;
+			}
+		}
+
+		if (!isLeftRecursive) {
+			return;
+		}
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -2125,6 +2125,11 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 		branchTest();
 	}
 
+	@Test
+	public void test770() throws Exception {
+		branchTest();
+	}
+
 	//---- Test for CUs with compiler errors
 
 	@Test


### PR DESCRIPTION
- fix ExtractMethodAnalyzer.canHandleBranches() to not flag a non-labelled break statement if the for loop is included
- add new test to ExtractMethodTests
- fixes #1291

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See original issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
