### PR TITLE
Fix NPE in OverriddenAssignmentFixCore moveDown method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/OverriddenAssignmentFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/OverriddenAssignmentFixCore.java
@@ -210,7 +210,16 @@ public class OverriddenAssignmentFixCore extends CompilationUnitRewriteOperation
 			Expression rhs= overridingAssignment.getRightHandSide();
 			String rhsText= cu.getBuffer().getText(rhs.getStartPosition(), extendedEnd(cuRewrite.getRoot(), overridingAssignment.getParent()) - rhs.getStartPosition());
 
-			String declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
+			String declarationText= ""; //$NON-NLS-1$
+			if (fragment.getInitializer() != null) {
+				declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getInitializer().getStartPosition() - declaration.getStartPosition());
+			} else {
+				declarationText= cu.getBuffer().getText(declaration.getStartPosition(), fragment.getStartPosition() + fragment.getLength() - declaration.getStartPosition());
+				Hashtable<String, String> options= JavaCore.getOptions();
+				String spaceBeforeAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_BEFORE_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
+				String spaceAfterAssignment= options.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_AFTER_ASSIGNMENT_OPERATOR) == JavaCore.INSERT ? " " : ""; //$NON-NLS-1$ //$NON-NLS-2$
+				declarationText= declarationText + spaceBeforeAssignment + "=" + spaceAfterAssignment; //$NON-NLS-1$
+			}
 			String targetText= declarationText + rhsText;
 			ASTRewrite astRewrite= cuRewrite.getASTRewrite();
 			ASTNode replacementNode= astRewrite.createStringPlaceholder(targetText, ASTNode.VARIABLE_DECLARATION_STATEMENT);


### PR DESCRIPTION
- fixes #1454

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes possible NPE in OverriddenAssignmentFixCore.moveDown() method.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Test scenario unknown at this time.  Patch was tested by forcing a move down for a variable declaration that is not initialized.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
