### PR TITLE
follow the deprecation advice and use the replacement classes to get rid of some deprecation warnings in the build log

### DIFF
--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ControlStatementsFix.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ControlStatementsFix.java
@@ -48,7 +48,7 @@ public class ControlStatementsFix extends CompilationUnitRewriteOperationsFix {
 
 	private final static class ControlStatementFinder extends GenericVisitor {
 
-		private final List<CompilationUnitRewriteOperation> fResult;
+		private final List<CompilationUnitRewriteOperationWithSourceRange> fResult;
 		private final boolean fFindControlStatementsWithoutBlock;
 		private final boolean fRemoveUnnecessaryBlocks;
 		private final boolean fRemoveUnnecessaryBlocksOnlyWhenReturnOrThrow;
@@ -56,7 +56,7 @@ public class ControlStatementsFix extends CompilationUnitRewriteOperationsFix {
 		public ControlStatementFinder(boolean findControlStatementsWithoutBlock,
 				boolean removeUnnecessaryBlocks,
 				boolean removeUnnecessaryBlocksOnlyWhenReturnOrThrow,
-				List<CompilationUnitRewriteOperation> resultingCollection) {
+				List<CompilationUnitRewriteOperationWithSourceRange> resultingCollection) {
 
 			fFindControlStatementsWithoutBlock= findControlStatementsWithoutBlock;
 			fRemoveUnnecessaryBlocks= removeUnnecessaryBlocks;
@@ -487,18 +487,18 @@ public class ControlStatementsFix extends CompilationUnitRewriteOperationsFix {
 		if (!convertSingleStatementToBlock && !removeUnnecessaryBlock && !removeUnnecessaryBlockContainingReturnOrThrow)
 			return null;
 
-		List<CompilationUnitRewriteOperation> operations= new ArrayList<>();
+		List<CompilationUnitRewriteOperationWithSourceRange> operations= new ArrayList<>();
 		ControlStatementFinder finder= new ControlStatementFinder(convertSingleStatementToBlock, removeUnnecessaryBlock, removeUnnecessaryBlockContainingReturnOrThrow, operations);
 		compilationUnit.accept(finder);
 
 		if (operations.isEmpty())
 			return null;
 
-		CompilationUnitRewriteOperation[] ops= operations.toArray(new CompilationUnitRewriteOperation[operations.size()]);
+		CompilationUnitRewriteOperationWithSourceRange[] ops= operations.toArray(new CompilationUnitRewriteOperationWithSourceRange[operations.size()]);
 		return new ControlStatementsFix(FixMessages.ControlStatementsFix_change_name, compilationUnit, ops);
 	}
 
-	protected ControlStatementsFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperation[] fixRewriteOperations) {
+	protected ControlStatementsFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperationWithSourceRange[] fixRewriteOperations) {
 		super(name, compilationUnit, fixRewriteOperations);
 	}
 

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ExpressionsFix.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ExpressionsFix.java
@@ -95,7 +95,7 @@ public class ExpressionsFix extends CompilationUnitRewriteOperationsFix {
 		}
 	}
 
-	private static class AddParenthesisOperation extends CompilationUnitRewriteOperation {
+	private static class AddParenthesisOperation extends CompilationUnitRewriteOperationWithSourceRange {
 
 		private final Expression[] fExpressions;
 
@@ -119,7 +119,7 @@ public class ExpressionsFix extends CompilationUnitRewriteOperationsFix {
 		}
 	}
 
-	private static class RemoveParenthesisOperation extends CompilationUnitRewriteOperation {
+	private static class RemoveParenthesisOperation extends CompilationUnitRewriteOperationWithSourceRange {
 
 		private final HashSet<ParenthesizedExpression> fExpressions;
 
@@ -172,8 +172,8 @@ public class ExpressionsFix extends CompilationUnitRewriteOperationsFix {
 			return null;
 
 
-		CompilationUnitRewriteOperation op= new AddParenthesisOperation(changedNodes.toArray(new Expression[changedNodes.size()]));
-		return new ExpressionsFix(FixMessages.ExpressionsFix_addParanoiacParentheses_description, compilationUnit, new CompilationUnitRewriteOperation[] {op});
+		CompilationUnitRewriteOperationWithSourceRange op= new AddParenthesisOperation(changedNodes.toArray(new Expression[changedNodes.size()]));
+		return new ExpressionsFix(FixMessages.ExpressionsFix_addParanoiacParentheses_description, compilationUnit, new CompilationUnitRewriteOperationWithSourceRange[] {op});
 	}
 
 	public static ExpressionsFix createRemoveUnnecessaryParenthesisFix(CompilationUnit compilationUnit, ASTNode[] nodes) {
@@ -188,7 +188,7 @@ public class ExpressionsFix extends CompilationUnitRewriteOperationsFix {
 
 		HashSet<ParenthesizedExpression> expressions= new HashSet<>(changedNodes);
 		RemoveParenthesisOperation op= new RemoveParenthesisOperation(expressions);
-		return new ExpressionsFix(FixMessages.ExpressionsFix_removeUnnecessaryParentheses_description, compilationUnit, new CompilationUnitRewriteOperation[] {op});
+		return new ExpressionsFix(FixMessages.ExpressionsFix_removeUnnecessaryParentheses_description, compilationUnit, new CompilationUnitRewriteOperationWithSourceRange[] {op});
 	}
 
 	public static ICleanUpFix createCleanUp(CompilationUnit compilationUnit,
@@ -202,8 +202,8 @@ public class ExpressionsFix extends CompilationUnitRewriteOperationsFix {
 			if (changedNodes.isEmpty())
 				return null;
 
-			CompilationUnitRewriteOperation op= new AddParenthesisOperation(changedNodes.toArray(new Expression[changedNodes.size()]));
-			return new ExpressionsFix(FixMessages.ExpressionsFix_add_parentheses_change_name, compilationUnit, new CompilationUnitRewriteOperation[] {op});
+			CompilationUnitRewriteOperationWithSourceRange op= new AddParenthesisOperation(changedNodes.toArray(new Expression[changedNodes.size()]));
+			return new ExpressionsFix(FixMessages.ExpressionsFix_add_parentheses_change_name, compilationUnit, new CompilationUnitRewriteOperationWithSourceRange[] {op});
 		} else if (removeUnnecessaryParenthesis) {
 			final ArrayList<ParenthesizedExpression> changedNodes = new ArrayList<>();
 			compilationUnit.accept(new UnnecessaryParenthesisVisitor(changedNodes));
@@ -212,13 +212,13 @@ public class ExpressionsFix extends CompilationUnitRewriteOperationsFix {
 				return null;
 
 			HashSet<ParenthesizedExpression> expressions= new HashSet<>(changedNodes);
-			CompilationUnitRewriteOperation op= new RemoveParenthesisOperation(expressions);
-			return new ExpressionsFix(FixMessages.ExpressionsFix_remove_parentheses_change_name, compilationUnit, new CompilationUnitRewriteOperation[] {op});
+			CompilationUnitRewriteOperationWithSourceRange op= new RemoveParenthesisOperation(expressions);
+			return new ExpressionsFix(FixMessages.ExpressionsFix_remove_parentheses_change_name, compilationUnit, new CompilationUnitRewriteOperationWithSourceRange[] {op});
 		}
 		return null;
 	}
 
-	protected ExpressionsFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperation[] fixRewriteOperations) {
+	protected ExpressionsFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperationWithSourceRange[] fixRewriteOperations) {
 		super(name, compilationUnit, fixRewriteOperations);
 	}
 }

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/NullAnnotationsFix.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/NullAnnotationsFix.java
@@ -53,7 +53,7 @@ public class NullAnnotationsFix extends CompilationUnitRewriteOperationsFix {
 
 	private CompilationUnit cu;
 
-	public NullAnnotationsFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperation[] operations) {
+	public NullAnnotationsFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperationWithSourceRange[] operations) {
 		super(name, compilationUnit, operations);
 		cu= compilationUnit;
 	}
@@ -170,7 +170,7 @@ public class NullAnnotationsFix extends CompilationUnitRewriteOperationsFix {
 		if (!JavaModelUtil.is50OrHigher(cu.getJavaProject()))
 			return null;
 
-		List<CompilationUnitRewriteOperation> operations= new ArrayList<>();
+		List<CompilationUnitRewriteOperationWithSourceRange> operations= new ArrayList<>();
 		if (locations == null) {
 			org.eclipse.jdt.core.compiler.IProblem[] problems= compilationUnit.getProblems();
 			locations= new IProblemLocation[problems.length];
@@ -190,11 +190,11 @@ public class NullAnnotationsFix extends CompilationUnitRewriteOperationsFix {
 		}
 		if (operations.isEmpty())
 			return null;
-		CompilationUnitRewriteOperation[] operationsArray= operations.toArray(new CompilationUnitRewriteOperation[operations.size()]);
+		CompilationUnitRewriteOperationWithSourceRange[] operationsArray= operations.toArray(new CompilationUnitRewriteOperationWithSourceRange[operations.size()]);
 		return new NullAnnotationsFix(message, compilationUnit, operationsArray);
 	}
 
-	private static boolean createMoveTypeAnnotationOperations(CompilationUnit compilationUnit, IProblemLocation[] locations, List<CompilationUnitRewriteOperation> operations) {
+	private static boolean createMoveTypeAnnotationOperations(CompilationUnit compilationUnit, IProblemLocation[] locations, List<CompilationUnitRewriteOperationWithSourceRange> operations) {
 		boolean isMove= false;
 		for (IProblemLocation location: locations) {
 			if (location == null)
@@ -206,7 +206,7 @@ public class NullAnnotationsFix extends CompilationUnitRewriteOperationsFix {
 		return isMove;
 	}
 
-	private static void createAddNullAnnotationOperations(CompilationUnit compilationUnit, IProblemLocation[] locations, List<CompilationUnitRewriteOperation> result) {
+	private static void createAddNullAnnotationOperations(CompilationUnit compilationUnit, IProblemLocation[] locations, List<CompilationUnitRewriteOperationWithSourceRange> result) {
 		String nullableAnnotationName= getNullableAnnotationName(compilationUnit.getJavaElement(), false);
 		String nonNullAnnotationName= getNonNullAnnotationName(compilationUnit.getJavaElement(), false);
 
@@ -262,7 +262,7 @@ public class NullAnnotationsFix extends CompilationUnitRewriteOperationsFix {
 		}
 	}
 
-	private static void createRemoveRedundantNullAnnotationsOperations(CompilationUnit compilationUnit, IProblemLocation[] locations, List<CompilationUnitRewriteOperation> result) {
+	private static void createRemoveRedundantNullAnnotationsOperations(CompilationUnit compilationUnit, IProblemLocation[] locations, List<CompilationUnitRewriteOperationWithSourceRange> result) {
 		for (IProblemLocation problem : locations) {
 			if (problem == null)
 				continue; // problem was filtered out by createCleanUp()

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/NullAnnotationsRewriteOperations.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/NullAnnotationsRewriteOperations.java
@@ -70,7 +70,7 @@ import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.codemanipulation.RedundantNullnessTypeAnnotationsFilter;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
@@ -96,7 +96,7 @@ public class NullAnnotationsRewriteOperations {
 		TARGET		// change the target method of a method call
 	}
 
-	static abstract class SignatureAnnotationRewriteOperation extends CompilationUnitRewriteOperation {
+	static abstract class SignatureAnnotationRewriteOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		// initialized from the Builder:
 		protected CompilationUnit fUnit;
 		protected String fAnnotationToAdd;
@@ -329,7 +329,7 @@ public class NullAnnotationsRewriteOperations {
 		}
 	}
 
-	static class RemoveRedundantAnnotationRewriteOperation extends CompilationUnitRewriteOperation {
+	static class RemoveRedundantAnnotationRewriteOperation extends CompilationUnitRewriteOperationWithSourceRange {
 
 		private IProblemLocation fProblem;
 		private CompilationUnit fCompilationUnit;
@@ -385,7 +385,7 @@ public class NullAnnotationsRewriteOperations {
 		}
 	}
 
-	static class AddMissingDefaultNullnessRewriteOperation extends CompilationUnitRewriteOperation {
+	static class AddMissingDefaultNullnessRewriteOperation extends CompilationUnitRewriteOperationWithSourceRange {
 
 		private IProblemLocation fProblem;
 		private CompilationUnit fCompilationUnit;

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/TypeAnnotationFix.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/TypeAnnotationFix.java
@@ -20,7 +20,7 @@ import org.eclipse.jdt.internal.corext.fix.TypeAnnotationRewriteOperations.MoveT
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 
 public class TypeAnnotationFix extends CompilationUnitRewriteOperationsFix {
-	public TypeAnnotationFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperation operation) {
+	public TypeAnnotationFix(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperationWithSourceRange operation) {
 		super(name, compilationUnit, operation);
 	}
 

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/TypeAnnotationRewriteOperations.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/TypeAnnotationRewriteOperations.java
@@ -40,13 +40,13 @@ import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 
 public class TypeAnnotationRewriteOperations {
-	static class MoveTypeAnnotationRewriteOperation extends CompilationUnitRewriteOperation {
+	static class MoveTypeAnnotationRewriteOperation extends CompilationUnitRewriteOperationWithSourceRange {
 
 		private IProblemLocation fProblem;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AddAllCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AddAllCleanUp.java
@@ -51,11 +51,11 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ForLoops;
-import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.dom.ForLoops.ForLoopContent;
+import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -111,7 +111,7 @@ public class AddAllCleanUp extends AbstractMultiFix implements ICleanUpFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -260,7 +260,7 @@ public class AddAllCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.AddAllCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -278,7 +278,7 @@ public class AddAllCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		return null;
 	}
 
-	private static class AddOrRemoveAllForArrayOperation extends CompilationUnitRewriteOperation {
+	private static class AddOrRemoveAllForArrayOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Statement toReplace;
 		private final Expression affectedCollection;
 		private final Expression addedData;
@@ -328,7 +328,7 @@ public class AddAllCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		}
 	}
 
-	private static class AddAllForCollectionOperation extends CompilationUnitRewriteOperation {
+	private static class AddAllForCollectionOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Statement toReplace;
 		private final Expression affectedCollection;
 		private final Expression addedData;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ArraysFillCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ArraysFillCleanUp.java
@@ -49,7 +49,7 @@ import org.eclipse.jdt.internal.corext.dom.ForLoops.ContainerType;
 import org.eclipse.jdt.internal.corext.dom.ForLoops.ForLoopContent;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -106,7 +106,7 @@ public class ArraysFillCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -197,7 +197,7 @@ public class ArraysFillCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.ArraysFillCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -210,7 +210,7 @@ public class ArraysFillCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class ArraysFillOperation extends CompilationUnitRewriteOperation {
+	private static class ArraysFillOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ForStatement node;
 		private final Assignment assignment;
 		private final ArrayAccess arrayAccess;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AutoboxingCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/AutoboxingCleanUp.java
@@ -42,7 +42,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -103,7 +103,7 @@ public class AutoboxingCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -186,7 +186,7 @@ public class AutoboxingCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.AutoboxingCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[rewriteOperations.size()]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[rewriteOperations.size()]));
 	}
 
 	@Override
@@ -199,7 +199,7 @@ public class AutoboxingCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class AutoboxingOperation extends CompilationUnitRewriteOperation {
+	private static class AutoboxingOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ASTNode node;
 
 		private final ITypeBinding primitiveType;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/BitwiseConditionalExpressionCleanup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/BitwiseConditionalExpressionCleanup.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -89,7 +89,7 @@ public class BitwiseConditionalExpressionCleanup extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -141,7 +141,7 @@ public class BitwiseConditionalExpressionCleanup extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CheckSignOfBitwiseOperation_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -154,7 +154,7 @@ public class BitwiseConditionalExpressionCleanup extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class RewriteInfixExpressionOperator extends CompilationUnitRewriteOperation {
+	private static class RewriteInfixExpressionOperator extends CompilationUnitRewriteOperationWithSourceRange {
 		private InfixExpression fExpression;
 
 		public RewriteInfixExpressionOperator(final InfixExpression expression) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/BooleanLiteralCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/BooleanLiteralCleanUp.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -87,7 +87,7 @@ public class BooleanLiteralCleanUp extends AbstractMultiFix implements ICleanUpF
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -115,7 +115,7 @@ public class BooleanLiteralCleanUp extends AbstractMultiFix implements ICleanUpF
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.BooleanLiteralCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -133,7 +133,7 @@ public class BooleanLiteralCleanUp extends AbstractMultiFix implements ICleanUpF
 		return null;
 	}
 
-	private static class BooleanLiteralOperation extends CompilationUnitRewriteOperation {
+	private static class BooleanLiteralOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final QualifiedName node;
 		private final boolean value;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/BreakLoopCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/BreakLoopCleanUp.java
@@ -56,7 +56,7 @@ import org.eclipse.jdt.internal.corext.dom.InterruptibleVisitor;
 import org.eclipse.jdt.internal.corext.dom.VarConflictVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -130,7 +130,7 @@ public class BreakLoopCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			final class DisturbingEffectVisitor extends InterruptibleVisitor {
@@ -379,7 +379,7 @@ public class BreakLoopCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.BreakLoopCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -392,7 +392,7 @@ public class BreakLoopCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class BreakLoopOperation extends CompilationUnitRewriteOperation {
+	private static class BreakLoopOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement ifStatement;
 
 		public BreakLoopOperation(final IfStatement ifStatement) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/CollectionCloningCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/CollectionCloningCleanUp.java
@@ -59,7 +59,7 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -111,7 +111,7 @@ public class CollectionCloningCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -236,7 +236,7 @@ public class CollectionCloningCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CollectionCloningCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -249,7 +249,7 @@ public class CollectionCloningCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class CollectionCloningOperation extends CompilationUnitRewriteOperation {
+	private static class CollectionCloningOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ExpressionStatement nodeToRemove;
 		private final ClassInstanceCreation classInstanceCreation;
 		private final Expression arg0;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ComparingOnCriteriaCleanUp.java
@@ -63,7 +63,7 @@ import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.OrderedInfixExpression;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.ControlWorkflowMatcher;
@@ -73,7 +73,6 @@ import org.eclipse.jdt.internal.corext.util.NodeMatcher;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
-
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 
 /**
@@ -168,7 +167,7 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -479,7 +478,7 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.ComparingOnCriteriaCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -492,7 +491,7 @@ public class ComparingOnCriteriaCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class ComparingOnCriteriaOperation extends CompilationUnitRewriteOperation {
+	private static class ComparingOnCriteriaOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Expression visited;
 		private final ITypeBinding typeArgument;
 		private final SimpleName name1;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ControlFlowMergeCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ControlFlowMergeCleanUp.java
@@ -47,7 +47,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTSemanticMatcher;
 import org.eclipse.jdt.internal.corext.dom.VarConflictVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -111,7 +111,7 @@ public class ControlFlowMergeCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -303,7 +303,7 @@ public class ControlFlowMergeCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.ControlFlowMergeCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -316,7 +316,7 @@ public class ControlFlowMergeCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class ControlFlowMergeOperation extends CompilationUnitRewriteOperation {
+	private static class ControlFlowMergeOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement visited;
 		private final List<ASTNode> allCases;
 		private final List<List<Statement>> allCasesStatements;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/DoubleNegationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/DoubleNegationCleanUp.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -96,7 +96,7 @@ public class DoubleNegationCleanUp extends AbstractMultiFix implements ICleanUpF
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -133,7 +133,7 @@ public class DoubleNegationCleanUp extends AbstractMultiFix implements ICleanUpF
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.DoubleNegationCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -151,7 +151,7 @@ public class DoubleNegationCleanUp extends AbstractMultiFix implements ICleanUpF
 		return null;
 	}
 
-	private static class DoubleNegationOperation extends CompilationUnitRewriteOperation {
+	private static class DoubleNegationOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final InfixExpression visited;
 		private final Expression leftExpression;
 		private final Expression rightExpression;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EmbeddedIfCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EmbeddedIfCleanUp.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -95,7 +95,7 @@ public class EmbeddedIfCleanUp extends AbstractMultiFix implements ICleanUpFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -127,7 +127,7 @@ public class EmbeddedIfCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.EmbeddedIfCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -145,7 +145,7 @@ public class EmbeddedIfCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		return null;
 	}
 
-	private static class EmbeddedIfOperation extends CompilationUnitRewriteOperation {
+	private static class EmbeddedIfOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement visited;
 		private final IfStatement innerIf;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EvaluateNullableCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EvaluateNullableCleanUp.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -98,7 +98,7 @@ public class EvaluateNullableCleanUp extends AbstractMultiFix implements ICleanU
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -166,7 +166,7 @@ public class EvaluateNullableCleanUp extends AbstractMultiFix implements ICleanU
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.EvaluateNullableCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -184,7 +184,7 @@ public class EvaluateNullableCleanUp extends AbstractMultiFix implements ICleanU
 		return null;
 	}
 
-	private static class EvaluateNullableOperation extends CompilationUnitRewriteOperation {
+	private static class EvaluateNullableOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final InfixExpression visited;
 		private final List<Expression> operands;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ExtractIncrementCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ExtractIncrementCleanUp.java
@@ -48,7 +48,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -107,7 +107,7 @@ public class ExtractIncrementCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -286,7 +286,7 @@ public class ExtractIncrementCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CodeStyleCleanUp_ExtractIncrement_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -299,7 +299,7 @@ public class ExtractIncrementCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class ExtractIncrementOperation extends CompilationUnitRewriteOperation {
+	private static class ExtractIncrementOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Expression visited;
 		private final Expression variable;
 		private final Statement statement;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/HashCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/HashCleanUp.java
@@ -60,7 +60,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.OrderedInfixExpression;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -131,7 +131,7 @@ public class HashCleanUp extends AbstractMultiFix implements ICleanUpFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -510,7 +510,7 @@ public class HashCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.HashCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -528,7 +528,7 @@ public class HashCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		return null;
 	}
 
-	private static class HashOperation extends CompilationUnitRewriteOperation {
+	private static class HashOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodDeclaration node;
 		private final CollectedData data;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/InstanceofCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/InstanceofCleanUp.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -90,7 +90,7 @@ public class InstanceofCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -116,7 +116,7 @@ public class InstanceofCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CodeStyleCleanUp_Instanceof_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -129,7 +129,7 @@ public class InstanceofCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class InstanceofOperation extends CompilationUnitRewriteOperation {
+	private static class InstanceofOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodInvocation visited;
 		private final TypeLiteral clazz;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/JoinCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/JoinCleanUp.java
@@ -66,7 +66,7 @@ import org.eclipse.jdt.internal.corext.dom.OrderedInfixExpression;
 import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -133,7 +133,7 @@ public class JoinCleanUp extends AbstractMultiFix implements ICleanUpFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -684,7 +684,7 @@ public class JoinCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.JoinCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -702,7 +702,7 @@ public class JoinCleanUp extends AbstractMultiFix implements ICleanUpFix {
 		return null;
 	}
 
-	private static class JoinOperation extends CompilationUnitRewriteOperation {
+	private static class JoinOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Statement node;
 		private Expression containerVariable;
 		private final Statement booleanStatement;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/LazyLogicalCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/LazyLogicalCleanUp.java
@@ -33,7 +33,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -92,7 +92,7 @@ public class LazyLogicalCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -126,7 +126,7 @@ public class LazyLogicalCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CodeStyleCleanUp_LazyLogical_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[rewriteOperations.size()]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[rewriteOperations.size()]));
 	}
 
 	@Override
@@ -139,7 +139,7 @@ public class LazyLogicalCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class LazyLogicalInInfixExpressionOperation extends CompilationUnitRewriteOperation {
+	private static class LazyLogicalInInfixExpressionOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final InfixExpression node;
 
 		public LazyLogicalInInfixExpressionOperation(InfixExpression node) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MapCloningCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MapCloningCleanUp.java
@@ -49,7 +49,7 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -100,7 +100,7 @@ public class MapCloningCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -210,7 +210,7 @@ public class MapCloningCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.MapCloningCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -223,7 +223,7 @@ public class MapCloningCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class MapCloningOperation extends CompilationUnitRewriteOperation {
+	private static class MapCloningOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ExpressionStatement nodeToRemove;
 		private final ClassInstanceCreation classInstanceCreation;
 		private final Expression arg0;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MapMethodCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MapMethodCleanUp.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -108,7 +108,7 @@ public class MapMethodCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 		    @Override
@@ -167,7 +167,7 @@ public class MapMethodCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.UseDirectlyMapMethodCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[rewriteOperations.size()]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[rewriteOperations.size()]));
 	}
 
 	@Override
@@ -180,7 +180,7 @@ public class MapMethodCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class MapMethodOperation extends CompilationUnitRewriteOperation {
+	private static class MapMethodOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodInvocation subAggregateMi;
 		private final MethodInvocation globalMi;
 		private final String methodName;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MergeConditionalBlocksCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MergeConditionalBlocksCleanUp.java
@@ -38,7 +38,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -100,7 +100,7 @@ public class MergeConditionalBlocksCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -178,7 +178,7 @@ public class MergeConditionalBlocksCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.MergeConditionalBlocksCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -191,7 +191,7 @@ public class MergeConditionalBlocksCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class InnerIfOperation extends CompilationUnitRewriteOperation {
+	private static class InnerIfOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement visited;
 		private final IfStatement innerIf;
 		private final boolean isInnerMainFirst;
@@ -229,7 +229,7 @@ public class MergeConditionalBlocksCleanUp extends AbstractMultiFix {
 		}
 	}
 
-	private static class MergeConditionalBlocksOperation extends CompilationUnitRewriteOperation {
+	private static class MergeConditionalBlocksOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final List<IfStatement> duplicateIfBlocks;
 		private final List<Boolean> isThenStatement;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/NumberSuffixCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/NumberSuffixCleanUp.java
@@ -33,7 +33,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -90,7 +90,7 @@ public class NumberSuffixCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -111,7 +111,7 @@ public class NumberSuffixCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CodeStyleCleanUp_numberSuffix_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[rewriteOperations.size()]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[rewriteOperations.size()]));
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public class NumberSuffixCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class NumberSuffixOperation extends CompilationUnitRewriteOperation {
+	private static class NumberSuffixOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ASTNode node;
 
 		private final String token;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ObjectsEqualsCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ObjectsEqualsCleanUp.java
@@ -48,7 +48,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.OrderedInfixExpression;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -111,7 +111,7 @@ public class ObjectsEqualsCleanUp extends AbstractMultiFix implements ICleanUpFi
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 
@@ -210,7 +210,7 @@ public class ObjectsEqualsCleanUp extends AbstractMultiFix implements ICleanUpFi
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.ObjectsEqualsCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -228,7 +228,7 @@ public class ObjectsEqualsCleanUp extends AbstractMultiFix implements ICleanUpFi
 		return null;
 	}
 
-	private static class ObjectsEqualsOperation extends CompilationUnitRewriteOperation {
+	private static class ObjectsEqualsOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement node;
 		private final Expression firstField;
 		private final Expression secondField;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OperandFactorizationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/OperandFactorizationCleanUp.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ASTSemanticMatcher;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -107,7 +107,7 @@ public class OperandFactorizationCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -193,7 +193,7 @@ public class OperandFactorizationCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.OperandFactorizationCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -206,7 +206,7 @@ public class OperandFactorizationCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class OperandFactorizationOperation extends CompilationUnitRewriteOperation {
+	private static class OperandFactorizationOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final InfixExpression visited;
 		private final InfixExpression.Operator innerOperator;
 		private final Expression factor;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PatternCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PatternCleanUp.java
@@ -61,7 +61,7 @@ import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
 import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
@@ -135,7 +135,7 @@ public class PatternCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 		final Map<ASTNode, Set<String>> addedPatternFields= new HashMap<>();
 
 		unit.accept(new ASTVisitor() {
@@ -275,7 +275,7 @@ public class PatternCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.PatternCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -288,7 +288,7 @@ public class PatternCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class PatternOperation extends CompilationUnitRewriteOperation {
+	private static class PatternOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Type type;
 		private final Expression initializer;
 		private final List<SimpleName> regExUses;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveParsingCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveParsingCleanUp.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -98,7 +98,7 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -208,7 +208,7 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.PrimitiveParsingCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -221,7 +221,7 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class PrimitiveParsingWithTheSingleArgumentOperation extends CompilationUnitRewriteOperation {
+	private static class PrimitiveParsingWithTheSingleArgumentOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodInvocation visited;
 
 		public PrimitiveParsingWithTheSingleArgumentOperation(final MethodInvocation visited) {
@@ -237,7 +237,7 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 		}
 	}
 
-	private static class PrimitiveParsingMethodNameOperation extends CompilationUnitRewriteOperation {
+	private static class PrimitiveParsingMethodNameOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodInvocation visited;
 		private final String methodName;
 
@@ -256,7 +256,7 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 		}
 	}
 
-	private static class PrimitiveParsingReplaceByParsingOperation extends CompilationUnitRewriteOperation {
+	private static class PrimitiveParsingReplaceByParsingOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodInvocation visited;
 		private final ITypeBinding typeBinding;
 		private final String methodName;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveSerializationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveSerializationCleanUp.java
@@ -36,7 +36,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -99,7 +99,7 @@ public class PrimitiveSerializationCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -155,7 +155,7 @@ public class PrimitiveSerializationCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.PrimitiveSerializationCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -168,7 +168,7 @@ public class PrimitiveSerializationCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class PrimitiveSerializationOperation extends CompilationUnitRewriteOperation {
+	private static class PrimitiveSerializationOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodInvocation visited;
 		private final Expression primitiveValue;
 		private final Class<?> wrapperClass;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PullUpAssignmentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PullUpAssignmentCleanUp.java
@@ -51,7 +51,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -108,7 +108,7 @@ public class PullUpAssignmentCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -283,7 +283,7 @@ public class PullUpAssignmentCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CodeStyleCleanUp_PullUpAssignment_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -296,7 +296,7 @@ public class PullUpAssignmentCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class PullUpAssignmentOperation extends CompilationUnitRewriteOperation {
+	private static class PullUpAssignmentOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement visited;
 		private final Assignment assignment;
 		private final Expression leftHandSide;
@@ -328,7 +328,7 @@ public class PullUpAssignmentCleanUp extends AbstractMultiFix {
 		}
 	}
 
-	private static class MoveToDeclarationOperation extends CompilationUnitRewriteOperation {
+	private static class MoveToDeclarationOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Assignment assignment;
 		private final Expression leftHandSide;
 		private final VariableDeclarationFragment fragment;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PushDownNegationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PushDownNegationCleanUp.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -97,7 +97,7 @@ public class PushDownNegationCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			PrefixExpression secondNotOperator= null;
@@ -152,7 +152,7 @@ public class PushDownNegationCleanUp extends AbstractMultiFix {
 		}
 
 		RemoveDoubleNegationOperation lastDoubleNegation= null;
-		for (CompilationUnitRewriteOperation op : rewriteOperations) {
+		for (CompilationUnitRewriteOperationWithSourceRange op : rewriteOperations) {
 			if (op instanceof ReplacementOperation) {
 				ReplacementOperation chainedOp= (ReplacementOperation) op;
 				if (lastDoubleNegation != null && chainedOp.getNode().subtreeMatch(new ASTMatcher(), lastDoubleNegation.getReplacementExpression())) {
@@ -165,7 +165,7 @@ public class PushDownNegationCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.PushDownNegationCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[rewriteOperations.size()]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[rewriteOperations.size()]));
 	}
 
 	@Override
@@ -178,7 +178,7 @@ public class PushDownNegationCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private abstract static class ReplacementOperation extends CompilationUnitRewriteOperation {
+	private abstract static class ReplacementOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private ASTNode node;
 
 		public void setNode(ASTNode node) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ReduceIndentationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ReduceIndentationCleanUp.java
@@ -44,7 +44,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -185,7 +185,7 @@ public class ReduceIndentationCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -239,7 +239,7 @@ public class ReduceIndentationCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.CodeStyleCleanUp_ReduceIndentation_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -252,7 +252,7 @@ public class ReduceIndentationCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class ReduceIndentationThenOperation extends CompilationUnitRewriteOperation {
+	private static class ReduceIndentationThenOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement visited;
 
 		public ReduceIndentationThenOperation(final IfStatement visited) {
@@ -293,7 +293,7 @@ public class ReduceIndentationCleanUp extends AbstractMultiFix {
 		}
 	}
 
-	private static class ReduceIndentationElseOperation extends CompilationUnitRewriteOperation {
+	private static class ReduceIndentationElseOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement visited;
 
 		public ReduceIndentationElseOperation(final IfStatement visited) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantComparisonStatementCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantComparisonStatementCleanUp.java
@@ -39,7 +39,7 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -101,7 +101,7 @@ public class RedundantComparisonStatementCleanUp extends AbstractMultiFix implem
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -211,7 +211,7 @@ public class RedundantComparisonStatementCleanUp extends AbstractMultiFix implem
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.RedundantComparisonStatementCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -229,7 +229,7 @@ public class RedundantComparisonStatementCleanUp extends AbstractMultiFix implem
 		return null;
 	}
 
-	private static class RedundantComparisonStatementOperation extends CompilationUnitRewriteOperation {
+	private static class RedundantComparisonStatementOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement node;
 		private final Statement toMove;
 		private final ReturnStatement toRemove;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantFallingThroughBlockEndCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantFallingThroughBlockEndCleanUp.java
@@ -49,7 +49,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ASTSemanticMatcher;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -117,7 +117,7 @@ public class RedundantFallingThroughBlockEndCleanUp extends AbstractMultiFix imp
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -279,7 +279,7 @@ public class RedundantFallingThroughBlockEndCleanUp extends AbstractMultiFix imp
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.RedundantFallingThroughBlockEndCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -297,7 +297,7 @@ public class RedundantFallingThroughBlockEndCleanUp extends AbstractMultiFix imp
 		return null;
 	}
 
-	private static class RedundantFallingThroughBlockEndOperation extends CompilationUnitRewriteOperation {
+	private static class RedundantFallingThroughBlockEndOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Statement redundantStatement;
 		private final List<Statement> stmtsToCompare;
 		private final Statement lastStatement;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantIfConditionCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantIfConditionCleanUp.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ASTSemanticMatcher;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -97,7 +97,7 @@ public class RedundantIfConditionCleanUp extends AbstractMultiFix implements ICl
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -122,7 +122,7 @@ public class RedundantIfConditionCleanUp extends AbstractMultiFix implements ICl
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.RedundantIfConditionCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -140,7 +140,7 @@ public class RedundantIfConditionCleanUp extends AbstractMultiFix implements ICl
 		return null;
 	}
 
-	private static class RedundantIfConditionOperation extends CompilationUnitRewriteOperation {
+	private static class RedundantIfConditionOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement secondIf;
 
 		public RedundantIfConditionOperation(final IfStatement secondIf) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantModifiersCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantModifiersCleanUp.java
@@ -38,7 +38,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ModifierRewrite;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -132,7 +132,7 @@ public class RedundantModifiersCleanUp extends AbstractMultiFix {
 		if (!isEnabled(CleanUpConstants.REMOVE_REDUNDANT_MODIFIERS)) {
 			return null;
 		}
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -200,7 +200,7 @@ public class RedundantModifiersCleanUp extends AbstractMultiFix {
 			return null;
 		}
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.RedundantModifiersCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[rewriteOperations.size()]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[rewriteOperations.size()]));
 	}
 
 	@Override
@@ -213,7 +213,7 @@ public class RedundantModifiersCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class RemoveModifiersOperation extends CompilationUnitRewriteOperation {
+	private static class RemoveModifiersOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ASTNode node;
 
 		private final int excludedModifiers;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantSuperCallCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/RedundantSuperCallCleanUp.java
@@ -33,7 +33,7 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -89,7 +89,7 @@ public class RedundantSuperCallCleanUp extends AbstractMultiFix implements IClea
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -108,7 +108,7 @@ public class RedundantSuperCallCleanUp extends AbstractMultiFix implements IClea
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.RedundantSuperCallCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -126,7 +126,7 @@ public class RedundantSuperCallCleanUp extends AbstractMultiFix implements IClea
 		return null;
 	}
 
-	private static class RedundantSuperCallOperation extends CompilationUnitRewriteOperation {
+	private static class RedundantSuperCallOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final SuperConstructorInvocation node;
 
 		public RedundantSuperCallOperation(final SuperConstructorInvocation node) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/SingleUsedFieldCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/SingleUsedFieldCleanUp.java
@@ -54,7 +54,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -154,7 +154,7 @@ public class SingleUsedFieldCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -369,7 +369,7 @@ public class SingleUsedFieldCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.SingleUsedFieldCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -382,7 +382,7 @@ public class SingleUsedFieldCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class SingleUsedFieldOperation extends CompilationUnitRewriteOperation {
+	private static class SingleUsedFieldOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final FieldDeclaration field;
 		private final VariableDeclarationFragment fragment;
 		private final SimpleName reassignment;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StrictlyEqualOrDifferentCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StrictlyEqualOrDifferentCleanUp.java
@@ -40,7 +40,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ASTSemanticMatcher;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -104,7 +104,7 @@ public class StrictlyEqualOrDifferentCleanUp extends AbstractMultiFix implements
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -190,7 +190,7 @@ public class StrictlyEqualOrDifferentCleanUp extends AbstractMultiFix implements
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.StrictlyEqualOrDifferentCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -208,7 +208,7 @@ public class StrictlyEqualOrDifferentCleanUp extends AbstractMultiFix implements
 		return null;
 	}
 
-	private static class StrictlyEqualOrDifferentOperation extends CompilationUnitRewriteOperation {
+	private static class StrictlyEqualOrDifferentOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Expression visited;
 		private final Expression firstExpression;
 		private final Expression secondExpression;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringBuilderCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringBuilderCleanUp.java
@@ -67,7 +67,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -135,7 +135,7 @@ public class StringBuilderCleanUp extends AbstractMultiFix implements ICleanUpFi
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			class VarOccurrenceVisitor extends ASTVisitor {
@@ -526,7 +526,7 @@ public class StringBuilderCleanUp extends AbstractMultiFix implements ICleanUpFi
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.StringBuilderCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	private static InfixExpression asStringConcatenation(final Expression expression) {
@@ -555,7 +555,7 @@ public class StringBuilderCleanUp extends AbstractMultiFix implements ICleanUpFi
 		return null;
 	}
 
-	private static class StringBuilderOperation extends CompilationUnitRewriteOperation {
+	private static class StringBuilderOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private static final String APPEND_METHOD= "append"; //$NON-NLS-1$
 		private static final String TO_STRING_METHOD= "toString"; //$NON-NLS-1$
 		private static final String VALUE_OF_METHOD= "valueOf"; //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/TernaryOperatorCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/TernaryOperatorCleanUp.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ASTSemanticMatcher;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -90,7 +90,7 @@ public class TernaryOperatorCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -159,7 +159,7 @@ public class TernaryOperatorCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.TernaryOperatorCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -172,7 +172,7 @@ public class TernaryOperatorCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class TernaryOperatorOperation extends CompilationUnitRewriteOperation {
+	private static class TernaryOperatorOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final InfixExpression visited;
 		private final Expression oneCondition;
 		private final Expression oneExpression;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UnboxingCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UnboxingCleanUp.java
@@ -40,7 +40,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -113,7 +113,7 @@ public class UnboxingCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -200,7 +200,7 @@ public class UnboxingCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.UnboxingCleanup_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[rewriteOperations.size()]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[rewriteOperations.size()]));
 	}
 
 	@Override
@@ -213,7 +213,7 @@ public class UnboxingCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class UnboxingOperation extends CompilationUnitRewriteOperation {
+	private static class UnboxingOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final MethodInvocation node;
 
 		public UnboxingOperation(MethodInvocation node) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UnloopedWhileCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UnloopedWhileCleanUp.java
@@ -43,7 +43,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.InterruptibleVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -229,7 +229,7 @@ public class UnloopedWhileCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -258,7 +258,7 @@ public class UnloopedWhileCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.UnloopedWhileCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -271,7 +271,7 @@ public class UnloopedWhileCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class UnloopedWhileOperation extends CompilationUnitRewriteOperation {
+	private static class UnloopedWhileOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final WhileStatement visited;
 		private final BreakVisitor breakVisitor;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UnreachableBlockCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UnreachableBlockCleanUp.java
@@ -31,7 +31,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -101,7 +101,7 @@ public class UnreachableBlockCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -143,7 +143,7 @@ public class UnreachableBlockCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.UnreachableBlockCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -156,7 +156,7 @@ public class UnreachableBlockCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class UnreachableBlockOperation extends CompilationUnitRewriteOperation {
+	private static class UnreachableBlockOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final IfStatement duplicateIf;
 
 		public UnreachableBlockOperation(final IfStatement duplicateIf) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UseStringIsBlankCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UseStringIsBlankCleanUp.java
@@ -34,7 +34,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.OrderedInfixExpression;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
@@ -103,7 +103,7 @@ public class UseStringIsBlankCleanUp extends AbstractCleanUp {
 			return null;
 		}
 
-		CompilationUnitRewriteOperation[] ops= operations.toArray(new CompilationUnitRewriteOperation[0]);
+		CompilationUnitRewriteOperationWithSourceRange[] ops= operations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]);
 		return new CompilationUnitRewriteOperationsFixCore(FixMessages.UseStringIsBlankCleanUp_description, compilationUnit, ops);
 	}
 
@@ -203,7 +203,7 @@ public class UseStringIsBlankCleanUp extends AbstractCleanUp {
 		}
 	}
 
-	private static class UseStringIsBlankFixOperation extends CompilationUnitRewriteOperation {
+	private static class UseStringIsBlankFixOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final Expression visited;
 		private final Expression trim;
 		private final boolean isPositive;
@@ -215,7 +215,7 @@ public class UseStringIsBlankCleanUp extends AbstractCleanUp {
 		}
 
 		@Override
-		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+		public void rewriteASTInternal(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
 			AST ast= cuRewrite.getRoot().getAST();
 			TextEditGroup group= createTextEditGroup(FixMessages.UseStringIsBlankCleanUp_description, cuRewrite);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessContinueCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessContinueCleanUp.java
@@ -41,7 +41,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -102,7 +102,7 @@ public class UselessContinueCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -169,7 +169,7 @@ public class UselessContinueCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.UselessContinueCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -182,7 +182,7 @@ public class UselessContinueCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class UselessContinueOperation extends CompilationUnitRewriteOperation {
+	private static class UselessContinueOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ContinueStatement node;
 		private final Block block;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
@@ -42,7 +42,7 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
@@ -98,7 +98,7 @@ public class UselessReturnCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		final List<CompilationUnitRewriteOperation> rewriteOperations= new ArrayList<>();
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
 
 		unit.accept(new ASTVisitor() {
 			@Override
@@ -164,7 +164,7 @@ public class UselessReturnCleanUp extends AbstractMultiFix {
 		}
 
 		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.UselessReturnCleanUp_description, unit,
-				rewriteOperations.toArray(new CompilationUnitRewriteOperation[0]));
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 
 	@Override
@@ -177,7 +177,7 @@ public class UselessReturnCleanUp extends AbstractMultiFix {
 		return null;
 	}
 
-	private static class UselessReturnOperation extends CompilationUnitRewriteOperation {
+	private static class UselessReturnOperation extends CompilationUnitRewriteOperationWithSourceRange {
 		private final ReturnStatement node;
 		private final Block block;
 


### PR DESCRIPTION
Currently we have more than 400 warnings in the jdt.ui build log.

## What it does
This change reduces the amount of deprecations of a certain kind that is used in the cleanups. 

## How to test
Run the cleanups, where the change is invalid it should cause issues. 

## Author checklist

- [ ] I have thoroughly tested my changes
- [x ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
