### PR TITLE
Fix concat to MessageFormat and String.format

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToMessageFormatFixCore.java
@@ -243,6 +243,7 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 			Expression lastStringLiteral= firstStringLiteral;
 			Expression firstArgumentExpression= operands.get(0);
 			Expression lastArgumentExpression= firstArgumentExpression;
+			int totalSize= 0;
 			for (Expression operand : operands) {
 				if (operand instanceof StringLiteral) {
 					if (isFirstStringLiteral) {
@@ -262,6 +263,7 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 						}
 					}
 					String value= ((StringLiteral) operand).getEscapedValue();
+					totalSize += value.length();
 					value= value.replace("'", "''"); //$NON-NLS-1$ //$NON-NLS-2$
 					value= value.replace("{", "'{'"); //$NON-NLS-1$ //$NON-NLS-2$
 					value= value.replace("}", "'}'"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -304,7 +306,6 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 				}
 			}
 
-
 			importRewrite.addImport("java.text.MessageFormat", importContext); //$NON-NLS-1$
 
 			StringBuilder buffer= new StringBuilder();
@@ -314,9 +315,9 @@ public class ConvertToMessageFormatFixCore extends CompilationUnitRewriteOperati
 			int maxOffset= lastStringLiteral.getStartPosition() > lastArgumentExpression.getStartPosition() ?
 					lastStringLiteral.getStartPosition() + lastStringLiteral.getLength() : lastArgumentExpression.getStartPosition() + lastArgumentExpression.getLength();
 
-			boolean isSingleLine= root.getLineNumber(maxOffset) == root.getLineNumber(minOffset);
+			boolean isLessThanThreeLines= root.getLineNumber(maxOffset) - root.getLineNumber(minOffset) < 2;
 
-			if (is15OrHigher && !isSingleLine) {
+			if (is15OrHigher && !isLessThanThreeLines && totalSize > 80) {
 				StringBuilder buf= new StringBuilder();
 
 				List<String> parts= new ArrayList<>();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
@@ -235,6 +235,7 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 			Expression lastStringLiteral= firstStringLiteral;
 			Expression firstArgumentExpression= operands.get(0);
 			Expression lastArgumentExpression= firstArgumentExpression;
+			int totalSize= 0;
 			for (Expression operand : operands) {
 				if (operand instanceof StringLiteral) {
 					if (isFirstStringLiteral) {
@@ -254,6 +255,7 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 						}
 					}
 					String value= ((StringLiteral) operand).getEscapedValue();
+					totalSize += value.length();
 					value= value.replace("%", "%%"); //$NON-NLS-1$ //$NON-NLS-2$
 					fLiterals.add(value);
 					value= value.substring(1, value.length() - 1);
@@ -281,9 +283,9 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 			int maxOffset= lastStringLiteral.getStartPosition() > lastArgumentExpression.getStartPosition() ?
 					lastStringLiteral.getStartPosition() + lastStringLiteral.getLength() : lastArgumentExpression.getStartPosition() + lastArgumentExpression.getLength();
 
-			boolean isSingleLine= root.getLineNumber(maxOffset) == root.getLineNumber(minOffset);
+			boolean isLessThanThreeLines= root.getLineNumber(maxOffset) - root.getLineNumber(minOffset) < 2;
 
-			if (is15OrHigher && !isSingleLine) {
+			if (is15OrHigher && !isLessThanThreeLines && totalSize > 80) {
 				StringBuilder buf= new StringBuilder();
 
 				List<String> parts= new ArrayList<>();

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.15.400.qualifier
+Bundle-Version: 3.15.500.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.15.400-SNAPSHOT</version>
+  <version>3.15.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>


### PR DESCRIPTION
- fix ConvertToMessageFormatFixCore and ConvertToStringFormatFixCore to refine the logic for determining when to use a text block vs a single line - logic now only uses text block if there are 3 or more lines used in the concatenation AND the number of string literal characters is greater than 80
- modify existing tests and add new tests to AssistQuickFixTest15
- fixes #1406

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See commit message.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
