### PR TITLE
Fix calculation if cast needed for simplifying lambda to method ref

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertLambdaToMethodReferenceFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertLambdaToMethodReferenceFixCore.java
@@ -366,9 +366,9 @@ public class ConvertLambdaToMethodReferenceFixCore extends CompilationUnitRewrit
 			if (lambda.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
 				MethodInvocation parent= (MethodInvocation) lambda.getParent();
 				List<Expression> args= parent.arguments();
-				IMethodBinding parentBinding= parent.resolveMethodBinding();
+				IMethodBinding parentBinding= parent.resolveMethodBinding().getMethodDeclaration();
 				if (parentBinding != null) {
-					ITypeBinding parentTypeBinding= parentBinding.getDeclaringClass();
+					ITypeBinding parentTypeBinding= parentBinding.getDeclaringClass().getErasure();
 					while (parentTypeBinding != null) {
 						IMethodBinding[] parentTypeMethods= parentTypeBinding.getDeclaredMethods();
 						for (IMethodBinding parentTypeMethod : parentTypeMethods) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionAndMethodRefFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionAndMethodRefFixCore.java
@@ -473,9 +473,9 @@ public class LambdaExpressionAndMethodRefFixCore extends CompilationUnitRewriteO
 			if (visited.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
 				MethodInvocation parent= (MethodInvocation) visited.getParent();
 				List<Expression> args= parent.arguments();
-				IMethodBinding parentBinding= parent.resolveMethodBinding();
+				IMethodBinding parentBinding= parent.resolveMethodBinding().getMethodDeclaration();
 				if (parentBinding != null) {
-					ITypeBinding parentTypeBinding= parentBinding.getDeclaringClass();
+					ITypeBinding parentTypeBinding= parentBinding.getDeclaringClass().getErasure();
 					while (parentTypeBinding != null) {
 						IMethodBinding[] parentTypeMethods= parentTypeBinding.getDeclaredMethods();
 						for (IMethodBinding parentTypeMethod : parentTypeMethods) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -515,16 +515,16 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface I {
 			    int foo(String s);
 			}
-			
+
 			interface J {
 			    Integer foo(String s);
 			}
-			
+
 			public class X {
 			    static void goo(I i) { }
-			
+
 			    static void goo(J j) { }
-			
+
 			    public static void main(String[] args) {
 			        goo(new I() {
 			            @Override
@@ -550,16 +550,16 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface I {
 			    int foo(String s);
 			}
-			
+
 			interface J {
 			    Integer foo(String s);
 			}
-			
+
 			public class X {
 			    static void goo(I i) { }
-			
+
 			    static void goo(J j) { }
-			
+
 			    public static void main(String[] args) {
 			        goo((I) s -> 0);
 			    }
@@ -577,11 +577,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface I {
 			    int foo(String s);
 			}
-			
+
 			interface J {
 			    Integer foo(String s);
 			}
-			
+
 			public class X extends Y {
 			    static void goo(I i) { }
 			    public static void main(String[] args) {
@@ -593,7 +593,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        });
 			    }
 			}
-			
+
 			class Y {
 			    private static void goo(J j) { }   \s
 			}
@@ -613,18 +613,18 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface I {
 			    int foo(String s);
 			}
-			
+
 			interface J {
 			    Integer foo(String s);
 			}
-			
+
 			public class X extends Y {
 			    static void goo(I i) { }
 			    public static void main(String[] args) {
 			        goo(s -> 0);
 			    }
 			}
-			
+
 			class Y {
 			    private static void goo(J j) { }   \s
 			}
@@ -641,11 +641,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface I {
 			    int foo(String s);
 			}
-			
+
 			interface J {
 			    Integer foo(String s);
 			}
-			
+
 			public class X extends Y {
 			    static void goo(I i) { }
 			    public static void main(String[] args) {
@@ -657,7 +657,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        });
 			    }
 			}
-			
+
 			class Y {
 			    static void goo(J j) { }   \s
 			}
@@ -677,18 +677,18 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface I {
 			    int foo(String s);
 			}
-			
+
 			interface J {
 			    Integer foo(String s);
 			}
-			
+
 			public class X extends Y {
 			    static void goo(I i) { }
 			    public static void main(String[] args) {
 			        goo((I) s -> 0);
 			    }
 			}
-			
+
 			class Y {
 			    static void goo(J j) { }   \s
 			}
@@ -705,7 +705,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface J {
 			    <M> J run(M x);
 			}
-			
+
 			class Test {
 			    J j = new J() {
 			        @Override
@@ -735,7 +735,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FI {
 			    int foo(int x, int y, int z);
 			}
-			
+
 			class C {
 			    int i;
 			    private void test(int x) {
@@ -765,7 +765,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FI {
 			    int foo(int x, int y, int z);
 			}
-			
+
 			class C {
 			    int i;
 			    private void test(int x) {
@@ -787,7 +787,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FI {
 			    int foo(int x, int y, int z);
 			}
-			
+
 			class C {
 			    int i;
 			    private void test(int x, int y, int z) {
@@ -817,7 +817,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FI {
 			    int foo(int x, int y, int z);
 			}
-			
+
 			class C {
 			    int i;
 			    private void test(int x, int y, int z) {
@@ -840,7 +840,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FI {
 			    void foo();
 			}
-			
+
 			class C1 {
 			    void fun1() {
 			        int c = 0; // [1]
@@ -869,7 +869,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FI {
 			    void foo();
 			}
-			
+
 			class C1 {
 			    void fun1() {
 			        int c = 0; // [1]
@@ -892,7 +892,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface X {
 			    void foo();
 			}
-			
+
 			public class CX {
 			    private void fun(int a) {
 			        X x= new X() {
@@ -920,7 +920,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface X {
 			    void foo();
 			}
-			
+
 			public class CX {
 			    private void fun(int a) {
 			        X x= () -> {
@@ -942,7 +942,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FIOther {
 			    void run(int x);
 			}
-			
+
 			public class TestOther {
 			    void init() {
 			        String x;
@@ -955,7 +955,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			            };
 			        });
 			    }
-			
+
 			    void m(FIOther fi) {
 			    };
 			}
@@ -975,7 +975,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface FIOther {
 			    void run(int x);
 			}
-			
+
 			public class TestOther {
 			    void init() {
 			        String x;
@@ -985,7 +985,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			            };
 			        });
 			    }
-			
+
 			    void m(FIOther fi) {
 			    };
 			}
@@ -1111,10 +1111,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String str= """
 			package test;
-			
+
 			import java.lang.annotation.ElementType;
 			import java.lang.annotation.Target;
-			
+
 			public class C1 {
 			    FI fi= new  FI() {
 			        @Override
@@ -1140,10 +1140,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected= """
 			package test;
-			
+
 			import java.lang.annotation.ElementType;
 			import java.lang.annotation.Target;
-			
+
 			public class C1 {
 			    FI fi= (@A String... strs) -> {
 			    };
@@ -1503,12 +1503,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
 			package test1;
-			
+
 			interface FI {
 			    int e= 0;
 			    void run(int x);
 			}
-			
+
 			class Test {
 			    {
 			        FI fi = new FI() {
@@ -1537,12 +1537,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			interface FI {
 			    int e= 0;
 			    void run(int x);
 			}
-			
+
 			class Test {
 			    {
 			        FI fi = new FI() {
@@ -1639,23 +1639,23 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			public class C1 {
 			    interface IOverwriteQuery {
 			        String ALL = "ALL";
-			
+
 			        String queryOverwrite(String pathString);
 			    }
-			
+
 			    class ImportOperation {
 			        public ImportOperation(IOverwriteQuery query) {
 			        }
 			    }
-			
+
 			    public C1() {
 			        ImportOperation io = new ImportOperation(new IOverwriteQuery() {
-			
+
 			            @Override
 			            public String queryOverwrite(String pathString) {
 			                return ALL;
 			            }
-			
+
 			        });
 			    }
 			}
@@ -1674,15 +1674,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			public class C1 {
 			    interface IOverwriteQuery {
 			        String ALL = "ALL";
-			
+
 			        String queryOverwrite(String pathString);
 			    }
-			
+
 			    class ImportOperation {
 			        public ImportOperation(IOverwriteQuery query) {
 			        }
 			    }
-			
+
 			    public C1() {
 			        ImportOperation io = new ImportOperation(pathString -> IOverwriteQuery.ALL);
 			    }
@@ -1698,7 +1698,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			package test1;
 			import java.util.ArrayList;
 			import java.util.function.Predicate;
-			
+
 			public class Test {
 			    void foo(ArrayList<String> list) {
 			        list.removeIf(new Predicate<String>() {
@@ -1723,7 +1723,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected1= """
 			package test1;
 			import java.util.ArrayList;
-			
+
 			public class Test {
 			    void foo(ArrayList<String> list) {
 			        list.removeIf(String::isEmpty);
@@ -1943,10 +1943,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    default int defaultMethod(String x) {
 			        return -1;
 			    }
-			
+
 			    int foo(int x);
 			}
-			
+
 			class TestX {
 			    FX fxx = x -> {
 			        return (new FX() {
@@ -1974,10 +1974,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    default int defaultMethod(String x) {
 			        return -1;
 			    }
-			
+
 			    int foo(int x);
 			}
-			
+
 			class TestX {
 			    FX fxx = new FX() {
 			        @Override
@@ -2002,7 +2002,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String str= """
 			package test1;
 			import java.util.function.UnaryOperator;
-			
+
 			public class Snippet {
 			    UnaryOperator<String> fi3 = x -> {
 			        return x.toString();
@@ -2022,7 +2022,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected1= """
 			package test1;
 			import java.util.function.UnaryOperator;
-			
+
 			public class Snippet {
 			    UnaryOperator<String> fi3 = new UnaryOperator<String>() {
 			        @Override
@@ -2045,7 +2045,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface J<S> { S m(Class<?> c); }
 			interface K<T> { T m(Class<?> c); }
 			interface Functional<S,T> extends I, J<S>, K<T> {}
-			
+
 			class C {
 			    Functional<?, ?> fun= (c) -> { return null;};
 			}
@@ -2066,7 +2066,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			interface J<S> { S m(Class<?> c); }
 			interface K<T> { T m(Class<?> c); }
 			interface Functional<S,T> extends I, J<S>, K<T> {}
-			
+
 			class C {
 			    Functional<?, ?> fun= new Functional<Object, Object>() {
 			        @Override
@@ -2096,12 +2096,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			            return this.m();
 			        };
 			    }
-			
+
 			    public int m() {
 			        return 7;
 			    }
 			}
-			
+
 			class C {
 			    int varC;
 			    public void o() {}
@@ -2133,12 +2133,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			            }
 			        };
 			    }
-			
+
 			    public int m() {
 			        return 7;
 			    }
 			}
-			
+
 			class C {
 			    int varC;
 			    public void o() {}
@@ -2176,7 +2176,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    public int n() {
 			        return 7;
 			    }
-			
+
 			    @FunctionalInterface
 			    public interface F<T> {
 			        void run();
@@ -2196,7 +2196,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected1= """
 			package test1;
 			import java.util.function.IntSupplier;
-			
+
 			import test1.D.F;
 			public class D {
 			    D() {
@@ -2223,7 +2223,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    public int n() {
 			        return 7;
 			    }
-			
+
 			    @FunctionalInterface
 			    public interface F<T> {
 			        void run();
@@ -2278,7 +2278,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			class E {
 			    FI1 fi1a= x -> -1;
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    int foo(int x);
@@ -2301,7 +2301,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return -1;
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    int foo(int x);
@@ -2320,7 +2320,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    FI1 fi1b= x -> m1();
 			    int m1(){ return 0; }
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    int foo(int x);
@@ -2344,7 +2344,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    };
 			    int m1(){ return 0; }
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    int foo(int x);
@@ -2363,7 +2363,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    FI2 fi2b= x -> m1();
 			    int m1() { return 0; }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2387,7 +2387,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    };
 			    int m1() { return 0; }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2405,7 +2405,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			class E {
 			    FI2 fi2a= x -> System.out.println();
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2428,7 +2428,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        System.out.println();
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2448,7 +2448,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return x=0;
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    int foo(int x);
@@ -2469,7 +2469,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			class E {
 			    FI1 fi1= x -> x=0;
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    int foo(int x);
@@ -2492,7 +2492,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        };
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2516,7 +2516,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2535,7 +2535,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    FI2 fi2= x -> { m1(); };
 			    int m1(){ return 0; }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2557,7 +2557,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    FI2 fi2= x -> m1();
 			    int m1(){ return 0; }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2577,7 +2577,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        super.toString();
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2597,7 +2597,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			class E {
 			    FI2 fi2= x -> super.toString();
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2617,7 +2617,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        --x;
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2637,7 +2637,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			class E {
 			    FI2 fi2= x -> --x;
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2655,7 +2655,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			class E {
 			    FI2 fi2z= x -> { };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2682,7 +2682,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return;
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2709,7 +2709,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        int n= 0;
 			    };
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void foo(int x);
@@ -2743,7 +2743,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 					k.foo(3);
 				}
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    int foo(int x);
@@ -2764,7 +2764,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 					FI2 k = (e) -> extracted(a, e);
 					k.foo(3);
 				}
-			
+
 			    private int extracted(int a, int e) {
 			        int x = e + 3;
 			        if (x > 3) {
@@ -2773,7 +2773,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return x;
 			    }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    int foo(int x);
@@ -2800,7 +2800,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 					k.foo(3);
 				}
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    int foo(int x);
@@ -2820,7 +2820,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 					FI2 k = (e) -> extracted(a, e);
 					k.foo(3);
 				}
-			
+
 			    private int extracted(int a, int e) {
 			        int x = e + 3;
 			        if (x > 3) {
@@ -2829,7 +2829,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return x;
 			    }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    int foo(int x);
@@ -2849,12 +2849,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 					};
 					k.foo(3);
 				}
-			
+
 			    private int extracted(int e) {
 			        return e + 3;
 			    }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    int foo(int x);
@@ -2881,7 +2881,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 					k.foo(3);
 				}
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    int foo(int x);
@@ -2901,7 +2901,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 					FI2 k = (e) -> extracted(a, e);
 					k.foo(3);
 				}
-			
+
 			    private int extracted(int a, int e) {
 			        int x = e + 3;
 			        System.out.println("help");
@@ -2911,7 +2911,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return x;
 			    }
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    int foo(int x);
@@ -2926,7 +2926,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
 			package test1;
-			
+
 			class E {
 			    private void foo() {
 			        for (String str : new String[1]) {
@@ -2945,7 +2945,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			class E {
 			    private void foo() {
 			        String[] strings = new String[1];
@@ -3805,10 +3805,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			package test1;
 			import java.lang.annotation.*;
 			import java.util.function.*;
-			
+
 			@Target(ElementType.TYPE_USE)
 			@interface Great {}
-			
+
 			public class E10 {
 			    LongSupplier foo() {
 			        return @Great System::currentTimeMillis;
@@ -3828,10 +3828,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			package test1;
 			import java.lang.annotation.*;
 			import java.util.function.*;
-			
+
 			@Target(ElementType.TYPE_USE)
 			@interface Great {}
-			
+
 			public class E10 {
 			    LongSupplier foo() {
 			        return () -> System.currentTimeMillis();
@@ -3852,15 +3852,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = this::/*[1]*/method1;
 			        Supplier<String> v2 = this::/*[2]*/<Number>method1;
-			
+
 			        Supplier<String> n1 = E10::/*[3]*/method2;
 			        Supplier<String> n2 = E10::/*[4]*/method2a;
 			        Supplier<String> n3 = E10::/*[5]*/method3;
 			        Supplier<String> n4 = E10::/*[6]*/<Number>method2a;
-			
+
 			        Supplier<String> a1 = E10a::/*[7]*/method4;
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -3874,13 +3874,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -3904,15 +3904,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = () -> /*[1]*/method1();
 			        Supplier<String> v2 = this::/*[2]*/<Number>method1;
-			
+
 			        Supplier<String> n1 = E10::/*[3]*/method2;
 			        Supplier<String> n2 = E10::/*[4]*/method2a;
 			        Supplier<String> n3 = E10::/*[5]*/method3;
 			        Supplier<String> n4 = E10::/*[6]*/<Number>method2a;
-			
+
 			        Supplier<String> a1 = E10a::/*[7]*/method4;
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -3926,13 +3926,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -3957,15 +3957,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = this::/*[1]*/method1;
 			        Supplier<String> v2 = () -> this.<Number>method1();
-			
+
 			        Supplier<String> n1 = E10::/*[3]*/method2;
 			        Supplier<String> n2 = E10::/*[4]*/method2a;
 			        Supplier<String> n3 = E10::/*[5]*/method3;
 			        Supplier<String> n4 = E10::/*[6]*/<Number>method2a;
-			
+
 			        Supplier<String> a1 = E10a::/*[7]*/method4;
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -3979,13 +3979,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -4010,15 +4010,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = this::/*[1]*/method1;
 			        Supplier<String> v2 = this::/*[2]*/<Number>method1;
-			
+
 			        Supplier<String> n1 = () -> /*[3]*/method2();
 			        Supplier<String> n2 = E10::/*[4]*/method2a;
 			        Supplier<String> n3 = E10::/*[5]*/method3;
 			        Supplier<String> n4 = E10::/*[6]*/<Number>method2a;
-			
+
 			        Supplier<String> a1 = E10a::/*[7]*/method4;
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -4032,13 +4032,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -4063,15 +4063,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = this::/*[1]*/method1;
 			        Supplier<String> v2 = this::/*[2]*/<Number>method1;
-			
+
 			        Supplier<String> n1 = E10::/*[3]*/method2;
 			        Supplier<String> n2 = () -> /*[4]*/method2a();
 			        Supplier<String> n3 = E10::/*[5]*/method3;
 			        Supplier<String> n4 = E10::/*[6]*/<Number>method2a;
-			
+
 			        Supplier<String> a1 = E10a::/*[7]*/method4;
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -4085,13 +4085,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -4116,15 +4116,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = this::/*[1]*/method1;
 			        Supplier<String> v2 = this::/*[2]*/<Number>method1;
-			
+
 			        Supplier<String> n1 = E10::/*[3]*/method2;
 			        Supplier<String> n2 = E10::/*[4]*/method2a;
 			        Supplier<String> n3 = () -> /*[5]*/method3();
 			        Supplier<String> n4 = E10::/*[6]*/<Number>method2a;
-			
+
 			        Supplier<String> a1 = E10a::/*[7]*/method4;
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -4138,13 +4138,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -4169,15 +4169,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = this::/*[1]*/method1;
 			        Supplier<String> v2 = this::/*[2]*/<Number>method1;
-			
+
 			        Supplier<String> n1 = E10::/*[3]*/method2;
 			        Supplier<String> n2 = E10::/*[4]*/method2a;
 			        Supplier<String> n3 = E10::/*[5]*/method3;
 			        Supplier<String> n4 = () -> E10.<Number>method2a();
-			
+
 			        Supplier<String> a1 = E10a::/*[7]*/method4;
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -4191,13 +4191,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -4222,15 +4222,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    {
 			        Supplier<String> v1 = this::/*[1]*/method1;
 			        Supplier<String> v2 = this::/*[2]*/<Number>method1;
-			
+
 			        Supplier<String> n1 = E10::/*[3]*/method2;
 			        Supplier<String> n2 = E10::/*[4]*/method2a;
 			        Supplier<String> n3 = E10::/*[5]*/method3;
 			        Supplier<String> n4 = E10::/*[6]*/<Number>method2a;
-			
+
 			        Supplier<String> a1 = () -> E10a./*[7]*/method4();
 			    }
-			
+
 			    <T> String method1() {
 			        return "1";
 			    }
@@ -4244,13 +4244,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return "4";
 			    }
 			}
-			
+
 			class Sup {
 			    static String method3() {
 			        return "3";
 			    }
 			}
-			
+
 			class E10a {
 			    static String method4() {
 			        return "4";
@@ -4279,7 +4279,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Consumer<String> a2= s ->/*[2]*/ {
 			        return;
 			    };
-			
+
 			    Supplier<E1.In> a3= () ->/*[3]*/ (new E1()).new In();
 			    Supplier<E1> a4= () ->/*[4]*/ new E1() {
 			        void test() {
@@ -4287,11 +4287,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    };
 			    Function<String, Integer> a5= s ->/*[5]*/ Integer.valueOf(s+1);
-			
+
 			    BiFunction<Integer, Integer, int[][][]> a6 = (a, b) ->/*[6]*/ new int[a][b][];
 			    IntFunction<Integer[][][]> a61 = value ->/*[61]*/ new Integer[][][] {{{7, 8}}};
 			    Function<Integer, int[]> a7 = t ->/*[7]*/ new int[100];
-			
+
 			    BiFunction<Character, Integer, String> a8 = (c, i) ->/*[8]*/ super.method1();
 			    BiFunction<Character, Integer, String> a9 = (c, i) ->/*[9]*/ method1();
 			   \s
@@ -4478,17 +4478,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4511,17 +4511,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = super::method1;
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4544,17 +4544,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = E3.super::method1;
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4577,17 +4577,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = SuperE3::<Float>staticMethod1;
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4610,17 +4610,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = E3::staticMethod1;
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4643,17 +4643,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = E3::staticMethod1;
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4676,17 +4676,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = this::method1;
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4709,17 +4709,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = this::method1;
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4742,17 +4742,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = (new SuperE3<String>())::method1;
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4775,17 +4775,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = E3<Integer>::<Float>method2;
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -4809,17 +4809,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> a1 = t -> /*[1]*/super.method1(t);
 			    Function<Integer, String> a2 = t -> /*[2]*/E3.super.method1(t);
 			    Function<Integer, String> a3 = t -> /*[3]*/super.<Float>staticMethod1(t);
-			
+
 			    Function<Integer, String> s1 = t -> /*[4]*/(new E3()).staticMethod1(t);
 			    Function<Integer, String> s2 = t -> /*[5]*/staticMethod1(t);
-			
+
 			    Function<Integer, String> b1 = t -> /*[6]*/method1(t);
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
-			
+
 			    Function<E3<Integer>, String> p1 = t -> /*[9]*/t.<Float>method2();
 			    Function<E3, String> p2 = E3::method2;
-			
+
 			    <V> String method2() { return "m2";    }
 			}
 			class SuperE3<S> {
@@ -5038,16 +5038,16 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String str= """
 			package test1;
 			public class E6 {
-			
+
 			    private interface I6 {
 			        public boolean isCorrect(Object z);
 			    }
-			
+
 			    public boolean foo() {
 			        I6 x = z -> z instanceof String;
 			        return x.isCorrect(this);
 			    }
-			
+
 			}
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E6.java", str, false, null);
@@ -5060,18 +5060,67 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public class E6 {
-			
+
 			    private interface I6 {
 			        public boolean isCorrect(Object z);
 			    }
-			
+
 			    public boolean foo() {
 			        I6 x = String.class::isInstance;
 			        return x.isCorrect(this);
 			    }
-			
+
 			}
 			""";
+		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
+	public void testIssue1498() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str= """
+				package test1;
+
+				import java.util.stream.Stream;
+
+				public class E7 {
+
+					public interface IInterface {
+						public String getId();
+					}
+
+					public void foo() {
+						Stream<IInterface> ees = Stream.empty();
+						ees.map(ee -> ee.getId());
+					}
+
+				}
+				""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E7.java", str, false, null);
+
+		int offset= str.indexOf("ee ->");
+		AssistContext context= getCorrectionContext(cu, offset, 5);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		String expected1= """
+				package test1;
+
+				import java.util.stream.Stream;
+
+				public class E7 {
+
+					public interface IInterface {
+						public String getId();
+					}
+
+					public void foo() {
+						Stream<IInterface> ees = Stream.empty();
+						ees.map(IInterface::getId);
+					}
+
+				}
+				""";
 		assertExpectedExistInProposals(proposals, new String[] { expected1 });
 	}
 
@@ -5081,17 +5130,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String str= """
 			package test1;
 			import java.util.function.Supplier;
-			
+
 			public class E {
 			    void func( String ... args) {
 			    }
-			
+
 			    private void called( Supplier<Object> r ) {
 			    }
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called(() -> func());
 			    }
@@ -5108,17 +5157,17 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected1= """
 			package test1;
 			import java.util.function.Supplier;
-			
+
 			public class E {
 			    void func( String ... args) {
 			    }
-			
+
 			    private void called( Supplier<Object> r ) {
 			    }
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called((Runnable) this::func);
 			    }
@@ -5133,25 +5182,25 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String str= """
 			package test1;
 			import java.util.function.Supplier;
-			
+
 			public class E1 {
 			    private void called( Supplier<Object> r ) {
 			    }
-			
+
 			}
 			""";
 		pack1.createCompilationUnit("E1.java", str, false, null);
 
 		String str1= """
 			package test1;
-			
+
 			public class E extends E1 {
 			    void func( String ... args) {
 			    }
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called(() -> func());
 			    }
@@ -5166,14 +5215,14 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertCorrectLabels(proposals);
 		String expected1= """
 			package test1;
-			
+
 			public class E extends E1 {
 			    void func( String ... args) {
 			    }
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called((Runnable) this::func);
 			    }
@@ -5188,25 +5237,25 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String str= """
 			package test1;
 			import java.util.function.Supplier;
-			
+
 			public class E1 {
 			    void func( String ... args) {
 			    }
 			    private void called( Supplier<Object> r ) {
 			    }
-			
+
 			}
 			""";
 		pack1.createCompilationUnit("E1.java", str, false, null);
 
 		String str1= """
 			package test1;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called(() -> super.func());
 			    }
@@ -5221,12 +5270,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertCorrectLabels(proposals);
 		String expected1= """
 			package test1;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called((Runnable) super::func);
 			    }
@@ -5241,25 +5290,25 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String str= """
 			package test1;
 			import java.util.function.Supplier;
-			
+
 			public class E1 {
 			    public static void func( String ... args) {
 			    }
 			    private void called( Supplier<Object> r ) {
 			    }
-			
+
 			}
 			""";
 		pack1.createCompilationUnit("E1.java", str, false, null);
 
 		String str1= """
 			package test1;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called(() -> E1.func());
 			    }
@@ -5274,12 +5323,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertCorrectLabels(proposals);
 		String expected1= """
 			package test1;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
 			    }
-			
+
 			    void test() {
 			        called((Runnable) E1::func);
 			    }
@@ -5425,10 +5474,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
 			package test1;
-			
+
 			import java.util.Comparator;
 			import java.util.List;
-			
+
 			public class Lambda1 {
 				Comparator<List<?>> c = (l1, l2) -> Integer.compare(l1.size(), l2.size());
 			}
@@ -5442,10 +5491,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			import java.util.Comparator;
 			import java.util.List;
-			
+
 			public class Lambda1 {
 				Comparator<List<?>> c = (List<?> l1, List<?> l2) -> Integer.compare(l1.size(), l2.size());
 			}
@@ -5454,10 +5503,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import java.util.Comparator;
 			import java.util.List;
-			
+
 			public class Lambda1 {
 				Comparator<List<?>> c = new Comparator<List<?>>() {
 			        @Override
@@ -5489,16 +5538,16 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			public class Lambda2 {
 				interface Sink<T> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<? extends Number> source) {
 					source.sendTo(a -> a.doubleValue());
 				}
@@ -5512,16 +5561,16 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			public class Lambda2 {
 				interface Sink<T> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<? extends Number> source) {
 					source.sendTo(Number::doubleValue);
 				}
@@ -5532,16 +5581,16 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str3= """
 			package test1;
-			
+
 			public class Lambda2 {
 				interface Sink<T> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<? extends Number> source) {
 					source.sendTo((Number a) -> a.doubleValue());
 				}
@@ -5551,16 +5600,16 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str4= """
 			package test1;
-			
+
 			public class Lambda2 {
 				interface Sink<T> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<? extends Number> source) {
 					source.sendTo(new Sink<Number>() {
 			            @Override
@@ -5593,18 +5642,18 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			import java.math.BigDecimal;
-			
+
 			public class Lambda3 {
 				interface Sink<T extends Number> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends BigDecimal> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo(a -> a.scale());
 				}
@@ -5618,18 +5667,18 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import java.math.BigDecimal;
-			
+
 			public class Lambda3 {
 				interface Sink<T extends Number> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends BigDecimal> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo(BigDecimal::scale);
 				}
@@ -5640,18 +5689,18 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str3= """
 			package test1;
-			
+
 			import java.math.BigDecimal;
-			
+
 			public class Lambda3 {
 				interface Sink<T extends Number> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends BigDecimal> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo((BigDecimal a) -> a.scale());
 				}
@@ -5661,18 +5710,18 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str4= """
 			package test1;
-			
+
 			import java.math.BigDecimal;
-			
+
 			public class Lambda3 {
 				interface Sink<T extends Number> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends BigDecimal> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo(new Sink<BigDecimal>() {
 			            @Override
@@ -5705,19 +5754,19 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			import java.util.ArrayList;
 			import java.util.List;
-			
+
 			public class Lambda4 {
 				interface Sink<T extends List<Number>> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends ArrayList<Number>> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo(a -> a.size());
 				}
@@ -5731,19 +5780,19 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import java.util.ArrayList;
 			import java.util.List;
-			
+
 			public class Lambda4 {
 				interface Sink<T extends List<Number>> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends ArrayList<Number>> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo(ArrayList<Number>::size);
 				}
@@ -5754,19 +5803,19 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str3= """
 			package test1;
-			
+
 			import java.util.ArrayList;
 			import java.util.List;
-			
+
 			public class Lambda4 {
 				interface Sink<T extends List<Number>> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends ArrayList<Number>> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo((ArrayList<Number> a) -> a.size());
 				}
@@ -5776,19 +5825,19 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str4= """
 			package test1;
-			
+
 			import java.util.ArrayList;
 			import java.util.List;
-			
+
 			public class Lambda4 {
 				interface Sink<T extends List<Number>> {
 					void receive(T t);
 				}
-			
+
 				interface Source<U extends ArrayList<Number>> {
 					void sendTo(Sink<? super U> c);
 				}
-			
+
 				void f(Source<?> source) {
 					source.sendTo(new Sink<ArrayList<Number>>() {
 			            @Override
@@ -5815,7 +5864,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String str= """
 			@NonNullByDefault({ PARAMETER, RETURN_TYPE, FIELD, TYPE_BOUND, TYPE_ARGUMENT, ARRAY_CONTENTS })
 			package test1;
-			
+
 			import static org.eclipse.jdt.annotation.DefaultLocation.*;
 			import org.eclipse.jdt.annotation.NonNullByDefault;
 			""";
@@ -5828,10 +5877,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			import java.lang.annotation.ElementType;
 			import java.lang.annotation.Target;
-			
+
 			@Target(ElementType.TYPE_USE)
 			@interface X {}
 			""";
@@ -5839,10 +5888,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str2= """
 			package test1;
-			
+
 			import java.lang.annotation.ElementType;
 			import java.lang.annotation.Target;
-			
+
 			@Target(ElementType.TYPE_USE)
 			@interface Y {}
 			""";
@@ -5850,10 +5899,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str3= """
 			package test1;
-			
+
 			import java.lang.annotation.ElementType;
 			import java.lang.annotation.Target;
-			
+
 			@Target(ElementType.TYPE_USE)
 			@interface Z {}
 			""";
@@ -5861,14 +5910,14 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str4= """
 			package test1;
-			
+
 			class Ref<A> {}
 			""";
 		pack1.createCompilationUnit("Ref.java", str4, false, null);
 
 		String str5= """
 			package test1;
-			
+
 			interface SAM<A> {
 				void f(A[] a);
 			}
@@ -5877,7 +5926,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str6= """
 			package test1;
-			
+
 			public class Test {
 				static int nn(Object o) {
 					return 0;
@@ -5890,9 +5939,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str7= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN1 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					@NonNullByDefault({})
@@ -5909,9 +5958,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str8= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN2 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					SAM<? super @NonNull Ref<? extends @NonNull @Y Ref<@X @Nullable String @Y @NonNull [] @Z @NonNull []>>> sam0 = a0 -> Test.nn(a0);
@@ -5930,9 +5979,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str9= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN1 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					@NonNullByDefault({})
@@ -5946,9 +5995,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str10= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN2 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					SAM<? super @NonNull Ref<? extends @NonNull @Y Ref<@X @Nullable String @Y @NonNull [] @Z @NonNull []>>> sam0 = Test::nn;
@@ -5962,9 +6011,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str11= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN1 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					@NonNullByDefault({})
@@ -5977,9 +6026,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str12= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN2 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					SAM<? super @NonNull Ref<? extends @NonNull @Y Ref<@X @Nullable String @Y @NonNull [] @Z @NonNull []>>> sam0 = (Ref<? extends @Y Ref<@X @Nullable String @Y [] @Z []>>[] a0) -> Test.nn(a0);
@@ -5992,9 +6041,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		// --- Convert to anonymous class creation without and with NNBD --
 		String str13= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN1 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					@NonNullByDefault({})
@@ -6013,9 +6062,9 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str14= """
 			package test1;
-			
+
 			import org.eclipse.jdt.annotation.*;
-			
+
 			public class LambdaNN2 {
 				void g(Ref<? extends Ref<@X @Nullable String @Y [] @Z []>>[] data) {
 					SAM<? super @NonNull Ref<? extends @NonNull @Y Ref<@X @Nullable String @Y @NonNull [] @Z @NonNull []>>> sam0 = new SAM<Ref<? extends @Y Ref<@X @Nullable String @Y [] @Z []>>>() {
@@ -6036,15 +6085,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
 			package test1;
-			
+
 			public class Example {
 				@java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
 				public @interface X {}
-			
+
 				interface SAM<T> {
 					T f(T t);
 				}
-			
+
 				@X
 				SAM<String> c = a -> a;
 			}
@@ -6057,15 +6106,15 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String str1= """
 			package test1;
-			
+
 			public class Example {
 				@java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
 				public @interface X {}
-			
+
 				interface SAM<T> {
 					T f(T t);
 				}
-			
+
 				@X
 				SAM<String> c = new @X SAM<String>() {
 			        @Override
@@ -6167,11 +6216,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			import java.io.IOException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws IOException {
 			        /*1*/Socket s = new Socket(), s2 = new Socket();
@@ -6181,7 +6230,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        System.out.println(is.markSupported());/*0*/
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 		String strEnd= "/*0*/";
@@ -6198,11 +6247,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected1= """
 			package p;
-			
+
 			import java.io.IOException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws IOException {
 			        try (/*1*/Socket s = new Socket();
@@ -6214,7 +6263,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		assertEqualStringsIgnoreOrder(new String[] { preview1 }, new String[] { expected1 });
@@ -6231,11 +6280,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected2= """
 			package p;
-			
+
 			import java.io.IOException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws IOException {
 			        /*1*/Socket s = new Socket(), s2 = new Socket();
@@ -6246,7 +6295,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		assertEqualStringsIgnoreOrder(new String[] { preview2 }, new String[] { expected2 });
@@ -6263,12 +6312,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws FileNotFoundException {
 			        /*1*/Socket s = new Socket(), s2 = new Socket();
@@ -6279,7 +6328,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        System.out.println(is.markSupported());/*0*/
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 		String strEnd= "/*0*/";
@@ -6296,13 +6345,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected1= """
 			package p;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.IOException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws FileNotFoundException {
 			        try (/*1*/Socket s = new Socket();
@@ -6320,7 +6369,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		assertEqualStringsIgnoreOrder(new String[] { preview1 }, new String[] { expected1 });
@@ -6337,13 +6386,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected2= """
 			package p;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.IOException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws FileNotFoundException {
 			        /*1*/Socket s = new Socket(), s2 = new Socket();
@@ -6360,7 +6409,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		assertEqualStringsIgnoreOrder(new String[] { preview2 }, new String[] { expected2 });
@@ -6377,12 +6426,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() {
 			        try {
@@ -6396,7 +6445,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 		String strEnd= "/*0*/";
@@ -6412,13 +6461,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected1= """
 			package p;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.IOException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() {
 			        try (/*1*/Socket s = new Socket();
@@ -6435,7 +6484,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		assertEqualStringsIgnoreOrder(new String[] { preview1 }, new String[] { expected1 });
@@ -6446,12 +6495,12 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws FileNotFoundException {
 			        try {
@@ -6465,7 +6514,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 		String strEnd= "/*0*/";
@@ -6481,13 +6530,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected1= """
 			package p;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.IOException;
 			import java.io.InputStream;
 			import java.net.Socket;
-			
+
 			public class E {
 			    public void foo() throws FileNotFoundException {
 			        try (/*1*/Socket s = new Socket();
@@ -6504,7 +6553,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		assertEqualStringsIgnoreOrder(new String[] { preview1 }, new String[] { expected1 });
@@ -6516,10 +6565,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			import java.io.File;
 			import java.util.stream.Stream;
-			
+
 			public class X {
 				public static void main(String[] args) throws Exception {
 					try {
@@ -6545,10 +6594,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 
 		String expected1= """
 			package p;
-			
+
 			import java.io.File;
 			import java.util.stream.Stream;
-			
+
 			public class X {
 				public static void main(String[] args) throws Exception {
 					try {
@@ -6704,10 +6753,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.IOException;
-			
+
 			class E {
 			    void f() throws IOException {
 			        new FileInputStream("f");
@@ -6725,10 +6774,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.IOException;
-			
+
 			class E {
 			    void f() throws IOException {
 			        try (FileInputStream fileInputStream = new FileInputStream("f")) {
@@ -6746,10 +6795,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
-			
+
 			class E {
 			    void f() throws FileNotFoundException {
 			        new FileInputStream("f");
@@ -6767,11 +6816,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.IOException;
-			
+
 			class E {
 			    void f() throws FileNotFoundException {
 			        try (FileInputStream fileInputStream = new FileInputStream("f")) {
@@ -6794,10 +6843,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
-			
+
 			class E {
 			    void f() {
 			        try {
@@ -6819,11 +6868,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.IOException;
-			
+
 			class E {
 			    void f() {
 			        try (FileInputStream fileInputStream = new FileInputStream("f")) {
@@ -6845,10 +6894,10 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
-			
+
 			class E {
 			    void f() throws FileNotFoundException {
 			        try {
@@ -6871,11 +6920,11 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			import java.io.FileInputStream;
 			import java.io.FileNotFoundException;
 			import java.io.IOException;
-			
+
 			class E {
 			    void f() throws FileNotFoundException {
 			        try {
@@ -6903,13 +6952,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			import java.io.BufferedReader;
 			import java.io.FileNotFoundException;
 			import java.io.FileReader;
 			import java.io.IOException;
 			import java.io.Reader;
-			
+
 			class E {
 			    public void foo() {
 			        try (Reader s = new BufferedReader(new FileReader("c.d"));
@@ -6933,13 +6982,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			import java.io.BufferedReader;
 			import java.io.FileNotFoundException;
 			import java.io.FileReader;
 			import java.io.IOException;
 			import java.io.Reader;
-			
+
 			class E {
 			    public void foo() {
 			        try (Reader s = new BufferedReader(new FileReader("c.d"))) {
@@ -6965,13 +7014,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			import java.io.BufferedReader;
 			import java.io.FileNotFoundException;
 			import java.io.FileReader;
 			import java.io.IOException;
 			import java.io.Reader;
-			
+
 			class E {
 			    public void foo() {
 			        try (Reader s = new BufferedReader(new FileReader("c.d"));
@@ -6995,13 +7044,13 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			import java.io.BufferedReader;
 			import java.io.FileNotFoundException;
 			import java.io.FileReader;
 			import java.io.IOException;
 			import java.io.Reader;
-			
+
 			class E {
 			    public void foo() {
 			        try (Reader s = new BufferedReader(new FileReader("c.d"));
@@ -7030,7 +7079,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			class E {
 			    private class E1 {
 			        public int foo(int a, int b) {
@@ -7066,7 +7115,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			class E {
 			    private class E1 {
 			        public int foo(int a, int b) {
@@ -7104,7 +7153,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			class E {
 			    private class E1 {
 			        public int foo(int a, int b) {
@@ -7145,7 +7194,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			class E {
 			    private class E1 {
 			        private int v = 5;
@@ -7182,7 +7231,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			class E {
 			    private class E1 {
 			        private int v = 5;
@@ -7220,7 +7269,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			public class E1 {
 			    private int v = 5;
 			    public int foo(int a, int b) {
@@ -7243,7 +7292,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src1=
 				"""
 			package test1;
-			
+
 			class E {
 			    public int callfoo(int a, int b, int c) {
 			        E1 e1= new E1();
@@ -7268,7 +7317,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			public class E1 {
 			    public int v = 5;
 			    public int foo(int a, int b) {
@@ -7291,7 +7340,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src1=
 				"""
 			package test1;
-			
+
 			class E {
 			    public int callfoo(int a, int b, int c) {
 			        E1 e1= new E1();
@@ -7308,7 +7357,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected=
 				"""
 			package test1;
-			
+
 			class E {
 			    public int callfoo(int a, int b, int c) {
 			        E1 e1= new E1();
@@ -7329,7 +7378,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src=
 				"""
 			package test1;
-			
+
 			public class E1 {
 			    public int v = 5;
 			    public int foo(int a, int b) {
@@ -7346,7 +7395,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String src1=
 				"""
 			package test1;
-			
+
 			class E {
 			    public int callfoo(int a, int b, int c) {
 			        E1 e1= new E1();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -439,23 +439,23 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			public class C1 {
 			    interface IOverwriteQuery {
 			        String ALL = "ALL";
-			
+
 			        String queryOverwrite(String pathString);
 			    }
-			
+
 			    class ImportOperation {
 			        public ImportOperation(IOverwriteQuery query) {
 			        }
 			    }
-			
+
 			    public C1() {
 			        ImportOperation io = new ImportOperation(new IOverwriteQuery() {
-			
+
 			            @Override
 			            public String queryOverwrite(String pathString) {
 			                return ALL;
 			            }
-			
+
 			        });
 			    }
 			}
@@ -471,15 +471,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			public class C1 {
 			    interface IOverwriteQuery {
 			        String ALL = "ALL";
-			
+
 			        String queryOverwrite(String pathString);
 			    }
-			
+
 			    class ImportOperation {
 			        public ImportOperation(IOverwriteQuery query) {
 			        }
 			    }
-			
+
 			    public C1() {
 			        ImportOperation io = new ImportOperation(pathString -> IOverwriteQuery.ALL);
 			    }
@@ -495,13 +495,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			public class E {
 			    @FunctionalInterface
 			    interface FI1 extends Runnable {
 			        int CONSTANT_VALUE = 123;
 			    }
-			
+
 			    void foo() {
 			        Runnable r = new FI1() {
 			            @Override
@@ -519,13 +519,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test;
-			
+
 			public class E {
 			    @FunctionalInterface
 			    interface FI1 extends Runnable {
 			        int CONSTANT_VALUE = 123;
 			    }
-			
+
 			    void foo() {
 			        Runnable r = () -> System.out.println(FI1.CONSTANT_VALUE);
 			    };
@@ -591,25 +591,25 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			interface ISuper {
 			    void foo(FI1 fi1);
 			}
-			
+
 			interface ISub extends ISuper {
 			    void foo(FI2 fi2);
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    void abc();
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void xyz();
 			}
-			
+
 			class Test1 {
 			    private void test1() {
 			        f1().foo(new FI1() {
@@ -618,14 +618,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                System.out.println();
 			            }
 			        });
-			
+
 			    }
 			   \s
 			    private ISub f1() {
 			        return null;
 			    }
 			}
-			
+
 			abstract class Test2 implements ISub {
 			    private void test2() {
 			        foo(new FI1() {
@@ -636,7 +636,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        });
 			    }
 			}
-			
+
 			class Test3 {
 			    void foo(FI1 fi1) {}
 			    void foo(FI2 fi2) {}
@@ -649,7 +649,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        });
 			    }
 			}
-			
+
 			class Outer {
 			    class Test4 {
 			        {
@@ -672,42 +672,42 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test;
-			
+
 			interface ISuper {
 			    void foo(FI1 fi1);
 			}
-			
+
 			interface ISub extends ISuper {
 			    void foo(FI2 fi2);
 			}
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    void abc();
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void xyz();
 			}
-			
+
 			class Test1 {
 			    private void test1() {
 			        f1().foo((FI1) () -> System.out.println());
-			
+
 			    }
 			   \s
 			    private ISub f1() {
 			        return null;
 			    }
 			}
-			
+
 			abstract class Test2 implements ISub {
 			    private void test2() {
 			        foo((FI1) () -> System.out.println());
 			    }
 			}
-			
+
 			class Test3 {
 			    void foo(FI1 fi1) {}
 			    void foo(FI2 fi2) {}
@@ -715,7 +715,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        foo((FI1) () -> System.out.println());
 			    }
 			}
-			
+
 			class Outer {
 			    class Test4 {
 			        {
@@ -743,17 +743,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    void abc();
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void xyz();
 			}
-			
+
 			class Outer {
 			    void outer(FI1 fi1) {}
 			}
@@ -792,7 +792,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			    void outer(FI1 fi1) {}
 			    void outer(FI2 fi2) {}
 			}
-			
+
 			class OuterSub2 extends OuterSub {
 			    OuterSub2() {
 			        super.outer(new FI1() {
@@ -834,17 +834,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test;
-			
+
 			@FunctionalInterface
 			interface FI1 {
 			    void abc();
 			}
-			
+
 			@FunctionalInterface
 			interface FI2 {
 			    void xyz();
 			}
-			
+
 			class Outer {
 			    void outer(FI1 fi1) {}
 			}
@@ -863,7 +863,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			    void outer(FI1 fi1) {}
 			    void outer(FI2 fi2) {}
 			}
-			
+
 			class OuterSub2 extends OuterSub {
 			    OuterSub2() {
 			        super.outer((FI1) () -> System.out.println());
@@ -908,17 +908,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        });
 			    }
-			
+
 			    void bar(int i, FI fi);
 			    void bar(int i, FV fv);
-			
+
 			    void baz(int i, ZI zi);
 			    void baz(int i, ZV zv);
 			}
-			
+
 			@FunctionalInterface interface FI { int  foo(int a); }
 			@FunctionalInterface interface FV { void foo(int a); }
-			
+
 			@FunctionalInterface interface ZI { int  zoo(); }
 			@FunctionalInterface interface ZV { void zoo(); }
 			""";
@@ -935,17 +935,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        bar(0, (FI) x -> x++);
 			        baz(0, () -> 1);
 			    }
-			
+
 			    void bar(int i, FI fi);
 			    void bar(int i, FV fv);
-			
+
 			    void baz(int i, ZI zi);
 			    void baz(int i, ZV zv);
 			}
-			
+
 			@FunctionalInterface interface FI { int  foo(int a); }
 			@FunctionalInterface interface FV { void foo(int a); }
-			
+
 			@FunctionalInterface interface ZI { int  zoo(); }
 			@FunctionalInterface interface ZV { void zoo(); }
 			""";
@@ -964,11 +964,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test1;
-			
+
 			interface FI {
 			    void run(int x);
 			}
-			
+
 			public class Test {
 			    {
 			        int e;
@@ -994,7 +994,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                            }
 			                        });
 			                    }
-			
+
 			                    void init2() {
 			                        m(new FI() {
 			                            @Override
@@ -1017,7 +1017,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			    }
-			
+
 			    void m(FI fi) {
 			    };
 			}
@@ -1030,11 +1030,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test1;
-			
+
 			interface FI {
 			    void run(int x);
 			}
-			
+
 			public class Test {
 			    {
 			        int e;
@@ -1049,7 +1049,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                        };
 			                    });
 			                }
-			
+
 			                void init2() {
 			                    m(e2 -> new FI() {
 			                        @Override
@@ -1063,7 +1063,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			    }
-			
+
 			    void m(FI fi) {
 			    };
 			}
@@ -1078,7 +1078,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
 		String original= """
 			package test;
-			
+
 			interface FI {
 			    void doIt(String p);
 			}
@@ -1102,7 +1102,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String fixed= """
 			package test;
-			
+
 			interface FI {
 			    void doIt(String p);
 			}
@@ -1305,11 +1305,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			interface I<M> {
 			    M run(M x);
 			}
-			
+
 			class Test {
 			    I<?> li = s -> null;
 			}
@@ -1322,11 +1322,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test;
-			
+
 			interface I<M> {
 			    M run(M x);
 			}
-			
+
 			class Test {
 			    I<?> li = new I<Object>() {
 			        @Override
@@ -1352,7 +1352,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			interface Foo<T, N extends Number> {
 			    void m(T t);
 			    void m(N n);
@@ -1370,7 +1370,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test;
-			
+
 			interface Foo<T, N extends Number> {
 			    void m(T t);
 			    void m(N n);
@@ -1399,7 +1399,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			public class Snippet {
 			    void test(Interface context) {
 			        context.set("bar", new Runnable() {
@@ -1409,7 +1409,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			       \s
 			    }   \s
 			}
-			
+
 			interface Interface {
 			    public void set(String name, Object value);
 			}
@@ -1422,14 +1422,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test;
-			
+
 			public class Snippet {
 			    void test(Interface context) {
 			        context.set("bar", (Runnable) () -> {});
 			       \s
 			    }   \s
 			}
-			
+
 			interface Interface {
 			    public void set(String name, Object value);
 			}
@@ -1477,17 +1477,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			public class C1 {
 			    final String s;
-			
+
 			    Runnable run1 = new Runnable() {
 			        @Override
 			        public void run() {
 			            System.out.println(s);
 			        }
 			    };
-			
+
 			    public C1() {
 			        s = "abc";
 			    };
@@ -1537,17 +1537,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			public class C1 {
 			    static final String previousField = "abc";
-			
+
 			    Runnable run1 = new Runnable() {
 			        @Override
 			        public void run() {
 			            System.out.println(previousField + instanceField + classField + getString());
 			        }
 			    };
-			
+
 			    static final String classField = "abc";
 			    final String instanceField = "abc";
 			    public String getString() {
@@ -1562,12 +1562,12 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			package test;
-			
+
 			public class C1 {
 			    static final String previousField = "abc";
-			
+
 			    Runnable run1 = () -> System.out.println(previousField + this.instanceField + C1.classField + getString());
-			
+
 			    static final String classField = "abc";
 			    final String instanceField = "abc";
 			    public String getString() {
@@ -1583,17 +1583,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			public class C1 {
 			    static final String previousField = "abc";
-			
+
 			    Runnable run1 = new Runnable() {
 			        @Override
 			        public void run() {
 			            System.out.println(C1.previousField + C1.this.instanceField + C1.classField + C1.this.getString());
 			        }
 			    };
-			
+
 			    static final String classField = "def";
 			    final String instanceField = "abc";
 			    public String getString() {
@@ -1608,12 +1608,12 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			package test;
-			
+
 			public class C1 {
 			    static final String previousField = "abc";
-			
+
 			    Runnable run1 = () -> System.out.println(C1.previousField + this.instanceField + C1.classField + this.getString());
-			
+
 			    static final String classField = "def";
 			    final String instanceField = "abc";
 			    public String getString() {
@@ -1630,10 +1630,10 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given= """
 			package test1;
-			
+
 			import static java.util.Calendar.getInstance;
 			import static java.util.Calendar.getAvailableLocales;
-			
+
 			import java.time.Instant;
 			import java.util.ArrayList;
 			import java.util.Calendar;
@@ -1643,91 +1643,91 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			import java.util.function.BiFunction;
 			import java.util.function.Function;
 			import java.util.function.Supplier;
-			
+
 			public class E extends Date {
 			    public String changeableText = "foo";
-			
+
 			    public Function<String, String> removeParentheses() {
 			        return (someString) -> someString.trim().toLowerCase();
 			    }
-			
+
 			    public Function<String, String> removeReturnAndBrackets() {
 			        return someString -> {return someString.trim().toLowerCase();};
 			    }
-			
+
 			    public Function<String, String> removeReturnAndBracketsWithParentheses() {
 			        return (someString) -> {return someString.trim().toLowerCase() + "bar";};
 			    }
-			
+
 			    public Supplier<ArrayList<String>> useCreationReference() {
 			        return () -> { return new ArrayList<>(); };
 			    }
-			
+
 			    public Function<Integer, ArrayList<String>> useCreationReferenceWithParameter() {
 			        return (capacity) -> new ArrayList<>(capacity);
 			    }
-			
+
 			    public Function<Integer, ArrayList<String>> useCreationReferenceWithParameterAndType() {
 			        // TODO this can be refactored like useCreationReferenceWithParameter
 			        return (Integer capacity) -> new ArrayList<>(capacity);
 			    }
-			
+
 			    public BiFunction<Integer, Integer, Vector<String>> useCreationReferenceWithParameters() {
 			        return (initialCapacity, capacityIncrement) -> new Vector<>(initialCapacity, capacityIncrement);
 			    }
-			
+
 			    public Function<Date, Long> useMethodReference() {
 			        return date -> date.getTime();
 			    }
-			
+
 			    public BiFunction<Date, Date, Integer> useMethodReferenceWithParameter() {
 			        return (date, anotherDate) -> date.compareTo(anotherDate);
 			    }
-			
+
 			    public static Function<String, Long> useTypeReference() {
 			        return (numberInText) -> { return Long.getLong(numberInText); };
 			    }
-			
+
 			    public static Function<Locale, Calendar> useTypeReferenceOnImportedMethod() {
 			        return locale -> Calendar.getInstance(locale);
 			    }
-			
+
 			    public static Supplier<Locale[]> useTypeReferenceAsSupplier() {
 			        return () -> Calendar.getAvailableLocales();
 			    }
-			
+
 			    public Function<String, Integer> useExpressionMethodReferenceOnLiteral() {
 			        return textToSearch -> "AutoRefactor".indexOf(textToSearch);
 			    }
-			
+
 			    public Function<Date, Integer> useThisMethodReference() {
 			        return anotherDate -> compareTo(anotherDate);
 			    }
-			
+
 			    public Function<Date, Integer> useThisMethodReferenceAddThis() {
 			        return anotherDate -> this.compareTo(anotherDate);
 			    }
-			
+
 			    public Function<Date, Integer> useSuperMethodReference() {
 			        return anotherDate -> super.compareTo(anotherDate);
 			    }
-			
+
 			    public static Integer dummy(String arg) {
 			        return 0;
 			    }
-			
+
 			    public static Function<String, Integer> useTypeReferenceQualifyingLocalType() {
 			        return numberInText -> E.dummy(numberInText);
 			    }
-			
+
 			    public static Function<String, Integer> useTypeReferenceFullyQualifyingLocalType() {
 			        return numberInText -> test1.E.dummy(numberInText);
 			    }
-			
+
 			    public static Function<String, Integer> useTypeReferenceOnLocalType() {
 			        return numberInText -> dummy(numberInText);
 			    }
-			
+
 			    public static Function<Instant, java.sql.Date> useTypeReferenceQualifyingInheritedType() {
 			        return instant -> java.sql.Date.from(instant);
 			    }
@@ -1736,10 +1736,10 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			package test1;
-			
+
 			import static java.util.Calendar.getInstance;
 			import static java.util.Calendar.getAvailableLocales;
-			
+
 			import java.time.Instant;
 			import java.util.ArrayList;
 			import java.util.Calendar;
@@ -1749,91 +1749,91 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			import java.util.function.BiFunction;
 			import java.util.function.Function;
 			import java.util.function.Supplier;
-			
+
 			public class E extends Date {
 			    public String changeableText = "foo";
-			
+
 			    public Function<String, String> removeParentheses() {
 			        return someString -> someString.trim().toLowerCase();
 			    }
-			
+
 			    public Function<String, String> removeReturnAndBrackets() {
 			        return someString -> someString.trim().toLowerCase();
 			    }
-			
+
 			    public Function<String, String> removeReturnAndBracketsWithParentheses() {
 			        return someString -> (someString.trim().toLowerCase() + "bar");
 			    }
-			
+
 			    public Supplier<ArrayList<String>> useCreationReference() {
 			        return ArrayList::new;
 			    }
-			
+
 			    public Function<Integer, ArrayList<String>> useCreationReferenceWithParameter() {
 			        return ArrayList::new;
 			    }
-			
+
 			    public Function<Integer, ArrayList<String>> useCreationReferenceWithParameterAndType() {
 			        // TODO this can be refactored like useCreationReferenceWithParameter
 			        return (Integer capacity) -> new ArrayList<>(capacity);
 			    }
-			
+
 			    public BiFunction<Integer, Integer, Vector<String>> useCreationReferenceWithParameters() {
 			        return Vector::new;
 			    }
-			
+
 			    public Function<Date, Long> useMethodReference() {
 			        return Date::getTime;
 			    }
-			
+
 			    public BiFunction<Date, Date, Integer> useMethodReferenceWithParameter() {
 			        return Date::compareTo;
 			    }
-			
+
 			    public static Function<String, Long> useTypeReference() {
 			        return Long::getLong;
 			    }
-			
+
 			    public static Function<Locale, Calendar> useTypeReferenceOnImportedMethod() {
 			        return Calendar::getInstance;
 			    }
-			
+
 			    public static Supplier<Locale[]> useTypeReferenceAsSupplier() {
 			        return Calendar::getAvailableLocales;
 			    }
-			
+
 			    public Function<String, Integer> useExpressionMethodReferenceOnLiteral() {
 			        return "AutoRefactor"::indexOf;
 			    }
-			
+
 			    public Function<Date, Integer> useThisMethodReference() {
 			        return this::compareTo;
 			    }
-			
+
 			    public Function<Date, Integer> useThisMethodReferenceAddThis() {
 			        return this::compareTo;
 			    }
-			
+
 			    public Function<Date, Integer> useSuperMethodReference() {
 			        return super::compareTo;
 			    }
-			
+
 			    public static Integer dummy(String arg) {
 			        return 0;
 			    }
-			
+
 			    public static Function<String, Integer> useTypeReferenceQualifyingLocalType() {
 			        return E::dummy;
 			    }
-			
+
 			    public static Function<String, Integer> useTypeReferenceFullyQualifyingLocalType() {
 			        return E::dummy;
 			    }
-			
+
 			    public static Function<String, Integer> useTypeReferenceOnLocalType() {
 			        return E::dummy;
 			    }
-			
+
 			    public static Function<Instant, java.sql.Date> useTypeReferenceQualifyingInheritedType() {
 			        return java.sql.Date::from;
 			    }
@@ -1851,21 +1851,72 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testIssue1498() throws Exception {
+		// Given
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
+		String given= """
+				package test1;
+
+				import java.util.stream.Stream;
+
+				public class E {
+
+					public interface IInterface {
+						public String getId();
+					}
+
+					public void foo() {
+						Stream<IInterface> ees = Stream.empty();
+						ees.map(ee -> ee.getId());
+					}
+
+				}
+				""";
+
+		String expected= """
+				package test1;
+
+				import java.util.stream.Stream;
+
+				public class E {
+
+					public interface IInterface {
+						public String getId();
+					}
+
+					public void foo() {
+						Stream<IInterface> ees = Stream.empty();
+						ees.map(IInterface::getId);
+					}
+
+				}
+				""";
+		// When
+		ICompilationUnit cu= pack.createCompilationUnit("E.java", given, false, null);
+		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
+
+		// Then
+		assertNotEquals("The class must be changed", given, expected);
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
+				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
+	}
+
+	@Test
 	public void testDoNotSimplifyLambdaExpression() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """
 			package test1;
-			
+
 			import java.util.ArrayList;
 			import java.util.Date;
 			import java.util.Vector;
 			import java.util.function.BiFunction;
 			import java.util.function.Function;
 			import java.util.function.Supplier;
-			
+
 			public class E extends Date {
 			    public String changeableText = "foo";
-			
+
 			    public Supplier<Date> doNotRefactorWithAnonymousBody() {
 			        return () -> new Date() {
 			            @Override
@@ -1874,46 +1925,46 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			    }
-			
+
 			    public Function<String, String> doNotRemoveParenthesesWithSingleVariableDeclaration() {
 			        return (String someString) -> someString.trim().toLowerCase();
 			    }
-			
+
 			    public BiFunction<String, String, Integer> doNotRemoveParenthesesWithTwoParameters() {
 			        return (someString, anotherString) -> someString.trim().compareTo(anotherString.trim());
 			    }
-			
+
 			    public Supplier<Boolean> doNotRemoveParenthesesWithNoParameter() {
 			        return () -> {System.out.println("foo");return true;};
 			    }
-			
+
 			    public Function<String, String> doNotRemoveReturnWithSeveralStatements() {
 			        return someString -> {String trimmed = someString.trim();
 			        return trimmed.toLowerCase();};
 			    }
-			
+
 			    public Function<Integer, ArrayList<String>> doNotRefactorWithExpressions() {
 			        return capacity -> new ArrayList<>(capacity + 1);
 			    }
-			
+
 			    public BiFunction<Integer, Integer, Vector<String>> doNotRefactorShuffledParams() {
 			        return (initialCapacity, capacityIncrement) -> new Vector<>(capacityIncrement, initialCapacity);
 			    }
-			
+
 			    public Function<String, Integer> doNotUseExpressionMethodReferenceOnVariable() {
 			        return textToSearch -> this.changeableText.indexOf(textToSearch);
 			    }
-			
+
 			    public class InnerClass {
 			        public Function<Date, Integer> doNotUseThisMethodReferenceOnTopLevelClassMethod() {
 			            return anotherDate -> compareTo(anotherDate);
 			        }
 			    }
-			
+
 			    public Function<Integer, String> doNotUseConflictingMethodReference() {
 			        return numberToPrint -> numberToPrint.toString();
 			    }
-			
+
 			    public Function<Integer, String> doNotUseConflictingStaticMethodReference() {
 			        return numberToPrint -> Integer.toString(numberToPrint);
 			    }
@@ -1932,17 +1983,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given= """
 			import java.util.function.Supplier;
-			
+
 			public class E {
-			
+
 			    void func( String ... args) {
-			
+
 			    }
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void called( Supplier<Object> r ) {
-			
+
 			    }
 			    void test() {
 			        called(() -> func());
@@ -1952,17 +2003,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			import java.util.function.Supplier;
-			
+
 			public class E {
-			
+
 			    void func( String ... args) {
-			
+
 			    }
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void called( Supplier<Object> r ) {
-			
+
 			    }
 			    void test() {
 			        called((Runnable) this::func);
@@ -1985,11 +2036,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given1= """
 			import java.util.function.Supplier;
-			
+
 			public class E1 {
-			
+
 			    void called( Supplier<Object> r ) {
-			
+
 			    }
 			}
 			"""; //
@@ -1997,14 +2048,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String given= """
 			import java.util.function.Supplier;
-			
+
 			public class E extends E1 {
-			
+
 			    void func( String ... args) {
-			
+
 			    }
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void test() {
 			        called(() -> func());
@@ -2014,14 +2065,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			import java.util.function.Supplier;
-			
+
 			public class E extends E1 {
-			
+
 			    void func( String ... args) {
-			
+
 			    }
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void test() {
 			        called((Runnable) this::func);
@@ -2044,14 +2095,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given1= """
 			import java.util.function.Supplier;
-			
+
 			public class E1 {
-			
+
 			    void func( String ... args) {
-			
+
 			    }
 			    void called( Supplier<Object> r ) {
-			
+
 			    }
 			}
 			"""; //
@@ -2059,11 +2110,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String given= """
 			import java.util.function.Supplier;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void test() {
 			        called(() -> super.func());
@@ -2073,11 +2124,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			import java.util.function.Supplier;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void test() {
 			        called((Runnable) super::func);
@@ -2100,14 +2151,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given1= """
 			import java.util.function.Supplier;
-			
+
 			public class E1 {
-			
+
 			    static void func( String ... args) {
-			
+
 			    }
 			    void called( Supplier<Object> r ) {
-			
+
 			    }
 			}
 			"""; //
@@ -2115,11 +2166,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String given= """
 			import java.util.function.Supplier;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void test() {
 			        called(() -> E1.func());
@@ -2129,11 +2180,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			import java.util.function.Supplier;
-			
+
 			public class E extends E1 {
-			
+
 			    void called( Runnable r ) {
-			
+
 			    }
 			    void test() {
 			        called((Runnable) E1::func);
@@ -2156,7 +2207,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given= """
 			import java.util.stream.Stream;
-			
+
 			public class E {
 			    public static void main(String[] args) {
 			        new A() {
@@ -2164,7 +2215,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        get();
 			        System.out.println("done");
 			    }
-			
+
 			    public static A get(B<?>... sources) {
 			        return Stream.of(sources)
 			                .map(B::getT)
@@ -2172,11 +2223,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                .findFirst()
 			                .orElse(null);
 			    }
-			
+
 			    public interface B<T extends A> extends A {
 			        T getT();
 			    }
-			
+
 			    public interface A {
 			        default boolean exists_testOpen() {
 			            return true;
@@ -2187,7 +2238,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			import java.util.stream.Stream;
-			
+
 			public class E {
 			    public static void main(String[] args) {
 			        new A() {
@@ -2195,7 +2246,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        get();
 			        System.out.println("done");
 			    }
-			
+
 			    public static A get(B<?>... sources) {
 			        return Stream.of(sources)
 			                .map(B::getT)
@@ -2203,11 +2254,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                .findFirst()
 			                .orElse(null);
 			    }
-			
+
 			    public interface B<T extends A> extends A {
 			        T getT();
 			    }
-			
+
 			    public interface A {
 			        default boolean exists_testOpen() {
 			            return true;
@@ -2231,15 +2282,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """
 			package test;
-			
+
 			import java.util.function.Function;
-			
+
 			public class C1 {
-			
+
 			    public interface I1 {
 			        public int add(int a);
 			    }
-			
+
 			    I1 k = new I1() {
 			        @Override
 			        public int add(int a) {
@@ -2249,7 +2300,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            return a + 7;
 			        }
 			    };
-			
+
 			    public static I1 j = new I1() {
 			        @Override
 			        public int add(int a) {
@@ -2268,22 +2319,22 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected= """
 			package test;
-			
+
 			import java.util.function.Function;
-			
+
 			public class C1 {
-			
+
 			    public interface I1 {
 			        public int add(int a);
 			    }
-			
+
 			    I1 k = a -> {
 			        if (a == 2) {
 			            return this.k.add(3);
 			        }
 			        return a + 7;
 			    };
-			
+
 			    public static I1 j = a -> {
 			        if (a == 2) {
 			            return C1.j.add(4);
@@ -2300,15 +2351,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """
 			package test1;
-			
+
 			import java.util.function.Function;
-			
+
 			public class C2 {
-			
+
 			    public interface I1 {
 			        public int add(int a);
 			    }
-			
+
 			    public int foo() {
 			        I1 doNotConvert = new I1() {
 			            @Override
@@ -2335,16 +2386,16 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """
 			package test1;
-			
+
 			public class C2 {
-			
+
 			    public interface IInteractionContext {
 			    }
-			
+
 			    public interface IAdaptable {
 			        public <T> T getAdapter(Class<T> adapter);
 			    }
-			
+
 			    @SuppressWarnings("unchecked")
 			    public IAdaptable asAdaptable(final IInteractionContext result) {
 			        return new IAdaptable() {
@@ -2372,7 +2423,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given= """
 			package test1;
-			
+
 			import java.io.File;
 			import java.util.Collections;
 			import java.util.Comparator;
@@ -2382,7 +2433,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			import java.util.TreeSet;
 			import java.util.Map.Entry;
 			import java.util.stream.Stream;
-			
+
 			public class E {
 			    private Comparator<Date> refactorField = new Comparator<Date>() {
 			        @Override
@@ -2390,155 +2441,155 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            return o1.toString().compareTo(o2.toString());
 			        }
 			    };
-			
+
 			    public List<Date> useMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                return o1.toString().compareTo(o2.toString());
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useReversedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                return o2.toString().compareTo(o1.toString());
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useNegatedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                return -o1.toString().compareTo(o2.toString());
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> useTypedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = new Comparator<File>() {
-			
+
 			            @Override
 			            public int compare(File f1, File f2) {
 			                return f1.separator.compareTo(f2.separator);
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> useUntypedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator comparator = new Comparator<File>() {
-			
+
 			            @Override
 			            public int compare(File f1, File f2) {
 			                return f1.separator.compareTo(f2.separator);
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> useReversedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = new Comparator<File>() {
-			
+
 			            @Override
 			            public int compare(File f1, File f2) {
 			                return f2.separator.compareTo(f1.separator);
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> o1.toString().compareTo(o2.toString());
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByReversedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> o2.toString().compareTo(o1.toString());
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByNegatedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> -o1.toString().compareTo(o2.toString());
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> replaceLambdaByTypedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = (f1, f2) -> f1.separator.compareTo(f2.separator);
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> replaceLambdaByReversedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = (f1, f2) -> f2.separator.compareTo(f1.separator);
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaUsingRightType(List<Date> initialPackagesToDelete) {
 			        // Keep this comment
 			        Collections.sort(initialPackagesToDelete, (Date one, Date two) -> one.toString().compareTo(two.toString()));
-			
+
 			        return initialPackagesToDelete;
 			    }
-			
+
 			    public List<Date> useMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                if (o1 != null) {
 			                    if (o2 != null) {
 			                        return o1.toString().compareTo(o2.toString());
 			                    }
-			
+
 			                    return 1;
 			                } else if (o2 != null) {
 			                    return -1;
@@ -2546,17 +2597,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                    return 0;
 			                }
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                if (o1 != null) {
@@ -2569,17 +2620,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                    return (o2 == null) ? 0 : 20;
 			                }
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useReversedMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                if (o1 != null)
@@ -2587,20 +2638,20 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                        return 123;
 			                     else
 			                        return o2.toString().compareTo(o1.toString());
-			
+
 			                return (o2 == null) ? 0 : -123;
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useReversedMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Collections.sort(listToSort, new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                if (o1 != null) {
@@ -2610,15 +2661,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                        return Long.compare(o2.getTime(), o1.getTime());
 			                    }
 			                }
-			
+
 			                return (o2 == null) ? 0 : 20;
 			            }
-			
+
 			        });
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useMethodRefWithNegation(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
@@ -2634,27 +2685,27 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                    if (o2 != null) {
 			                        return -o1.toString().compareTo(o2.toString());
 			                    }
-			
+
 			                    return 1;
 			                }
 			            }
 			        };
 			        listToSort.sort(comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useMethodRefUnorderedCondition(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                if (o2 != null) {
 			                    if (o1 != null) {
 			                        return o1.toString().compareTo(o2.toString());
 			                    }
-			
+
 			                    return -1;
 			                } else if (o1 != null) {
 			                    return 1;
@@ -2662,13 +2713,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                    return 0;
 			                }
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> {
@@ -2676,7 +2727,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                if (o2 != null) {
 			                    return o1.toString().compareTo(o2.toString());
 			                }
-			
+
 			                return 1;
 			            } else if (o2 != null) {
 			                return -1;
@@ -2685,10 +2736,10 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> {
@@ -2703,10 +2754,10 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByReversedMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> {
@@ -2715,14 +2766,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                    return 123;
 			                 else
 			                    return o2.toString().compareTo(o1.toString());
-			
+
 			            return (o2 == null) ? 0 : -123;
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByReversedMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator= (o1, o2) -> {
@@ -2733,14 +2784,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                    return Long.compare(o2.getTime(), o1.getTime());
 			                }
 			            }
-			
+
 			            return (o2 == null) ? 0 : 20;
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefWithNegation(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> {
@@ -2754,15 +2805,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                if (o2 != null) {
 			                    return -o1.toString().compareTo(o2.toString());
 			                }
-			
+
 			                return 1;
 			            }
 			        };
 			        listToSort.sort(comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefUnorderedCondition(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = (o1, o2) -> {
@@ -2770,7 +2821,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                if (o1 != null) {
 			                    return o1.toString().compareTo(o2.toString());
 			                }
-			
+
 			                return -1;
 			            } else if (o1 != null) {
 			                return 1;
@@ -2779,26 +2830,26 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    void wildcardMethod() {
 			        Stream.<Entry<String, String>>of().sorted((entry1, entry2) -> entry1.getKey().compareTo(entry2.getKey()));
 			    }
-			
+
 			    public class FooBar {
 			        public String value;
 			    }
-			
+
 			    private final TreeSet<FooBar> foo = new TreeSet<>((a,b) -> b.value.compareTo(a.value));
-			
+
 			}
 			""";
 
 		String expected= """
 			package test1;
-			
+
 			import java.io.File;
 			import java.util.Collections;
 			import java.util.Comparator;
@@ -2808,210 +2859,210 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			import java.util.TreeSet;
 			import java.util.Map.Entry;
 			import java.util.stream.Stream;
-			
+
 			public class E {
 			    private Comparator<Date> refactorField = Comparator.comparing(Date::toString);
-			
+
 			    public List<Date> useMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.comparing(Date::toString);
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useReversedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.comparing(Date::toString).reversed();
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useNegatedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.comparing(Date::toString).reversed();
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> useTypedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = Comparator.comparing(f1 -> f1.separator);
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> useUntypedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator comparator = Comparator.comparing((File f1) -> f1.separator);
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> useReversedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = Comparator.comparing((File f1) -> f1.separator).reversed();
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.comparing(Date::toString);
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByReversedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.comparing(Date::toString).reversed();
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByNegatedMethodRef(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.comparing(Date::toString).reversed();
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> replaceLambdaByTypedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = Comparator.comparing(f1 -> f1.separator);
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<File> replaceLambdaByReversedLambdaExpression(List<File> listToSort) {
 			        // Keep this comment
 			        Comparator<File> comparator = Comparator.comparing((File f1) -> f1.separator).reversed();
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaUsingRightType(List<Date> initialPackagesToDelete) {
 			        // Keep this comment
 			        Collections.sort(initialPackagesToDelete, Comparator.comparing(Date::toString));
-			
+
 			        return initialPackagesToDelete;
 			    }
-			
+
 			    public List<Date> useMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsLast(Comparator.comparing(Date::toString));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useReversedMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString).reversed());
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useReversedMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Collections.sort(listToSort, Comparator.nullsLast(Comparator.comparing(Date::getTime)));
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useMethodRefWithNegation(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString).reversed());
 			        listToSort.sort(comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> useMethodRefUnorderedCondition(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsLast(Comparator.comparing(Date::toString));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByReversedMethodRefNullFirst(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString).reversed());
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByReversedMethodRefNullLast(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator= Comparator.nullsLast(Comparator.comparing(Date::getTime));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefWithNegation(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString).reversed());
 			        listToSort.sort(comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<Date> replaceLambdaByMethodRefUnorderedCondition(List<Date> listToSort) {
 			        // Keep this comment
 			        Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    void wildcardMethod() {
 			        Stream.<Entry<String, String>>of().sorted(Comparator.comparing(Entry<String, String>::getKey));
 			    }
-			
+
 			    public class FooBar {
 			        public String value;
 			    }
-			
+
 			    private final TreeSet<FooBar> foo = new TreeSet<>(Comparator.comparing((FooBar a) -> a.value).reversed());
-			
+
 			}
 			""";
 
@@ -3030,17 +3081,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """
 			package test1;
-			
+
 			import java.util.Collections;
 			import java.util.Comparator;
 			import java.util.Date;
 			import java.util.List;
 			import java.util.Locale;
-			
+
 			public class E {
 			    public List<Date> doNotUseMethodRefWithWeirdBehavior(List<Date> listToSort) {
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                if (o1 != null) {
@@ -3055,13 +3106,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                    return 100;
 			                }
 			            }
-			
+
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<String> doNotUseMethodRef(List<String> listToSort) {
 			        Comparator<String> comparator = new Comparator<String>() {
 			            @Override
@@ -3070,54 +3121,54 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public Comparator<Date> doNotRefactorComparisonWithoutCompareToMethod(List<Date> listToSort) {
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                return (int) (o1.getTime() - o2.getTime());
 			            }
 			        };
-			
+
 			        return comparator;
 			    }
-			
+
 			    public int compareTo(E anc) {
 			        return 0;
 			    }
-			
+
 			    public E getNewInstance() {
 			        return new E();
 			    }
-			
+
 			    private Comparator<E> doNotRefactorNotComparableObjects = new Comparator<E>() {
 			        @Override
 			        public int compare(E o1, E o2) {
 			            return o1.getNewInstance().compareTo(o2.getNewInstance());
 			        }
 			    };
-			
+
 			    public Comparator<Date> doNotRemoveSecondaryMethod(List<Date> listToSort) {
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                return o1.toString().compareTo(o2.toString());
 			            }
-			
+
 			            @Override
 			            public String toString() {
 			                return "Compare formatted dates";
 			            }
 			        };
-			
+
 			        return comparator;
 			    }
-			
+
 			    public List<Date> doNotReplaceLambdaByUseMethodRefWithWeirdBehavior(List<Date> listToSort) {
 			        Comparator<Date> comparator = (o1, o2) -> {
 			            if (o1 != null) {
@@ -3133,37 +3184,37 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			        };
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public List<String> doNotReplaceLambdaByUseMethodRef(List<String> listToSort) {
 			        Comparator<String> comparator = (o1, o2) -> o1.toLowerCase(Locale.ENGLISH).compareTo(o2.toLowerCase(Locale.ENGLISH));
 			        Collections.sort(listToSort, comparator);
-			
+
 			        return listToSort;
 			    }
-			
+
 			    public Comparator<Date> doNotReplaceLambdaByRefactorComparisonWithoutCompareToMethod(List<Date> listToSort) {
 			        Comparator<Date> comparator = (o1, o2) -> (int) (o1.getTime() - o2.getTime());
-			
+
 			        return comparator;
 			    }
-			
+
 			    public Comparator<Date> doNotReplaceLambdaByRemoveSecondaryMethod(List<Date> listToSort) {
 			        Comparator<Date> comparator = new Comparator<Date>() {
-			
+
 			            @Override
 			            public int compare(Date o1, Date o2) {
 			                return o1.toString().compareTo(o2.toString());
 			            }
-			
+
 			            @Override
 			            public String toString() {
 			                return "Compare formatted dates";
 			            }
 			        };
-			
+
 			        return comparator;
 			    }
 			}
@@ -3180,14 +3231,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String input= """
 			package test1;
-			
+
 			public class E {
 			    public String refactorConcatenation(String[] texts) {
 			        // Keep this comment
 			        boolean isFirst = true;
 			        // Keep this comment too
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment also
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
@@ -3197,14 +3248,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorReassignment(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String text : texts) {
 			            if (isFirst) {
@@ -3214,14 +3265,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation = concatenation.append(text);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public Runnable refactorFinalConcatenation(String[] names) {
 			        boolean isFirst = true;
 			        final StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < names.length; i++) {
 			            if (isFirst) {
@@ -3231,7 +3282,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(names[i]);
 			        }
-			
+
 			        Runnable supplier= new Runnable() {
 			            @Override
 			            public void run() {
@@ -3240,11 +3291,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        };
 			        return supplier;
 			    }
-			
+
 			    public String refactorConcatenationWithChar(String[] titles) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String title : titles) {
 			            if (isFirst) {
@@ -3254,14 +3305,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(title);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithCharVariable(String[] titles, char delimiter) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String title : titles) {
 			            if (isFirst) {
@@ -3271,14 +3322,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(title);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithCharacterWrapper(String[] titles, Character delimiter) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String title : titles) {
 			            if (isFirst) {
@@ -3288,14 +3339,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(title);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithEscapedChar(String[] titles) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String title : titles) {
 			            if (isFirst) {
@@ -3305,14 +3356,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(title);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithInt(String[] titles) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String title : titles) {
 			            if (isFirst) {
@@ -3322,14 +3373,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(title);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithHardCodedDelimiter(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
@@ -3339,14 +3390,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithBuilderFirst(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
 			        boolean isFirst = true;
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
@@ -3356,14 +3407,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithStringBuffer(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuffer concatenation = new StringBuffer();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
@@ -3373,14 +3424,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithBooleanObject(String[] texts) {
 			        Boolean isFirst = Boolean.TRUE;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
@@ -3390,14 +3441,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation = concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithNegatedBoolean(String[] texts) {
 			        Boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (!isFirst) {
@@ -3407,14 +3458,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithReversedBoolean(String[] texts) {
 			        boolean isVisited = Boolean.FALSE;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isVisited) {
@@ -3424,14 +3475,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithLotsOfMethods(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
@@ -3441,7 +3492,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        System.out.println(concatenation.charAt(0));
 			        System.out.println(concatenation.chars());
 			        System.out.println(concatenation.codePoints());
@@ -3452,11 +3503,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        System.out.println(concatenation.subSequence(0, 0));
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationOnForeach(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
 			        boolean isFirst = true;
-			
+
 			        // Keep this comment
 			        for (String text : texts) {
 			            if (isFirst) {
@@ -3466,13 +3517,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(text);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithConditionOnIndex(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (i > 0) {
@@ -3480,13 +3531,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithInequalityOnIndex(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (i != 0) {
@@ -3494,13 +3545,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithReversedConditionOnIndex(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (0 < i) {
@@ -3508,13 +3559,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithGreaterOrEqualsOnIndex(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (i >= 1) {
@@ -3522,13 +3573,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithDelimiterAtTheEnd(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            concatenation.append(texts[i]);
@@ -3536,13 +3587,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                concatenation.append(", ");
 			            }
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithMirroredCondition(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            concatenation.append(texts[i]);
@@ -3550,13 +3601,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                concatenation.append(", ");
 			            }
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithNotEqualsCondition(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            concatenation.append(texts[i]);
@@ -3564,13 +3615,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                concatenation.append(", ");
 			            }
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationWithLessOrEqualsCondition(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            concatenation.append(texts[i]);
@@ -3578,13 +3629,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                concatenation.append(", ");
 			            }
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationTestingLength(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (concatenation.length() > 0) {
@@ -3592,13 +3643,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationTestingNotEmpty(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (concatenation.length() != 0) {
@@ -3606,13 +3657,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationTestingGreaterOrEqualsOne(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (concatenation.length() >= 1) {
@@ -3620,13 +3671,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationTestingLengthMirrored(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (0 < concatenation.length()) {
@@ -3634,13 +3685,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationTestingNotEmptyMirrored(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (0 != concatenation.length()) {
@@ -3648,13 +3699,13 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConcatenationTestingGreaterOrEqualsOneMirrored(String[] texts) {
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (int i = 0; i < texts.length; i++) {
 			            if (1 <= concatenation.length()) {
@@ -3662,14 +3713,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorConstantBooleanShift(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String text : texts) {
 			            if (!isFirst) {
@@ -3678,14 +3729,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            isFirst = false;
 			            concatenation.append(text);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorWithBooleanShiftAtTheEnd(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String text : texts) {
 			            if (!isFirst) {
@@ -3694,14 +3745,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            concatenation.append(text);
 			            isFirst = false;
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String refactorWithReversedBooleanShift(String[] texts) {
 			        boolean isNotFirst = false;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        // Keep this comment
 			        for (String text : texts) {
 			            if (isNotFirst) {
@@ -3710,7 +3761,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            concatenation.append(text);
 			            isNotFirst = true;
 			        }
-			
+
 			        return concatenation.toString();
 			    }
 			}
@@ -3721,35 +3772,35 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String output= """
 			package test1;
-			
+
 			public class E {
 			    public String refactorConcatenation(String[] texts) {
 			        // Keep this comment
 			       \s
 			        // Keep this comment too
 			       \s
-			
+
 			        // Keep this comment also
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorReassignment(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public Runnable refactorFinalConcatenation(String[] names) {
 			       \s
-			
+
 			        // Keep this comment
 			        final String concatenation = String.join(", ", names);
-			
+
 			        Runnable supplier= new Runnable() {
 			            @Override
 			            public void run() {
@@ -3758,112 +3809,112 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        };
 			        return supplier;
 			    }
-			
+
 			    public String refactorConcatenationWithChar(String[] titles) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(",", titles);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithCharVariable(String[] titles, char delimiter) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(String.valueOf(delimiter), titles);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithCharacterWrapper(String[] titles, Character delimiter) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(String.valueOf(delimiter), titles);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithEscapedChar(String[] titles) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join("\\n", titles);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithInt(String[] titles) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(String.valueOf(123), titles);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithHardCodedDelimiter(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(" " + 1, texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithBuilderFirst(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithStringBuffer(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithBooleanObject(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithNegatedBoolean(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithReversedBoolean(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithLotsOfMethods(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        System.out.println(concatenation.charAt(0));
 			        System.out.println(concatenation.chars());
 			        System.out.println(concatenation.codePoints());
@@ -3874,166 +3925,166 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        System.out.println(concatenation.subSequence(0, 0));
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationOnForeach(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithConditionOnIndex(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithInequalityOnIndex(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithReversedConditionOnIndex(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithGreaterOrEqualsOnIndex(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithDelimiterAtTheEnd(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithMirroredCondition(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithNotEqualsCondition(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationWithLessOrEqualsCondition(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationTestingLength(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationTestingNotEmpty(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationTestingGreaterOrEqualsOne(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationTestingLengthMirrored(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationTestingNotEmptyMirrored(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConcatenationTestingGreaterOrEqualsOneMirrored(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorConstantBooleanShift(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorWithBooleanShiftAtTheEnd(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
-			
+
 			    public String refactorWithReversedBooleanShift(String[] texts) {
 			       \s
-			
+
 			        // Keep this comment
 			        String concatenation = String.join(", ", texts);
-			
+
 			        return concatenation;
 			    }
 			}
@@ -4049,12 +4100,12 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """
 			package test1;
-			
+
 			public class E {
 			    public boolean doNotRefactorUsedBoolean(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4063,15 +4114,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        System.out.println(concatenation.toString());
 			        return isFirst;
 			    }
-			
+
 			    public String doNotRefactorUnhandledMethod(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4080,7 +4131,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        System.out.println(concatenation.codePointAt(0));
 			        System.out.println(concatenation.codePointBefore(0));
 			        System.out.println(concatenation.codePointCount(0, 0));
@@ -4092,11 +4143,11 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        System.out.println(concatenation.capacity());
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorPartialConcatenation(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 1; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4105,14 +4156,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorUnfinishedConcatenation(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length - 1; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4121,14 +4172,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorReversedConcatenation(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = texts.length - 1; i >= 0; i--) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4137,14 +4188,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithOppositeBoolean(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 1; i < texts.length; i++) {
 			            if (isFirst) {
 			                concatenation.append(", ");
@@ -4153,14 +4204,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorOnObjects(Object[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4169,14 +4220,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithOtherAppending(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4185,16 +4236,16 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        concatenation.append("foo");
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithInitialization(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder("foo");
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4203,14 +4254,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithWrongIndex(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4219,14 +4270,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[0]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithWrongBoolean(String[] texts, boolean isSecond) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isSecond) {
 			                isFirst = false;
@@ -4235,15 +4286,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithWrongBoolean(String[] texts) {
 			        boolean isSecond = false;
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isSecond = false;
@@ -4252,14 +4303,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithWrongArray(String[] texts, String[] names) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4268,14 +4319,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(names[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithWrongBuilder(String[] texts, StringBuilder otherBuilder) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4284,14 +4335,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            otherBuilder.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithAnotherBuilder(String[] texts, StringBuilder otherBuilder) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4300,14 +4351,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i]);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithAdditionalStatement(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4317,14 +4368,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            concatenation.append(texts[i]);
 			            System.out.println("Hi!");
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithWrongMethod(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (int i = 0; i < texts.length; i++) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4333,14 +4384,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(texts[i], 0, 2);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWrongVariable(String[] texts, String test) {
 			        StringBuilder concatenation = new StringBuilder();
 			        boolean isFirst = true;
-			
+
 			        for (String text : texts) {
 			            if (isFirst) {
 			                isFirst = false;
@@ -4349,14 +4400,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(test);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithBooleanShiftFirst(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (String text : texts) {
 			            isFirst = false;
 			            if (!isFirst) {
@@ -4364,14 +4415,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            concatenation.append(text);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithAppendingFirst(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (String text : texts) {
 			            concatenation.append(text);
 			            if (!isFirst) {
@@ -4379,14 +4430,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            }
 			            isFirst = false;
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithConditionAtTheEnd(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (String text : texts) {
 			            concatenation.append(text);
 			            isFirst = false;
@@ -4394,14 +4445,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                concatenation.append(", ");
 			            }
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWithNonsense(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (String text : texts) {
 			            isFirst = false;
 			            concatenation.append(text);
@@ -4409,14 +4460,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			                concatenation.append(", ");
 			            }
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorUnshiftedBoolean(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (String text : texts) {
 			            if (!isFirst) {
 			                concatenation.append(", ");
@@ -4424,14 +4475,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            isFirst = true;
 			            concatenation.append(text);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWrongCondition(String[] texts) {
 			        boolean isFirst = true;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (String text : texts) {
 			            if (isFirst) {
 			                concatenation.append(", ");
@@ -4439,14 +4490,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            isFirst = false;
 			            concatenation.append(text);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
-			
+
 			    public String doNotRefactorWrongInit(String[] texts) {
 			        boolean isFirst = false;
 			        StringBuilder concatenation = new StringBuilder();
-			
+
 			        for (String text : texts) {
 			            if (!isFirst) {
 			                concatenation.append(", ");
@@ -4454,7 +4505,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            isFirst = false;
 			            concatenation.append(text);
 			        }
-			
+
 			        return concatenation.toString();
 			    }
 			}
@@ -4471,7 +4522,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample0= """
 			package test1;
-			
+
 			public class SuperClass {
 			    public StringBuffer field0;
 			    public void method0(StringBuffer parm) {
@@ -4482,7 +4533,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String sample= """
 			package test1;
-			
+
 			public class TestStringBuilderCleanup extends SuperClass {
 			    StringBuffer field1;
 			    StringBuffer field2;
@@ -4504,7 +4555,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test1;
-			
+
 			public class TestStringBuilderCleanup extends SuperClass {
 			    StringBuffer field1;
 			    StringBuffer field2;
@@ -4529,7 +4580,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample0= """
 			package test1;
-			
+
 			public class SuperClass {
 			    public StringBuffer field0;
 			    public void method0(StringBuffer parm) {
@@ -4540,9 +4591,9 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String sample= """
 			package test1;
-			
+
 			import java.io.StringWriter;
-			
+
 			public class TestStringBuilderCleanup extends SuperClass {
 			    StringBuffer field1;
 			    StringBuffer field2;
@@ -4609,7 +4660,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample0= """
 			package test1;
-			
+
 			public class SuperClass {
 			    public StringBuffer field0;
 			    public void method0(StringBuffer parm) {
@@ -4621,7 +4672,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String sample= """
 			package test1;
 			import java.io.StringWriter;
-			
+
 			public class TestStringBuilderCleanup extends SuperClass {
 			    StringBuffer field1;
 			    StringBuffer field2;
@@ -4675,7 +4726,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String expected0= """
 			package test1;
-			
+
 			public class SuperClass {
 			    public StringBuilder field0;
 			    public void method0(StringBuilder parm) {
@@ -4686,7 +4737,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String expected1= """
 			package test1;
 			import java.io.StringWriter;
-			
+
 			public class TestStringBuilderCleanup extends SuperClass {
 			    StringBuilder field1;
 			    StringBuilder field2;
@@ -5293,24 +5344,24 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			package test;
 			import java.util.HashSet;
 			import java.util.Iterator;
-			
+
 			public class Test {
 			   \s
 			    public class Element {
 			    }
-			
+
 			    public class ElementOccurrenceResult {
 			    }
-			
+
 			    public void foo(Element element, HashSet<ElementOccurrenceResult> hashSet) {
 			        Iterator<ElementOccurrenceResult> minIterator= hashSet.iterator();
 			        while (minIterator.hasNext()) {
 			            reportProblem(element, minIterator.next(), null);
 			        }
 			    }
-			
+
 			    private void reportProblem(Element element, ElementOccurrenceResult next, Object object) {}
-			
+
 			}
 			"""; //
 		ICompilationUnit cu= pack.createCompilationUnit("Test.java", sample, false, null);
@@ -5320,23 +5371,23 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String expected= """
 			package test;
 			import java.util.HashSet;
-			
+
 			public class Test {
 			   \s
 			    public class Element {
 			    }
-			
+
 			    public class ElementOccurrenceResult {
 			    }
-			
+
 			    public void foo(Element element, HashSet<ElementOccurrenceResult> hashSet) {
 			        for (ElementOccurrenceResult element2 : hashSet) {
 			            reportProblem(element, element2, null);
 			        }
 			    }
-			
+
 			    private void reportProblem(Element element, ElementOccurrenceResult next, Object object) {}
-			
+
 			}
 			"""; //
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
@@ -5356,9 +5407,9 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			import java.io.File;
 			import java.util.Iterator;
 			import java.util.List;
-			
+
 			public class Test {
-			
+
 			    public int foo(String x, List<? extends File> files) {
 			        Iterator<? extends File> iter= files.iterator();
 			        while(iter.hasNext()){
@@ -5374,7 +5425,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        }
 			        return 0;
 			    }
-			
+
 			    public static void dumpIMethodList(List<?> l){
 			        Iterator<?> iter= l.iterator();
 			        while(iter.hasNext()){
@@ -5384,7 +5435,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            dumpIMethod((String)i.next());
 			        }
 			    }
-			
+
 			    private static void dumpIMethod(String next) {
 			        System.out.println(next);
 			    }
@@ -5400,9 +5451,9 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			import java.io.File;
 			import java.util.Iterator;
 			import java.util.List;
-			
+
 			public class Test {
-			
+
 			    public int foo(String x, List<? extends File> files) {
 			        for (File file : files) {
 			            dumpIMethod((String)file.getAbsolutePath());
@@ -5416,7 +5467,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        }
 			        return 0;
 			    }
-			
+
 			    public static void dumpIMethodList(List<?> l){
 			        for (Object element : l) {
 			            dumpIMethod((String)element);
@@ -5425,7 +5476,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			            dumpIMethod((String)name);
 			        }
 			    }
-			
+
 			    private static void dumpIMethod(String next) {
 			        System.out.println(next);
 			    }
@@ -6077,7 +6128,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			package test;
 			import java.util.ArrayList;
 			import java.util.List;
-			
+
 			public class E {
 			   \s
 			    public interface I1 {
@@ -6109,7 +6160,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			package test;
 			import java.util.ArrayList;
 			import java.util.List;
-			
+
 			public class E {
 			   \s
 			    public interface I1 {
@@ -6158,9 +6209,9 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        x.run( //
 			        System.out.println(f //
 			    }
-			
+
 			}
-			
+
 			""";
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
 
@@ -6188,9 +6239,9 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        x.run( //
 			        System.out.println(f //
 			    }
-			
+
 			}
-			
+
 			""";
 		String expected1= sample;
 
@@ -6204,18 +6255,18 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String sample= """
 			package test;
 			public class E1 {
-			
+
 			    String blah = "blah";
 			   \s
 			    class Blah {
 			        public static String blah2 = "blah2";
 			    }
-			
+
 			    public int foo(String a, String b) {
 			        System.out.println(a + b);
 			        return a.length() + b.length();
 			    }
-			
+
 			    /**
 			     * @deprecated use {@link #foo(String, String)}
 			     * @param a
@@ -6228,7 +6279,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k = a.toLowerCase() + Blah.blah2;
 			        return foo(k, b);
 			    }
-			
+
 			}
 			"""; //
 		pack1.createCompilationUnit("E1.java", sample, false, null);
@@ -6236,7 +6287,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		sample= """
 			package test;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6248,14 +6299,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(a, b, c);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        k.foo(x, y, z);
 			        { E1 e = new E1();
 			        e.foo(x, y, z); }
 			    }
-			
+
 			}
 			""";
 		ICompilationUnit cu2= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -6264,7 +6315,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		sample= """
 			package test;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6279,7 +6330,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(k, b);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        String k1_1 = x.toLowerCase() + Blah.blah2;
@@ -6288,7 +6339,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k1 = x.toLowerCase() + Blah.blah2;
 			        e.foo(k1, y); }
 			    }
-			
+
 			}
 			""";
 		String expected1= sample;
@@ -6303,18 +6354,18 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String sample1= """
 			package test;
 			public class E1 {
-			
+
 			    String blah = "blah";
 			   \s
 			    public class Blah {
 			        public static String blah2 = "blah2";
 			    }
-			
+
 			    public int foo(String a, String b) {
 			        System.out.println(a + b);
 			        return a.length() + b.length();
 			    }
-			
+
 			    /**
 			     * @deprecated use {@link #foo(String, String)}
 			     * @param a
@@ -6327,7 +6378,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k = a.toLowerCase() + Blah.blah2;
 			        return foo(k, b);
 			    }
-			
+
 			}
 			"""; //
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample1, false, null);
@@ -6337,7 +6388,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			package test2;
 			import test.E1;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6349,14 +6400,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(a, b, c);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        k.foo(x, y, z);
 			        { E1 e = new E1();
 			        e.foo(x, y, z); }
 			    }
-			
+
 			}
 			""";
 		ICompilationUnit cu2= pack2.createCompilationUnit("E.java", sample, false, null);
@@ -6367,7 +6418,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			import test.E1;
 			import test.E1.Blah;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6382,7 +6433,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(k, b);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        String k1_1 = x.toLowerCase() + Blah.blah2;
@@ -6391,7 +6442,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k1 = x.toLowerCase() + Blah.blah2;
 			        e.foo(k1, y); }
 			    }
-			
+
 			}
 			""";
 		String expected1= sample;
@@ -6406,18 +6457,18 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String sample= """
 			package test;
 			public class E1 {
-			
+
 			    String blah = "blah";
 			   \s
 			    private static class Blah {
 			        public static String blah2 = "blah2";
 			    }
-			
+
 			    public int foo(String a, String b) {
 			        System.out.println(a + b);
 			        return a.length() + b.length();
 			    }
-			
+
 			    /**
 			     * @deprecated use {@link #foo(String, String)}
 			     * @param a
@@ -6430,7 +6481,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k = a.toLowerCase() + Blah.blah2;
 			        return foo(k, b);
 			    }
-			
+
 			}
 			"""; //
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
@@ -6438,7 +6489,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		sample= """
 			package test;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6450,14 +6501,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(a, b, c);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        k.foo(x, y, z);
 			        { E1 e = new E1();
 			        e.foo(x, y, z); }
 			    }
-			
+
 			}
 			""";
 		ICompilationUnit cu2= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -6472,18 +6523,18 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String sample1= """
 			package test;
 			public class E1 {
-			
+
 			    String blah = "blah";
 			   \s
 			    protected static class Blah {
 			        public static String blah2 = "blah2";
 			    }
-			
+
 			    public int foo(String a, String b) {
 			        System.out.println(a + b);
 			        return a.length() + b.length();
 			    }
-			
+
 			    /**
 			     * @deprecated use {@link #foo(String, String)}
 			     * @param a
@@ -6496,7 +6547,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k = a.toLowerCase() + Blah.blah2;
 			        return foo(k, b);
 			    }
-			
+
 			}
 			"""; //
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample1, false, null);
@@ -6506,7 +6557,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			package test2;
 			import test.E1;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6518,14 +6569,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(a, b, c);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        k.foo(x, y, z);
 			        { E1 e = new E1();
 			        e.foo(x, y, z); }
 			    }
-			
+
 			}
 			""";
 		ICompilationUnit cu2= pack2.createCompilationUnit("E.java", sample, false, null);
@@ -6540,18 +6591,18 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String sample1= """
 			package test;
 			public class E1 {
-			
+
 			    String blah = "blah";
 			   \s
 			    static class Blah {
 			        public static String blah2 = "blah2";
 			    }
-			
+
 			    public int foo(String a, String b) {
 			        System.out.println(a + b);
 			        return a.length() + b.length();
 			    }
-			
+
 			    /**
 			     * @deprecated use {@link #foo(String, String)}
 			     * @param a
@@ -6564,7 +6615,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k = a.toLowerCase() + Blah.blah2;
 			        return foo(k, b);
 			    }
-			
+
 			}
 			"""; //
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample1, false, null);
@@ -6574,7 +6625,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			package test2;
 			import test.E1;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6586,14 +6637,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(a, b, c);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        k.foo(x, y, z);
 			        { E1 e = new E1();
 			        e.foo(x, y, z); }
 			    }
-			
+
 			}
 			""";
 		ICompilationUnit cu2= pack2.createCompilationUnit("E.java", sample, false, null);
@@ -6608,18 +6659,18 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		String sample1= """
 			package test;
 			public class E1 {
-			
+
 			    String blah = "blah";
 			   \s
 			    static class Blah {
 			        public static String blah2 = "blah2";
 			    }
-			
+
 			    public int foo(String a, String b) {
 			        System.out.println(a + b);
 			        return a.length() + b.length();
 			    }
-			
+
 			    /**
 			     * @deprecated use {@link #foo(String, String)}
 			     * @param a
@@ -6632,7 +6683,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        String k = a.toLowerCase() + this.blah;
 			        return foo(k, b);
 			    }
-			
+
 			}
 			"""; //
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample1, false, null);
@@ -6642,7 +6693,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			package test2;
 			import test.E1;
 			public class E {
-			
+
 			    public static void depfunc(String a, String b, Object c) {
 			        E1 d = new E1();
 			        int k1= 8;
@@ -6654,14 +6705,14 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			        int v = e.foo(a, b, c);
 			        System.out.println(v);
 			    }
-			
+
 			    public static void depfunc2(String x, String y, Object z) {
 			        E1 k = new E1();
 			        k.foo(x, y, z);
 			        { E1 e = new E1();
 			        e.foo(x, y, z); }
 			    }
-			
+
 			}
 			""";
 		ICompilationUnit cu2= pack2.createCompilationUnit("E.java", sample, false, null);
@@ -6676,17 +6727,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		String sample= """
 			package test1;
-			
+
 			public class A {
 			    public interface PropertyChangeListener {
 			        void propertyChange(Object evt);
-			
+
 			    }
-			
+
 			    private final PropertyChangeListener listener = evt -> {
 			        this.clientCache.get();
 			    };
-			
+
 			    public void x() {
 			        PropertyChangeListener listener = evt -> {
 			            this.clientCache.get();
@@ -6696,7 +6747,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			    interface Cache<V> {
 			        V get();
 			    }
-			
+
 			    final Cache<String> clientCache = new Cache<>() {
 			        @Override
 			        public String get() {
@@ -6713,17 +6764,17 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 
 		sample= """
 			package test1;
-			
+
 			public class A {
 			    public interface PropertyChangeListener {
 			        void propertyChange(Object evt);
-			
+
 			    }
-			
+
 			    private final PropertyChangeListener listener = evt -> {
 			        this.clientCache.get();
 			    };
-			
+
 			    public void x() {
 			        PropertyChangeListener listener = evt -> {
 			            clientCache.get();
@@ -6733,7 +6784,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			    interface Cache<V> {
 			        V get();
 			    }
-			
+
 			    final Cache<String> clientCache = new Cache<>() {
 			        @Override
 			        public String get() {


### PR DESCRIPTION
- change castMethodRefIfNeeded() methods in LambdaExpressionAndMethodRefFixCore and ConvertLambdaToMethodReferenceFixCore to handle parameterized types better
- add new tests to CleanUpTests1d8 and AssistQuickFixTest1d8
- fixes #1498

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes lambda to method ref cleanup/quick assists to not add extraneous cast.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
