### PR TITLE
Adapt to removing AbstractUnnamedTypeDeclaration in jdt.core

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/HierarchicalASTVisitor.java
@@ -115,11 +115,11 @@ public abstract class HierarchicalASTVisitor extends ASTVisitor {
 
 	//---- Begin AbstractTypeDeclaration Hierarchy ---------------------------
 	public boolean visit(AbstractTypeDeclaration node) {
-		return visit((AbstractUnnamedTypeDeclaration)node);
+		return visit((BodyDeclaration)node);
 	}
 
 	public void endVisit(AbstractTypeDeclaration node) {
-		endVisit((AbstractUnnamedTypeDeclaration)node);
+		endVisit((BodyDeclaration)node);
 	}
 
 	@Override
@@ -156,22 +156,14 @@ public abstract class HierarchicalASTVisitor extends ASTVisitor {
 
 	//---- Begin AbstractUnnamedTypeDeclaration Hierarchy ---------------------------
 
-	public boolean visit(AbstractUnnamedTypeDeclaration node) {
-		return visit((BodyDeclaration)node);
-	}
-
-	public void endVisit(AbstractUnnamedTypeDeclaration node) {
-		endVisit((BodyDeclaration)node);
-	}
-
 	@Override
 	public boolean visit(ImplicitTypeDeclaration node) {
-		return visit((AbstractUnnamedTypeDeclaration)node);
+		return visit((AbstractTypeDeclaration)node);
 	}
 
 	@Override
 	public void endVisit(ImplicitTypeDeclaration node) {
-		endVisit((AbstractUnnamedTypeDeclaration)node);
+		endVisit((AbstractTypeDeclaration)node);
 	}
 
 	//---- End AbstractUnnamedTypeDeclaration Hierarchy ---------------------------

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/PasteAction.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/PasteAction.java
@@ -108,7 +108,6 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
-import org.eclipse.jdt.core.dom.AbstractUnnamedTypeDeclaration;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -429,14 +428,14 @@ public class PasteAction extends SelectionDispatchAction{
 				}
 
 				ArrayList<ParsedCu> cus= new ArrayList<>();
-				List<AbstractUnnamedTypeDeclaration> types= unit.types();
+				List<AbstractTypeDeclaration> types= unit.types();
 
 				int startOffset= 0;
 				String typeName= null;
 				int maxVisibility= JdtFlags.VISIBILITY_CODE_INVALID;
 
 				// Public types must be in separate CUs:
-				for (AbstractUnnamedTypeDeclaration type : types) {
+				for (AbstractTypeDeclaration type : types) {
 					if (typeName == null) {
 						// first in group:
 						maxVisibility= JdtFlags.getVisibilityCode(type);
@@ -468,7 +467,7 @@ public class PasteAction extends SelectionDispatchAction{
 				return cus;
 			}
 
-			private static String getTypeName(AbstractUnnamedTypeDeclaration type) {
+			private static String getTypeName(AbstractTypeDeclaration type) {
 				return type instanceof AbstractTypeDeclaration named? named.getName().getIdentifier() : ""; //$NON-NLS-1$
 			}
 


### PR DESCRIPTION
## What it does
Adapt to removing `AbstractUnnamedTypeDeclaration` in jdt.core. See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2483.

## How to test
jdt.ui should compile when you are using https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2483, and the use case in https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1414 should continue to work.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
