### PR TITLE
Force signing of split package bundles to use new certificate

### DIFF
--- a/org.eclipse.jdt.core.manipulation/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.manipulation/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1979
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ Bug 534597 - Unanticipated comparator errors in I20180511-2000
 Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/org.eclipse.jdt.junit/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit/forceQualifierUpdate.txt
@@ -15,3 +15,4 @@ Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/org.eclipse.jdt.ui/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.ui/forceQualifierUpdate.txt
@@ -20,3 +20,4 @@ Comparator errors in I20230906-0400
 Comparator errors in I20231127-0750
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1979
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044