### PR TITLE
Fix false extract method failure due to local variable access

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_in/A_test579.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_in/A_test579.java
@@ -1,0 +1,23 @@
+package locals_in;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class A_test579 {
+	public static void foo(List<String> defs) {
+		List<String> newDefs= new ArrayList<>();
+
+		for (String rule : defs) {
+			/*]*/boolean isLeftRecursive= false;
+			if (!isLeftRecursive) {
+				continue;
+			}
+
+			List<String> oldRules= new ArrayList<String>();
+			List<String> newSuffixes= new ArrayList<String>();
+
+			newDefs.addAll(oldRules);
+			newDefs.addAll(newSuffixes);/*[*/
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test579.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/locals_out/A_test579.java
@@ -1,0 +1,27 @@
+package locals_out;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class A_test579 {
+	public static void foo(List<String> defs) {
+		List<String> newDefs= new ArrayList<>();
+
+		for (String rule : defs) {
+			/*]*/extracted(newDefs);/*[*/
+		}
+	}
+
+	protected static void extracted(List<String> newDefs) {
+		boolean isLeftRecursive= false;
+		if (!isLeftRecursive) {
+			return;
+		}
+
+		List<String> oldRules= new ArrayList<String>();
+		List<String> newSuffixes= new ArrayList<String>();
+
+		newDefs.addAll(oldRules);
+		newDefs.addAll(newSuffixes);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -1655,6 +1655,11 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 		localsTest();
 	}
 
+	@Test
+	public void test579() throws Exception {
+		localsTest();
+	}
+
 	//---- Test expressions
 
 	@Test


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
