### PR TITLE
Refactor StaticInnerClassCleanUp to jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/StaticInnerClassCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/StaticInnerClassCleanUpCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 Fabrice TIERCELIN and others.
+ * Copyright (c) 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     Fabrice TIERCELIN - initial API and implementation
+ *     Red Hat Inc. - refactored from StaticInnerClassCleanUp
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.fix;
 
@@ -53,8 +54,8 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.InterruptibleVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -70,15 +71,15 @@ import org.eclipse.jdt.ui.text.java.IProblemLocation;
  * <li>The top level class should not be inheritable or the inner class must be <code>private</code></li>
  * </ul>
  */
-public class StaticInnerClassCleanUp extends AbstractMultiFix {
+public class StaticInnerClassCleanUpCore extends AbstractMultiFix {
 
 	private static final String JUPITER_NESTED= "org.junit.jupiter.api.Nested"; //$NON-NLS-1$
 
-	public StaticInnerClassCleanUp() {
+	public StaticInnerClassCleanUpCore() {
 		this(Collections.emptyMap());
 	}
 
-	public StaticInnerClassCleanUp(final Map<String, String> options) {
+	public StaticInnerClassCleanUpCore(final Map<String, String> options) {
 		super(options);
 	}
 
@@ -341,7 +342,7 @@ public class StaticInnerClassCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.StaticInnerClassCleanUp_description, unit,
+		return new CompilationUnitRewriteOperationsFixCore(MultiFixMessages.StaticInnerClassCleanUp_description, unit,
 				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
 	}
 
@@ -365,7 +366,7 @@ public class StaticInnerClassCleanUp extends AbstractMultiFix {
 		}
 
 		@Override
-		public void rewriteASTInternal(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
 			ListRewrite listRewrite= rewrite.getListRewrite(visited, TypeDeclaration.MODIFIERS2_PROPERTY);
 			AST ast= cuRewrite.getRoot().getAST();

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7177,7 +7177,7 @@
             runAfter="org.eclipse.jdt.ui.cleanup.single_used_field">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.StaticInnerClassCleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.StaticInnerClassCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.static_inner_class"
             runAfter="org.eclipse.jdt.ui.cleanup.break_loop">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/PerformanceTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/PerformanceTabPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,7 @@ import org.eclipse.jdt.internal.ui.fix.PrimitiveParsingCleanUp;
 import org.eclipse.jdt.internal.ui.fix.PrimitiveRatherThanWrapperCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PrimitiveSerializationCleanUp;
 import org.eclipse.jdt.internal.ui.fix.SingleUsedFieldCleanUp;
-import org.eclipse.jdt.internal.ui.fix.StaticInnerClassCleanUp;
+import org.eclipse.jdt.internal.ui.fix.StaticInnerClassCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.StringBufferToStringBuilderCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.StringBuilderCleanUp;
 import org.eclipse.jdt.internal.ui.fix.UseStringIsBlankCleanUp;
@@ -46,7 +46,7 @@ public final class PerformanceTabPage extends AbstractCleanUpTabPage {
 		return new AbstractCleanUp[] {
 				new SingleUsedFieldCleanUp(values),
 				new BreakLoopCleanUp(values),
-				new StaticInnerClassCleanUp(values),
+				new StaticInnerClassCleanUpCore(values),
 				new StringBuilderCleanUp(values),
 				new PlainReplacementCleanUpCore(values),
 				new UseStringIsBlankCleanUp(values),


### PR DESCRIPTION
- move StaticInnerClassCleanUp to StaticInnerClassCleanUpCore in jdt.core.manipulation
- fixes #1492

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run the jdt.ui cleanup tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
