### PR TITLE
Tweak RenameLocalVariableProcessor.checkFieldCollision() logic

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -580,7 +580,7 @@ RenameTempRefactoring_lowercase=This name is discouraged. According to conventio
 RenameTempRefactoring_lowercase2=The variable name ''{0}'' in ''{1}'' (type ''{2}'') is discouraged. According to convention, names of local variables should start with a lowercase letter.
 RenameTempRefactoring_rename=Rename Local Variable
 RenameTempRefactoring_changeName=Update local variable reference
-RenameTempRefactoring_field_collision=Name chosen collides with field: ''{0}'' 
+RenameTempRefactoring_field_collision=Name chosen collides with field: ''{0}''
 
 MethodChecks_overrides=The selected method overrides method ''{0}'' declared in type ''{1}''.
 MethodChecks_implements=The selected method is an implementation of method ''{0}'' declared in type ''{1}''

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameLocalVariableProcessor.java
@@ -46,6 +46,7 @@ import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
@@ -53,6 +54,7 @@ import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.RecordDeclaration;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
@@ -322,7 +324,8 @@ public class RenameLocalVariableProcessor extends JavaRenameProcessor implements
 			ASTVisitor checkCollistionVisitor= new ASTVisitor() {
 				@Override
 				public boolean visit(SimpleName node) {
-					if (node.getFullyQualifiedName().equals(tempBinding.getName())) {
+					if (node.getFullyQualifiedName().equals(tempBinding.getName()) && !(node.getParent() instanceof FieldAccess) &&
+							!(node.getParent() instanceof QualifiedName) && !(node.getParent() instanceof VariableDeclaration)) {
 						IBinding binding= node.resolveBinding();
 						if (tempBinding.isEqualTo(binding)) {
 							ASTNode ancestor= ASTNodes.getFirstAncestorOrNull(node, AbstractTypeDeclaration.class, AnonymousClassDeclaration.class);
@@ -333,7 +336,7 @@ public class RenameLocalVariableProcessor extends JavaRenameProcessor implements
 									for (IVariableBinding field : fields) {
 										if (field.getName().equals(fNewName)) {
 											try {
-												result.merge(RefactoringStatus.createWarningStatus(Messages.format(RefactoringCoreMessages.RenameTempRefactoring_field_collision, typeDeclBinding.getName() + "." + field.getName()), //$NON-NLS-1$
+												result.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.RenameTempRefactoring_field_collision, typeDeclBinding.getName() + "." + field.getName()), //$NON-NLS-1$
 														new JavaStringStatusContext(fCu.getSource(),
 																SourceRangeFactory.create(node))));
 											} catch (JavaModelException e) {
@@ -350,7 +353,7 @@ public class RenameLocalVariableProcessor extends JavaRenameProcessor implements
 									for (IVariableBinding field : fields) {
 										if (field.getName().equals(fNewName)) {
 											try {
-												result.merge(RefactoringStatus.createWarningStatus(Messages.format(RefactoringCoreMessages.RenameTempRefactoring_field_collision, "ANONYMOUS." + field.getName()), //$NON-NLS-1$
+												result.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.RenameTempRefactoring_field_collision, "ANONYMOUS." + field.getName()), //$NON-NLS-1$
 														new JavaStringStatusContext(fCu.getSource(),
 																SourceRangeFactory.create(node))));
 											} catch (JavaModelException e) {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/RenameTemp/canRename/A_test4_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/RenameTemp/canRename/A_test4_in.java
@@ -1,0 +1,9 @@
+//rename to: k
+package p;
+class A{
+	int k;
+	void m(){
+		A /*[*/i/*]*/= new A();
+		i.k= i.k;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/RenameTemp/canRename/A_test4_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/RenameTemp/canRename/A_test4_out.java
@@ -1,0 +1,9 @@
+//rename to: k
+package p;
+class A{
+	int k;
+	void m(){
+		A /*[*/k/*]*/= new A();
+		k.k= k.k;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenameTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenameTempTests.java
@@ -176,7 +176,7 @@ public class RenameTempTests extends GenericRefactoringTest{
 
 	@Test
 	public void test4() throws Exception{
-		helper2("k"); // this test now issues a warning
+		helper1("k");
 	}
 
 	@Test
@@ -278,12 +278,12 @@ public class RenameTempTests extends GenericRefactoringTest{
 
 	@Test
 	public void test25() throws Exception{
-		helper2("j"); // this test now issues a warning
+		helper2("j"); // this test now issues an error
 	}
 
 	@Test
 	public void test26() throws Exception{
-		helper2("j"); // this test now issues a warning
+		helper2("j"); // this test now issues an error
 	}
 
 //  deleted - incorrect. see testFail26
@@ -323,7 +323,7 @@ public class RenameTempTests extends GenericRefactoringTest{
 
 	@Test
 	public void test34() throws Exception{
-		helper2("j"); // this test now issues a warning
+		helper2("j"); // this test now issues an error
 	}
 
 	@Test


### PR DESCRIPTION
- change method above to ignore qualified name references, field accesses, and the original variable declaration for the check
- reinstate RenameTempTests.test4() to work again and not fail
- change warning to error and tweak message
- fixes #1527

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or test change.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
