### PR TITLE
PluginsNotLoadedTest fails complaining about loaded o.e.jdt.junit bundle

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
@@ -14,13 +14,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
 import org.eclipse.jdt.text.tests.codemining.CodeMiningTriggerTest;
 import org.eclipse.jdt.text.tests.codemining.ParameterNamesCodeMiningTest;
 import org.eclipse.jdt.text.tests.contentassist.ContentAssistTestSuite;
 import org.eclipse.jdt.text.tests.spelling.SpellCheckEngineTestCase;
 import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 
 /**
@@ -30,6 +31,7 @@ import org.junit.runners.Suite;
  */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+	PluginsNotLoadedTest.class,
 	CompilationUnitDocumentProviderTest.class,
 	JavaHeuristicScannerTest.class,
 	JavaAutoIndentStrategyTest.class,
@@ -47,14 +49,6 @@ import org.junit.runners.Suite;
 	MarkOccurrenceTest.class,
 	MarkOccurrenceTest1d7.class,
 	MarkOccurrenceTest1d8.class,
-	PluginsNotLoadedTest.class,
-//	PluginsNotLoadedTest.addLoadedPlugIns(
-//			new String[] {
-//					"org.eclipse.core.filebuffers.tests",
-//					"org.eclipse.core.variables",
-//					"org.eclipse.team.cvs.core",
-//					"org.eclipse.test.performance"
-//			});
 	BracketInserterTest.class,
 	SpellCheckEngineTestCase.class,
 	SemanticHighlightingTest.class,

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
@@ -224,6 +224,7 @@ public class PluginsNotLoadedTest {
 
 	@Before
 	public void setUp() throws Exception {
+		EditorTestHelper.showView(EditorTestHelper.INTRO_VIEW_ID, false);
 		JavaPlugin.getDefault().getPreferenceStore().setValue(PreferenceConstants.EDITOR_MARK_OCCURRENCES, true);
 		fEditor= openJavaEditor(new Path("/" + JUnitProjectTestSetup.getProject().getElementName() + "/src/junit/framework/TestCase.java"));
 		assertNotNull(fEditor);


### PR DESCRIPTION
Follow up from
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2536. After switching to minimal 1.8 project compliance in JDT, test `PluginsNotLoadedTest.pluginsNotLoaded` fails complaining about loaded org.eclipse.jdt.junit bundle.

See
https://download.eclipse.org/eclipse/downloads/drops4/I20240725-1800/testresults/html/org.eclipse.jdt.text.tests_ep433I-unit-cen64-gtk3-java22_linux.gtk.x86_64_22.html

Interestingly, it doesn't fail on both Mac platforms, but see below.

While debugging (break point at
`org.eclipse.jdt.internal.junit.ui.JUnitPlugin.start(BundleContext)`) one can see that the class is loaded at
`org.eclipse.jdt.text.tests.MarkOccurrenceTest.markMethodOccurrences()` test, which, surprisingly ... opens Java editor on `junit.framework.TestCase` class and that one tries to draw warning marker annotations that in turn activate warning marker quick fix processor `org.eclipse.jdt.internal.junit.ui.JUnitQuickFixProcessor` that triggers JUnit loading.

Not clear why this doesn't work on Mac, probably drawing there is a bit different and so no JUnit bundle is loaded.

To solve that, let run PluginsNotLoadedTest as first test in the test suite (not sure why it wasn't done before).

Also while debugging the test I saw that the JUnit bundle is not loaded if the welcome page was open, which was hiding opened Java editor and that in turn didn't activated all of Java editor functionality. So let close welcome page, which should have been done anyway for any UI test.