### PR TITLE
Do not flag spelling errors in Javadoc code or link tags

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/IJavaDocTagConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/IJavaDocTagConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,9 @@ public interface IJavaDocTagConstants {
 
 	/** Javadoc root tags */
 	String[] JAVADOC_ROOT_TAGS= new String[] { "@author", "@deprecated", "@return", "@see", "@serial", "@serialData", "@since", "@version", "@inheritDoc", "@category", "@value", "@literal", "@code", "@noinstantiate", "@noreference", "@noimplement", "@noextend", "@nooverride" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$ //$NON-NLS-7$ //$NON-NLS-8$ //$NON-NLS-9$ //$NON-NLS-10$ //$NON-NLS-11$ //$NON-NLS-12$ //$NON-NLS-13$ //$NON-NLS-14$ //$NON-NLS-15$ //$NON-NLS-16$ //$NON-NLS-17$ //$NON-NLS-18$
+
+	/** Javadoc example tags */
+	String[] JAVADOC_INLINE_EXAMPLE_TAGS= new String[] { "@code", "@see" }; //$NON-NLS-1$ //$NON-NLS-2$
 
 	/** Javadoc tag prefix */
 	char JAVADOC_TAG_PREFIX= '@';


### PR DESCRIPTION
- revert previous fix for param tag spelling errors as it is no longer needed
- add logic to recognize an in-line code or see tag and skip tokens in SpellCheckIterator until closing bracket of in-line tag
- fixes #1502

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes spell checking not to flag items within an inlined code tag or inlined see tag.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
