### PR TITLE
Fix MoveMembersTest failures due to moving to Java 1.8 as min version

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail19/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail19/in/A.java
@@ -1,4 +1,0 @@
-package p;
-public class A{
-	public static void m(){}
-}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail19/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail19/in/B.java
@@ -1,3 +1,0 @@
-package p;
-interface B{
-}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail21/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail21/in/A.java
@@ -1,4 +1,0 @@
-package p;
-public interface A{
-	static void m();
-}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail21/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail21/in/B.java
@@ -1,3 +1,0 @@
-package p;
-class B{
-}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
@@ -674,9 +674,7 @@ public class MoveMembersTests extends GenericRefactoringTest {
 
 	@Test
 	public void testFail19() throws Exception{
-		fieldMethodTypeHelper_failing(new String[0],
-				new String[]{"m"}, new String[][]{new String[0]}, new String[0],
-				RefactoringStatus.ERROR, "p.B");
+		// no longer failure due to min JDK 1.8...move static to interface tested in MoveMemberTest1d8
 	}
 
 	@Test
@@ -686,9 +684,7 @@ public class MoveMembersTests extends GenericRefactoringTest {
 
 	@Test
 	public void testFail21() throws Exception{
-		fieldMethodTypeHelper_failing(new String[0],
-				new String[]{"m"}, new String[][]{new String[0]}, new String[0],
-				RefactoringStatus.FATAL, "p.B");
+		// no longer failure due to min JDK 1.8...move static to interface tested in MoveMemberTest1d8
 	}
 
 	// Issue 1299


### PR DESCRIPTION
- remove testFail19() and testFail21() tests which assume static methods in interfaces are forbidden which they are not in 1.8

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See title.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run MoveMembersTest.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
