### PR TITLE
Fix Javadoc hover for snippets to show type parameters

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
@@ -196,7 +196,8 @@ public class CoreJavaDocSnippetStringEvaluator {
 	}
 
 	private String getString(String str, List<ActionElement> actionElements) {
-		String modifiedStr= str;
+		String modifiedStr= str.replaceAll(">", "&gt;"); //$NON-NLS-1$ //$NON-NLS-2$
+		modifiedStr= modifiedStr.replaceAll("<", "&lt;"); //$NON-NLS-1$ //$NON-NLS-2$
 		List<StringItem> items= new ArrayList<>();
 		for (ActionElement actElem : actionElements) {
 			StringItem startItem= new StringItem(actElem.start, actElem.startTag);


### PR DESCRIPTION
- fix CoreJavaDocSnippetStringEvaluator.getString() to convert < and > to &lt; and &gt;, respectively
- fixes #1496

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes Javadoc hover so type parameters show up in a snippet.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
