### PR TITLE
Fix lambda to method ref quick assist to not add type parameter

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertLambdaToMethodReferenceFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertLambdaToMethodReferenceFixCore.java
@@ -269,7 +269,7 @@ public class ConvertLambdaToMethodReferenceFixCore extends CompilationUnitRewrit
 					typeMethodReference.setName((SimpleName) rewrite.createCopyTarget(superMethodInvocation.getName()));
 					ImportRewrite importRewrite= cuRewrite.getImportRewrite();
 					ITypeBinding invocationTypeBinding= ASTNodes.getInvocationType(superMethodInvocation, methodBinding, superQualifier);
-					typeMethodReference.setType(importRewrite.addImport(invocationTypeBinding.getTypeDeclaration(), ast));
+					typeMethodReference.setType(importRewrite.addImport(invocationTypeBinding.getTypeDeclaration().getErasure(), ast));
 					typeMethodReference.typeArguments().addAll(QuickAssistProcessorUtil.getCopiedTypeArguments(rewrite, superMethodInvocation.typeArguments()));
 					replacement= castMethodRefIfNeeded(cuRewrite, ast, typeMethodReference);
 				} else {
@@ -288,7 +288,7 @@ public class ConvertLambdaToMethodReferenceFixCore extends CompilationUnitRewrit
 				TypeLiteral typeLiteral= ast.newTypeLiteral();
 				ImportRewrite importRewrite= cuRewrite.getImportRewrite();
 				ITypeBinding instanceofTypeBinding= instanceofExpression.getRightOperand().resolveBinding();
-				typeLiteral.setType(importRewrite.addImport(instanceofTypeBinding.getTypeDeclaration(), ast));
+				typeLiteral.setType(importRewrite.addImport(instanceofTypeBinding.getTypeDeclaration().getErasure(), ast));
 				expMethodReference.setName(ast.newSimpleName("isInstance")); //$NON-NLS-1$
 				expMethodReference.setExpression(typeLiteral);
 				replacement= castMethodRefIfNeeded(cuRewrite, ast, expMethodReference);
@@ -308,7 +308,7 @@ public class ConvertLambdaToMethodReferenceFixCore extends CompilationUnitRewrit
 					ITypeBinding invocationTypeBinding= ASTNodes.getInvocationType(methodInvocation, methodBinding, invocationQualifier);
 					invocationTypeBinding= StubUtility2Core.replaceWildcardsAndCaptures(invocationTypeBinding);
 					ImportRewriteContext importRewriteContext= new ContextSensitiveImportRewriteContext(lambda, importRewrite);
-					typeMethodReference.setType(importRewrite.addImport(invocationTypeBinding, ast, importRewriteContext, TypeLocation.OTHER));
+					typeMethodReference.setType(importRewrite.addImport(invocationTypeBinding.getErasure(), ast, importRewriteContext, TypeLocation.OTHER));
 					typeMethodReference.typeArguments().addAll(QuickAssistProcessorUtil.getCopiedTypeArguments(rewrite, methodInvocation.typeArguments()));
 					replacement= castMethodRefIfNeeded(cuRewrite, ast, typeMethodReference);
 				} else {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -4783,7 +4783,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			    Function<Integer, String> b2 = t -> /*[7]*/this.method1(t);
 			    Function<Integer, String> b3 = t -> /*[8]*/(new SuperE3<String>()).method1(t);
 
-			    Function<E3<Integer>, String> p1 = E3<Integer>::<Float>method2;
+			    Function<E3<Integer>, String> p1 = E3::<Float>method2;
 			    Function<E3, String> p2 = t -> /*[10]*/t.method2();
 
 			    <V> String method2() { return "m2";    }
@@ -5070,6 +5070,55 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			        return x.isCorrect(this);
 			    }
 
+			}
+			""";
+		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
+	public void testIssue1520() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str= """
+			package test1;
+			import java.util.Optional;
+			import java.util.function.Supplier;
+			public class E6 {
+
+				public static void main(String[] args) {
+					create("Hello").map(c -> c.get()).map(s -> s.concat("World"));
+				}
+
+				public static <X> Optional<Supplier<X>> create(X value) {
+					if (value == null) {
+						return Optional.empty();
+					}
+					return Optional.of(() -> value);
+				}
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E6.java", str, false, null);
+
+		int offset= str.indexOf("c ->");
+		AssistContext context= getCorrectionContext(cu, offset, 4);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		String expected1= """
+			package test1;
+			import java.util.Optional;
+			import java.util.function.Supplier;
+			public class E6 {
+
+				public static void main(String[] args) {
+					create("Hello").map(Supplier::get).map(s -> s.concat("World"));
+				}
+
+				public static <X> Optional<Supplier<X>> create(X value) {
+					if (value == null) {
+						return Optional.empty();
+					}
+					return Optional.of(() -> value);
+				}
 			}
 			""";
 		assertExpectedExistInProposals(proposals, new String[] { expected1 });
@@ -5794,7 +5843,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 				}
 
 				void f(Source<?> source) {
-					source.sendTo(ArrayList<Number>::size);
+					source.sendTo(ArrayList::size);
 				}
 			}
 			""";


### PR DESCRIPTION
- fix ConvertLambdaToMethodReferenceProposalOperation.rewriteAST() method to use type erasure when setting type of method reference
- add new test to AssistQuickFixTest1d8
- fixes #1520

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes lambda to method reference quick assist to not add extraneous type parameter.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
