### PR TITLE
Fix inlined return message to not clip white-space

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
@@ -951,8 +951,10 @@ public class CoreJavadocAccessImpl implements IJavadocAccess {
 			handleSummary(node.fragments());
 		else if (isIndex)
 			handleIndex(node.fragments());
-		else if (isCode || isLiteral || isReturn)
+		else if (isCode || isLiteral)
 			handleContentElements(node.fragments(), true, node);
+		else if (isReturn)
+			handleContentElements(node.fragments(), false, node);
 		else if (isSnippet) {
 			handleSnippet(node);
 		} else if (handleInheritDoc(node) || handleDocRoot(node)) {


### PR DESCRIPTION
- fix CoreJavadocAccessImpl to properly handle text elements embedded in inlined return statement
- fixes #1464 in conjunction with jdt.core fix

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes inline return output to not clip white-space from text elements.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
