### PR TITLE
Increase Jenkins timeout to 60 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
 	options {
-		timeout(time: 40, unit: 'MINUTES')
+		timeout(time: 60, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()


### PR DESCRIPTION
## What it does
Should reduce the amount of timeouting builds like https://ci.eclipse.org/jdt/job/eclipse.jdt.ui-github/job/PR-1479/ .

## How to test
Builds no longer timeout on Jenkins

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
