### PR TITLE
Add support for extracting method to outer class

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodAnalyzer.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
@@ -452,6 +453,29 @@ public class ExtractMethodAnalyzer extends CodeAnalyzer {
 			}
 		}
 		return problems[0];
+	}
+
+	public List<SimpleName> findFieldReferencesForType(AbstractTypeDeclaration type) {
+		final List<SimpleName> fieldList= new ArrayList<>();
+		ASTNode[] selectedNodes= getSelectedNodes();
+		ITypeBinding typeBinding= type.resolveBinding();
+		if (typeBinding != null) {
+			for (ASTNode astNode : selectedNodes) {
+				astNode.accept(new ASTVisitor() {
+					@Override
+					public boolean visit(SimpleName node) {
+						IBinding binding= node.resolveBinding();
+						if (binding instanceof IVariableBinding varBinding && varBinding.isField()) {
+							if (typeBinding.isEqualTo(varBinding.getDeclaringClass())) {
+								fieldList.add(node);
+							}
+						}
+						return true;
+					}
+				});
+			}
+		}
+		return fieldList;
 	}
 
 	private String canHandleBranches() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/nested_in/A_test655.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/nested_in/A_test655.java
@@ -1,0 +1,11 @@
+package nested_in;
+
+public class A_test655 {
+	public static class NestedStatic {
+		private int i= 0;
+
+		public void foo() {
+			/*[*/System.out.println("Greetings" + ++i);/*]*/
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/nested_out/A_test655.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/nested_out/A_test655.java
@@ -1,0 +1,15 @@
+package nested_in;
+
+public class A_test655 {
+	public static class NestedStatic {
+		private int i= 0;
+
+		public void foo() {
+			extracted(this);
+		}
+	}
+
+	protected static void extracted(NestedStatic passedNestedStatic) {
+		/*[*/System.out.println("Greetings" + ++passedNestedStatic.i);/*]*/
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -181,6 +181,11 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 		performTest(fgTestSetup.getNestedPackage(), "A", COMPARE_WITH_OUTPUT, "nested_out");
 	}
 
+	protected void nestedTest1() throws Exception {
+		performTest(fgTestSetup.getNestedPackage(), "A", COMPARE_WITH_OUTPUT, "nested_out", null, null, 1);
+
+	}
+
 	protected void returnTest() throws Exception {
 		performTest(fgTestSetup.getReturnPackage(), "A", COMPARE_WITH_OUTPUT, "return_out");
 	}
@@ -1837,6 +1842,11 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	@Test
 	public void test654() throws Exception {
 		nestedTest();
+	}
+
+	@Test
+	public void test655() throws Exception {
+		nestedTest1();
 	}
 
 	//---- Extracting method containing a return statement.


### PR DESCRIPTION
- add new findFieldReferencesForType() method to ExtractMethodAnalyzer to find field references in the inner type where selection is made
- add new logic to ExtractMethodRefactoring to recognize a move to an outer class where fields are referenced in inner in which case pass an extra parameter of the inner type and qualify any field references using this extra parameter
- add new test to ExtractMethodTests
- fixes #1458

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes extracting from an inner class to an outer class method.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
