### PR TITLE
Fixed tests failing after requiring minimal 1.8 compliance, part 5

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ModifierCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ModifierCorrectionsQuickFixTest.java
@@ -502,7 +502,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			package test1;
 			public class C {
 			    protected class Inner{
-			
+
 			        public Inner() {
 			        }
 			    }
@@ -633,7 +633,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			package test1;
 			public class E extends C {
 			    private int fXoo;
-			
+
 			    public void foo() {
 			         fXoo= 1;
 			    }
@@ -996,7 +996,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
 			package test1;
-			
+
 			enum E {
 			    A {
 			        public void foo() {}
@@ -1015,7 +1015,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package test1;
-			
+
 			enum E {
 			    A {
 			        public void foo() {}
@@ -1123,181 +1123,6 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		assertEqualStringsIgnoreOrder(new String[] { preview1, preview2 }, new String[] { expected1, expected2 });
 	}
-
-	@Test
-	public void testOuterLocalMustBeFinal() throws Exception {
-
-		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		String str= """
-			package test1;
-			public class E {
-			    public void foo() {
-			        int i= 9;
-			        Runnable run= new Runnable() {
-			            public void run() {
-			                int x= i;
-			            }
-			        };
-			    }
-			}
-			""";
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
-
-		CompilationUnit astRoot= getASTRoot(cu);
-		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
-		assertNumberOfProposals(proposals, 1);
-		assertCorrectLabels(proposals);
-
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
-		String preview= getPreviewContent(proposal);
-
-		String str1= """
-			package test1;
-			public class E {
-			    public void foo() {
-			        final int i= 9;
-			        Runnable run= new Runnable() {
-			            public void run() {
-			                int x= i;
-			            }
-			        };
-			    }
-			}
-			""";
-		assertEqualString(preview, str1);
-	}
-
-	@Test
-	public void testOuterLocalMustBeFinal2() throws Exception {
-
-		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		String str= """
-			package test1;
-			import java.util.List;
-			public class E {
-			    public void foo() {
-			        List<String> i= null, j= null;
-			        Runnable run= new Runnable() {
-			            public void run() {
-			                Object x= i;
-			            }
-			        };
-			    }
-			}
-			""";
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
-
-		CompilationUnit astRoot= getASTRoot(cu);
-		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
-		assertNumberOfProposals(proposals, 1);
-		assertCorrectLabels(proposals);
-
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
-		String preview= getPreviewContent(proposal);
-
-		String str1= """
-			package test1;
-			import java.util.List;
-			public class E {
-			    public void foo() {
-			        final List<String> i= null;
-			        List<String> j= null;
-			        Runnable run= new Runnable() {
-			            public void run() {
-			                Object x= i;
-			            }
-			        };
-			    }
-			}
-			""";
-		assertEqualString(preview, str1);
-	}
-
-
-	@Test
-	public void testOuterParameterMustBeFinal() throws Exception {
-		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		String str= """
-			package test1;
-			public class E {
-			    public void foo(int i) {
-			        Runnable run= new Runnable() {
-			            public void run() {
-			                int x= i;
-			            }
-			        };
-			    }
-			}
-			""";
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
-
-		CompilationUnit astRoot= getASTRoot(cu);
-		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
-		assertNumberOfProposals(proposals, 1);
-		assertCorrectLabels(proposals);
-
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
-		String preview= getPreviewContent(proposal);
-
-		String str1= """
-			package test1;
-			public class E {
-			    public void foo(final int i) {
-			        Runnable run= new Runnable() {
-			            public void run() {
-			                int x= i;
-			            }
-			        };
-			    }
-			}
-			""";
-		assertEqualString(preview, str1);
-	}
-
-	@Test
-	public void testOuterForParamMustBeFinal() throws Exception {
-		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		String str= """
-			package test1;
-			public class E {
-			    public void foo() {
-			        for (int i= 1; true;) {
-			            Runnable run= new Runnable() {
-			                public void run() {
-			                    int x= i;
-			                }
-			            };
-			        }
-			    }
-			}
-			""";
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
-
-		CompilationUnit astRoot= getASTRoot(cu);
-		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
-		assertNumberOfProposals(proposals, 1);
-		assertCorrectLabels(proposals);
-
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
-		String preview= getPreviewContent(proposal);
-
-		String str1= """
-			package test1;
-			public class E {
-			    public void foo() {
-			        for (final int i= 1; true;) {
-			            Runnable run= new Runnable() {
-			                public void run() {
-			                    int x= i;
-			                }
-			            };
-			        }
-			    }
-			}
-			""";
-		assertEqualString(preview, str1);
-	}
-
 
 	@Test
 	public void testMethodRequiresBody() throws Exception {
@@ -2235,20 +2060,8 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
 		CompilationUnit astRoot= getASTRoot(cu);
-		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
-		assertNumberOfProposals(proposals, 1);
-		assertCorrectLabels(proposals);
-
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
-		String preview= getPreviewContent(proposal);
-
-		String str1= """
-			package test1;
-			public interface E  {
-			    void foo();
-			}
-			""";
-		assertEqualString(preview, str1);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 2);
+		assertNumberOfProposals(proposals, 0);
 	}
 
 	@Test
@@ -2412,7 +2225,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			public class Bug {
 			    public static Bug() {
 			    }
@@ -2429,7 +2242,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package pack;
-			
+
 			public class Bug {
 			    public Bug() {
 			    }
@@ -3034,7 +2847,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String str= """
 			package test1;\s
 			import java.util.ArrayList;
-			
+
 			public class A {
 			    public void foo(ArrayList<String> c) {
 			        new ArrayList(c);
@@ -3053,7 +2866,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[0]= """
 			package test1;\s
 			import java.util.ArrayList;
-			
+
 			public class A {
 			    @SuppressWarnings("unchecked")
 			    public void foo(ArrayList<String> c) {
@@ -3076,7 +2889,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String str= """
 			package test1;\s
 			import java.util.ArrayList;
-			
+
 			public class A {
 			    public void foo() {
 			         @SuppressWarnings("unused")
@@ -3095,7 +2908,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[0]= """
 			package test1;\s
 			import java.util.ArrayList;
-			
+
 			public class A {
 			    public void foo() {
 			         @SuppressWarnings({"unused", "rawtypes"})
@@ -3107,7 +2920,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[1]= """
 			package test1;\s
 			import java.util.ArrayList;
-			
+
 			public class A {
 			    @SuppressWarnings("rawtypes")
 			    public void foo() {
@@ -3130,7 +2943,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String str= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    List<String> myList = new ArrayList();
 			}
@@ -3147,7 +2960,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[0]= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    @SuppressWarnings("unchecked")
 			    List<String> myList = new ArrayList();
@@ -3168,7 +2981,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String str= """
 			package test1;\s
 			import java.util.ArrayList;
-			
+
 			class A {
 			    @SuppressWarnings("rawtypes")
 			    ArrayList array;
@@ -3187,7 +3000,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[0]= """
 			package test1;\s
 			import java.util.ArrayList;
-			
+
 			class A {
 			    @SuppressWarnings("rawtypes")
 			    ArrayList array;
@@ -3210,7 +3023,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String str= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    public int foo(int param1, List param2) {
 			         return param1;
@@ -3228,7 +3041,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[0]= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    public int foo(int param1, @SuppressWarnings("rawtypes") List param2) {
 			         return param1;
@@ -3239,7 +3052,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[1]= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    @SuppressWarnings("rawtypes")
 			    public int foo(int param1, List param2) {
@@ -3263,7 +3076,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String str= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    public void foo() {
 			        @SuppressWarnings("unused")
@@ -3290,7 +3103,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[0]= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    public void foo() {
 			        @SuppressWarnings("unused")
@@ -3310,7 +3123,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[1]= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    public void foo() {
 			        @SuppressWarnings({"unused", "rawtypes"})
@@ -3329,7 +3142,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[1]= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    @SuppressWarnings("rawtypes")
 			    public void foo() {
@@ -3359,7 +3172,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String str= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    final Runnable r= new Runnable() {
 			        public void run() {
@@ -3384,7 +3197,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		expected[0]= """
 			package test1;\s
 			import java.util.*;
-			
+
 			public class A {
 			    final Runnable r= new Runnable() {
 			        @SuppressWarnings("unchecked")
@@ -3407,7 +3220,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("a", false, null);
 		String str= """
 			package a;
-			
+
 			public class A {
 			    @SuppressWarnings("unusd")
 			    public static void main(String[] args) {
@@ -3425,7 +3238,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package a;
-			
+
 			public class A {
 			    @SuppressWarnings("unused")
 			    public static void main(String[] args) {
@@ -3435,7 +3248,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		expected[1]= """
 			package a;
-			
+
 			public class A {
 			    public static void main(String[] args) {
 			    }
@@ -3451,7 +3264,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment other= fSourceFolder.createPackageFragment("other", false, null);
 		String str= """
 			package other;\s
-			
+
 			public @interface SuppressWarnings {
 			    String value();
 			}
@@ -3462,7 +3275,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String str1= """
 			package a.b;
-			
+
 			public class E {
 			    @Deprecated()
 			    public void foo() {
@@ -3473,9 +3286,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String str2= """
 			package a.b;
-			
+
 			import other.SuppressWarnings;
-			
+
 			public class Test {
 			    @SuppressWarnings("BC")
 			    public void foo() {
@@ -3494,9 +3307,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package a.b;
-			
+
 			import other.SuppressWarnings;
-			
+
 			public class Test {
 			    @java.lang.SuppressWarnings("deprecation")
 			    @SuppressWarnings("BC")
@@ -3514,9 +3327,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			import java.util.Vector;
-			
+
 			public class A {
 			}
 			""";
@@ -3531,9 +3344,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		expected[0]= """
 			package p;
-			
+
 			import java.util.Vector;
-			
+
 			@SuppressWarnings("unused")
 			public class A {
 			}
@@ -3552,10 +3365,10 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			@SuppressWarnings(value="unused")
 			public class E {
-			
+
 			}
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
@@ -3569,9 +3382,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package p;
-			
+
 			public class E {
-			
+
 			}
 			""";
 
@@ -3587,10 +3400,10 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			@SuppressWarnings("unused")
 			public class E {
-			
+
 			}
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
@@ -3604,9 +3417,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package p;
-			
+
 			public class E {
-			
+
 			}
 			""";
 
@@ -3622,10 +3435,10 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			@SuppressWarnings({ "unused", "X" })
 			public class E {
-			
+
 			}
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
@@ -3639,63 +3452,14 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package p;
-			
+
 			@SuppressWarnings({ "X" })
 			public class E {
-			
+
 			}
 			""";
 
 		assertExpectedExistInProposals(proposals, expected);
-	}
-
-
-	@Test
-	public void testMakeFinalBug129165() throws Exception {
-		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		String str= """
-			package test1;
-			import java.io.Serializable;
-			public class E {
-			    @SuppressWarnings("serial")
-			    public void foo() {
-			        int i= 1, j= i + 1, h= j + 1;
-			        Serializable ser= new Serializable() {
-			            public void bar() {
-			                System.out.println(j);
-			            }
-			        };
-			    }
-			}
-			""";
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
-
-		CompilationUnit astRoot= getASTRoot(cu);
-		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
-		assertNumberOfProposals(proposals, 1);
-		assertCorrectLabels(proposals);
-
-		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
-		String preview= getPreviewContent(proposal);
-
-		String str1= """
-			package test1;
-			import java.io.Serializable;
-			public class E {
-			    @SuppressWarnings("serial")
-			    public void foo() {
-			        int i= 1;
-			        final int j= i + 1;
-			        int h= j + 1;
-			        Serializable ser= new Serializable() {
-			            public void bar() {
-			                System.out.println(j);
-			            }
-			        };
-			    }
-			}
-			""";
-		assertEqualString(preview, str1);
 	}
 
 	@Test
@@ -3703,7 +3467,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			public class E {
 			    class F {
 			        static int x;
@@ -3721,7 +3485,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package pack;
-			
+
 			public class E {
 			    class F {
 			        int x;
@@ -3731,7 +3495,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		expected[1]= """
 			package pack;
-			
+
 			public class E {
 			    static class F {
 			        static int x;
@@ -3747,7 +3511,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			public class E {
 			    class F {
 			        static int foo() {
@@ -3766,7 +3530,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package pack;
-			
+
 			public class E {
 			    class F {
 			        int foo() {
@@ -3777,7 +3541,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		expected[1]= """
 			package pack;
-			
+
 			public class E {
 			    static class F {
 			        static int foo() {
@@ -3794,7 +3558,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			public class E {
 			    class F {
 			        volatile final int x;
@@ -3812,7 +3576,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package pack;
-			
+
 			public class E {
 			    class F {
 			        final int x;
@@ -3822,7 +3586,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		expected[1]= """
 			package pack;
-			
+
 			public class E {
 			    class F {
 			        volatile int x;
@@ -3840,7 +3604,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String str= """
 			package pack;
-			
+
 			public class OtherMachine {
 			}
 			""";
@@ -3848,9 +3612,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String str1= """
 			package pack;
-			
+
 			import java.io.IOException;
-			
+
 			public class Machine extends OtherMachine {
 			    @Override
 			    public boolean isAlive(OtherMachine m) throws IOException {
@@ -3869,9 +3633,9 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package pack;
-			
+
 			import java.io.IOException;
-			
+
 			public class Machine extends OtherMachine {
 			    public boolean isAlive(OtherMachine m) throws IOException {
 			        return true;
@@ -3881,11 +3645,11 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		expected[1]= """
 			package pack;
-			
+
 			import java.io.IOException;
-			
+
 			public class OtherMachine {
-			
+
 			    public boolean isAlive(OtherMachine m) throws IOException {
 			        return false;
 			    }
@@ -3901,7 +3665,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String str= """
 			package pack;
-			
+
 			public abstract class OtherMachine {
 			}
 			""";
@@ -3909,7 +3673,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String str1= """
 			package pack;
-			
+
 			public abstract class Machine extends OtherMachine {
 			    @Override
 			    public abstract void m1();
@@ -3926,16 +3690,16 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package pack;
-			
+
 			public abstract class OtherMachine {
-			
+
 			    public abstract void m1();
 			}
 			""";
 
 		expected[1]= """
 			package pack;
-			
+
 			public abstract class Machine extends OtherMachine {
 			    public abstract void m1();
 			}
@@ -3958,12 +3722,12 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}   \s
-			
+
 			class F extends E {
 			    public void foo() {
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -3981,13 +3745,13 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}   \s
-			
+
 			class F extends E {
 			    @Deprecated
 			    public void foo() {
 			    }
 			}
-			
+
 			""";
 
 		expected[1]= """
@@ -3997,13 +3761,13 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}   \s
-			
+
 			class F extends E {
 			    @SuppressWarnings("deprecation")
 			    public void foo() {
 			    }
 			}
-			
+
 			""";
 
 		assertExpectedExistInProposals(proposals, expected);
@@ -4023,14 +3787,14 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}   \s
-			
+
 			class F extends E {
 			    /**
 			     */
 			    public void foo() {
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -4048,7 +3812,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}   \s
-			
+
 			class F extends E {
 			    /**
 			     * @deprecated
@@ -4057,7 +3821,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}
-			
+
 			""";
 
 		expected[1]= """
@@ -4067,7 +3831,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}   \s
-			
+
 			class F extends E {
 			    /**
 			     */
@@ -4075,7 +3839,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 			    public void foo() {
 			    }
 			}
-			
+
 			""";
 
 		assertExpectedExistInProposals(proposals, expected);
@@ -4086,7 +3850,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("r", false, null);
 		String str= """
 			package r;
-			
+
 			enum E {
 			    ;
 			    public abstract boolean foo();
@@ -4103,7 +3867,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package r;
-			
+
 			enum E {
 			    ;
 			    public boolean foo() {
@@ -4120,7 +3884,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("r", false, null);
 		String str= """
 			package r;
-			
+
 			private final strictfp enum E {
 			}
 			""";
@@ -4135,7 +3899,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package r;
-			
+
 			strictfp enum E {
 			}
 			""";
@@ -4148,7 +3912,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("r", false, null);
 		String str= """
 			package r;
-			
+
 			public abstract enum E {
 			}
 			""";
@@ -4163,7 +3927,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package r;
-			
+
 			public enum E {
 			}
 			""";
@@ -4176,7 +3940,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("r", false, null);
 		String str= """
 			package r;
-			
+
 			enum E {
 				private final WHITE;
 			}
@@ -4192,7 +3956,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package r;
-			
+
 			enum E {
 				WHITE;
 			}
@@ -4206,10 +3970,10 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("r", false, null);
 		String str= """
 			package r;
-			
+
 			enum E {
 				WHITE(1);
-			
+
 				public final E(int foo) {
 				}
 			}
@@ -4225,10 +3989,10 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package r;
-			
+
 			enum E {
 				WHITE(1);
-			
+
 				E(int foo) {
 				}
 			}
@@ -4242,7 +4006,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("r", false, null);
 		String str= """
 			package r;
-			
+
 			class E {
 				final enum A {
 				}
@@ -4259,7 +4023,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package r;
-			
+
 			class E {
 				enum A {
 				}
@@ -4274,7 +4038,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("r", false, null);
 		String str= """
 			package r;
-			
+
 			public class A {
 				protected synchronized void foo() {
 				}
@@ -4284,7 +4048,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String str1= """
 			package r;
-			
+
 			class B extends A {
 				protected void foo() {
 				}
@@ -4301,7 +4065,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package r;
-			
+
 			class B extends A {
 				protected synchronized void foo() {
 				}
@@ -4498,7 +4262,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String sample= """
 			package test1;
-			
+
 			public interface Interface1 {
 			  String getName();
 			}
@@ -4507,7 +4271,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		sample= """
 			package test2;
-			
+
 			public class AbsImpl implements test1.Interface1 {
 			  String getName() {
 			    return "name";
@@ -4536,7 +4300,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String sample= """
 			package test;
-			
+
 			public interface Interface1 {
 			  String getName();
 			}
@@ -4545,7 +4309,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		sample= """
 			package test;
-			
+
 			protected interface Interface2 {
 			  protected String getName();
 			}
@@ -4554,7 +4318,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		sample= """
 			package test;
-			
+
 			public class AbsImpl implements Interface1, Interface2 {
 			  String getName() {
 			    return "name";
@@ -4585,7 +4349,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String sample= """
 			package test1;
-			
+
 			public interface Interface1 {
 			  String getName();
 			}
@@ -4594,7 +4358,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		sample= """
 			package test2;
-			
+
 			public interface Interface2 {
 			  String getName();
 			}
@@ -4603,7 +4367,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		sample= """
 			package test3;
-			
+
 			public class AbsImpl implements test1.Interface1, test2.Interface2 {
 			  String getName() {
 			    return "name";
@@ -4634,7 +4398,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		String sample= """
 			package test1;
-			
+
 			public interface Interface1 {
 			  String getName();
 			}
@@ -4643,7 +4407,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		sample= """
 			package test2;
-			
+
 			public interface Interface2 extends test1.Interface1 {
 			}
 			""";
@@ -4651,7 +4415,7 @@ public class ModifierCorrectionsQuickFixTest extends QuickFixTest {
 
 		sample= """
 			package test3;
-			
+
 			public class AbsImpl implements test2.Interface2 {
 			  String getName() {
 			    return "name";

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ReturnTypeQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ReturnTypeQuickFixTest.java
@@ -670,9 +670,9 @@ public class ReturnTypeQuickFixTest extends QuickFixTest {
 
 			String str1= """
 				package test1;
-				
+
 				import java.util.Properties;
-				
+
 				public class E {
 				    public Properties E() {
 				        return System.getProperties();
@@ -844,9 +844,9 @@ public class ReturnTypeQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String input= """
 			package test1;
-			
+
 			import java.util.Map;
-			
+
 			public class E {
 			    <K1, K2, V> V foo(K1 key1, Map<K1, Map<K2, V>> map) {
 			        Map<K2, V> map2 = map.get(key1);
@@ -866,13 +866,13 @@ public class ReturnTypeQuickFixTest extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			import java.util.Map;
-			
+
 			public class E {
 			    <K1, K2, V> V foo(K1 key1, Map<K1, Map<K2, V>> map) {
 			        Map<K2, V> map2 = map.get(key1);
-			        return (V) (map2 == null ? null : map2.entrySet());
+			        return map2 == null ? null : (V) map2.entrySet();
 			    }
 			}
 			"""; //
@@ -882,11 +882,11 @@ public class ReturnTypeQuickFixTest extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import java.util.Map;
 			import java.util.Map.Entry;
 			import java.util.Set;
-			
+
 			public class E {
 			    <K1, K2, V> Set<Entry<K2, V>> foo(K1 key1, Map<K1, Map<K2, V>> map) {
 			        Map<K2, V> map2 = map.get(key1);
@@ -904,9 +904,9 @@ public class ReturnTypeQuickFixTest extends QuickFixTest {
 
 		String input= """
 			package test1;
-			
+
 			import java.util.Map;
-			
+
 			public class E {
 			    <K1, K2, V> V foo(K1 key1, Map<K1, Map<K2, V>> aMap) {
 			        Map<K2, V> newMap = aMap.get(key1);
@@ -926,13 +926,13 @@ public class ReturnTypeQuickFixTest extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			import java.util.Map;
-			
+
 			public class E {
 			    <K1, K2, V> V foo(K1 key1, Map<K1, Map<K2, V>> aMap) {
 			        Map<K2, V> newMap = aMap.get(key1);
-			        return (V) (newMap == null ? null : aMap == null ? null : newMap.entrySet());
+			        return newMap == null ? null : aMap == null ? null : (V) newMap.entrySet();
 			    }
 			}
 			"""; //
@@ -942,11 +942,11 @@ public class ReturnTypeQuickFixTest extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import java.util.Map;
 			import java.util.Map.Entry;
 			import java.util.Set;
-			
+
 			public class E {
 			    <K1, K2, V> Set<Entry<K2, V>> foo(K1 key1, Map<K1, Map<K2, V>> aMap) {
 			        Map<K2, V> newMap = aMap.get(key1);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/TypeMismatchQuickFixTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/TypeMismatchQuickFixTests.java
@@ -17,7 +17,7 @@ package org.eclipse.jdt.ui.tests.quickfix;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -410,9 +410,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import test0.PrimaryContainer;
-			
+
 			public class Container {
 			    public static PrimaryContainer getContainer() {
 			        return null;
@@ -425,9 +425,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected4= """
 			package test1;
-			
+
 			import test0.PrimaryContainer;
-			
+
 			public class Container implements PrimaryContainer {
 			    public static Container getContainer() {
 			        return null;
@@ -496,9 +496,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import test0.PrimaryContainer;
-			
+
 			public class Container {
 			    public static PrimaryContainer getContainer() {
 			        return null;
@@ -511,9 +511,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import test0.PrimaryContainer;
-			
+
 			public class Container implements PrimaryContainer {
 			    public static Container getContainer() {
 			        return null;
@@ -526,9 +526,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected4= """
 			package test0;
-			
+
 			import test1.Container;
-			
+
 			public interface PrimaryContainer {
 			    PrimaryContainer duplicate(Container container);
 			}
@@ -539,12 +539,12 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected5= """
 			package test0;
-			
+
 			import test1.Container;
-			
+
 			public interface PrimaryContainer {
 			    PrimaryContainer duplicate(PrimaryContainer container);
-			
+
 			    void duplicate(Container container);
 			}
 			""";
@@ -621,9 +621,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import test0.PrimaryContainer;
-			
+
 			public class Container<A> {
 			    public PrimaryContainer<String> getContainer() {
 			        return null;
@@ -636,9 +636,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected4= """
 			package test1;
-			
+
 			import test0.PrimaryContainer;
-			
+
 			public class Container<A> implements PrimaryContainer<String> {
 			    public Container<A> getContainer() {
 			        return null;
@@ -722,9 +722,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import test0.PrimaryContainer;
-			
+
 			public class Container<A> {
 			    public PrimaryContainer<?> getContainer() {
 			        return null;
@@ -1351,9 +1351,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			import java.util.List;
-			
+
 			public class E implements IBase {
 			    public List getCollection() {
 			        return null;
@@ -1550,12 +1550,11 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 			String expected1= """
 				package test1;
-				import java.lang.annotation.Annotation;
 				import java.lang.reflect.AccessibleObject;
 				public class E {
 				    void m() {
 				        new AccessibleObject() {
-				            public Annotation getAnnotation(Class annotationClass) {
+				            public T getAnnotation(Class annotationClass) {
 				            }
 				        };
 				    }
@@ -1740,9 +1739,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			import java.io.IOException;
-			
+
 			public interface IBase {
 			    String[] getValues() throws IOException;
 			}
@@ -1753,7 +1752,7 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			public class E implements IBase {
 			    public String[] getValues() {
 			        return null;
@@ -1946,9 +1945,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			import java.io.IOException;
-			
+
 			public interface IBase<T> {
 			    T[] getValues() throws IOException;
 			}
@@ -1959,7 +1958,7 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			public class E implements IBase<String> {
 			    public String[] getValues() {
 			        return null;
@@ -2261,9 +2260,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        List<String> l= null;   \s
@@ -2283,9 +2282,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        List<String> l= null;   \s
@@ -2303,9 +2302,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        List<? extends String> l= null;   \s
@@ -2325,9 +2324,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        List<? extends String> l= null;   \s
@@ -2345,9 +2344,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        List<? super String> l= null;   \s
@@ -2367,9 +2366,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        List<? super String> l= null;   \s
@@ -2387,9 +2386,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        String[] l= null;
@@ -2409,9 +2408,9 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package pack;
-			
+
 			import java.util.List;
-			
+
 			public class E {
 			    public void foo() {
 			        String[] l= null;
@@ -2429,7 +2428,7 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			public class E {
 			    public void foo(String[] strings) {
 			        for (s: strings) {
@@ -2448,7 +2447,7 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package pack;
-			
+
 			public class E {
 			    public void foo(String[] strings) {
 			        for (String s: strings) {
@@ -2465,14 +2464,14 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
+
 			public class E {
 			    public static void main(String arg) {
 			        while (arg) {
 			        }
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -2485,26 +2484,26 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package pack;
-			
+
 			public class E {
 			    public static void main(boolean arg) {
 			        while (arg) {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		expected[1]= """
 			package pack;
-			
+
 			public class E {
 			    public static void main(String arg) {
 			        while (arg != null) {
 			        }
 			    }
 			}
-			
+
 			""";
 
 		assertExpectedExistInProposals(proposals, expected);
@@ -2516,8 +2515,8 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo() {
 			        Object o= new Object();
@@ -2534,25 +2533,25 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		assertNumberOfProposals(proposals, 3);
 
 		ICompletionProposal proposal= proposals.get(0);
-		assertNotEquals(-1, proposal.getDisplayString().indexOf("Integer"));
+		assertNotEquals(-1, proposal.getDisplayString().indexOf("int"));
 
 		String[] expected= new String[3];
 		expected[0]= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo() {
 			        Object o= new Object();
-			        int i= (Integer) o;
+			        int i= (int) o;
 			    }
 			}
 			""";
 
 		expected[1]= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo() {
 			        int o= new Object();
@@ -2563,8 +2562,8 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		expected[2]= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo() {
 			        Object o= new Object();
@@ -2581,8 +2580,8 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo(long o) {
 			        int i= o;
@@ -2609,8 +2608,8 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 		String[] expected= new String[3];
 		expected[0]= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo(long o) {
 			        int i= (int) o;
@@ -2620,8 +2619,8 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		expected[1]= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo(int o) {
 			        int i= o;
@@ -2631,8 +2630,8 @@ public class TypeMismatchQuickFixTests extends QuickFixTest {
 
 		expected[2]= """
 			package pack;
-			
-			
+
+
 			public class E {
 			    public void foo(long o) {
 			        long i= o;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UnresolvedMethodsQuickFixTest.java
@@ -111,7 +111,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
-			
+
 			    private int goo(Vector vec, boolean b) {
 			        return 0;
 			    }
@@ -149,7 +149,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        for (int i= 0, j= goo(3); i < 0; i++) {
 			        }
 			    }
-			
+
 			    private int goo(int i) {
 			        return 0;
 			    }
@@ -185,7 +185,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    private boolean foo() {
 			        return f(1) || f(2);
 			    }
-			
+
 			    private boolean f(int i) {
 			        return false;
 			    }
@@ -221,7 +221,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    private boolean foo() {
 			        return f(1) == f(2);
 			    }
-			
+
 			    private Object f(int i) {
 			        return null;
 			    }
@@ -237,7 +237,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
 			    void foo(Vector vec) {
@@ -259,7 +259,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
 			    void foo(Vector vec) {
@@ -280,10 +280,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
@@ -303,14 +303,14 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
-			
+
 			    private int goo(Vector vec, boolean b) {
 			        return 0;
 			    }
@@ -326,7 +326,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
 			   \s
@@ -350,7 +350,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
 			   \s
@@ -358,8 +358,8 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
-			
-			
+
+
 			    private int goo(Vector vec, boolean b) {
 			        return 0;
 			    }
@@ -375,12 +375,12 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			//comment
-			
+
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
@@ -400,16 +400,16 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			//comment
-			
+
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
-			
+
 			    private int goo(Vector vec, boolean b) {
 			        return 0;
 			    }
@@ -425,10 +425,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			    /**
 			     * javadoc
 			     */
@@ -451,17 +451,17 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			    /**
 			     * javadoc
 			     */
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
-			
+
 			    private int goo(Vector vec, boolean b) {
 			        return 0;
 			    }
@@ -477,10 +477,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			    /*
 			     * non javadoc
 			     */
@@ -503,17 +503,17 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			import java.util.Vector;
 			public class E {
-			
+
 			    void fred() {
 			    }
-			
+
 			    /*
 			     * non javadoc
 			     */
 			    void foo(Vector vec) {
 			        int i= goo(vec, true);
 			    }
-			
+
 			    private int goo(Vector vec, boolean b) {
 			        return 0;
 			    }
@@ -551,7 +551,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void foo(Vector vec) {
 			        int i= this.goo(vec, true);
 			    }
-			
+
 			    private int goo(Vector vec, boolean b) {
 			        return 0;
 			    }
@@ -601,7 +601,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public class X {
-			
+
 			    public boolean goo(int i, double d) {
 			        return false;
 			    }
@@ -637,7 +637,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        help.help(this);
 			    }
 			}
-			
+
 			class Help {
 			}
 			""";
@@ -659,9 +659,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        help.help(this);
 			    }
 			}
-			
+
 			class Help {
-			
+
 			    public void help(Bork<T> bork) {
 			    }
 			}
@@ -700,7 +700,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            public void run() {}
 			        });
 			    }
-			
+
 			    private void foo(Runnable runnable) {
 			    }
 			}
@@ -750,7 +750,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public class X<A> {
-			
+
 			    public boolean goo(X<String> x) {
 			        return false;
 			    }
@@ -798,7 +798,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void foo(Vector<? extends Number> vec) {
 			        vec.add(goo());
 			    }
-			
+
 			    private Object goo() {
 			        return null;
 			    }
@@ -833,7 +833,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void foo(Vector<? super Number> vec) {
 			        vec.add(goo());
 			    }
-			
+
 			    private Number goo() {
 			        return null;
 			    }
@@ -868,7 +868,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void foo(Vector<? super Number> vec) {
 			        goo(vec.get(0));
 			    }
-			
+
 			    private void goo(Object object) {
 			    }
 			}
@@ -888,7 +888,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void testMethod(Vector<? extends Number> vec) {
 			        goo(vec.get(0));
 			    }
-			
+
 			    private void goo(int i) {
 			    }
 			}
@@ -906,10 +906,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void testMethod(Vector<? extends Number> vec) {
 			        goo(vec.get(0));
 			    }
-			
+
 			    private void goo(Number number) {
 			    }
-			
+
 			    private void goo(int i) {
 			    }
 			}
@@ -922,7 +922,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void testMethod(Vector<? extends Number> vec) {
 			        goo(vec.get(0));
 			    }
-			
+
 			    private void goo(Number number) {
 			    }
 			}
@@ -1001,7 +1001,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    void testMethod(T t) {
 			        t.goo();
 			    }
-			
+
 			    private void goo() {
 			    }
 			}
@@ -1047,7 +1047,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			public class E {
 			    public class X<A> {
-			
+
 			        public int goo(X<String> x) {
 			            return 0;
 			        }
@@ -1118,7 +1118,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public class X<A> {
-			
+
 			    public boolean goo(X x) {
 			        return false;
 			    }
@@ -1177,7 +1177,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            public void run() {
 			                xoo();
 			            }
-			
+
 			            private void xoo() {
 			            }
 			        };
@@ -1198,7 +1198,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            }
 			        };
 			    }
-			
+
 			    protected void xoo() {
 			    }
 			}
@@ -1263,7 +1263,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package other;
 			public class A {
-			
+
 			    public static void xoo() {
 			    }
 			}
@@ -1306,7 +1306,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            public void run() {
 			                xoo();
 			            }
-			
+
 			            private void xoo() {
 			            }
 			        };
@@ -1327,7 +1327,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            }
 			        };
 			    }
-			
+
 			    protected static void xoo() {
 			    }
 			}
@@ -1390,7 +1390,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            }
 			        };
 			    }
-			
+
 			    protected void foobar() {
 			    }
 			}
@@ -1449,7 +1449,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            public int compareTo(String s) {
 			                xoo();
 			            }
-			
+
 			            private void xoo() {
 			            }
 			        };
@@ -1470,7 +1470,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            }
 			        };
 			    }
-			
+
 			    protected void xoo() {
 			    }
 			}
@@ -1589,7 +1589,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            public void run() {
 			                run(1);
 			            }
-			
+
 			            private void run(int i) {
 			            }
 			        };
@@ -1692,7 +1692,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			            public void run() {
 			                run(1);
 			            }
-			
+
 			            private void run(int i) {
 			            }
 			        };
@@ -1786,7 +1786,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        public void run() {
 			            run(1);
 			        }
-			
+
 			        private void run(int i) {
 			        }
 			    }
@@ -1831,7 +1831,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        public void run() {
 			            run(1);
 			        }
-			
+
 			        private void run(int i) {
 			        }
 			    }
@@ -1907,7 +1907,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public interface X {
-			
+
 			    boolean goo(Class<? extends E> class1);
 			}
 			""";
@@ -1933,7 +1933,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("p", false, null);
 		String str= """
 			package p;
-			
+
 			public class E {
 			    void foo() {
 			        int i = bar()[0];
@@ -1951,12 +1951,12 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[1];
 		expected[0]= """
 			package p;
-			
+
 			public class E {
 			    void foo() {
 			        int i = bar()[0];
 			    }
-			
+
 			    private int[] bar() {
 			        return null;
 			    }
@@ -2011,7 +2011,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        long x= 0;
 			        foo(x + 1);
 			    }
-			
+
 			    private void foo(long l) {
 			    }
 			}
@@ -2084,7 +2084,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class X {
 			    public static void xoo(int i, Object o) {
 			    }
-			
+
 			    public static void xoo(float x, E o) {
 			    }
 			}
@@ -2145,7 +2145,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    public void foo(Integer i) {
 			        foo(1.0);
 			    }
-			
+
 			    private void foo(double d) {
 			    }
 			}
@@ -2290,9 +2290,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class E<T> {
 			    public void foo(A<Number> a, Vector<Number> x) {
 			        a.goo(x);
@@ -2309,7 +2309,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A<T> {
 			    public void goo(Vector<T> v) {
 			    }
-			
+
 			    public void goo(long x) {
 			    }
 			}
@@ -2324,9 +2324,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
 			package test1;
-			
+
 			import java.util.Collections;
-			
+
 			class E {
 			    void foo(@Deprecated final String map){}
 			    {foo(Collections.EMPTY_MAP);}
@@ -2343,10 +2343,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String[] expected= new String[2];
 		expected[0]= """
 			package test1;
-			
+
 			import java.util.Collections;
 			import java.util.Map;
-			
+
 			class E {
 			    void foo(@Deprecated final Map emptyMap){}
 			    {foo(Collections.EMPTY_MAP);}
@@ -2355,10 +2355,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		expected[1]= """
 			package test1;
-			
+
 			import java.util.Collections;
 			import java.util.Map;
-			
+
 			class E {
 			    void foo(@Deprecated final String map){}
 			    {foo(Collections.EMPTY_MAP);}
@@ -2484,9 +2484,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected1= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class X<A> {
 			    Vector<String> count= 0;
 			}
@@ -2784,7 +2784,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        int x= 0;
 			        foo(x);
 			    }
-			
+
 			    private void foo(int x) {
 			    }
 			}
@@ -2856,7 +2856,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class X {
 			    public static void xoo(int i, Object o) {
 			    }
-			
+
 			    public static void xoo(Object object) {
 			    }
 			}
@@ -2936,7 +2936,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			     */
 			    public static void xoo(int i, Object o) {
 			    }
-			
+
 			    public static void xoo(int i) {
 			    }
 			}
@@ -3011,7 +3011,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        int x= 0;
 			        e.foo(x);
 			    }
-			
+
 			    private void foo(int x) {
 			    }
 			}
@@ -3037,7 +3037,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        int x= 0;
 			        e.foo(x);
 			    }
-			
+
 			    protected abstract void foo(int x);
 			}
 			""";
@@ -3073,7 +3073,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			      void test () {
 			        foo ();
 			      }
-			
+
 			    private void foo() {
 			    }
 			    }
@@ -3088,7 +3088,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        foo ();
 			      }
 			    }
-			
+
 			    public void foo() {
 			    }
 			}
@@ -3102,7 +3102,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        foo ();
 			      }
 			    }
-			
+
 			    protected abstract void foo();
 			}
 			""";
@@ -3146,7 +3146,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			      void test () {
 			        foo ();
 			      }
-			
+
 			    private void foo() {
 			    }
 			    }
@@ -3161,7 +3161,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        foo ();
 			      }
 			    }
-			
+
 			    public void foo() {
 			    }
 			}
@@ -3175,7 +3175,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        foo ();
 			      }
 			    }
-			
+
 			    protected abstract void foo();
 			}
 			""";
@@ -3187,7 +3187,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			      void test () {
 			        foo ();
 			      }
-			
+
 			    protected abstract void foo();
 			    }
 			}
@@ -3253,13 +3253,13 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class X {
 			    public X(Object o, int i) {
 			    }
-			
+
 			    public X(Vector vector) {
 			    }
 			}
@@ -3555,7 +3555,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class X {
 			    public void xoo(int i, String o) {
 			    }
-			
+
 			    public void xoo(int i, int j, String string) {
 			    }
 			}
@@ -3608,7 +3608,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        int x= 0;
 			        foo(s, x);
 			    }
-			
+
 			    private void foo(String s, int x) {
 			    }
 			}
@@ -3682,9 +3682,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import java.util.Set;
-			
+
 			public class X {
 			    /**
 			     * @param emptySet\s
@@ -3702,9 +3702,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import java.util.Set;
-			
+
 			public class X {
 			    /**
 			     * @param i The int value
@@ -3712,7 +3712,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    public void xoo(int i) {
 			       int j= 0;
 			    }
-			
+
 			    public void xoo(Set emptySet, int i, int j) {
 			    }
 			}
@@ -3766,7 +3766,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        Object[] o= null;
 			        foo(o.length);
 			    }
-			
+
 			    private void foo(int length) {
 			    }
 			}
@@ -3842,7 +3842,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			     */
 			    public void xoo(String s) {
 			    }
-			
+
 			    public void xoo(String string, X<T> x, int i) {
 			    }
 			}
@@ -3899,13 +3899,13 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class X {
 			    public X() {
 			    }
-			
+
 			    public X(Vector vector) {
 			    }
 			}
@@ -3916,9 +3916,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class X {
 			    public X(Vector vector) {
 			    }
@@ -4130,7 +4130,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    public void foo(int i, String[] o) {
 			        foo(new String[] { }, i - 1);
 			    }
-			
+
 			    private void foo(String[] strings, int i) {
 			    }
 			}
@@ -4199,7 +4199,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A<T> {
 			    public void b(int i, T[] t) {
 			    }
-			
+
 			    public void b(String[] strings, int i) {
 			    }
 			}
@@ -4452,7 +4452,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    public void foo(int i, Object o, boolean b) {
 			        foo(false, o, i - 1);
 			    }
-			
+
 			    private void foo(boolean b, Object o, int i) {
 			    }
 			}
@@ -4510,7 +4510,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public class A {
-			
+
 			    public A(int i) {
 			    }
 			}
@@ -4564,7 +4564,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public class A {
-			
+
 			    public A(int i) {
 			    }
 			}
@@ -4615,7 +4615,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			        A a= new A("test");
 			    }
 			    class A {
-			
+
 			        public A(String string) {
 			        }
 			    }
@@ -4671,7 +4671,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String expected1= """
 			package test1;
 			public class A<T> {
-			
+
 			    public A(int i) {
 			    }
 			}
@@ -4751,7 +4751,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A {
 			    public A(int i) {
 			    }
-			
+
 			    public A(int i, String valueOf, boolean b) {
 			    }
 			}
@@ -4818,7 +4818,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A {
 			    public A(boolean b, String ... strings) {
 			    }
-			
+
 			    public A(int i, boolean b) {
 			    }
 			}
@@ -4887,7 +4887,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A<T> {
 			    public A(int i) {
 			    }
-			
+
 			    public A(int i, String valueOf, boolean b) {
 			    }
 			}
@@ -4954,7 +4954,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A {
 			    public A(int i, String s) {
 			    }
-			
+
 			    public A() {
 			    }
 			}
@@ -5023,7 +5023,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A<T> {
 			    public A(int i, String s) {
 			    }
-			
+
 			    public A() {
 			    }
 			}
@@ -5060,7 +5060,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    public E(int i) {
 			        this(i, true);
 			    }
-			
+
 			    public E(int i, boolean b) {
 			    }
 			}
@@ -5097,7 +5097,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    public E(int i) {
 			        this(i, true);
 			    }
-			
+
 			    public E(int i, boolean b) {
 			    }
 			}
@@ -5137,7 +5137,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 		String str2= """
 			package test1;
 			public class A {
-			
+
 			    public void foo(int i) {
 			    }
 			}
@@ -5204,7 +5204,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class A {
 			    public A(boolean b, String ... strings) {
 			    }
-			
+
 			    public A(int i, boolean b) {
 			    }
 			}
@@ -5262,9 +5262,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected2= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class X {
 			    public int foo(Vector vector) {
 			        return 0;
@@ -5277,14 +5277,14 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class X {
 			    public int foo() {
 			        return 0;
 			    }
-			
+
 			    public void foo(Vector vector) {
 			    }
 			}
@@ -5355,14 +5355,14 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		String expected3= """
 			package test1;
-			
+
 			import java.util.Vector;
-			
+
 			public class X {
 			    public int foo(Object o, boolean b) {
 			        return 0;
 			    }
-			
+
 			    public void foo(Vector vector) {
 			    }
 			}
@@ -5567,7 +5567,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			    public void foo(Object[] array) {
 			        throw RuntimeException();
 			    }
-			
+
 			    private Exception RuntimeException() {
 			        return null;
 			    }
@@ -5586,7 +5586,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class E {
 			    public @interface Annot {
 			    }
-			
+
 			    @Annot(count= 1)
 			    public void foo() {
 			    }
@@ -5605,10 +5605,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package pack;
 			public class E {
 			    public @interface Annot {
-			
+
 			        int count();
 			    }
-			
+
 			    @Annot(count= 1)
 			    public void foo() {
 			    }
@@ -5626,7 +5626,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class E {
 			    public @interface Annot {
 			    }
-			
+
 			    @Annot(1)
 			    public void foo() {
 			    }
@@ -5645,10 +5645,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package pack;
 			public class E {
 			    public @interface Annot {
-			
+
 			        int value();
 			    }
-			
+
 			    @Annot(1)
 			    public void foo() {
 			    }
@@ -5666,7 +5666,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 			String str= """
 				package pack;
-				
+
 				public class E {
 				    private int foo() {
 				        return max(1, 2);
@@ -5683,9 +5683,9 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			String[] expected= new String[1];
 			expected[0]= """
 				package pack;
-				
+
 				import static java.lang.Math.max;
-				
+
 				public class E {
 				    private int foo() {
 				        return max(1, 2);
@@ -5707,7 +5707,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 			String str= """
 				package pack;
-				
+
 				public class E {
 				    private int max() {
 				        return max(1, 2);
@@ -5724,7 +5724,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			String[] expected= new String[1];
 			expected[0]= """
 				package pack;
-				
+
 				public class E {
 				    private int max() {
 				        return Math.max(1, 2);
@@ -5807,7 +5807,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		CompilationUnit astRoot= getASTRoot(cu);
 		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
-		assertNumberOfProposals(proposals, 0);
+		assertNumberOfProposals(proposals, 1);
 	}
 
 	@Test
@@ -5826,7 +5826,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		CompilationUnit astRoot= getASTRoot(cu);
 		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
-		assertNumberOfProposals(proposals, 0);
+		assertNumberOfProposals(proposals, 1);
 	}
 
 	@Test
@@ -5844,7 +5844,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		CompilationUnit astRoot= getASTRoot(cu);
 		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
-		assertNumberOfProposals(proposals, 1);
+		assertNumberOfProposals(proposals, 2);
 		assertCorrectLabels(proposals);
 
 		CUCorrectionProposal proposal= (CUCorrectionProposal) proposals.get(0);
@@ -5854,10 +5854,10 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			public class XX {
 			    interface I {
 			        int i= n();
-			    }
-			
-			    protected static int n() {
-			        return 0;
+
+			        static int n() {
+			            return 0;
+			        }
 			    }
 			}
 			""";
@@ -5877,7 +5877,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 
 		CompilationUnit astRoot= getASTRoot(cu);
 		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
-		assertNumberOfProposals(proposals, 0);
+		assertNumberOfProposals(proposals, 1);
 	}
 
 	@Test
@@ -5907,7 +5907,7 @@ public class UnresolvedMethodsQuickFixTest extends QuickFixTest {
 			package test1;
 			interface Snippet {
 			    abstract String name();
-			
+
 			    abstract int[] values();
 			}
 			class Ref {


### PR DESCRIPTION
- UnresolvedMethodsQuickFixTest
- TypeMismatchQuickFixTests
- ReturnTypeQuickFixTest
- ModifierCorrectionsQuickFixTest

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2536
