### PR TITLE
Add additional logic to MoveInstanceMethodProcessor

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1353,6 +1353,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String MoveInstanceMethodProcessor_method_type_clash;
 
+	public static String MoveInstanceMethodProcessor_method_will_override_call_in_inner_subclass;
+
 	public static String MoveInstanceMethodProcessor_moved_element_pattern;
 
 	public static String MoveInstanceMethodProcessor_name;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -899,6 +899,7 @@ MoveInstanceMethodProcessor_no_generic_targets=This method cannot be moved to th
 MoveInstanceMethodProcessor_no_binary=Cannot move methods to binary types.
 MoveInstanceMethodProcessor_no_interface=This refactoring cannot be used to move interface methods.
 MoveInstanceMethodProcessor_no_annotation=This refactoring cannot be used to move annotation methods.
+MoveInstanceMethodProcessor_method_will_override_call_in_inner_subclass=Moving method to target will cause logic change in class: ''{0}'' that sub-classes target.
 MoveInstanceMethodProcessor_this_reference=A reference to 'this' has been found
 MoveInstanceMethodProcessor_no_resolved_target=The target of the method could not be resolved.
 MoveInstanceMethodProcessor_no_null_argument=The method invocation ''{0}'' cannot be updated, since it uses null as argument.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail18/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail18/in/A.java
@@ -1,0 +1,31 @@
+package p1;
+
+public class A {
+	public B b;
+
+	public void m() {
+		System.out.println("d");
+	}
+}
+
+class B {
+
+}
+
+class C {
+
+	public void m() {
+		System.out.println("c");
+	}
+
+	public void foo() {
+		class D extends B {
+			public void t() {
+				m();
+			}
+		}
+	}
+
+}
+
+

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -813,6 +813,12 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 		failHelper1(new String[] { "p1.A", "p2.B"}, "p1.A", 13, 16, 13, 24, FIELD, "a1", true, true);
 	}
 
+	// Issue 1517
+	@Test
+	public void testFail18() throws Exception {
+		failHelper1(new String[] { "p1.A" }, "p1.A", 6, 17, 6, 18, FIELD, "b", true, true);
+	}
+
 	// Cannot move static method
 	@Test
 	public void testFail2() throws Exception {


### PR DESCRIPTION
- add new MoveInstanceMethodProcessor.checkOverrideOuterMethod() that checks if a sub-class inner type of the target type calls a method with same name as moved but the method is declared in a different type so an unexpected override will occur
- add new test to MoveInstanceMethodTests
- fixes #1517

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
