### PR TITLE
Disable code that determines if method cast is required

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
@@ -61,7 +61,6 @@ import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.ArrayCreation;
 import org.eclipse.jdt.core.dom.ArrayInitializer;
 import org.eclipse.jdt.core.dom.ArrayType;
-import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -81,7 +80,6 @@ import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.Type;
@@ -92,7 +90,6 @@ import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.TypeLocation;
-import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.core.manipulation.ImportReferencesCollector;
 import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
@@ -284,32 +281,33 @@ public class InlineConstantRefactoring extends Refactoring {
 				addExplicitTypeArgumentsIfNecessary(initializer);
 			}
 
-			private void addExplicitTypeArgumentsIfNecessary(Expression invocation) {
-				if (Invocations.isResolvedTypeInferredFromExpectedType(invocation)) {
-					ASTNode referenceContext= fNewLocation.getParent();
-					if (!(referenceContext instanceof VariableDeclarationFragment)
-							&& !(referenceContext instanceof SingleVariableDeclaration)
-							&& !(referenceContext instanceof Assignment)) {
-						ListRewrite typeArgsRewrite= Invocations.getInferredTypeArgumentsRewrite(fInitializerRewrite, invocation);
-						for (ITypeBinding typeArgument2 : Invocations.getInferredTypeArguments(invocation)) {
-							Type typeArgument= fNewLocationCuRewrite.getImportRewrite().addImport(typeArgument2, fNewLocationCuRewrite.getAST(), fNewLocationContext, TypeLocation.TYPE_ARGUMENT);
-							fNewLocationCuRewrite.getImportRemover().registerAddedImports(typeArgument);
-							typeArgsRewrite.insertLast(typeArgument, null);
-						}
-
-						if (invocation instanceof MethodInvocation) {
-							MethodInvocation methodInvocation= (MethodInvocation) invocation;
-							Expression expression= methodInvocation.getExpression();
-							if (expression == null) {
-								IMethodBinding methodBinding= methodInvocation.resolveMethodBinding();
-								if (methodBinding != null) {
-									expression= fNewLocationCuRewrite.getAST().newName(fNewLocationCuRewrite.getImportRewrite().addImport(methodBinding.getDeclaringClass().getTypeDeclaration(), fNewLocationContext));
-									fInitializerRewrite.set(invocation, MethodInvocation.EXPRESSION_PROPERTY, expression, null);
-								}
-							}
-						}
-					}
-				}
+			private void addExplicitTypeArgumentsIfNecessary(@SuppressWarnings("unused") Expression invocation) {
+// TODO: this requires additional logic, for example, mark these locations and recompile new source
+//				if (Invocations.isResolvedTypeInferredFromExpectedType(invocation)) {
+//					ASTNode referenceContext= fNewLocation.getParent();
+//					if (!(referenceContext instanceof VariableDeclarationFragment)
+//							&& !(referenceContext instanceof SingleVariableDeclaration)
+//							&& !(referenceContext instanceof Assignment)) {
+//						ListRewrite typeArgsRewrite= Invocations.getInferredTypeArgumentsRewrite(fInitializerRewrite, invocation);
+//						for (ITypeBinding typeArgument2 : Invocations.getInferredTypeArguments(invocation)) {
+//							Type typeArgument= fNewLocationCuRewrite.getImportRewrite().addImport(typeArgument2, fNewLocationCuRewrite.getAST(), fNewLocationContext, TypeLocation.TYPE_ARGUMENT);
+//							fNewLocationCuRewrite.getImportRemover().registerAddedImports(typeArgument);
+//							typeArgsRewrite.insertLast(typeArgument, null);
+//						}
+//
+//						if (invocation instanceof MethodInvocation) {
+//							MethodInvocation methodInvocation= (MethodInvocation) invocation;
+//							Expression expression= methodInvocation.getExpression();
+//							if (expression == null) {
+//								IMethodBinding methodBinding= methodInvocation.resolveMethodBinding();
+//								if (methodBinding != null) {
+//									expression= fNewLocationCuRewrite.getAST().newName(fNewLocationCuRewrite.getImportRewrite().addImport(methodBinding.getDeclaringClass().getTypeDeclaration(), fNewLocationContext));
+//									fInitializerRewrite.set(invocation, MethodInvocation.EXPRESSION_PROPERTY, expression, null);
+//								}
+//							}
+//						}
+//					}
+//				}
 			}
 
 			@Override

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
@@ -63,7 +63,6 @@ import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.ArrayCreation;
 import org.eclipse.jdt.core.dom.ArrayInitializer;
 import org.eclipse.jdt.core.dom.ArrayType;
-import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -82,13 +81,11 @@ import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.TryStatement;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
-import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite.ImportRewriteContext;
@@ -427,18 +424,19 @@ public class InlineTempRefactoring extends Refactoring {
 				return replaceClashingNames(rewrite, groupDesc, initializer, replacements);
 			}
 		}
-		ASTNode referenceContext= reference.getParent();
-		if (Invocations.isResolvedTypeInferredFromExpectedType(initializer)) {
-			if (!(referenceContext instanceof VariableDeclarationFragment)
-					&& !(referenceContext instanceof SingleVariableDeclaration)
-					&& !(referenceContext instanceof Assignment)) {
-				ITypeBinding[] typeArguments= Invocations.getInferredTypeArguments(initializer);
-				if (typeArguments != null) {
-					String newSource= createParameterizedInvocation(initializer, typeArguments, rewrite);
-					return (Expression) rewrite.getASTRewrite().createStringPlaceholder(newSource, initializer.getNodeType());
-				}
-			}
-		}
+// TODO: rework casting logic to mark the location and do casting after testing new source for failure
+//		ASTNode referenceContext= reference.getParent();
+//		if (Invocations.isResolvedTypeInferredFromExpectedType(initializer)) {
+//			if (!(referenceContext instanceof VariableDeclarationFragment)
+//					&& !(referenceContext instanceof SingleVariableDeclaration)
+//					&& !(referenceContext instanceof Assignment)) {
+//				ITypeBinding[] typeArguments= Invocations.getInferredTypeArguments(initializer);
+//				if (typeArguments != null) {
+//					String newSource= createParameterizedInvocation(initializer, typeArguments, rewrite);
+//					return (Expression) rewrite.getASTRewrite().createStringPlaceholder(newSource, initializer.getNodeType());
+//				}
+//			}
+//		}
 
 		Expression copy= (Expression) rewrite.getASTRewrite().createCopyTarget(initializer);
 		AST ast= rewrite.getAST();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
@@ -414,6 +414,7 @@ public class InlineTempRefactoring extends Refactoring {
 		return copy;
 	}
 
+	@SuppressWarnings("unused")
 	private Expression getModifiedInitializerSource(CompilationUnitRewrite rewrite, SimpleName reference, TextEditGroup groupDesc) throws JavaModelException {
 		VariableDeclaration varDecl= getVariableDeclaration();
 		Expression initializer= varDecl.getInitializer();
@@ -704,6 +705,7 @@ public class InlineTempRefactoring extends Refactoring {
 		return ast.newName(qualifiedName.toString());
 	}
 
+	@SuppressWarnings("unused")
 	private String createParameterizedInvocation(Expression invocation, ITypeBinding[] typeArguments, CompilationUnitRewrite cuRewrite) throws JavaModelException {
 		ASTRewrite rewrite= ASTRewrite.create(invocation.getAST());
 		ListRewrite typeArgsRewrite= Invocations.getInferredTypeArgumentsRewrite(rewrite, invocation);

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
@@ -290,6 +290,7 @@ public class InlineTempTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	@Ignore //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1565
 	public void test31() throws Exception{
 		helper1(8, 30, 8, 30);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/AdvancedQuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/AdvancedQuickAssistProcessor.java
@@ -52,7 +52,6 @@ import org.eclipse.jdt.core.dom.BreakStatement;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
-import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ConditionalExpression;
 import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.ContinueStatement;
@@ -73,7 +72,6 @@ import org.eclipse.jdt.core.dom.InstanceofExpression;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
-import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.PrefixExpression;
@@ -115,7 +113,6 @@ import org.eclipse.jdt.internal.corext.dom.StatementRewrite;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.ExpressionsFix;
 import org.eclipse.jdt.internal.corext.fix.IProposableFix;
-import org.eclipse.jdt.internal.corext.refactoring.code.Invocations;
 import org.eclipse.jdt.internal.corext.refactoring.util.NoCommentSourceRangeComputer;
 import org.eclipse.jdt.internal.corext.refactoring.util.TightSourceRangeComputer;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
@@ -1950,40 +1947,42 @@ public class AdvancedQuickAssistProcessor implements IQuickAssistProcessor {
 		return true;
 	}
 
+	@SuppressWarnings("unused")
 	private static void addExplicitTypeArgumentsIfNecessary(ASTRewrite rewrite, ASTRewriteCorrectionProposal proposal, Expression invocation) {
-		if (Invocations.isResolvedTypeInferredFromExpectedType(invocation)) {
-			ITypeBinding[] typeArguments= Invocations.getInferredTypeArguments(invocation);
-			if (typeArguments == null)
-				return;
-
-			ImportRewrite importRewrite= proposal.getImportRewrite();
-			if (importRewrite == null) {
-				importRewrite= proposal.createImportRewrite((CompilationUnit) invocation.getRoot());
-			}
-			ImportRewriteContext importRewriteContext= new ContextSensitiveImportRewriteContext(invocation, importRewrite);
-
-			AST ast= invocation.getAST();
-			ListRewrite typeArgsRewrite= Invocations.getInferredTypeArgumentsRewrite(rewrite, invocation);
-
-			for (ITypeBinding typeArgument : typeArguments) {
-				Type typeArgumentNode= importRewrite.addImport(typeArgument, ast, importRewriteContext, TypeLocation.TYPE_ARGUMENT);
-				typeArgsRewrite.insertLast(typeArgumentNode, null);
-			}
-
-			if (invocation instanceof MethodInvocation) {
-				MethodInvocation methodInvocation= (MethodInvocation) invocation;
-				Expression expression= methodInvocation.getExpression();
-				if (expression == null) {
-					IMethodBinding methodBinding= methodInvocation.resolveMethodBinding();
-					if (methodBinding != null && Modifier.isStatic(methodBinding.getModifiers())) {
-						expression= ast.newName(importRewrite.addImport(methodBinding.getDeclaringClass().getTypeDeclaration(), importRewriteContext));
-					} else {
-						expression= ast.newThisExpression();
-					}
-					rewrite.set(invocation, MethodInvocation.EXPRESSION_PROPERTY, expression, null);
-				}
-			}
-		}
+// TODO: figure out if cast is needed with more than flag below (e.g. recompiling without and adding back for error lines)
+//		if (Invocations.isResolvedTypeInferredFromExpectedType(invocation)) {
+//			ITypeBinding[] typeArguments= Invocations.getInferredTypeArguments(invocation);
+//			if (typeArguments == null)
+//				return;
+//
+//			ImportRewrite importRewrite= proposal.getImportRewrite();
+//			if (importRewrite == null) {
+//				importRewrite= proposal.createImportRewrite((CompilationUnit) invocation.getRoot());
+//			}
+//			ImportRewriteContext importRewriteContext= new ContextSensitiveImportRewriteContext(invocation, importRewrite);
+//
+//			AST ast= invocation.getAST();
+//			ListRewrite typeArgsRewrite= Invocations.getInferredTypeArgumentsRewrite(rewrite, invocation);
+//
+//			for (ITypeBinding typeArgument : typeArguments) {
+//				Type typeArgumentNode= importRewrite.addImport(typeArgument, ast, importRewriteContext, TypeLocation.TYPE_ARGUMENT);
+//				typeArgsRewrite.insertLast(typeArgumentNode, null);
+//			}
+//
+//			if (invocation instanceof MethodInvocation) {
+//				MethodInvocation methodInvocation= (MethodInvocation) invocation;
+//				Expression expression= methodInvocation.getExpression();
+//				if (expression == null) {
+//					IMethodBinding methodBinding= methodInvocation.resolveMethodBinding();
+//					if (methodBinding != null && Modifier.isStatic(methodBinding.getModifiers())) {
+//						expression= ast.newName(importRewrite.addImport(methodBinding.getDeclaringClass().getTypeDeclaration(), importRewriteContext));
+//					} else {
+//						expression= ast.newThisExpression();
+//					}
+//					rewrite.set(invocation, MethodInvocation.EXPRESSION_PROPERTY, expression, null);
+//				}
+//			}
+//		}
 	}
 
 	private static ReturnStatement createReturnExpression(ASTRewrite rewrite, Expression expression) {


### PR DESCRIPTION
- flag being used to determine this is no longer the only thing that needs to be checked so disable using it temporarily
- fixes #1565

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
