### PR TITLE
Suggest import for missing type in a parenthesized cast expression

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
@@ -88,6 +88,7 @@ import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.ProvidesDirective;
 import org.eclipse.jdt.core.dom.QualifiedName;
@@ -669,6 +670,10 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 			return;
 		}
 
+		while (selectedNode instanceof ParenthesizedExpression parenthesizedExp) {
+			selectedNode= parenthesizedExp.getExpression();
+		}
+
 		IJavaProject javaProject= cu.getJavaProject();
 		int kind= evauateTypeKind(selectedNode, javaProject);
 
@@ -677,6 +682,14 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 			if (s != null && Character.isLowerCase(s.getFullyQualifiedName().charAt(0))) {
 				return;
 			}
+		}
+
+		if (selectedNode instanceof CastExpression castExp) {
+			selectedNode= castExp.getType();
+		}
+
+		if (selectedNode instanceof ParameterizedType parameterizedType) {
+			selectedNode= parameterizedType.getType();
 		}
 
 		while (selectedNode.getLocationInParent() == QualifiedName.NAME_PROPERTY) {


### PR DESCRIPTION
- Fix UnresolvedElementsBaseSubProcessor.collectTypeProposals() to handle cast expressions and parenthesized cast expressions
- fixes #1318

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the case where a type is missing and used in a cast or parenthesized cast expression.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
