### PR TITLE
Fix inline method to handle inner class static references

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1515_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1515_1.java
@@ -1,0 +1,28 @@
+package bugs_in;
+
+class B {
+	public static void m() {
+		System.out.println("b");
+	}
+}
+
+public class A {
+
+	public static int k;
+
+	public static void f() {
+		m();
+		k= 3;
+	}
+
+	public static void m() {
+		System.out.println("a");
+	}
+
+	public class D extends B {
+		public static void t() {
+			/*]*/f();/*[*/
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1515_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1515_2.java
@@ -1,0 +1,29 @@
+package bugs_in;
+
+class B {
+	protected static int k;
+	public static void m() {
+		System.out.println("b");
+	}
+}
+
+public class A {
+
+	public static int k;
+
+	public static void f() {
+		m();
+		k= 3;
+	}
+
+	public static void m() {
+		System.out.println("a");
+	}
+
+	public class D extends B {
+		public static void t() {
+			/*]*/f();/*[*/
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1515_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1515_3.java
@@ -1,0 +1,29 @@
+package bugs_in;
+
+class B {
+	private static int k;
+	public static void m() {
+		System.out.println("b");
+	}
+}
+
+public class A {
+
+	public static int k;
+
+	public static void f() {
+		m();
+		k= 3;
+	}
+
+	public static void m() {
+		System.out.println("a");
+	}
+
+	public class D extends B {
+		public static void t() {
+			/*]*/f();/*[*/
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1515_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1515_1.java
@@ -1,0 +1,29 @@
+package bugs_in;
+
+class B {
+	public static void m() {
+		System.out.println("b");
+	}
+}
+
+public class A {
+
+	public static int k;
+
+	public static void f() {
+		m();
+		k= 3;
+	}
+
+	public static void m() {
+		System.out.println("a");
+	}
+
+	public class D extends B {
+		public static void t() {
+			/*]*/A.m();
+			k= 3;/*[*/
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1515_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1515_2.java
@@ -1,0 +1,30 @@
+package bugs_in;
+
+class B {
+	protected static int k;
+	public static void m() {
+		System.out.println("b");
+	}
+}
+
+public class A {
+
+	public static int k;
+
+	public static void f() {
+		m();
+		k= 3;
+	}
+
+	public static void m() {
+		System.out.println("a");
+	}
+
+	public class D extends B {
+		public static void t() {
+			/*]*/A.m();
+			A.k= 3;/*[*/
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1515_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1515_3.java
@@ -1,0 +1,30 @@
+package bugs_in;
+
+class B {
+	private static int k;
+	public static void m() {
+		System.out.println("b");
+	}
+}
+
+public class A {
+
+	public static int k;
+
+	public static void f() {
+		m();
+		k= 3;
+	}
+
+	public static void m() {
+		System.out.println("a");
+	}
+
+	public class D extends B {
+		public static void t() {
+			/*]*/A.m();
+			k= 3;/*[*/
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -469,6 +469,21 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 
 	@Test
 	public void test_issue_1358_3() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_1515_1() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_1515_2() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_1515_3() throws Exception {
 		performBugTest();
 	}
 


### PR DESCRIPTION
- add logic to SourceProvider to change static field/method references that don't have a qualifier and collide with field/method names in an inner target class
- add new tests to InlineMethodTests
- fixes #1515

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes inlining to an inlined class where there is a static field/method reference with a name that exists in the inner class.  See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
