### PR TITLE
Fixed tests failing after requiring minimal 1.8 compliance, part 4

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/test108/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractInterface/test108/out/A.java
@@ -1,6 +1,7 @@
 package p;
 
 public class A implements I {
+	@Override
 	public void m() {
 		for (A a : getCollection()) {
 			a.abc();

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination_out/A_test1059.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination_out/A_test1059.java
@@ -4,10 +4,10 @@ public class A_test1059 {
 	interface B {
 		@interface C {
 			int i= /*[*/extracted();/*]*/
-		}		
-	}
+		}
 
-	protected static int extracted() {
-		return 0;
+		static int extracted() {
+			return 0;
+		}		
 	}
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination_out/A_test1060.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination_out/A_test1060.java
@@ -7,9 +7,9 @@ public class A_test1060 {
 				return extracted();
 			}
 		}
-	}
 
-	protected static int extracted() {
-		/*[*/return 0;/*]*/
+		static int extracted() {
+			/*[*/return 0;/*]*/
+		}
 	}
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineConstant/canInline17/test0/out/C.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineConstant/canInline17/test0/out/C.java
@@ -9,7 +9,7 @@ class C<T> {
         field1 = param;
     }
     public static void main(String[] args) {
-        C.testFunction(new C<String>(null).getField());
+        C.testFunction(new C<>(null).getField());
     }
     public static void testFunction(String param){
         System.out.println("S " + param);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test37_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test37_out.java
@@ -2,7 +2,7 @@ package p;
 
 class A<E> {
 	String x() {
-		return A.<String>bar();
+		return bar();
 	}
 
 	static <T> T bar() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test38_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test38_out.java
@@ -2,7 +2,7 @@ package p;
 
 class A<E> {
 	String x() {
-		return this.<String>bar();
+		return bar();
 	}
 
 	<T> T bar() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test39_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test39_out.java
@@ -2,7 +2,7 @@ package p;
 
 class A<E> extends Super {
 	String x() {
-		return super.<String>bar();
+		return super.bar();
 	}
 
 	<T> T bar() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test46/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test46/out/A.java
@@ -7,6 +7,7 @@ interface A{
 }
 class B implements A {
 
+	@Override
 	public int getConst() {
 		return CONST;
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test47/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test47/out/A.java
@@ -4,6 +4,7 @@ public interface A {
 	void method();
 }
 class B implements A {
+	@Override
 	public final void method() {
 		
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test51/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test51/out/A.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public class A implements B.Foo {
 
+	@Override
 	public void b() {
 		List<Object> l = null;
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test52/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test52/out/A.java
@@ -43,12 +43,16 @@ class PullUpToInterfaceBug {
 	}
 
 	static class B implements Foo {
+		@Override
 		public void baz1() {
 		}
+		@Override
 		public void baz2() {
 		}
+		@Override
 		public void baz3() {
 		}
+		@Override
 		public void baz4() {
 		}
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test53/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test53/out/A.java
@@ -4,6 +4,7 @@ interface A{
 	int[] m()[];
 }
 class B implements A{
+	@Override
 	public int[] m()[] {
 		return null;
 	}


### PR DESCRIPTION
- PullUpTests
- InlineTempTests (all except test31())
- InlineConstantTests1d7
- ExtractMethodTests
- ExtractInterfaceTests

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2536
