### PR TITLE
dogfooding - Convert String concatenation to Text Block

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/BooleanValueRatherThanComparisonCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/BooleanValueRatherThanComparisonCleanUpCore.java
@@ -66,17 +66,19 @@ public class BooleanValueRatherThanComparisonCleanUpCore extends AbstractCleanUp
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.BOOLEAN_VALUE_RATHER_THAN_COMPARISON)) {
-			return "" //$NON-NLS-1$
-					+ "boolean booleanValue = isValid;\n" //$NON-NLS-1$
-					+ "boolean booleanValue2 = !isValid;\n" //$NON-NLS-1$
-					+ "boolean booleanValue3 = i <= 0;\n" //$NON-NLS-1$
-					+ "boolean booleanValue4 = !booleanObject;\n"; //$NON-NLS-1$
+			return """
+				boolean booleanValue = isValid;
+				boolean booleanValue2 = !isValid;
+				boolean booleanValue3 = i <= 0;
+				boolean booleanValue4 = !booleanObject;
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "boolean booleanValue = isValid == true;\n" //$NON-NLS-1$
-				+ "boolean booleanValue2 = isValid == false;\n" //$NON-NLS-1$
-				+ "boolean booleanValue3 = Boolean.FALSE.equals(i > 0);\n" //$NON-NLS-1$
-				+ "boolean booleanValue4 = booleanObject.equals(Boolean.FALSE);\n"; //$NON-NLS-1$
+		return """
+			boolean booleanValue = isValid == true;
+			boolean booleanValue2 = isValid == false;
+			boolean booleanValue3 = Boolean.FALSE.equals(i > 0);
+			boolean booleanValue4 = booleanObject.equals(Boolean.FALSE);
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ElseIfCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ElseIfCleanUpCore.java
@@ -61,22 +61,26 @@ public class ElseIfCleanUpCore extends AbstractMultiFix implements ICleanUpFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.ELSE_IF)) {
-			return "" //$NON-NLS-1$
-					+ "if (isValid) {\n" //$NON-NLS-1$
-					+ "  System.out.println(isValid);\n" //$NON-NLS-1$
-					+ "} else if (isEnabled) {\n" //$NON-NLS-1$
-					+ "  System.out.println(isEnabled);\n" //$NON-NLS-1$
-					+ "}\n\n\n"; //$NON-NLS-1$
+			return """
+				if (isValid) {
+				  System.out.println(isValid);
+				} else if (isEnabled) {
+				  System.out.println(isEnabled);
+				}
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (isValid) {\n" //$NON-NLS-1$
-				+ "  System.out.println(isValid);\n" //$NON-NLS-1$
-				+ "} else {\n" //$NON-NLS-1$
-				+ "  if (isEnabled) {\n" //$NON-NLS-1$
-				+ "    System.out.println(isEnabled);\n" //$NON-NLS-1$
-				+ "  }\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (isValid) {
+			  System.out.println(isValid);
+			} else {
+			  if (isEnabled) {
+			    System.out.println(isEnabled);
+			  }
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/InvertEqualsCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/InvertEqualsCleanUpCore.java
@@ -70,17 +70,19 @@ public class InvertEqualsCleanUpCore extends AbstractCleanUp {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.INVERT_EQUALS)) {
-			return "" //$NON-NLS-1$
-					+ "boolean result = \"foo\".equals(text);\n" //$NON-NLS-1$
-					+ "boolean result2 = (text1 + text2).equals(text);\n" //$NON-NLS-1$
-					+ "boolean result3 = DayOfWeek.MONDAY.equals(object);\n" //$NON-NLS-1$
-					+ "boolean result4 = \"foo\".equalsIgnoreCase(text);\n"; //$NON-NLS-1$
+			return """
+				boolean result = "foo".equals(text);
+				boolean result2 = (text1 + text2).equals(text);
+				boolean result3 = DayOfWeek.MONDAY.equals(object);
+				boolean result4 = "foo".equalsIgnoreCase(text);
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "boolean result = text.equals(\"foo\");\n" //$NON-NLS-1$
-				+ "boolean result2 = text.equals(text1 + text2);\n" //$NON-NLS-1$
-				+ "boolean result3 = object.equals(DayOfWeek.MONDAY);\n" //$NON-NLS-1$
-				+ "boolean result4 = text.equalsIgnoreCase(\"foo\");\n"; //$NON-NLS-1$
+		return """
+			boolean result = text.equals("foo");
+			boolean result2 = text.equals(text1 + text2);
+			boolean result3 = object.equals(DayOfWeek.MONDAY);
+			boolean result4 = text.equalsIgnoreCase("foo");
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/NoStringCreationCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/NoStringCreationCleanUpCore.java
@@ -82,16 +82,18 @@ public class NoStringCreationCleanUpCore extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.NO_STRING_CREATION)) {
-			return "" //$NON-NLS-1$
-					+ "String bar = \"foo\";\n" //$NON-NLS-1$
-					+ "String newBar = bar.concat(\"abc\");\n" //$NON-NLS-1$
-					+ "String cantChange = new String(possibleNullObject)\n"; //$NON-NLS-1$
+			return """
+				String bar = "foo";
+				String newBar = bar.concat("abc");
+				String cantChange = new String(possibleNullObject)
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "String bar = new String(\"foo\");\n" //$NON-NLS-1$
-				+ "String newBar = (new String(bar)).concat(\"abc\");\n" //$NON-NLS-1$
-				+ "String cantChange = new String(possibleNullObject)\n"; //$NON-NLS-1$
+		return """
+			String bar = new String("foo");
+			String newBar = (new String(bar)).concat("abc");
+			String cantChange = new String(possibleNullObject)
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PatternMatchingForInstanceofCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PatternMatchingForInstanceofCleanUpCore.java
@@ -73,16 +73,19 @@ public class PatternMatchingForInstanceofCleanUpCore extends AbstractCleanUp {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.USE_PATTERN_MATCHING_FOR_INSTANCEOF)) {
-			return "" //$NON-NLS-1$
-					+ "if (object instanceof Integer i) {\n" //$NON-NLS-1$
-					+ "    return i.intValue();\n" //$NON-NLS-1$
-					+ "}\n\n"; //$NON-NLS-1$
+			return """
+				if (object instanceof Integer i) {
+				    return i.intValue();
+				}
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (object instanceof Integer) {\n" //$NON-NLS-1$
-				+ "    Integer i = (Integer) object;\n" //$NON-NLS-1$
-				+ "    return i.intValue();\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (object instanceof Integer) {
+			    Integer i = (Integer) object;
+			    return i.intValue();
+			}
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PlainReplacementCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PlainReplacementCleanUpCore.java
@@ -70,17 +70,19 @@ public class PlainReplacementCleanUpCore extends AbstractCleanUp {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.PLAIN_REPLACEMENT)) {
-			return "" //$NON-NLS-1$
-					+ "String result = text.replace(\"foo\", \"bar\");\n" //$NON-NLS-1$
-					+ "String result2 = text.replace(\"$0.02\", \"$0.50\");\n" //$NON-NLS-1$
-					+ "String result3 = text.replace('.', '/');\n" //$NON-NLS-1$
-					+ "String result4 = text.replace(placeholder, value);\n"; //$NON-NLS-1$
+			return """
+				String result = text.replace("foo", "bar");
+				String result2 = text.replace("$0.02", "$0.50");
+				String result3 = text.replace('.', '/');
+				String result4 = text.replace(placeholder, value);
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "String result = text.replaceAll(\"foo\", \"bar\");\n" //$NON-NLS-1$
-				+ "String result2 = text.replaceAll(\"\\\\$0\\\\.02\", \"\\\\$0.50\");\n" //$NON-NLS-1$
-				+ "String result3 = text.replaceAll(\"\\\\.\", \"/\");\n" //$NON-NLS-1$
-				+ "String result4 = text.replaceAll(Pattern.quote(placeholder), Matcher.quoteReplacement(value));\n"; //$NON-NLS-1$
+		return """
+			String result = text.replaceAll("foo", "bar");
+			String result2 = text.replaceAll("\\\\$0\\\\.02", "\\\\$0.50");
+			String result3 = text.replaceAll("\\\\.", "/");
+			String result4 = text.replaceAll(Pattern.quote(placeholder), Matcher.quoteReplacement(value));
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PullOutIfFromIfElseCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PullOutIfFromIfElseCleanUpCore.java
@@ -66,25 +66,29 @@ public class PullOutIfFromIfElseCleanUpCore extends AbstractCleanUp {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.PULL_OUT_IF_FROM_IF_ELSE)) {
-			return "" //$NON-NLS-1$
-					+ "if (isActive) {\n" //$NON-NLS-1$
-					+ "    if (isFound) {\n" //$NON-NLS-1$
-					+ "        System.out.println(\"foo\");\n" //$NON-NLS-1$
-					+ "    } else {\n" //$NON-NLS-1$
-					+ "        System.out.println(\"bar\");\n" //$NON-NLS-1$
-					+ "    }\n" //$NON-NLS-1$
-					+ "}\n\n\n"; //$NON-NLS-1$
+			return """
+				if (isActive) {
+				    if (isFound) {
+				        System.out.println("foo");
+				    } else {
+				        System.out.println("bar");
+				    }
+				}
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (isFound) {\n" //$NON-NLS-1$
-				+ "    if (isActive) {\n" //$NON-NLS-1$
-				+ "        System.out.println(\"foo\");\n" //$NON-NLS-1$
-				+ "    }\n" //$NON-NLS-1$
-				+ "} else {\n" //$NON-NLS-1$
-				+ "    if (isActive) {\n" //$NON-NLS-1$
-				+ "        System.out.println(\"bar\");\n" //$NON-NLS-1$
-				+ "    }\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (isFound) {
+			    if (isActive) {
+			        System.out.println("foo");
+			    }
+			} else {
+			    if (isActive) {
+			        System.out.println("bar");
+			    }
+			}
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/RedundantComparatorCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/RedundantComparatorCleanUpCore.java
@@ -73,12 +73,13 @@ public class RedundantComparatorCleanUpCore extends AbstractCleanUp {
 			return "Collections.sort(listToSort);\n\n\n\n\n\n"; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "Collections.sort(listToSort, new Comparator<Date>() {\n" //$NON-NLS-1$
-				+ "    @Override\n" //$NON-NLS-1$
-				+ "    public int compare(Date o1, Date o2) {\n" //$NON-NLS-1$
-				+ "        return o1.compareTo(o2);\n" //$NON-NLS-1$
-				+ "    }\n" //$NON-NLS-1$
-				+ "});\n"; //$NON-NLS-1$
+		return """
+			Collections.sort(listToSort, new Comparator<Date>() {
+			    @Override
+			    public int compare(Date o1, Date o2) {
+			        return o1.compareTo(o2);
+			    }
+			});
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SwitchCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SwitchCleanUpCore.java
@@ -76,32 +76,39 @@ public class SwitchCleanUpCore extends AbstractCleanUp {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.USE_SWITCH)) {
-			return "" //$NON-NLS-1$
-					+ "switch (number) {\n" //$NON-NLS-1$
-					+ "case 0:\n" //$NON-NLS-1$
-					+ "  i = 0;\n" //$NON-NLS-1$
-					+ "  break;\n" //$NON-NLS-1$
-					+ "case 1:\n" //$NON-NLS-1$
-					+ "  j = 10;\n" //$NON-NLS-1$
-					+ "  break;\n" //$NON-NLS-1$
-					+ "case 2:\n" //$NON-NLS-1$
-					+ "  k = 20;\n" //$NON-NLS-1$
-					+ "  break;\n" //$NON-NLS-1$
-					+ "default:\n" //$NON-NLS-1$
-					+ "  m = -1;\n" //$NON-NLS-1$
-					+ "  break;\n" //$NON-NLS-1$
-					+ "}\n"; //$NON-NLS-1$
+			return """
+				switch (number) {
+				case 0:
+				  i = 0;
+				  break;
+				case 1:
+				  j = 10;
+				  break;
+				case 2:
+				  k = 20;
+				  break;
+				default:
+				  m = -1;
+				  break;
+				}
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (number == 0) {\n" //$NON-NLS-1$
-				+ "    i = 0;\n" //$NON-NLS-1$
-				+ "} else if (number == 1) {\n" //$NON-NLS-1$
-				+ "    j = 10;\n" //$NON-NLS-1$
-				+ "} else if (2 == number) {\n" //$NON-NLS-1$
-				+ "    k = 20;\n" //$NON-NLS-1$
-				+ "} else {\n" //$NON-NLS-1$
-				+ "    m = -1;\n" //$NON-NLS-1$
-				+ "}\n\n\n\n\n\n"; //$NON-NLS-1$
+		return """
+			if (number == 0) {
+			    i = 0;
+			} else if (number == 1) {
+			    j = 10;
+			} else if (2 == number) {
+			    k = 20;
+			} else {
+			    m = -1;
+			}
+			
+			
+			
+			
+			
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SwitchExpressionsCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SwitchExpressionsCleanUpCore.java
@@ -71,27 +71,37 @@ public class SwitchExpressionsCleanUpCore extends AbstractCleanUp {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS)) {
-			return "" //$NON-NLS-1$
-					+ "int i = switch(j) {\n" //$NON-NLS-1$
-					+ "    case 1 -> 3;\n" //$NON-NLS-1$
-					+ "    case 2 -> 4;\n" //$NON-NLS-1$
-					+ "    default -> 0;\n" //$NON-NLS-1$
-					+ "};\n\n\n\n\n\n\n\n\n"; //$NON-NLS-1$
+			return """
+				int i = switch(j) {
+				    case 1 -> 3;
+				    case 2 -> 4;
+				    default -> 0;
+				};
+				
+				
+				
+				
+				
+				
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "int i;\n" //$NON-NLS-1$
-				+ "switch(j) {\n" //$NON-NLS-1$
-				+ "    case 1:\n" //$NON-NLS-1$
-				+ "        i = 3;\n" //$NON-NLS-1$
-				+ "        break;\n" //$NON-NLS-1$
-				+ "    case 2:\n" //$NON-NLS-1$
-				+ "        i = 4;\n" //$NON-NLS-1$
-				+ "        break;\n" //$NON-NLS-1$
-				+ "    default:\n" //$NON-NLS-1$
-				+ "        i = 0;\n" //$NON-NLS-1$
-				+ "        break;\n" //$NON-NLS-1$
-				+ "}\n" //$NON-NLS-1$
-				+ "\n"; //$NON-NLS-1$
+		return """
+			int i;
+			switch(j) {
+			    case 1:
+			        i = 3;
+			        break;
+			    case 2:
+			        i = 4;
+			        break;
+			    default:
+			        i = 0;
+			        break;
+			}
+			
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
@@ -170,23 +170,27 @@ public class UnusedCodeCleanUpCore extends AbstractMultiFix {
 
 
 		if (isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_METHOD_PARAMETERS)) {
-			String code= "    public void zoz() {\n" //$NON-NLS-1$
-					+ "        zozo();\n" //$NON-NLS-1$
-					+ "    }\n" //$NON-NLS-1$
-					+ "\n" //$NON-NLS-1$
-					+ "    private void zozo() {\n" //$NON-NLS-1$
-					+ "        System.out.println(\"\");\n" //$NON-NLS-1$
-					+ "    };\n"; //$NON-NLS-1$
+			String code= """
+				    public void zoz() {
+				        zozo();
+				    }
+				
+				    private void zozo() {
+				        System.out.println("");
+				    };
+				"""; //$NON-NLS-1$
 
 			buf.append(code);
 		} else {
-			String code= "    public void zoz() {\n" //$NON-NLS-1$
-					+ "        zozo(34);\n" //$NON-NLS-1$
-					+ "    }\n" //$NON-NLS-1$
-					+ "\n" //$NON-NLS-1$
-					+ "    private void zozo(int k) {\n" //$NON-NLS-1$
-					+ "        System.out.println(\"\");\n" //$NON-NLS-1$
-					+ "    };\n"; //$NON-NLS-1$
+			String code= """
+				    public void zoz() {
+				        zozo(34);
+				    }
+				
+				    private void zozo(int k) {
+				        System.out.println("");
+				    };
+				"""; //$NON-NLS-1$
 			buf.append(code);
 		}
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ValueOfRatherThanInstantiationCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ValueOfRatherThanInstantiationCleanUpCore.java
@@ -70,15 +70,17 @@ public class ValueOfRatherThanInstantiationCleanUpCore extends AbstractCleanUp {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.VALUEOF_RATHER_THAN_INSTANTIATION)) {
-			return "" //$NON-NLS-1$
-					+ "Object characterObject = Character.valueOf('a');\n" //$NON-NLS-1$
-					+ "Byte.valueOf(\"0\").byteValue();\n" //$NON-NLS-1$
-					+ "long l = 42;\n"; //$NON-NLS-1$
+			return """
+				Object characterObject = Character.valueOf('a');
+				Byte.valueOf("0").byteValue();
+				long l = 42;
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-					+ "Object characterObject = Character.valueOf('a');\n" //$NON-NLS-1$
-					+ "new Byte(\"0\").byteValue();\n" //$NON-NLS-1$
-					+ "long l = new Long(42);\n"; //$NON-NLS-1$
+		return """
+			Object characterObject = Character.valueOf('a');
+			new Byte("0").byteValue();
+			long l = new Long(42);
+			"""; //$NON-NLS-1$
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/VarCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/VarCleanUpCore.java
@@ -100,16 +100,18 @@ public class VarCleanUpCore extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.USE_VAR)) {
-			return "" //$NON-NLS-1$
-					+ "var number = 0;\n" //$NON-NLS-1$
-					+ "var list = new ArrayList<String>();\n" //$NON-NLS-1$
-					+ "var map = new HashMap<Integer, String>();\n"; //$NON-NLS-1$
+			return """
+				var number = 0;
+				var list = new ArrayList<String>();
+				var map = new HashMap<Integer, String>();
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "int number = 0;\n" //$NON-NLS-1$
-				+ "ArrayList<String> list = new ArrayList<String>();\n" //$NON-NLS-1$
-				+ "HashMap<Integer, String> map = new HashMap<>();\n"; //$NON-NLS-1$
+		return """
+			int number = 0;
+			ArrayList<String> list = new ArrayList<String>();
+			HashMap<Integer, String> map = new HashMap<>();
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AddAllCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AddAllCleanUp.java
@@ -99,10 +99,11 @@ public class AddAllCleanUp extends AbstractMultiFix implements ICleanUpFix {
 			return "outputList.addAll(inputList);\n\n\n"; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "for (int i = 0; i < inputList.size(); i++) {\n" //$NON-NLS-1$
-				+ "    outputList.add(inputList.get(i));\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			for (int i = 0; i < inputList.size(); i++) {
+			    outputList.add(inputList.get(i));
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ArraysFillCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ArraysFillCleanUp.java
@@ -94,10 +94,11 @@ public class ArraysFillCleanUp extends AbstractMultiFix {
 			return "Arrays.fill(array, true);\n\n\n"; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "for (int i = 0; i < array.length; i++) {\n" //$NON-NLS-1$
-				+ "  array[i] = true;\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			for (int i = 0; i < array.length; i++) {
+			  array[i] = true;
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AutoboxingCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AutoboxingCleanUp.java
@@ -87,14 +87,16 @@ public class AutoboxingCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.USE_AUTOBOXING)) {
-			return "" //$NON-NLS-1$
-					+ "Integer i = 0;\n" //$NON-NLS-1$
-					+ "Character c = '*';\n"; //$NON-NLS-1$
+			return """
+				Integer i = 0;
+				Character c = '*';
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "Integer i = Integer.valueOf(0);\n" //$NON-NLS-1$
-				+ "Character c = Character.valueOf('*');\n"; //$NON-NLS-1$
+		return """
+			Integer i = Integer.valueOf(0);
+			Character c = Character.valueOf('*');
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/CollectionCloningCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/CollectionCloningCleanUp.java
@@ -100,9 +100,10 @@ public class CollectionCloningCleanUp extends AbstractMultiFix {
 			return "List<Integer> output = new ArrayList<>(collection);\n\n"; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "List<Integer> output = new ArrayList<>();\n" //$NON-NLS-1$
-				+ "output.addAll(collection);\n"; //$NON-NLS-1$
+		return """
+			List<Integer> output = new ArrayList<>();
+			output.addAll(collection);
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
@@ -140,22 +140,23 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 			return "Comparator<Date> comparator = Comparator.nullsFirst(Comparator.comparing(Date::toString));\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "Comparator<Date> comparator = new Comparator<Date>() {\n" //$NON-NLS-1$
-				+ "    @Override\n" //$NON-NLS-1$
-				+ "    public int compare(Date o1, Date o2) {\n" //$NON-NLS-1$
-				+ "        if (o2 != null) {\n" //$NON-NLS-1$
-				+ "            if (o1 != null) {\n" //$NON-NLS-1$
-				+ "                return o1.toString().compareTo(o2.toString());\n" //$NON-NLS-1$
-				+ "            }\n" //$NON-NLS-1$
-				+ "            return -1;\n" //$NON-NLS-1$
-				+ "        } else if (o1 != null) {\n" //$NON-NLS-1$
-				+ "            return 1;\n" //$NON-NLS-1$
-				+ "        } else {\n" //$NON-NLS-1$
-				+ "            return 0;\n" //$NON-NLS-1$
-				+ "        }\n" //$NON-NLS-1$
-				+ "    }\n" //$NON-NLS-1$
-				+ "};\n"; //$NON-NLS-1$
+		return """
+			Comparator<Date> comparator = new Comparator<Date>() {
+			    @Override
+			    public int compare(Date o1, Date o2) {
+			        if (o2 != null) {
+			            if (o1 != null) {
+			                return o1.toString().compareTo(o2.toString());
+			            }
+			            return -1;
+			        } else if (o1 != null) {
+			            return 1;
+			        } else {
+			            return 0;
+			        }
+			    }
+			};
+			"""; //$NON-NLS-1$
 	}
 
 	private static boolean equalNotNull(final Object obj1, final Object obj2) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ControlFlowMergeCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ControlFlowMergeCleanUp.java
@@ -89,20 +89,24 @@ public class ControlFlowMergeCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.CONTROLFLOW_MERGE)) {
-			return "" //$NON-NLS-1$
-					+ "if (!isValid) {\n" //$NON-NLS-1$
-					+ "    j++;\n" //$NON-NLS-1$
-					+ "}\n" //$NON-NLS-1$
-					+ "++i;\n\n\n"; //$NON-NLS-1$
+			return """
+				if (!isValid) {
+				    j++;
+				}
+				++i;
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (isValid) {\n" //$NON-NLS-1$
-				+ "    ++i;\n" //$NON-NLS-1$
-				+ "} else {\n" //$NON-NLS-1$
-				+ "    j++;\n" //$NON-NLS-1$
-				+ "    i = i + 1;\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (isValid) {
+			    ++i;
+			} else {
+			    j++;
+			    i = i + 1;
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/DoubleNegationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/DoubleNegationCleanUp.java
@@ -78,16 +78,18 @@ public class DoubleNegationCleanUp extends AbstractMultiFix implements ICleanUpF
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.DOUBLE_NEGATION)) {
-			return "" //$NON-NLS-1$
-					+ "boolean b1 = isValid == isEnabled;\n" //$NON-NLS-1$
-					+ "boolean b2 = isValid ^ isEnabled;\n" //$NON-NLS-1$
-					+ "boolean b3 = isValid == isEnabled;\n"; //$NON-NLS-1$
+			return """
+				boolean b1 = isValid == isEnabled;
+				boolean b2 = isValid ^ isEnabled;
+				boolean b3 = isValid == isEnabled;
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "boolean b1 = !isValid == !isEnabled;\n" //$NON-NLS-1$
-				+ "boolean b2 = !isValid != !isEnabled;\n" //$NON-NLS-1$
-				+ "boolean b3 = !isValid ^ isEnabled;\n"; //$NON-NLS-1$
+		return """
+			boolean b1 = !isValid == !isEnabled;
+			boolean b2 = !isValid != !isEnabled;
+			boolean b3 = !isValid ^ isEnabled;
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EmbeddedIfCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EmbeddedIfCleanUp.java
@@ -75,18 +75,22 @@ public class EmbeddedIfCleanUp extends AbstractMultiFix implements ICleanUpFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.RAISE_EMBEDDED_IF)) {
-			return "" //$NON-NLS-1$
-					+ "if (isActive && isValid) {\n" //$NON-NLS-1$
-					+ "  int i = 0;\n" //$NON-NLS-1$
-					+ "}\n\n\n"; //$NON-NLS-1$
+			return """
+				if (isActive && isValid) {
+				  int i = 0;
+				}
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (isActive) {\n" //$NON-NLS-1$
-				+ "  if (isValid) {\n" //$NON-NLS-1$
-				+ "    int i = 0;\n" //$NON-NLS-1$
-				+ "  }\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (isActive) {
+			  if (isValid) {
+			    int i = 0;
+			  }
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EvaluateNullableCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EvaluateNullableCleanUp.java
@@ -80,16 +80,18 @@ public class EvaluateNullableCleanUp extends AbstractMultiFix implements ICleanU
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.EVALUATE_NULLABLE)) {
-			return "" //$NON-NLS-1$
-					+ "boolean b1 = \"\".equals(s);\n" //$NON-NLS-1$
-					+ "boolean b2 = \"\".equalsIgnoreCase(s);\n" //$NON-NLS-1$
-					+ "boolean b3 = s instanceof String;\n"; //$NON-NLS-1$
+			return """
+				boolean b1 = "".equals(s);
+				boolean b2 = "".equalsIgnoreCase(s);
+				boolean b3 = s instanceof String;
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "boolean b1 = s != null && \"\".equals(s);\n" //$NON-NLS-1$
-				+ "boolean b2 = null != s && \"\".equalsIgnoreCase(s);\n" //$NON-NLS-1$
-				+ "boolean b3 = s != null && s instanceof String;\n"; //$NON-NLS-1$
+		return """
+			boolean b1 = s != null && "".equals(s);
+			boolean b2 = null != s && "".equalsIgnoreCase(s);
+			boolean b3 = s != null && s instanceof String;
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ExtractIncrementCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ExtractIncrementCleanUp.java
@@ -93,9 +93,10 @@ public class ExtractIncrementCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.EXTRACT_INCREMENT)) {
-			return "" //$NON-NLS-1$
-					+ "i++;\n" //$NON-NLS-1$
-					+ "boolean isPositive = i > 0;\n"; //$NON-NLS-1$
+			return """
+				i++;
+				boolean isPositive = i > 0;
+				"""; //$NON-NLS-1$
 		}
 
 		return "boolean isPositive = ++i > 0;\n\n"; //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/HashCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/HashCleanUp.java
@@ -118,11 +118,12 @@ public class HashCleanUp extends AbstractMultiFix implements ICleanUpFix {
 				+ "return Objects.hash(aShort);\n\n\n\n"; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-			+ "final int prime = 31;\n" //$NON-NLS-1$
-			+ "int result = 1;\n" //$NON-NLS-1$
-			+ "result = prime * result + aShort;\n" //$NON-NLS-1$
-			+ "return result;\n"; //$NON-NLS-1$
+		return """
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + aShort;
+			return result;
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/JoinCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/JoinCleanUp.java
@@ -108,23 +108,34 @@ public class JoinCleanUp extends AbstractMultiFix implements ICleanUpFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.JOIN)) {
-			return "" //$NON-NLS-1$
-					+ "String concatenation= String.join(\", \", texts);\n" //$NON-NLS-1$
-					+ "return concatenation;\n\n\n\n\n\n\n\n\n\n"; //$NON-NLS-1$
+			return """
+				String concatenation= String.join(", ", texts);
+				return concatenation;
+				
+				
+				
+				
+				
+				
+				
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "boolean isFirst = true;\n" //$NON-NLS-1$
-				+ "StringBuilder concatenation = new StringBuilder();\n" //$NON-NLS-1$
-				+ "for (String text : texts) {\n" //$NON-NLS-1$
-				+ "  if (isFirst) {\n" //$NON-NLS-1$
-				+ "    isFirst = false;\n" //$NON-NLS-1$
-				+ "  } else {\n" //$NON-NLS-1$
-				+ "    concatenation.append(\", \");\n" //$NON-NLS-1$
-				+ "  }\n" //$NON-NLS-1$
-				+ "  concatenation.append(text);\n" //$NON-NLS-1$
-				+ "}\n" //$NON-NLS-1$
-				+ "return concatenation.toString();\n"; //$NON-NLS-1$
+		return """
+			boolean isFirst = true;
+			StringBuilder concatenation = new StringBuilder();
+			for (String text : texts) {
+			  if (isFirst) {
+			    isFirst = false;
+			  } else {
+			    concatenation.append(", ");
+			  }
+			  concatenation.append(text);
+			}
+			return concatenation.toString();
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/LambdaExpressionAndMethodRefCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/LambdaExpressionAndMethodRefCleanUp.java
@@ -65,20 +65,22 @@ public class LambdaExpressionAndMethodRefCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF)) {
-			return "" //$NON-NLS-1$
-					+ "someString -> someString.trim().toLowerCase();\n" //$NON-NLS-1$
-					+ "someString -> someString.trim().toLowerCase();\n" //$NON-NLS-1$
-					+ "someString -> (someString.trim().toLowerCase() + \"bar\");\n" //$NON-NLS-1$
-					+ "ArrayList::new;\n" //$NON-NLS-1$
-					+ "Date::getTime;\n"; //$NON-NLS-1$
+			return """
+				someString -> someString.trim().toLowerCase();
+				someString -> someString.trim().toLowerCase();
+				someString -> (someString.trim().toLowerCase() + "bar");
+				ArrayList::new;
+				Date::getTime;
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "(someString) -> someString.trim().toLowerCase();\n" //$NON-NLS-1$
-				+ "someString -> {return someString.trim().toLowerCase();};\n" //$NON-NLS-1$
-				+ "someString -> {return someString.trim().toLowerCase() + \"bar\";};\n" //$NON-NLS-1$
-				+ "() -> new ArrayList<>();\n" //$NON-NLS-1$
-				+ "date -> date.getTime();\n"; //$NON-NLS-1$
+		return """
+			(someString) -> someString.trim().toLowerCase();
+			someString -> {return someString.trim().toLowerCase();};
+			someString -> {return someString.trim().toLowerCase() + "bar";};
+			() -> new ArrayList<>();
+			date -> date.getTime();
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MergeConditionalBlocksCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MergeConditionalBlocksCleanUp.java
@@ -76,22 +76,26 @@ public class MergeConditionalBlocksCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.MERGE_CONDITIONAL_BLOCKS)) {
-			return "" //$NON-NLS-1$
-					+ "if (isValid || (i != 1)) {\n" //$NON-NLS-1$
-					+ "    System.out.println(\"Duplicate\");\n" //$NON-NLS-1$
-					+ "} else {\n" //$NON-NLS-1$
-					+ "    System.out.println(\"Different\");\n" //$NON-NLS-1$
-					+ "}\n\n\n"; //$NON-NLS-1$
+			return """
+				if (isValid || (i != 1)) {
+				    System.out.println("Duplicate");
+				} else {
+				    System.out.println("Different");
+				}
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (isValid) {\n" //$NON-NLS-1$
-				+ "    System.out.println(\"Duplicate\");\n" //$NON-NLS-1$
-				+ "} else if (i == 1) {\n" //$NON-NLS-1$
-				+ "    System.out.println(\"Different\");\n" //$NON-NLS-1$
-				+ "} else {\n" //$NON-NLS-1$
-				+ "    System.out.println(\"Duplicate\");\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (isValid) {
+			    System.out.println("Duplicate");
+			} else if (i == 1) {
+			    System.out.println("Different");
+			} else {
+			    System.out.println("Duplicate");
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ObjectsEqualsCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ObjectsEqualsCleanUp.java
@@ -89,20 +89,26 @@ public class ObjectsEqualsCleanUp extends AbstractMultiFix implements ICleanUpFi
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.USE_OBJECTS_EQUALS)) {
-			return "" //$NON-NLS-1$
-					+ "if (!Objects.equals(aText, other.aText)) {\n" //$NON-NLS-1$
-					+ "	return false;\n" //$NON-NLS-1$
-					+ "}\n\n\n\n\n"; //$NON-NLS-1$
+			return """
+				if (!Objects.equals(aText, other.aText)) {
+					return false;
+				}
+				
+				
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (aText == null) {\n" //$NON-NLS-1$
-				+ "  if (other.aText != null) {\n" //$NON-NLS-1$
-				+ "    return false;\n" //$NON-NLS-1$
-				+ "  }\n" //$NON-NLS-1$
-				+ "} else if (!aText.equals(other.aText)) {\n" //$NON-NLS-1$
-				+ "	return false;\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (aText == null) {
+			  if (other.aText != null) {
+			    return false;
+			  }
+			} else if (!aText.equals(other.aText)) {
+				return false;
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PatternCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PatternCleanUp.java
@@ -113,20 +113,22 @@ public class PatternCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.PRECOMPILE_REGEX)) {
-			return "" //$NON-NLS-1$
-					+ "Pattern dateCheck= Pattern.compile(\"\\\\d{4}-\\\\d{2}-\\\\d{2}\");\n" //$NON-NLS-1$
-					+ "dateCheck.matcher(\"2020-03-17\").matches();\n" //$NON-NLS-1$
-					+ "dateCheck.matcher(\"2020-03-17\").dateCheckplaceFirst(\"0000-00-00\");\n" //$NON-NLS-1$
-					+ "dateCheck.matcher(\"2020-03-17\").replaceAll(\"0000-00-00\");\n" //$NON-NLS-1$
-					+ "dateCheck.split(\"A2020-03-17B\");\n"; //$NON-NLS-1$
+			return """
+				Pattern dateCheck= Pattern.compile("\\\\d{4}-\\\\d{2}-\\\\d{2}");
+				dateCheck.matcher("2020-03-17").matches();
+				dateCheck.matcher("2020-03-17").dateCheckplaceFirst("0000-00-00");
+				dateCheck.matcher("2020-03-17").replaceAll("0000-00-00");
+				dateCheck.split("A2020-03-17B");
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "String dateCheck= \"\\\\d{4}-\\\\d{2}-\\\\d{2}\";\n" //$NON-NLS-1$
-				+ "\"2020-03-17\".matches(dateCheck);\n" //$NON-NLS-1$
-				+ "\"2020-03-17\".replaceFirst(dateCheck, \"0000-00-00\");\n" //$NON-NLS-1$
-				+ "\"2020-03-17\".replaceAll(dateCheck, \"0000-00-00\");\n" //$NON-NLS-1$
-				+ "\"A2020-03-17B\".split(dateCheck);\n"; //$NON-NLS-1$
+		return """
+			String dateCheck= "\\\\d{4}-\\\\d{2}-\\\\d{2}";
+			"2020-03-17".matches(dateCheck);
+			"2020-03-17".replaceFirst(dateCheck, "0000-00-00");
+			"2020-03-17".replaceAll(dateCheck, "0000-00-00");
+			"A2020-03-17B".split(dateCheck);
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveParsingCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveParsingCleanUp.java
@@ -82,14 +82,16 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.PRIMITIVE_PARSING)) {
-			return "" //$NON-NLS-1$
-					+ "int number = Integer.parseInt(\"42\", 8);\n" //$NON-NLS-1$
-					+ "Double.parseDouble(\"42.42\");\n"; //$NON-NLS-1$
+			return """
+				int number = Integer.parseInt("42", 8);
+				Double.parseDouble("42.42");
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "int number = Integer.valueOf(\"42\", 8);\n" //$NON-NLS-1$
-				+ "new Double(\"42.42\").doubleValue();\n"; //$NON-NLS-1$
+		return """
+			int number = Integer.valueOf("42", 8);
+			new Double("42.42").doubleValue();
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveSerializationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveSerializationCleanUp.java
@@ -83,14 +83,16 @@ public class PrimitiveSerializationCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.PRIMITIVE_SERIALIZATION)) {
-			return "" //$NON-NLS-1$
-					+ "String text1 = Integer.toString(number);\n" //$NON-NLS-1$
-					+ "String text2 = Character.toString(letter);\n"; //$NON-NLS-1$
+			return """
+				String text1 = Integer.toString(number);
+				String text2 = Character.toString(letter);
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "String text1 = Integer.valueOf(number).toString();\n" //$NON-NLS-1$
-				+ "String text2 = Character.valueOf(letter).toString();\n"; //$NON-NLS-1$
+		return """
+			String text1 = Integer.valueOf(number).toString();
+			String text2 = Character.valueOf(letter).toString();
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PullUpAssignmentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PullUpAssignmentCleanUp.java
@@ -93,9 +93,10 @@ public class PullUpAssignmentCleanUp extends AbstractMultiFix {
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.PULL_UP_ASSIGNMENT)) {
-			return "" //$NON-NLS-1$
-					+ "isRemoved = list.remove(o);\n" //$NON-NLS-1$
-					+ "if (isRemoved) {}\n"; //$NON-NLS-1$
+			return """
+				isRemoved = list.remove(o);
+				if (isRemoved) {}
+				"""; //$NON-NLS-1$
 		}
 
 		return "" //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantComparisonStatementCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantComparisonStatementCleanUp.java
@@ -87,12 +87,13 @@ public class RedundantComparisonStatementCleanUp extends AbstractMultiFix implem
 			return "return i;\n\n\n\n\n"; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "if (i != 123) {\n" //$NON-NLS-1$
-				+ " return i;\n" //$NON-NLS-1$
-				+ "} else {\n" //$NON-NLS-1$
-				+ " return 123;\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			if (i != 123) {
+			 return i;
+			} else {
+			 return 123;
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StrictlyEqualOrDifferentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StrictlyEqualOrDifferentCleanUp.java
@@ -84,18 +84,20 @@ public class StrictlyEqualOrDifferentCleanUp extends AbstractMultiFix implements
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.STRICTLY_EQUAL_OR_DIFFERENT)) {
-			return "" //$NON-NLS-1$
-					+ "boolean newBoolean1 = isValid == (i > 0);\n" //$NON-NLS-1$
-					+ "boolean newBoolean2 = isValid ^ isEnabled;\n" //$NON-NLS-1$
-					+ "boolean newBoolean3 = isActive == (0 <= i);\n" //$NON-NLS-1$
-					+ "boolean newBoolean4 = isActive ^ isEnabled;\n"; //$NON-NLS-1$
+			return """
+				boolean newBoolean1 = isValid == (i > 0);
+				boolean newBoolean2 = isValid ^ isEnabled;
+				boolean newBoolean3 = isActive == (0 <= i);
+				boolean newBoolean4 = isActive ^ isEnabled;
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "boolean newBoolean1 = isValid && (i > 0) || !isValid && (i <= 0);\n" //$NON-NLS-1$
-				+ "boolean newBoolean2 = !isValid && isEnabled || isValid && !isEnabled;\n" //$NON-NLS-1$
-				+ "boolean newBoolean3 = isActive ? (0 <= i) : (i < 0);\n" //$NON-NLS-1$
-				+ "boolean newBoolean4 = !isActive ? isEnabled : !isEnabled;\n"; //$NON-NLS-1$
+		return """
+			boolean newBoolean1 = isValid && (i > 0) || !isValid && (i <= 0);
+			boolean newBoolean2 = !isValid && isEnabled || isValid && !isEnabled;
+			boolean newBoolean3 = isActive ? (0 <= i) : (i < 0);
+			boolean newBoolean4 = !isActive ? isEnabled : !isEnabled;
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringBuilderCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringBuilderCleanUp.java
@@ -115,18 +115,20 @@ public class StringBuilderCleanUp extends AbstractMultiFix implements ICleanUpFi
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.STRINGBUILDER)) {
-			return "" //$NON-NLS-1$
-					+ "StringBuilder variable = new StringBuilder();\n" //$NON-NLS-1$
-					+ "variable.append(\"foo\");\n" //$NON-NLS-1$
-					+ "variable.append(\"bar\");\n" //$NON-NLS-1$
-					+ "System.out.println(variable.toString());\n"; //$NON-NLS-1$
+			return """
+				StringBuilder variable = new StringBuilder();
+				variable.append("foo");
+				variable.append("bar");
+				System.out.println(variable.toString());
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "String variable = \"\";\n" //$NON-NLS-1$
-				+ "variable = variable + \"foo\";\n" //$NON-NLS-1$
-				+ "variable += \"bar\";\n" //$NON-NLS-1$
-				+ "System.out.println(variable);\n"; //$NON-NLS-1$
+		return """
+			String variable = "";
+			variable = variable + "foo";
+			variable += "bar";
+			System.out.println(variable);
+			"""; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/TryWithResourceCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/TryWithResourceCleanUp.java
@@ -61,20 +61,24 @@ public class TryWithResourceCleanUp extends AbstractMultiFix implements ICleanUp
 	@Override
 	public String getPreview() {
 		if (isEnabled(CleanUpConstants.TRY_WITH_RESOURCE)) {
-			return "" //$NON-NLS-1$
-					+ "final FileInputStream inputStream = new FileInputStream(\"out.txt\");\n" //$NON-NLS-1$
-					+ "try (inputStream) {\n" //$NON-NLS-1$
-					+ "    System.out.println(inputStream.read());\n" //$NON-NLS-1$
-					+ "}\n\n\n"; //$NON-NLS-1$
+			return """
+				final FileInputStream inputStream = new FileInputStream("out.txt");
+				try (inputStream) {
+				    System.out.println(inputStream.read());
+				}
+				
+				
+				"""; //$NON-NLS-1$
 		}
 
-		return "" //$NON-NLS-1$
-				+ "final FileInputStream inputStream = new FileInputStream(\"out.txt\");\n" //$NON-NLS-1$
-				+ "try {\n" //$NON-NLS-1$
-				+ "    System.out.println(inputStream.read());\n" //$NON-NLS-1$
-				+ "} finally {\n" //$NON-NLS-1$
-				+ "    inputStream.close();\n" //$NON-NLS-1$
-				+ "}\n"; //$NON-NLS-1$
+		return """
+			final FileInputStream inputStream = new FileInputStream("out.txt");
+			try {
+			    System.out.println(inputStream.read());
+			} finally {
+			    inputStream.close();
+			}
+			"""; //$NON-NLS-1$
 	}
 
 	@Override


### PR DESCRIPTION
This is a run of the "Convert String concatenation to Text Block" cleanup without the option for "Stringbuffer" on jdt.ui (only runtime modules, no test code). With the "Stringbuffer" option we run into some errors unfortunately, there is a bug.
Since the JDT UI modules now are higher than Java 15 we can make use of it.
## What it does
By using text blocks  the code gets more readable and the formating characters like return get translated.

## How to test
Nothing should be changed because of this. Tests should run through as before and everywhere you should see Strings in the same way as before. Just check an arbitrary text block where it appears in the resulting ice.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
