### PR TITLE
Enable test that was disabled because of JDT core bug

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
@@ -290,7 +290,6 @@ public class InlineTempTests extends GenericRefactoringTest {
 	}
 
 	@Test
-	@Ignore("https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1552")
 	public void test31() throws Exception{
 		helper1(8, 30, 8, 30);
 	}


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2775
