### PR TITLE
ClassFileEditorInputFactory: do not use "callReadOnly" #1443

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
@@ -48,11 +48,6 @@ public class ClassFileEditorInputFactory implements IElementFactory {
 		if (identifier == null) {
 			return null;
 		}
-		return JavaCore.callReadOnly(() -> createElementCached(identifier));
-	}
-
-	private IAdaptable createElementCached(String identifier) {
-
 		IJavaElement element= JavaCore.create(identifier);
 		try {
 			if (!element.exists() && element instanceof IOrdinaryClassFile) {


### PR DESCRIPTION
To work around IllegalStateException "Its not allow to modify JavaModel during ReadOnly action"
As IJavaElement.exists() sometimes updates the classpath during eclipse start and i don't know how to fix that.

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1443
