### PR TITLE
Fix adding null annotation to qualified type of parameter

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/NullAnnotationsQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/NullAnnotationsQuickFixTest.java
@@ -2617,7 +2617,7 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 				// marker annotation with no members
 			}
 			""";
-		ICompilationUnit cu0= pack1.createCompilationUnit("SomeAnnotation.java", str0, false, null);
+		pack1.createCompilationUnit("SomeAnnotation.java", str0, false, null);
 
 		String str= """
 			package test1;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/NullAnnotationsQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/NullAnnotationsQuickFixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2020 GK Software AG and others.
+ * Copyright (c) 2012, 2024 GK Software AG and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -938,9 +938,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.Nullable;
-			
+
 			public class E2 extends E {
 			    void foo(@Nullable Exception e1) {
 			        e1.printStackTrace();
@@ -988,9 +988,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.NonNull;
-			
+
 			public class E2 extends E {
 			    void foo(@NonNull Exception e1) {
 			        e1.printStackTrace();
@@ -1105,9 +1105,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.NonNull;
-			
+
 			public class E2 {
 			    void test(E e, @NonNull Object in) {
 			        e.foo(in);
@@ -1245,9 +1245,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.Nullable;
-			
+
 			public class E {
 			    void foo(@Nullable Object o) {
 			        if (o == null) System.out.print("NOK");
@@ -1460,9 +1460,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.NonNull;
-			
+
 			public class E2 extends E {
 			    @NonNull
 			    Object foo() {
@@ -1522,9 +1522,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 			String str3= """
 				package test1;
-				
+
 				import org.eclipse.jdt.annotation.Nullable;
-				
+
 				public class E2 extends E implements IE {
 				    public @Nullable Object foo() {
 				        return this;
@@ -1541,9 +1541,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 			String str4= """
 				package test1;
-				
+
 				import org.eclipse.jdt.annotation.NonNull;
-				
+
 				public class E2 extends E implements IE {
 				    public @NonNull Object foo() {
 				        return this;
@@ -1675,9 +1675,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 			String str3= """
 				package test1;
-				
+
 				import org.eclipse.jdt.annotation.Nullable;
-				
+
 				public class E2 {
 				    public @Nullable Object foo(E e) {
 				        return e.bar();
@@ -1754,9 +1754,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.Nullable;
-			
+
 			public class E2 {
 			    public @Nullable Object foo(E e) {
 			        return e.bar();
@@ -2085,9 +2085,9 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.NonNull;
-			
+
 			public class E {
 			    public <T extends Number> double foo(boolean b) {
 			        @NonNull
@@ -2534,6 +2534,148 @@ public class NullAnnotationsQuickFixTest extends QuickFixTest {
 				JavaProjectHelper.delete(proj2);
 			}
 		}
+	}
+	@Test
+	public void testBug513423a() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str= """
+			package test1;
+			import org.eclipse.jdt.annotation.NonNullByDefault;
+
+			@NonNullByDefault
+			public class E extends RuntimeException {
+				private static final long serialVersionUID = 1L;
+
+				public void printStackTrace(
+					// Illegal redefinition of parameter s, inherited method from Throwable
+					// does not constrain this parameter
+					java.io.PrintStream s) {
+						if (s != null) {
+							synchronized (s) {
+								s.print(getClass().getName() + ": ");
+								s.print(getStackTrace());
+							}
+						}
+				}
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 2);
+		assertNumberOfProposals(proposals, 2); // ignore 2nd ("add @SW")
+
+		CUCorrectionProposal proposal= (CUCorrectionProposal)proposals.get(0);
+
+		assertEqualString(proposal.getDisplayString(), "Change parameter 's' to '@Nullable'");
+
+		String preview= getPreviewContent(proposal);
+
+		String str1= """
+			package test1;
+			import org.eclipse.jdt.annotation.NonNullByDefault;
+			import org.eclipse.jdt.annotation.Nullable;
+
+			@NonNullByDefault
+			public class E extends RuntimeException {
+				private static final long serialVersionUID = 1L;
+
+				public void printStackTrace(
+					// Illegal redefinition of parameter s, inherited method from Throwable
+					// does not constrain this parameter
+					java.io.@Nullable PrintStream s) {
+						if (s != null) {
+							synchronized (s) {
+								s.print(getClass().getName() + ": ");
+								s.print(getStackTrace());
+							}
+						}
+				}
+			}
+			""";
+		assertEqualString(preview, str1);
+
+	}
+	@Test
+	public void testBug513423b() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str0= """
+			package test1;
+
+			import static java.lang.annotation.ElementType.TYPE_USE;
+
+			import java.lang.annotation.Documented;
+			import java.lang.annotation.ElementType;
+			import java.lang.annotation.Retention;
+			import java.lang.annotation.RetentinPolicy;
+			import java.lang.annotation.Target;
+
+			@Documented
+			@Retention(RetentionPolicy.CLASS)
+			@Target({ TYPE_USE })
+			public @interface SomeAnnotation {
+				// marker annotation with no members
+			}
+			""";
+		ICompilationUnit cu0= pack1.createCompilationUnit("SomeAnnotation.java", str0, false, null);
+
+		String str= """
+			package test1;
+			import org.eclipse.jdt.annotation.NonNullByDefault;
+
+			@NonNullByDefault
+			public class E extends RuntimeException {
+				private static final long serialVersionUID = 1L;
+
+				public void printStackTrace(
+					// Illegal redefinition of parameter s, inherited method from Throwable
+					// does not constrain this parameter
+					java.io.@SomeAnnotation PrintStream s) {
+						if (s != null) {
+							synchronized (s) {
+								s.print(getClass().getName() + ": ");
+								s.print(getStackTrace());
+							}
+						}
+				}
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 2);
+		assertNumberOfProposals(proposals, 2); // ignore 2nd ("add @SW")
+
+		CUCorrectionProposal proposal= (CUCorrectionProposal)proposals.get(0);
+
+		assertEqualString(proposal.getDisplayString(), "Change parameter 's' to '@Nullable'");
+
+		String preview= getPreviewContent(proposal);
+
+		String str1= """
+			package test1;
+			import org.eclipse.jdt.annotation.NonNullByDefault;
+			import org.eclipse.jdt.annotation.Nullable;
+
+			@NonNullByDefault
+			public class E extends RuntimeException {
+				private static final long serialVersionUID = 1L;
+
+				public void printStackTrace(
+					// Illegal redefinition of parameter s, inherited method from Throwable
+					// does not constrain this parameter
+					java.io.@SomeAnnotation @Nullable PrintStream s) {
+						if (s != null) {
+							synchronized (s) {
+								s.print(getClass().getName() + ": ");
+								s.print(getStackTrace());
+							}
+						}
+				}
+			}
+			""";
+		assertEqualString(preview, str1);
+
 	}
 	@Test
 	public void testGH1294() throws Exception {


### PR DESCRIPTION
- fix NullAnnotationsRewriteOperations.ParameterAnnotationRewriteOperation to check for a SimpleType with qualified name or a NameQualifiedType and end up with a NameQualifiedType with the new annotation added
- add new tests to NullAnnotationsQuickFixTest
- fixes #1462

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the quick fix to change a parameter to add nullable annotation so that if the parameter type is qualified, it creates or modifies a NameQualifiedType reference and adds the annotation before the simple name (e.g. `int foo(java.io @Nullable PrintStream) {...
`
## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
