### PR TITLE
Fix move method to handle field access modifier adjustment

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -526,9 +526,6 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 		/** The target compilation unit rewrite to use */
 		protected final CompilationUnitRewrite fTargetRewrite;
 
-		/** List of member access adjustments needed */
-		protected Map<IMember, IncomingMemberVisibilityAdjustment> fAdjustments;
-
 		/**
 		 * Creates a new method body rewriter.
 		 *

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -550,7 +550,6 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 			fRewrite= rewrite;
 			fRewrites= rewrites;
 			fDeclaration= sourceDeclaration;
-			fAdjustments= adjustments;
 			fStaticImports.clear();
 			fAdjustments= adjustments;
 			fStatus= status;

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test79/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test79/in/A.java
@@ -1,0 +1,18 @@
+class B {
+    public void f() {
+
+    }
+}
+
+class A {
+    B b;
+    private int c;
+    
+    public void m() {
+        n(c);
+    }
+    
+    private void n(int x) {
+        
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test79/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test79/out/A.java
@@ -1,0 +1,18 @@
+class B {
+    public void f() {
+
+    }
+
+	public void m(A a) {
+	    a.n(a.c);
+	}
+}
+
+class A {
+    B b;
+    int c;
+    
+    void n(int x) {
+        
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -704,6 +704,10 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 		helper1(new String[] { "p1.A", "p1.B" }, "p1.A", 12, 17, 12, 18, FIELD, "b", true, true);
 	}
 
+	@Test
+	public void test79() throws Exception {
+		helper1(new String[] { "A" }, "A", 11, 17, 11, 18, FIELD, "b", true, true);
+	}
 	// Move mA1 to field fB, do not inline delegator
 	@Test
 	public void test3() throws Exception {


### PR DESCRIPTION
- fix MoveInstanceMethodProcessor.createMethodBody() to perform any needed adjustments to field modifiers if required by the move
- add new test to MoveInstanceMethodTests
- fixes #1297

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes move instance method to check field accesses and modify the access flags of the field if necessary.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
