### PR TITLE
remove unnecessary casts

### DIFF
--- a/org.eclipse.jdt.astview.feature/feature.xml
+++ b/org.eclipse.jdt.astview.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.astview.feature"
       label="Java AST View"
-      version="1.2.250.qualifier"
+      version="1.2.300.qualifier"
       provider-name="Eclipse.org"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.astview
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.astview; singleton:=true
-Bundle-Version: 1.6.150.qualifier
+Bundle-Version: 1.6.200.qualifier
 Bundle-Activator: org.eclipse.jdt.astview.ASTViewPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/TrayLabelProvider.java
+++ b/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/TrayLabelProvider.java
@@ -61,7 +61,7 @@ public class TrayLabelProvider extends LabelProvider implements IColorProvider {
 		} else if (obj instanceof ASTAttribute) {
 			return ((ASTAttribute) obj).getLabel();
 		} else if (obj instanceof ASTNode) {
-			return Signature.getSimpleName(((ASTNode) obj).getClass().getName());
+			return Signature.getSimpleName(obj.getClass().getName());
 		} else {
 			return ""; // https://bugs.eclipse.org/bugs/show_bug.cgi?id=126017
 		}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/ImportReferencesCollector.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/ImportReferencesCollector.java
@@ -228,7 +228,7 @@ public class ImportReferencesCollector extends GenericVisitor {
 	private void doVisitChildren(List<? extends ASTNode> elements) {
 		int nElements= elements.size();
 		for (int i= 0; i < nElements; i++) {
-			((ASTNode) elements.get(i)).accept(this);
+			elements.get(i).accept(this);
 		}
 	}
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/ResourcesUtility.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/ResourcesUtility.java
@@ -120,7 +120,7 @@ public class ResourcesUtility {
 	 */
 	public static IResource getResource(IJavaElement element){
 		if (element.getElementType() == IJavaElement.COMPILATION_UNIT)
-			return ((ICompilationUnit) element).getResource();
+			return element.getResource();
 		else if (element instanceof IOpenable)
 			return element.getResource();
 		else

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/dom/ASTResolving.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/dom/ASTResolving.java
@@ -307,7 +307,7 @@ public class ASTResolving {
 				}
 			}
 			if (creationType instanceof ArrayType) {
-				ITypeBinding creationTypeBinding= ((ArrayType) creationType).resolveBinding();
+				ITypeBinding creationTypeBinding= creationType.resolveBinding();
 				if (creationTypeBinding != null) {
 					return Bindings.getComponentType(creationTypeBinding, dim);
 				}
@@ -883,7 +883,7 @@ public class ASTResolving {
 			}
 			return Modifier.isStatic(decl.getModifiers());
 		} else if (decl instanceof Initializer) {
-			return Modifier.isStatic(((Initializer)decl).getModifiers());
+			return Modifier.isStatic(decl.getModifiers());
 		} else if (decl instanceof FieldDeclaration) {
 			return JdtFlags.isStatic(decl);
 		}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/ExceptionOccurrencesFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/ExceptionOccurrencesFinder.java
@@ -163,7 +163,7 @@ public class ExceptionOccurrencesFinder extends ASTVisitor implements IOccurrenc
 			if (variable instanceof VariableDeclarationExpression) {
 				typeBinding= ((VariableDeclarationExpression) variable).getType().resolveBinding();
 			} else if (variable instanceof Name) {
-				typeBinding= ((Name) variable).resolveTypeBinding();
+				typeBinding= variable.resolveTypeBinding();
 			}
 			if (typeBinding != null) {
 				IMethodBinding methodBinding= Bindings.findMethodInHierarchy(typeBinding, "close", new ITypeBinding[0]); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/MethodExitsFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/MethodExitsFinder.java
@@ -218,7 +218,7 @@ public class MethodExitsFinder extends ASTVisitor implements IOccurrencesFinder 
 			if (variable instanceof VariableDeclarationExpression) {
 				typeBinding= ((VariableDeclarationExpression) variable).getType().resolveBinding();
 			} else if (variable instanceof Name) {
-				typeBinding= ((Name) variable).resolveTypeBinding();
+				typeBinding= variable.resolveTypeBinding();
 			}
 			if (typeBinding != null) {
 				IMethodBinding methodBinding= Bindings.findMethodInHierarchy(typeBinding, "close", new ITypeBinding[0]); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/OccurrencesFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/core/manipulation/search/OccurrencesFinder.java
@@ -171,7 +171,7 @@ public class OccurrencesFinder extends ASTVisitor implements IOccurrencesFinder 
 		if (!(node instanceof QualifiedName))
 			return false;
 
-		ASTNode parent= ((QualifiedName)node).getParent();
+		ASTNode parent= node.getParent();
 		return parent instanceof ImportDeclaration && ((ImportDeclaration) parent).isStatic();
 	}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/RedundantNullnessTypeAnnotationsFilter.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/RedundantNullnessTypeAnnotationsFilter.java
@@ -38,7 +38,6 @@ import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
-import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
 
@@ -262,7 +261,7 @@ public class RedundantNullnessTypeAnnotationsFilter {
 				extendsMods= ((SingleVariableDeclaration) astNode).modifiers();
 				break;
 			case ASTNode.VARIABLE_DECLARATION_FRAGMENT:
-				final ASTNode parent= ((VariableDeclarationFragment) astNode).getParent();
+				final ASTNode parent= astNode.getParent();
 				if (parent instanceof BodyDeclaration)
 					extendsMods= ((BodyDeclaration) parent).modifiers();
 				break;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -560,7 +560,7 @@ public class ASTNodes {
 		if (declaration instanceof SingleVariableDeclaration) {
 			return ((SingleVariableDeclaration)declaration).getType();
 		} else if (declaration instanceof VariableDeclarationFragment) {
-			ASTNode parent= ((VariableDeclarationFragment)declaration).getParent();
+			ASTNode parent= declaration.getParent();
 			if (parent instanceof VariableDeclarationExpression)
 				return ((VariableDeclarationExpression)parent).getType();
 			else if (parent instanceof VariableDeclarationStatement)

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/AbstractPrimitiveRatherThanWrapperFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/AbstractPrimitiveRatherThanWrapperFinder.java
@@ -383,15 +383,15 @@ public abstract class AbstractPrimitiveRatherThanWrapperFinder extends ASTVisito
 
 				if (assignment.getRightHandSide().equals(node)) {
 					if (assignment.getLeftHandSide() instanceof Name) {
-						return isOfType(((Name) assignment.getLeftHandSide()).resolveTypeBinding());
+						return isOfType(assignment.getLeftHandSide().resolveTypeBinding());
 					}
 
 					if (assignment.getLeftHandSide() instanceof FieldAccess) {
-						return isOfType(((FieldAccess) assignment.getLeftHandSide()).resolveTypeBinding());
+						return isOfType(assignment.getLeftHandSide().resolveTypeBinding());
 					}
 
 					if (assignment.getLeftHandSide() instanceof SuperFieldAccess) {
-						return isOfType(((SuperFieldAccess) assignment.getLeftHandSide()).resolveTypeBinding());
+						return isOfType(assignment.getLeftHandSide().resolveTypeBinding());
 					}
 				}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/Java50FixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/Java50FixCore.java
@@ -359,7 +359,7 @@ public class Java50FixCore extends CompilationUnitRewriteOperationsFixCore {
 
 	private static boolean hasFatalError(CompilationUnit compilationUnit) {
 		try {
-			if (!((ICompilationUnit) compilationUnit.getJavaElement()).isStructureKnown())
+			if (!compilationUnit.getJavaElement().isStructureKnown())
 				return true;
 		} catch (JavaModelException e) {
 			JavaManipulationPlugin.log(e);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -258,7 +258,7 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 
 		private void checkForUninitializedFinalReference(IBinding binding) {
 			if (binding instanceof IVariableBinding) {
-				int modifiers= ((IVariableBinding)binding).getModifiers();
+				int modifiers= binding.getModifiers();
 				if ((modifiers & IModifierConstants.ACC_FINAL) == IModifierConstants.ACC_FINAL) {
 					if (((IVariableBinding) binding).isField()) {
 						ASTNode decl= ((CompilationUnit)fMethodDeclaration.getRoot()).findDeclaringNode(binding);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/RemoveVarOrInferredLambdaParameterTypesFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/RemoveVarOrInferredLambdaParameterTypesFixCore.java
@@ -61,7 +61,7 @@ public class RemoveVarOrInferredLambdaParameterTypesFixCore extends CompilationU
 		if (node instanceof LambdaExpression) {
 			lambda= (LambdaExpression) node;
 		} else if (node.getLocationInParent() == SingleVariableDeclaration.NAME_PROPERTY &&
-				((SingleVariableDeclaration) parent).getLocationInParent() == LambdaExpression.PARAMETERS_PROPERTY) {
+				parent.getLocationInParent() == LambdaExpression.PARAMETERS_PROPERTY) {
 			lambda= (LambdaExpression) node.getParent().getParent();
 		} else {
 			return null;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
@@ -772,7 +772,7 @@ public class InlineConstantRefactoring extends Refactoring {
 	}
 
 	private RefactoringStatus findField() {
-		fField= (IField) ((IVariableBinding) fSelectedConstantName.resolveBinding()).getJavaElement();
+		fField= (IField) fSelectedConstantName.resolveBinding().getJavaElement();
 		if (fField != null && ! fField.exists())
 			return RefactoringStatus.createStatus(RefactoringStatus.FATAL, RefactoringCoreMessages.InlineConstantRefactoring_local_anonymous_unsupported, null, CorextCore.getPluginId(), RefactoringStatusCodes.LOCAL_AND_ANONYMOUS_NOT_SUPPORTED, null);
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineMethodRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineMethodRefactoring.java
@@ -340,7 +340,7 @@ public class InlineMethodRefactoring extends Refactoring {
 						}
 						if (rewrite.hasRecordedChanges()) {
 							TextEdit edit= rewrite.rewriteImports(null);
-							if (edit instanceof MultiTextEdit ? ((MultiTextEdit)edit).getChildrenSize() > 0 : true) {
+							if (edit instanceof MultiTextEdit ? edit.getChildrenSize() > 0 : true) {
 								root.addChild(edit);
 								change.addTextEditGroup(
 										new TextEditGroup(RefactoringCoreMessages.InlineMethodRefactoring_edit_import, new TextEdit[] {edit}));

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MemberVisibilityAdjustor.java
@@ -508,7 +508,7 @@ public final class MemberVisibilityAdjustor {
 
 		if (member instanceof IType) {
 			// recursively check accessibility of member type's members
-			final IJavaElement[] typeMembers= ((IType) member).getChildren();
+			final IJavaElement[] typeMembers= member.getChildren();
 			for (IJavaElement typeMember : typeMembers) {
 				if (! (typeMember instanceof IInitializer))
 					adjustMemberVisibility((IMember) typeMember, monitor);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveStaticMembersProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveStaticMembersProcessor.java
@@ -529,7 +529,7 @@ public final class MoveStaticMembersProcessor extends MoveProcessor implements I
 	private RefactoringStatus checkMovedMemberAvailability(IMember memberToMove, IProgressMonitor pm) throws JavaModelException{
 		RefactoringStatus result= new RefactoringStatus();
 		if (memberToMove instanceof IType) { // recursively check accessibility of member type's members
-			IJavaElement[] typeMembers= ((IType) memberToMove).getChildren();
+			IJavaElement[] typeMembers= memberToMove.getChildren();
 			pm.beginTask(RefactoringCoreMessages.MoveMembersRefactoring_checking, typeMembers.length + 1);
 			for (IJavaElement typeMember : typeMembers) {
 				if (typeMember instanceof IInitializer)

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeRefactoringProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/constraints/SuperTypeRefactoringProcessor.java
@@ -845,7 +845,7 @@ public abstract class SuperTypeRefactoringProcessor extends RefactoringProcessor
 				binding= ((VariableDeclaration) ((VariableDeclarationStatement) node).fragments().get(0)).resolveBinding();
 				node= target.findDeclaringNode(binding.getKey());
 				if (node instanceof VariableDeclarationFragment)
-					rewriteTypeOccurrence(estimate, rewrite, ((VariableDeclarationStatement) ((VariableDeclarationFragment) node).getParent()).getType(), group);
+					rewriteTypeOccurrence(estimate, rewrite, ((VariableDeclarationStatement) node.getParent()).getType(), group);
 			} else if (node instanceof MethodDeclaration) {
 				binding= ((MethodDeclaration) node).resolveBinding();
 				node= target.findDeclaringNode(binding.getKey());

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/types/CaptureType.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/typeconstraints/types/CaptureType.java
@@ -47,7 +47,7 @@ public final class CaptureType extends AbstractTypeVariable {
 
 	@Override
 	public boolean doEquals(TType type) {
-		return getBindingKey().equals(((CaptureType)type).getBindingKey())
+		return getBindingKey().equals(type.getBindingKey())
 				&& fJavaProject.equals(((CaptureType)type).fJavaProject);
 	}
 

--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/NewAnnotationMemberProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/NewAnnotationMemberProposalCore.java
@@ -128,7 +128,7 @@ public class NewAnnotationMemberProposalCore extends LinkedCorrectionProposalCor
 		List<BodyDeclaration> methodDecls= targetTypeDecl.bodyDeclarations();
 		for (BodyDeclaration curr : methodDecls) {
 			if (curr instanceof AnnotationTypeMemberDeclaration) {
-				return ((AnnotationTypeMemberDeclaration) curr).getModifiers();
+				return curr.getModifiers();
 			}
 		}
 		return 0;

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractConstantRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractConstantRefactoring.java
@@ -655,9 +655,9 @@ public class ExtractConstantRefactoring extends Refactoring {
 
 			int modifiers;
 			if (decl instanceof FieldDeclaration)
-				modifiers= ((FieldDeclaration) decl).getModifiers();
+				modifiers= decl.getModifiers();
 			else if (decl instanceof Initializer)
-				modifiers= ((Initializer) decl).getModifiers();
+				modifiers= decl.getModifiers();
 			else {
 				continue; /* this declaration is not a field declaration
 				              or initializer, so the placement of the constant
@@ -727,9 +727,9 @@ public class ExtractConstantRefactoring extends Refactoring {
 
 		int modifiers;
 		if(node instanceof FieldDeclaration) {
-			modifiers = ((FieldDeclaration) node).getModifiers();
+			modifiers = node.getModifiers();
 		} else if(node instanceof Initializer) {
-			modifiers = ((Initializer) node).getModifiers();
+			modifiers = node.getModifiers();
 		} else {
 			Assert.isTrue(false);
 			return false;

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ReplaceInvocationsRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ReplaceInvocationsRefactoring.java
@@ -409,7 +409,7 @@ public class ReplaceInvocationsRefactoring extends Refactoring {
 					ImportRewrite rewrite= inliner.getImportEdit();
 					if (rewrite.hasRecordedChanges()) {
 						TextEdit edit= rewrite.rewriteImports(null);
-						if (edit instanceof MultiTextEdit ? ((MultiTextEdit)edit).getChildrenSize() > 0 : true) {
+						if (edit instanceof MultiTextEdit ? edit.getChildrenSize() > 0 : true) {
 							root.addChild(edit);
 							change.addTextEditGroup(
 								new TextEditGroup(RefactoringCoreMessages.InlineMethodRefactoring_edit_import, new TextEdit[] {edit}));

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/DeleteChangeCreator.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/DeleteChangeCreator.java
@@ -37,7 +37,6 @@ import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.ltk.core.refactoring.TextFileChange;
 import org.eclipse.ltk.core.refactoring.resource.DeleteResourceChange;
 
-import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -172,8 +171,8 @@ class DeleteChangeCreator {
 
 			case IJavaElement.CLASS_FILE:
 				//if this assert fails, it means that a precondition is missing
-				Assert.isTrue(((IClassFile)javaElement).getResource() instanceof IFile);
-				return createDeleteChange(((IClassFile)javaElement).getResource());
+				Assert.isTrue(javaElement.getResource() instanceof IFile);
+				return createDeleteChange(javaElement.getResource());
 
 			case IJavaElement.JAVA_MODEL: //cannot be done
 			case IJavaElement.JAVA_PROJECT: //handled differently

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/ReorgPolicyFactory.java
@@ -820,7 +820,7 @@ public final class ReorgPolicyFactory {
 			if (resDest instanceof IContainer)
 				return (IContainer) resDest;
 			if (resDest instanceof IFile)
-				return ((IFile) resDest).getParent();
+				return resDest.getParent();
 			return null;
 		}
 

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ExtractSupertypeProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/ExtractSupertypeProcessor.java
@@ -47,7 +47,6 @@ import org.eclipse.ltk.core.refactoring.GroupCategory;
 import org.eclipse.ltk.core.refactoring.GroupCategorySet;
 import org.eclipse.ltk.core.refactoring.RefactoringDescriptor;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-import org.eclipse.ltk.core.refactoring.TextChange;
 import org.eclipse.ltk.core.refactoring.participants.CheckConditionsContext;
 
 import org.eclipse.jdt.core.Flags;
@@ -1320,7 +1319,7 @@ public final class ExtractSupertypeProcessor extends PullUpRefactoringProcessor 
 						CompilationUnitChange change= rewrite.createChange(true);
 
 						if (change != null) {
-							final TextEdit edit= ((TextChange) change).getEdit();
+							final TextEdit edit= change.getEdit();
 							if (edit != null) {
 								final IDocument document= new Document(fSuperSource);
 								try {

--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.13.200.qualifier
+Bundle-Version: 3.13.300.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
@@ -461,7 +461,7 @@ public class TestRunSession implements ITestRunSession {
 	 */
 	public boolean rerunTest(String testId, String className, String testName) {
 		if (isKeptAlive()) {
-			Status status= ((TestCaseElement) getTestElement(testId)).getStatus();
+			Status status= getTestElement(testId).getStatus();
 			if (status == Status.ERROR) {
 				fErrorCount--;
 			} else if (status == Status.FAILURE) {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/UpdateTestSuite.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/wizards/UpdateTestSuite.java
@@ -120,7 +120,7 @@ public class UpdateTestSuite implements IObjectActionDelegate {
 			}
 			for (Object element : selection) {
 				if (element instanceof IType){
-					if (((IType)element).equals(suiteClass)){
+					if (element.equals(suiteClass)){
 						return new JUnitStatus(IStatus.WARNING, WizardMessages.UpdateTestSuite_infinite_recursion);
 					}
 				}

--- a/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.text.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.text.tests;singleton:=true
-Bundle-Version: 3.14.400.qualifier
+Bundle-Version: 3.14.500.qualifier
 Bundle-Activator: org.eclipse.jdt.text.tests.JdtTextTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.text.tests/pom.xml
+++ b/org.eclipse.jdt.text.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.text.tests</artifactId>
-  <version>3.14.400-SNAPSHOT</version>
+  <version>3.14.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/QuickDiffInvocationCountTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/QuickDiffInvocationCountTest.java
@@ -21,7 +21,6 @@ import org.eclipse.jface.text.DocumentRewriteSession;
 import org.eclipse.jface.text.DocumentRewriteSessionType;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentExtension4;
-import org.eclipse.jface.text.ITextViewerExtension;
 import org.eclipse.jface.text.source.SourceViewer;
 
 import org.eclipse.ui.internal.texteditor.quickdiff.QuickDiffRangeDifference;
@@ -66,7 +65,7 @@ public class QuickDiffInvocationCountTest extends TextPerformanceTestCase {
 		DocumentRewriteSession rewriteSession= null;
 		try {
 			if (viewer != null)
-				((ITextViewerExtension) viewer).getRewriteTarget().beginCompoundChange();
+				viewer.getRewriteTarget().beginCompoundChange();
 			if (document instanceof IDocumentExtension4)
 				rewriteSession= ((IDocumentExtension4) document).startRewriteSession(DocumentRewriteSessionType.STRICTLY_SEQUENTIAL);
 			for (int i= 0; i < document.getNumberOfLines(); i += 2) {
@@ -76,7 +75,7 @@ public class QuickDiffInvocationCountTest extends TextPerformanceTestCase {
 			if (document instanceof IDocumentExtension4)
 				((IDocumentExtension4) document).stopRewriteSession(rewriteSession);
 			if (viewer != null)
-				((ITextViewerExtension) viewer).getRewriteTarget().endCompoundChange();
+				viewer.getRewriteTarget().endCompoundChange();
 		}
 		EditorTestHelper.joinBackgroundActivities(fEditor);
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -141,7 +141,7 @@ public class JavadocHoverTests extends CoreTests {
 		IType type= myEnumCu.getType("MyEnum");
 		IField field = type.getField("ENUM1");
 		IJavaElement[] elements= { field };
-		ISourceRange range= ((ISourceReference) field).getNameRange();
+		ISourceRange range= field.getNameRange();
 		// Should not throw ClassCastException
 		JavadocHover.getHoverInfo(elements, myEnumCu, new Region(range.getOffset(), range.getLength()), null);
 	}

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/SortMembersOperation.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/SortMembersOperation.java
@@ -32,7 +32,6 @@ import org.eclipse.jdt.core.dom.AnnotationTypeMemberDeclaration;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
-import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
@@ -92,7 +91,7 @@ public class SortMembersOperation implements IWorkspaceRunnable {
 					}
 				case ASTNode.INITIALIZER :
 					{
-						int flags= ((Initializer) bodyDeclaration).getModifiers();
+						int flags= bodyDeclaration.getModifiers();
 						if (Modifier.isStatic(flags))
 							return MembersOrderPreferenceCacheCommon.STATIC_INIT_INDEX;
 						else

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CodeFormatFix.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CodeFormatFix.java
@@ -174,7 +174,7 @@ public class CodeFormatFix implements ICleanUpFix {
 						CategorizedTextEditGroup group= new CategorizedTextEditGroup(label, new GroupCategorySet(new GroupCategory(label, label, label)));
 
 						if (edit instanceof MultiTextEdit) {
-							for (TextEdit child : ((MultiTextEdit)edit).getChildren()) {
+							for (TextEdit child : edit.getChildren()) {
 								edit.removeChild(child);
 								if (!TextEditUtil.overlaps(formatEdit, child) && !TextEditUtil.overlaps(otherEdit, child)) {
 									otherEdit.addChild(child);

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/JavaPostfixContext.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/JavaPostfixContext.java
@@ -481,7 +481,7 @@ public class JavaPostfixContext extends JavaContext {
 			return -1;
 		}
 		if (node.getParent() instanceof MethodInvocation) {
-			return ((MethodInvocation) node.getParent()).getStartPosition();
+			return node.getParent().getStartPosition();
 		} else if (node.getParent() instanceof FieldAccess || node.getParent() instanceof SuperFieldAccess) {
 			return node.getParent().getStartPosition();
 		} else if (node instanceof Name) {
@@ -489,7 +489,7 @@ public class JavaPostfixContext extends JavaContext {
 			while (n.getParent() instanceof QualifiedName) {
 				n= n.getParent();
 			}
-			return ((Name) n).getStartPosition();
+			return n.getStartPosition();
 		}
 		return node.getStartPosition();
 	}

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/ExternalizeWizardPage.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/nls/ExternalizeWizardPage.java
@@ -720,7 +720,7 @@ class ExternalizeWizardPage extends UserInputWizardPage {
 			@Override
 			protected void hookControl(Control control) {
 				super.hookControl(control);
-				((Table) control).addMouseListener(new MouseAdapter() {
+				control.addMouseListener(new MouseAdapter() {
 					@Override
 					public void mouseDoubleClick(MouseEvent e) {
 						if (getTable().getSelection().length == 0)

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/JavaBrowsingContentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/JavaBrowsingContentProvider.java
@@ -410,7 +410,7 @@ class JavaBrowsingContentProvider extends StandardJavaElementContentProvider imp
 				Object[] newElements= getNewElements(elements);
 				if (fViewer instanceof AbstractTreeViewer) {
 					if (fViewer.testFindItem(parent) == null) {
-						Object root= ((AbstractTreeViewer)fViewer).getInput();
+						Object root= fViewer.getInput();
 						if (root != null)
 							((AbstractTreeViewer)fViewer).add(root, newElements);
 					}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/PackagesView.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/PackagesView.java
@@ -49,8 +49,6 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.part.IShowInTargetList;
 
-import org.eclipse.jdt.core.IClassFile;
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -322,9 +320,9 @@ public class PackagesView extends JavaBrowsingPart{
 			case IJavaElement.PACKAGE_FRAGMENT:
 				return je;
 			case IJavaElement.COMPILATION_UNIT:
-				return ((ICompilationUnit)je).getParent();
+				return je.getParent();
 			case IJavaElement.CLASS_FILE:
-				return ((IClassFile)je).getParent();
+				return je.getParent();
 			case IJavaElement.TYPE:
 				return ((IType)je).getPackageFragment();
 			default:

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/SortMembersCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/SortMembersCleanUp.java
@@ -31,7 +31,6 @@ import org.eclipse.debug.core.model.IBreakpoint;
 
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
-import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
@@ -67,7 +66,7 @@ public class SortMembersCleanUp extends AbstractCleanUp {
 			if (fTouchedFiles == null) {
 				fTouchedFiles= new HashSet<>();
 			}
-			fTouchedFiles.add(((ICompilationUnit)compilationUnit.getJavaElement()).getResource());
+			fTouchedFiles.add(compilationUnit.getJavaElement().getResource());
 		}
 		return fix;
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
@@ -70,7 +70,6 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.Signature;
-import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -488,11 +487,11 @@ public final class ClipboardOperationAction extends TextEditorAction {
 		// do process import if selection spans over import declaration or package
 		List<ImportDeclaration> list= astRoot.imports();
 		if (!list.isEmpty()) {
-			if (offset < ((ASTNode) list.get(list.size() - 1)).getStartPosition()) {
+			if (offset < list.get(list.size() - 1).getStartPosition()) {
 				return null;
 			}
 		} else if (astRoot.getPackage() != null) {
-			if (offset < ((ASTNode) astRoot.getPackage()).getStartPosition()) {
+			if (offset < astRoot.getPackage().getStartPosition()) {
 				return null;
 			}
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementHyperlinkDetector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementHyperlinkDetector.java
@@ -30,7 +30,6 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.texteditor.IDocumentProvider;
 import org.eclipse.ui.texteditor.ITextEditor;
 
-import org.eclipse.jdt.core.ICodeAssist;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaCore;
@@ -126,7 +125,7 @@ public class JavaElementHyperlinkDetector extends AbstractHyperlinkDetector {
 			if (input.equals(fLastInput) && modStamp == fLastModStamp && wordRegion.equals(fLastWordRegion)) {
 				elements= fLastElements;
 			} else {
-				elements= ((ICodeAssist) input).codeSelect(wordRegion.getOffset(), wordRegion.getLength());
+				elements= input.codeSelect(wordRegion.getOffset(), wordRegion.getLength());
 				elements= selectOpenableElements(elements);
 				fLastInput= input;
 				fLastModStamp= modStamp;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/propertiesfileeditor/PropertyKeyHyperlink.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/propertiesfileeditor/PropertyKeyHyperlink.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.PlatformObject;
@@ -370,7 +369,7 @@ public class PropertyKeyHyperlink implements IHyperlink {
 
 			String message= null;
 
-			IWorkbenchAdapter wbAdapter= ((IAdaptable)keyReference).getAdapter(IWorkbenchAdapter.class);
+			IWorkbenchAdapter wbAdapter= keyReference.getAdapter(IWorkbenchAdapter.class);
 			if (wbAdapter != null)
 				message= Messages.format(PropertiesFileEditorMessages.OpenAction_error_messageArgs,
 						new String[] { wbAdapter.getLabel(keyReference), x.getLocalizedMessage() } );

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ModifierCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ModifierCorrectionSubProcessor.java
@@ -229,7 +229,7 @@ public class ModifierCorrectionSubProcessor {
 		} else if (kind == TO_STATIC && bindingDecl.getKind() == IBinding.VARIABLE
 				&& problem.getProblemId() == IProblem.InstanceFieldDuringConstructorInvocation) {
 			if (selectedNode.getNodeType() == ASTNode.SIMPLE_NAME) {
-				if (((SimpleName)selectedNode).getLocationInParent() == SuperConstructorInvocation.ARGUMENTS_PROPERTY) {
+				if (selectedNode.getLocationInParent() == SuperConstructorInvocation.ARGUMENTS_PROPERTY) {
 					UnresolvedElementsSubProcessor.getVariableProposals(context, problem, (IVariableBinding) bindingDecl, proposals);
 				}
 			}
@@ -949,10 +949,10 @@ public class ModifierCorrectionSubProcessor {
 		if (!(selectedNode instanceof SimpleName)) {
 			return;
 		}
-		if (!(((SimpleName) selectedNode).getParent() instanceof TypeDeclaration)) {
+		if (!(selectedNode.getParent() instanceof TypeDeclaration)) {
 			return;
 		}
-		TypeDeclaration typeDecl= (TypeDeclaration) ((SimpleName) selectedNode).getParent();
+		TypeDeclaration typeDecl= (TypeDeclaration) selectedNode.getParent();
 		boolean isInterface= typeDecl.isInterface();
 
 		ICompilationUnit cu= context.getCompilationUnit();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -956,7 +956,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		if (coveringNode instanceof LambdaExpression) {
 			enclosingLambda= (LambdaExpression) coveringNode;
 		} else if (coveringNode.getLocationInParent() == VariableDeclarationFragment.NAME_PROPERTY
-				&& ((VariableDeclarationFragment) coveringNode.getParent()).getLocationInParent() == LambdaExpression.PARAMETERS_PROPERTY) {
+				&& coveringNode.getParent().getLocationInParent() == LambdaExpression.PARAMETERS_PROPERTY) {
 			enclosingLambda= (LambdaExpression) coveringNode.getParent().getParent();
 		} else {
 			return false;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMethodCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMethodCompletionProposal.java
@@ -30,7 +30,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.ISourceRange;
-import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.compiler.CharOperation;
@@ -177,7 +176,7 @@ public class JavaMethodCompletionProposal extends LazyJavaCompletionProposal {
 	// Simple member parser to see if we are not in matched parentheses and thus might be in a parameter list
 	private boolean areParenthesesMatched(ICompilationUnit cu, IMember element) throws JavaModelException {
 		String source= cu.getSource();
-		ISourceRange sourceRange= ((ISourceReference)element).getSourceRange();
+		ISourceRange sourceRange= element.getSourceRange();
 		int cnt= 0;
 		State state= State.NORMAL;
 		for (int i= sourceRange.getOffset(); i < getReplacementOffset(); ++i) {


### PR DESCRIPTION
When https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2471 is merged, ecj will signal more casts as unnecessary.

With this PR I suggest to remove affected casts before new errors/warnings will show up in the build.