### PR TITLE
Fix addStaticImportFavoriteProposals for generic types

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
@@ -1476,7 +1476,7 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 				ASTRewrite astRewrite= ASTRewrite.create(ast);
 
 				String label;
-				String qualifiedTypeName= Signature.getQualifier(curr);
+				String qualifiedTypeName= Signature.getQualifier(Signature.getTypeErasure(curr));
 				String elementLabel= BasicElementLabels.getJavaElementName(JavaModelUtil.concatenateName(Signature.getSimpleName(qualifiedTypeName), name));
 
 				String res= importRewrite.addStaticImport(qualifiedTypeName, name, isMethod, new ContextSensitiveImportRewriteContext(root, node.getStartPosition(), importRewrite));


### PR DESCRIPTION
When you add a static method to a **generic** type and add it to the list of content assist favorites you can't use Quick Fix to add the required static import.

Let's say you have a helper class as follows:

```
package content_assist_test;

public class EikesHelper<T>
{
   public static void help()
   {
   }
}
```

Then you configure that static method as a content assist favorite: `content_assist_test.EikesHelper.test`

Then you write a class to test it:

```
public class EikesTest
{
   public static void test()
   {
      help();
   }
}
```

The call to the help() method is marked as a compiler error. When you open the Quick Fix menu it looks as follows:

![image001](https://github.com/user-attachments/assets/fb0c560f-986f-47cf-beb7-febbb9adc7f2)

When you execute the Quick Fix a wrong import statement is inserted.

The problem is caused by a small bug in `org.eclipse.jdt.internal.ui.text.correction.UnresolvedElementsBaseSubProcessor.addStaticImportFavoriteProposals()`. In line 1497 it computes the `qualifiedTypeName` from the fully qualified method name `curr`. As `curr` contains the string "&lt;T&gt;", the `Signature.getQualifier()` method behaves wrongly and cuts off too much.

My fix is to strip off the generic part of the type name with the help of `Signature.getTypeErasure()` before `Signature.getQualifier()` is called. The result looks like so, now:

![image002](https://github.com/user-attachments/assets/6d2d8579-1ecf-4a2e-8670-3717569f3970)

