### PR TITLE
Enum support for if else to switch cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
@@ -238,7 +238,8 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 
 					for (Expression expression : sourceCase.literalExpressions) {
 						Object constantValue= expression.resolveConstantExpressionValue();
-						if(constantValue == null && expression.resolveTypeBinding().isEnum()) {
+						ITypeBinding expressiontypeBinding= expression.resolveTypeBinding();
+						if(constantValue == null && expressiontypeBinding != null && expressiontypeBinding.isEnum()) {
 							constantValue= expression;
 						}
 
@@ -272,9 +273,13 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 				} else if (expression instanceof MethodInvocation) {
 					MethodInvocation method= (MethodInvocation)expression;
 					if (method.resolveMethodBinding() != null) {
-						if (!"equals".equals(method.getName().getIdentifier())) return null; //$NON-NLS-1$
+						if (!"equals".equals(method.getName().getIdentifier())) { //$NON-NLS-1$
+							return null;
+						}
 						List<?> arguments= method.arguments();
-						if (arguments.size() != 1) return null;
+						if (arguments.size() != 1) {
+							return null;
+						}
 						IMethodBinding methodBinding= method.resolveMethodBinding();
 						String qualifiedName= methodBinding.getDeclaringClass().getQualifiedName();
 						if ("java.lang.String".equals(qualifiedName)) { //$NON-NLS-1$
@@ -327,10 +332,12 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 			}
 
 			private Variable extractVariableWithConstantValue(final Expression variable, final Expression constant) {
-				if (!(variable instanceof Name || variable instanceof FieldAccess || variable instanceof SuperFieldAccess))return null;
+				if (!(variable instanceof Name || variable instanceof FieldAccess || variable instanceof SuperFieldAccess)) {
+					return null;
+				}
 
 				ITypeBinding variabletypeBinding= variable.resolveTypeBinding();
-				boolean isVariableEnum= variabletypeBinding.isEnum();
+				boolean isVariableEnum= variabletypeBinding != null && variabletypeBinding.isEnum();
 				boolean hasType= ASTNodes.hasType(variable, char.class.getCanonicalName(),
 						byte.class.getCanonicalName(), short.class.getCanonicalName(),
 						int.class.getCanonicalName()) || isVariableEnum;
@@ -339,7 +346,7 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 				if (hasType
 						&& constanttypeBinding != null
 						&& (constanttypeBinding.isPrimitive() || isVariableEnum)
-						&& (constant.resolveConstantExpressionValue() != null|| isVariableEnum)) {
+						&& (constant.resolveConstantExpressionValue() != null || isVariableEnum)) {
 					return new Variable(variable, Arrays.asList(constant));
 				}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
@@ -343,10 +343,11 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 						int.class.getCanonicalName()) || isVariableEnum;
 
 				ITypeBinding constanttypeBinding= constant.resolveTypeBinding();
+				boolean isConstantEnum= constanttypeBinding != null && constanttypeBinding.isEnum();
 				if (hasType
 						&& constanttypeBinding != null
-						&& (constanttypeBinding.isPrimitive() || isVariableEnum)
-						&& (constant.resolveConstantExpressionValue() != null || isVariableEnum)) {
+						&& (constanttypeBinding.isPrimitive() || isConstantEnum)
+						&& (constant.resolveConstantExpressionValue() != null || isConstantEnum)) {
 					return new Variable(variable, Arrays.asList(constant));
 				}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
@@ -323,13 +323,16 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 			}
 
 			private Variable extractVariableWithConstantValue(final Expression variable, final Expression constant) {
-				if ((variable instanceof Name || variable instanceof FieldAccess || variable instanceof SuperFieldAccess)
-						&& ASTNodes.hasType(variable, char.class.getCanonicalName(),
-								byte.class.getCanonicalName(), short.class.getCanonicalName(),
-								int.class.getCanonicalName())
+				if (!(variable instanceof Name || variable instanceof FieldAccess || variable instanceof SuperFieldAccess))return null;
+
+				variable.resolveTypeBinding();
+				boolean hasType= ASTNodes.hasType(variable, char.class.getCanonicalName(),
+						byte.class.getCanonicalName(), short.class.getCanonicalName(),
+						int.class.getCanonicalName(), Enum.class.getCanonicalName());
+				if (hasType
 						&& constant.resolveTypeBinding() != null
-						&& constant.resolveTypeBinding().isPrimitive()
-						&& constant.resolveConstantExpressionValue() != null) {
+						&& (constant.resolveTypeBinding().isPrimitive() || ASTNodes.hasType(constant, Enum.class.getCanonicalName()))
+						&& (constant.resolveConstantExpressionValue() != null|| ASTNodes.hasType(constant, Enum.class.getCanonicalName()))) {
 					return new Variable(variable, Arrays.asList(constant));
 				}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
@@ -1169,7 +1169,7 @@ public class E {
 	public void testSwitchEnum() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String given= """
-			package test1;
+package test1;
 
 public class E {
 
@@ -1206,41 +1206,38 @@ package test1;
 
 public class E {
 
-	public static final String VALUE0 = "0";
-	public static final String VALUE1 = "1";
-	public static final String VALUE2 = "2";
-	public static final String VALUE3 = "3";
+	public enum MYENUM { VALUE0,VALUE1,VALUE2,VALUE3,VALUE4,VALUE5}
 
-    public void bug1(String i1) {
-        int i = 0;
-        switch (i1) {
-            case E.VALUE0 : {
+	public void bug1(MYENUM i1) {
+		int i = 0;
+		switch (i1) {
+            case MYENUM.VALUE0 : {
                 int integer1 = 0;
                 i = integer1;
                 break;
             }
-            case E.VALUE1 : {
+            case MYENUM.VALUE1 : {
                 char integer1 = 'a';
                 i = integer1;
                 break;
             }
-            case E.VALUE2 : {
+            case MYENUM.VALUE2 : {
                 char integer1 = 'b';
                 i = integer1;
                 break;
             }
             default :
-                if (computeit(i1) || i1.equals(E.VALUE3)) {
-                //
-                //
+                if (computeit(i1) || i1 == MYENUM.VALUE3) {
+                	//
+                	//
                 }
                 break;
         }
-    }
+	}
 
-    private boolean computeit(String i) {
-	    return i.equals("4") || i.equals("5");
-    }
+	private boolean computeit(MYENUM i) {
+		return i.equals(MYENUM.VALUE4) || i == MYENUM.VALUE5;
+	}
 }
 			""";
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
@@ -1164,6 +1164,91 @@ public class E {
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_Switch_description)));
 	}
 
+
+	@Test
+	public void testSwitchEnum() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
+		String given= """
+			package test1;
+
+public class E {
+
+	public enum MYENUM { VALUE0,VALUE1,VALUE2,VALUE3,VALUE4,VALUE5}
+
+	public void bug1(MYENUM i1) {
+		int i = 0;
+		if (i1 == MYENUM.VALUE0) {
+			int integer1 = 0;
+			i = integer1;
+		} else if (i1 == MYENUM.VALUE1) {
+			char integer1 = 'a';
+			i = integer1;
+		} else if (i1 == MYENUM.VALUE2) {
+			char integer1 = 'b';
+			i = integer1;
+		} else if (computeit(i1) || i1 == MYENUM.VALUE3) {
+			//
+			//
+		}
+	}
+
+	private boolean computeit(MYENUM i) {
+		return i.equals(MYENUM.VALUE4) || i == MYENUM.VALUE5;
+	}
+}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("E.java", given, false, null);
+
+		enable(CleanUpConstants.USE_SWITCH);
+
+		String expected= """
+package test1;
+
+public class E {
+
+	public static final String VALUE0 = "0";
+	public static final String VALUE1 = "1";
+	public static final String VALUE2 = "2";
+	public static final String VALUE3 = "3";
+
+    public void bug1(String i1) {
+        int i = 0;
+        switch (i1) {
+            case E.VALUE0 : {
+                int integer1 = 0;
+                i = integer1;
+                break;
+            }
+            case E.VALUE1 : {
+                char integer1 = 'a';
+                i = integer1;
+                break;
+            }
+            case E.VALUE2 : {
+                char integer1 = 'b';
+                i = integer1;
+                break;
+            }
+            default :
+                if (computeit(i1) || i1.equals(E.VALUE3)) {
+                //
+                //
+                }
+                break;
+        }
+    }
+
+    private boolean computeit(String i) {
+	    return i.equals("4") || i.equals("5");
+    }
+}
+			""";
+
+		assertNotEquals("The class must be changed", given, expected);
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
+				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_Switch_description)));
+	}
+
 	@Test
 	public void testDoNotUseSwitch() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Adds support for enum to the cleanup in charge for refactoring chains of "if else" to switch.

## How to test
Run the cleanup on code with if else chains or add junit test cases.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
