### PR TITLE
Add "Compliance" problems UI support

### DIFF
--- a/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ProblemNode.java
+++ b/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ProblemNode.java
@@ -180,6 +180,9 @@ public class ProblemNode extends ASTAttribute {
 			case CategorizedProblem.CAT_MODULE:
 				buf.append("Module");
 				break;
+			case CategorizedProblem.CAT_COMPLIANCE:
+				buf.append("Compliance");
+				break;
 			default:
 				buf.append("<UNKNOWN CATEGORY>");
 				break;

--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -1205,6 +1205,7 @@ JavaModelContent.name=Java Workspace
 #--- Java problem grouping
 MarkerCategory.name=Java Problem Type
 MarkerCategory.buildpath=Build Path
+MarkerCategory.compliance=Compliance
 MarkerCategory.fatal=Fatal Errors
 MarkerCategory.documentation=Documentation
 MarkerCategory.codestyle=Code Style

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -5203,6 +5203,10 @@
         markerGrouping="org.eclipse.jdt.ui.java_marker_category"
         label="%MarkerCategory.buildpath"
         priority="100"/>
+    <markerGroupingEntry id="org.eclipse.jdt.ui.category.compliance"
+        markerGrouping="org.eclipse.jdt.ui.java_marker_category"
+        label="%MarkerCategory.compliance"
+        priority="100"/>
     <markerGroupingEntry id="org.eclipse.jdt.ui.category.fatal"
         markerGrouping="org.eclipse.jdt.ui.java_marker_category"
         label="%MarkerCategory.fatal"
@@ -5259,6 +5263,7 @@
         <markerAttributeMapping value="130" markerGroupingEntry="org.eclipse.jdt.ui.category.generictypes"/>
         <markerAttributeMapping value="140" markerGroupingEntry="org.eclipse.jdt.ui.category.nls"/>
         <markerAttributeMapping value="150" markerGroupingEntry="org.eclipse.jdt.ui.category.restrictedAPI"/>
+        <markerAttributeMapping value="170" markerGroupingEntry="org.eclipse.jdt.ui.category.compliance"/>
      </markerAttributeGrouping>
      <markerAttributeGrouping markerType="org.eclipse.jdt.core.buildpath_problem"
         defaultGroupingEntry="org.eclipse.jdt.ui.category.buildpath"/>


### PR DESCRIPTION
Makes sure that new errors about "Not supported Java version" are sorted with high prio in the Problems view

**Before**

![image](https://github.com/user-attachments/assets/704e73b2-543f-43ac-9ff5-1ca03be0958e)


**After**

![image](https://github.com/user-attachments/assets/271e8433-487a-4905-a42a-02c489f4884c)


See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2536