### PR TITLE
Fix move of record to new file refactoring when component accessed

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
@@ -166,14 +166,14 @@ public final class MemberVisibilityAdjustor {
 			Assert.isNotNull(rewrite);
 			Assert.isNotNull(root);
 			final int visibility= fKeyword != null ? fKeyword.toFlagValue() : Modifier.NONE;
-			if (fMember instanceof IField && !Flags.isEnum(fMember.getFlags())) {
+			if (fMember instanceof IField && !Flags.isEnum(fMember.getFlags()) && !Flags.isRecord(fMember.getFlags())) {
 				final VariableDeclarationFragment fragment= ASTNodeSearchUtil.getFieldDeclarationFragmentNode((IField) fMember, root);
 				final FieldDeclaration declaration= (FieldDeclaration) fragment.getParent();
 				VariableDeclarationFragment[] fragmentsToChange= new VariableDeclarationFragment[] { fragment };
 				VariableDeclarationRewrite.rewriteModifiers(declaration, fragmentsToChange, visibility, ModifierRewrite.VISIBILITY_MODIFIERS, rewrite, group);
 				if (status != null)
 					adjustor.fStatus.merge(status);
-			} else if (fMember != null) {
+			} else if (fMember != null && !Flags.isRecord(fMember.getFlags())) {
 				final BodyDeclaration declaration= ASTNodeSearchUtil.getBodyDeclarationNode(fMember, root);
 				if (declaration != null) {
 					ModifierRewrite.create(rewrite, declaration).setVisibility(visibility, group);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew14/moveInnerRecord2/in/p1/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew14/moveInnerRecord2/in/p1/Foo.java
@@ -1,0 +1,9 @@
+package p1;
+
+public record Foo(Foo.Bar bar) {
+    static record Bar<T> (T left, T right) {}
+    
+    public String foo(Bar<String> in) {
+    	return in.left();
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew14/moveInnerRecord2/out/p1/Bar.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew14/moveInnerRecord2/out/p1/Bar.java
@@ -1,0 +1,6 @@
+/**
+ * 
+ */
+package p1;
+
+record Bar<T> (T left, T right) {}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew14/moveInnerRecord2/out/p1/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToNew14/moveInnerRecord2/out/p1/Foo.java
@@ -1,0 +1,7 @@
+package p1;
+
+public record Foo(Bar bar) {
+    public String foo(Bar<String> in) {
+    	return in.left();
+    }
+}


### PR DESCRIPTION
- add check in MemberVisibilityAdjustor.rewriteVisibility() to ignore record fields
- add new test to MoveInnerToNewTests16
- fixes #1419

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
