### PR TITLE
Fix SwitchFixOperation to not cause a MalformedTreeException

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.BreakStatement;
+import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.DoStatement;
 import org.eclipse.jdt.core.dom.EnhancedForStatement;
@@ -45,6 +46,7 @@ import org.eclipse.jdt.core.dom.SwitchStatement;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.WhileStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
@@ -354,6 +356,7 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 			}
 
 			if (remainingStatement != null) {
+				remainingStatement.setProperty(UNTOUCH_COMMENT_PROPERTY, Boolean.TRUE);
 				addCaseWithStatements(rewrite, ast, switchStatement, null, ASTNodes.asList(remainingStatement));
 			} else {
 				addCaseWithStatements(rewrite, ast, switchStatement, null, Collections.emptyList());
@@ -362,6 +365,10 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 			for (int i= 0; i < ifStatements.size() - 1; i++) {
 				ASTNodes.removeButKeepComment(rewrite, ifStatements.get(i), group);
 			}
+
+			IfStatement ifStatement= ifStatements.get(ifStatements.size() - 1);
+			ASTNode parent= ifStatement.getParent();
+			ListRewrite listRewrite= rewrite.getListRewrite(parent, (ChildListPropertyDescriptor) ifStatement.getLocationInParent());
 
 			ASTNodes.replaceButKeepComment(rewrite, ifStatements.get(ifStatements.size() - 1), switchStatement, group);
 		}
@@ -393,7 +400,7 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 			// Add the statement(s) for this case(s)
 			if (!innerStatements.isEmpty()) {
 				for (Statement statement : innerStatements) {
-					statementsList.add(ASTNodes.createMoveTarget(rewrite, statement));
+					statementsList.add((Statement) rewrite.createCopyTarget(statement));
 				}
 
 				isBreakNeeded= !ASTNodes.fallsThrough(innerStatements.get(innerStatements.size() - 1));

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2022 Red Hat Inc. and others.
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -57,13 +57,13 @@ public class CleanUpTest12 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given= """
 			package test1;
-			
+
 			public class E {
 			    public static final int CONSTANT_1 = 0;
 			    public static final int CONSTANT_2 = 1;
-			
+
 			    public int i2 = 0;
-			
+
 			    public void replaceIfWithSwitchOnParameter(int i1) {
 			        int i = 0;
 			        // Keep this comment
@@ -95,8 +95,9 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        } else if (i2 == 2) {
 			            i = 150;
 			        }
+			        // extra comment
 			    }
-			
+
 			    public void replaceIfWithSwitchUsingConstants(int date) {
 			        int i = 0;
 			        // Keep this comment
@@ -114,7 +115,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 150;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSwitchOnLocalVariable() {
 			        int i1 = 0;
 			        int i = 0;
@@ -138,7 +139,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 50;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSwitchOnField() {
 			        int i = 0;
 			        // Keep this comment
@@ -152,7 +153,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 20;
 			        }
 			    }
-			
+
 			    public void replaceWithSwitchOnField() {
 			        int i = 0;
 			        // Keep this comment
@@ -166,7 +167,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 20;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSwitchOnCharacter(char character) {
 			        int i = 0;
 			        // Keep this comment
@@ -183,7 +184,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        } else
 			            i = 40;
 			    }
-			
+
 			    public void replaceIfRemoveDuplicateConditions(char aCharacter) {
 			        int i = 0;
 			        if (aCharacter == 'a') {
@@ -202,7 +203,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 60;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSeveralConditions(char myCharacter) {
 			        int i = 0;
 			        if (myCharacter == 'a') {
@@ -217,7 +218,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 60;
 			        }
 			    }
-			
+
 			    public void replaceIfKeepExistingControlFlowBreaks(byte i1) {
 			        byte j = 0;
 			        loop: for (byte i = 0; i < 10; i++) {
@@ -251,7 +252,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            }
 			        }
 			    }
-			
+
 			    public void replaceWithInnerLoopBreak(short i1) {
 			        short j = 0;
 			        if (i1 == 0) {
@@ -301,7 +302,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            }
 			        }
 			    }
-			
+
 			    public void replaceIfWhenNoVariableNameConflictExists(int i1) {
 			        int i = 0;
 			        if (i1 == 0) {
@@ -315,7 +316,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = newVariable3;
 			        }
 			    }
-			
+
 			    public void replaceWhenOutOfScopeVariableNameConflicts(int i1) {
 			        int i = 0;
 			        if (i1 == 0) {
@@ -331,7 +332,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = i2;
 			        }
 			    }
-			
+
 			    public int replaceIfSuite(int i1) {
 			        // Keep this comment
 			        if (i1 == 0) {
@@ -370,7 +371,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        }
 			        return 155;
 			    }
-			
+
 			    public int replaceSuiteThatDoNotFallThrough(int i1) {
 			        if (i1 == 0) {
 			            if (i2 == 1) {
@@ -411,7 +412,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        }
 			        return 155;
 			    }
-			
+
 			    public int replaceSuiteIgnoring(int i1) {
 			        if (i1 == 0) {
 			            return 0;
@@ -452,7 +453,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        }
 			        return 155;
 			    }
-			
+
 			    public void replaceWhenVariableTypesConflict(int i1) {
 			        int i = 0;
 			        if (i1 == 0) {
@@ -469,7 +470,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = c;
 			        }
 			    }
-			
+
 			    public int replaceMeltCases(int i1) {
 			        // Keep this comment
 			        if (i1 == 0) {
@@ -513,13 +514,13 @@ public class CleanUpTest12 extends CleanUpTestCase {
 
 		String expected= """
 			package test1;
-			
+
 			public class E {
 			    public static final int CONSTANT_1 = 0;
 			    public static final int CONSTANT_2 = 1;
-			
+
 			    public int i2 = 0;
-			
+
 			    public void replaceIfWithSwitchOnParameter(int i1) {
 			        int i = 0;
 			        // Keep this comment
@@ -570,8 +571,9 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                }
 			                break;
 			        }
+			        // extra comment
 			    }
-			
+
 			    public void replaceIfWithSwitchUsingConstants(int date) {
 			        int i = 0;
 			        // Keep this comment
@@ -595,7 +597,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSwitchOnLocalVariable() {
 			        int i1 = 0;
 			        int i = 0;
@@ -626,7 +628,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSwitchOnField() {
 			        int i = 0;
 			        // Keep this comment
@@ -646,7 +648,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceWithSwitchOnField() {
 			        int i = 0;
 			        // Keep this comment
@@ -666,7 +668,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSwitchOnCharacter(char character) {
 			        int i = 0;
 			        // Keep this comment
@@ -690,7 +692,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceIfRemoveDuplicateConditions(char aCharacter) {
 			        int i = 0;
 			        switch (aCharacter) {
@@ -711,7 +713,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceIfWithSeveralConditions(char myCharacter) {
 			        int i = 0;
 			        switch (myCharacter) {
@@ -732,7 +734,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceIfKeepExistingControlFlowBreaks(byte i1) {
 			        byte j = 0;
 			        loop: for (byte i = 0; i < 10; i++) {
@@ -771,7 +773,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            }
 			        }
 			    }
-			
+
 			    public void replaceWithInnerLoopBreak(short i1) {
 			        short j = 0;
 			        switch (i1) {
@@ -832,7 +834,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceIfWhenNoVariableNameConflictExists(int i1) {
 			        int i = 0;
 			        switch (i1) {
@@ -855,7 +857,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public void replaceWhenOutOfScopeVariableNameConflicts(int i1) {
 			        int i = 0;
 			        switch (i1) {
@@ -879,7 +881,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			                break;
 			        }
 			    }
-			
+
 			    public int replaceIfSuite(int i1) {
 			        // Keep this comment
 			        switch (i1) {
@@ -918,7 +920,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        }
 			        return 155;
 			    }
-			
+
 			    public int replaceSuiteThatDoNotFallThrough(int i1) {
 			        if (i1 == 0) {
 			            if (i2 == 1) {
@@ -960,7 +962,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        }
 			        return 155;
 			    }
-			
+
 			    public int replaceSuiteIgnoring(int i1) {
 			        if (i1 == 0) {
 			            return 0;
@@ -1002,7 +1004,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			        }
 			        return 155;
 			    }
-			
+
 			    public void replaceWhenVariableTypesConflict(int i1) {
 			        int i = 0;
 			        switch (i1) {
@@ -1028,7 +1030,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            }
 			        }
 			    }
-			
+
 			    public int replaceMeltCases(int i1) {
 			        // Keep this comment
 			        switch (i1) {
@@ -1080,7 +1082,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """
 			package test1;
-			
+
 			public class E {
 			    public void doNotReplaceWithOuterLoopBreak(int i1) {
 			        int j = 0;
@@ -1102,7 +1104,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            }
 			        }
 			    }
-			
+
 			    public void doNotReplaceIfWithoutElseIf(int i1) {
 			        int i = 0;
 			        if (i1 == 0) {
@@ -1111,14 +1113,14 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 10;
 			        }
 			    }
-			
+
 			    public void doNotReplaceIfWithoutElse(int i1) {
 			        int i = 0;
 			        if (i1 == 0) {
 			            i = 10;
 			        }
 			    }
-			
+
 			    public void doNotReplaceWithSwitchOnPrimitiveWrapper(Integer i1) {
 			        int i = 0;
 			        if (i1 == 0) {
@@ -1131,7 +1133,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			            i = 30;
 			        }
 			    }
-			
+
 			    public void doNotRefactorLongVar(long l1) {
 			        int i = 0;
 			        if (l1 == 0) {


### PR DESCRIPTION
- fix SwitchFixCore.SwitchFixOperation to copy the remaining statement without extended range to avoid a mismatch of length when the original if statement is replaced
- add trailing comment to test in CleanUpTest12 to emulate circumstances of failure
- fixes #1509

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See original issue or test change.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
