### PR TITLE
Add quickfix to suggest types for constructor type mismatch

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.java
@@ -370,6 +370,7 @@ public final class CorrectionMessages extends NLS {
 	public static String TypeChangeCompletionProposal_variable_name;
 	public static String TypeChangeCompletionProposal_param_name;
 	public static String TypeChangeCompletionProposal_method_name;
+	public static String TypeChangeCompletionProposal_constructor_name;
 	public static String ImplementInterfaceProposal_name;
 	public static String AddUnimplementedMethodsOperation_AddMissingMethod_group;
 	public static String AddUnimplementedMethodReferenceOperation_AddMissingMethod_group;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/CorrectionMessages.properties
@@ -475,6 +475,7 @@ TypeChangeCompletionProposal_field_name=Change type of ''{0}'' to ''{1}''
 TypeChangeCompletionProposal_variable_name=Change type of ''{0}'' to ''{1}''
 TypeChangeCompletionProposal_param_name=Change type of ''{0}'' to ''{1}''
 TypeChangeCompletionProposal_method_name=Change return type of ''{0}(..)'' to ''{1}''
+TypeChangeCompletionProposal_constructor_name=Change ''{0}'' to compatible type
 ImplementInterfaceProposal_name=Let ''{0}'' implement ''{1}''
 
 AddUnimplementedMethodsOperation_AddMissingMethod_group=Add missing method

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchBaseSubProcessor.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.core.dom.ArrayInitializer;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CastExpression;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ConditionalExpression;
 import org.eclipse.jdt.core.dom.EnhancedForStatement;
@@ -324,6 +325,17 @@ public abstract class TypeMismatchBaseSubProcessor<T> {
 						proposals.add(p2);
 				}
 			}
+
+			if (nodeToCast.getNodeType() == ASTNode.CLASS_INSTANCE_CREATION) {
+				ASTNode constructorNode = context.getCoveringNode();
+				if(!(constructorNode instanceof ClassInstanceCreation)) {
+					constructorNode = ASTNodes.getParent(constructorNode, ClassInstanceCreation.class);
+				}
+				T p3= createChangeConstructorTypeProposal(cu, constructorNode, astRoot,
+						castTypeBinding, relevance);
+				if (p3 != null)
+					proposals.add(p3);
+			}
 		}
 	}
 
@@ -541,6 +553,8 @@ public abstract class TypeMismatchBaseSubProcessor<T> {
 
 	protected abstract T createChangeSenderTypeProposal(ICompilationUnit targetCu, IBinding callerBindingDecl, CompilationUnit astRoot, ITypeBinding castTypeBinding, boolean isAssignedNode,
 			int relevance);
+
+	protected abstract T createChangeConstructorTypeProposal(ICompilationUnit targetCu, ASTNode callerNode, CompilationUnit astRoot, ITypeBinding castTypeBinding, int relevance);
 
 	protected abstract T createCastCorrectionProposal(String label, ICompilationUnit cu, Expression nodeToCast, ITypeBinding castTypeBinding, int relevance);
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/TypeMismatchSubProcessor.java
@@ -139,6 +139,11 @@ public class TypeMismatchSubProcessor extends TypeMismatchBaseSubProcessor<IComm
 	}
 
 	@Override
+	protected ICommandAccess createChangeConstructorTypeProposal(ICompilationUnit targetCu, ASTNode callerNode, CompilationUnit astRoot, ITypeBinding castTypeBinding, int relevance) {
+		return new TypeChangeCorrectionProposal(targetCu, callerNode, astRoot, castTypeBinding, relevance);
+	}
+
+	@Override
 	protected ICommandAccess createCastCorrectionProposal(String label, ICompilationUnit cu, Expression nodeToCast, ITypeBinding castTypeBinding, int relevance) {
 		return new CastCorrectionProposal(label, cu, nodeToCast, castTypeBinding, relevance);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/TypeChangeCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/TypeChangeCorrectionProposal.java
@@ -16,6 +16,7 @@
 package org.eclipse.jdt.internal.ui.text.correction.proposals;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -37,5 +38,10 @@ public class TypeChangeCorrectionProposal extends LinkedCorrectionProposal {
 			int relevance) {
 		super("", targetCU, null, relevance, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE), //$NON-NLS-1$
 				new TypeChangeCorrectionProposalCore(targetCU, binding, astRoot, newType, isNewTypeVar, offerSuperTypeProposals, relevance));
+	}
+
+	public TypeChangeCorrectionProposal(ICompilationUnit targetCU, ASTNode nodeToChange, CompilationUnit astRoot, ITypeBinding variableTypeBinding, int relevance) {
+		super("", targetCU, null, relevance, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE), //$NON-NLS-1$
+				new TypeChangeCorrectionProposalCore(targetCU, nodeToChange, astRoot, variableTypeBinding, relevance));
 	}
 }


### PR DESCRIPTION
## What it does
Addresses https://github.com/redhat-developer/vscode-java/issues/3040
![quickfix-draft](https://github.com/eclipse-jdt/eclipse.jdt.ui/assets/115827695/c08c7a72-daed-42d7-a860-f7f06d1f6e8a)

## How to test
Get quickfix for a constructor invocation that does not match the type of the variable it's being assigned to

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
