### PR TITLE
Fix Bug 202162 - JUnit messages says failed first but it is not

### DIFF
--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.16.400.qualifier
+Bundle-Version: 3.16.500.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -296,6 +296,8 @@ public final class JUnitMessages extends NLS {
 	public static String TestRunnerViewPart_ExportTestRunSessionAction_name;
 
 	public static String TestRunnerViewPart_ExportTestRunSessionAction_title;
+
+	public static String TestRunnerViewPart_failures_first_suffix;
 
 	public static String TestRunnerViewPart_ImportTestRunSessionAction_error_title;
 

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
@@ -73,7 +73,7 @@ OpenTestAction_dialog_title=Go to Test
 OpenTestAction_error_methodNoFound=Method ''{0}'' not found. Opening the test class.
 OpenTestAction_select_element=&Select or enter the element to open:
 
-
+TestRunnerViewPart_failures_first_suffix=(Failed Tests first)
 TestRunnerViewPart_jobName=Update JUnit
 TestRunnerViewPart_history=&History...
 TestRunnerViewPart_wrapperJobName=JUnit Starter Job

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1426,9 +1426,12 @@ public class TestRunnerViewPart extends ViewPart {
 		try {
 			String attribute= configuration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, ""); //$NON-NLS-1$
 			if (attribute.length() != 0) {
-				String configName= Messages.format(JUnitMessages.TestRunnerViewPart_configName, configuration.getName());
+				String configName= configuration.getName();
+				if (configName.endsWith(JUnitMessages.TestRunnerViewPart_failures_first_suffix)) {
+					configName= configName.substring(0, configName.length() - JUnitMessages.TestRunnerViewPart_failures_first_suffix.length());
+				}
 				ILaunchConfigurationWorkingCopy tmp= configuration.copy(configName);
-				tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, ""); //$NON-NLS-1$
+				tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, (String)null);
 				return tmp;
 			}
 		} catch (CoreException e) {


### PR DESCRIPTION
- fix TestRunnerViewPart.prepareLaunchConfigForRelaunch() to strip the failed first part of a message as we are just rerunning
- also set the ATTR_FAILURES_NAMES to null instead of empty string so when we do failed first again we will create the proper message and do not add the Rerun to start of message as we do this inconsistently (only added after a failed run then rerun)
- fixes #1434

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the console message for a rerun to not have trailing info about failed tests first and makes the message more consistent by not adding Rerun to start of message some times and others not.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
