### PR TITLE
Fix inlining method returning constant into switch expression

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -480,7 +480,7 @@ public class CallInliner {
 		// of a SwitchExpression, we need to check if we are about to replace it with a non-implicit
 		// yield statement in which case, we need to remove the yield qualifier.
 		if (fContext.callMode == ASTNode.YIELD_STATEMENT && fTargetNode instanceof YieldStatement yieldStatement
-				&& yieldStatement.isImplicit() && blocks.length > 0 && blocks[0].startsWith("yield ")) { //$NON-NLS-1$
+				&& yieldStatement.isImplicit() && fBlock == null && blocks.length > 0 && blocks[0].startsWith("yield ")) { //$NON-NLS-1$
 			blocks[0]= blocks[0].substring(6);
 		}
 		replaceCall(result, blocks, textEditGroup);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -475,6 +475,14 @@ public class CallInliner {
 		}
 
 		addNewLocals(textEditGroup);
+
+		// if we are replacing a single method invocation which is in an implicit yield statement
+		// of a SwitchExpression, we need to check if we are about to replace it with a non-implicit
+		// yield statement in which case, we need to remove the yield qualifier.
+		if (fContext.callMode == ASTNode.YIELD_STATEMENT && fTargetNode instanceof YieldStatement yieldStatement
+				&& yieldStatement.isImplicit() && blocks.length > 0 && blocks[0].startsWith("yield ")) { //$NON-NLS-1$
+			blocks[0]= blocks[0].substring(6);
+		}
 		replaceCall(result, blocks, textEditGroup);
 		return result;
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_in/TestSwitchExpression8.java
@@ -1,0 +1,16 @@
+package simple18_in;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format () {
+		return "hello";
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 -> /*]*/format()/*[*/;
+			default -> "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/simple14_out/TestSwitchExpression8.java
@@ -1,0 +1,16 @@
+package simple18_out;
+
+import java.lang.String;
+
+public class TestSwitchExpression1 {
+	public static String format () {
+		return "hello";
+	}
+	public static void main(String[] args) {
+		int value = 0;
+		String message = switch (value) {
+			case 0 -> /*]*/"hello"/*[*/;
+			default -> "";
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests16.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests16.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2021 IBM Corporation and others.
+ * Copyright (c) 2019, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -97,6 +97,11 @@ public class InlineMethodTests16 extends InlineMethodTests {
 
 	@Test
 	public void testSwitchExpression7() throws Exception {
+		performSimpleTest();
+	}
+
+	@Test
+	public void testSwitchExpression8() throws Exception {
 		performSimpleTest();
 	}
 }


### PR DESCRIPTION
- add check in CallInliner.perform() to see if we are replacing an implicit yield with a non-implicit yield and instead replace with the yield's expression
- add new test to InlineMethodTests16
- fixes #1439

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes case where a method returning a single constant is inlined into the case expression of a switch expression.  We don't want to add a yield statement in such a case, just the constant.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
