### PR TITLE
Refactor RedundantSemicolonsCleanUp to jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/RedundantSemicolonsCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/RedundantSemicolonsCleanUpCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 itemis AG (http://www.itemis.eu) and others.
+ * Copyright (c) 2024 itemis AG (http://www.itemis.eu) and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     Karsten Thoms (itemis) - initial API and implementation
  *     Red Hat Inc. - copied and modified to replace extraneous semicolons
+ *     Red Hat Inc. - moved to jdt.core.manipulation and renamed
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.fix;
 
@@ -56,18 +57,18 @@ import org.eclipse.jdt.ui.text.java.IProblemLocation;
  * empty statements belonging to loops (e.g. empty for-loop) nor semicolons used
  * in a for-loop statement itself (e.g. for(;;)).
  */
-public class RedundantSemicolonsCleanUp extends AbstractMultiFix implements ICleanUpFix {
+public class RedundantSemicolonsCleanUpCore extends AbstractMultiFix implements ICleanUpFix {
 
 	private TextEditGroup[] fEditGroups;
 	private String fName;
 	private ICompilationUnit fCompilationUnit;
 	final static Pattern pattern= Pattern.compile("^((\\s*;)+)"); //$NON-NLS-1$
 
-	public RedundantSemicolonsCleanUp() {
+	public RedundantSemicolonsCleanUpCore() {
 		this(Collections.emptyMap());
 	}
 
-	public RedundantSemicolonsCleanUp(Map<String, String> options) {
+	public RedundantSemicolonsCleanUpCore(Map<String, String> options) {
 		super(options);
 	}
 
@@ -192,7 +193,7 @@ public class RedundantSemicolonsCleanUp extends AbstractMultiFix implements ICle
 		});
 
 		if (textedits.size() > 0) {
-			return new RedundantSemicolonsCleanUp(label, unit, textedits.toArray(new TextEditGroup[0]));
+			return new RedundantSemicolonsCleanUpCore(label, unit, textedits.toArray(new TextEditGroup[0]));
 		}
 		return null;
 	}
@@ -206,7 +207,7 @@ public class RedundantSemicolonsCleanUp extends AbstractMultiFix implements ICle
 		return -1;
 	}
 
-	private RedundantSemicolonsCleanUp(String name, CompilationUnit compilationUnit, TextEditGroup[] groups) {
+	private RedundantSemicolonsCleanUpCore(String name, CompilationUnit compilationUnit, TextEditGroup[] groups) {
 		fName= name;
 		fCompilationUnit= (ICompilationUnit)compilationUnit.getJavaElement();
 		fEditGroups= groups;

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7282,7 +7282,7 @@
             runAfter="org.eclipse.jdt.ui.cleanup.unnecessary_modifiers">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.RedundantSemicolonsCleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.RedundantSemicolonsCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.unnecessary_semicolons"
             runAfter="org.eclipse.jdt.ui.cleanup.embedded_if">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/UnnecessaryCodeTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/UnnecessaryCodeTabPage.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.internal.ui.fix.PushDownNegationCleanUp;
 import org.eclipse.jdt.internal.ui.fix.RedundantComparatorCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.RedundantComparisonStatementCleanUp;
 import org.eclipse.jdt.internal.ui.fix.RedundantModifiersCleanUp;
-import org.eclipse.jdt.internal.ui.fix.RedundantSemicolonsCleanUp;
+import org.eclipse.jdt.internal.ui.fix.RedundantSemicolonsCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.RedundantSuperCallCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ReturnExpressionCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.StringCleanUp;
@@ -73,7 +73,7 @@ public final class UnnecessaryCodeTabPage extends AbstractCleanUpTabPage {
 				new OverriddenAssignmentCleanUpCore(values),
 				new RedundantModifiersCleanUp(values),
 				new EmbeddedIfCleanUp(values),
-				new RedundantSemicolonsCleanUp(values),
+				new RedundantSemicolonsCleanUpCore(values),
 				new RedundantComparatorCleanUpCore(values),
 				new UnnecessaryArrayCreationCleanUpCore(values),
 				new ArrayWithCurlyCleanUpCore(values),


### PR DESCRIPTION
- refactor and rename to RedundantSemicolonsCleanUpCore
- fixes #1494

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run jdt.ui cleanup tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
