### PR TITLE
dogfooding - if else to switch cleanup

### DIFF
--- a/org.eclipse.jdt.bcoview.feature/feature.xml
+++ b/org.eclipse.jdt.bcoview.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.bcoview.feature"
       label="Bytecode Outline View"
-      version="1.2.500.qualifier"
+      version="1.2.600.qualifier"
       provider-name="Eclipse.org"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.bcoview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.bcoview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.bcoview;singleton:=true
-Bundle-Version: 1.2.500.qualifier
+Bundle-Version: 1.2.600.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.jdt.bcoview.BytecodeOutlinePlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.bcoview/pom.xml
+++ b/org.eclipse.jdt.bcoview/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.bcoview</artifactId>
-  <version>1.2.500-SNAPSHOT</version>
+  <version>1.2.600-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/org.eclipse.jdt.bcoview/src/org/eclipse/jdt/bcoview/asm/CommentedClassVisitor.java
+++ b/org.eclipse.jdt.bcoview/src/org/eclipse/jdt/bcoview/asm/CommentedClassVisitor.java
@@ -213,13 +213,13 @@ public class CommentedClassVisitor extends Textifier implements ICommentedClassV
 					break;
 				case FIELD_DESCRIPTOR:
 					switch (desc) {
-						case "T":
+						case "T": //$NON-NLS-1$
 							buf1.append("top"); //$NON-NLS-1$
 							break;
-						case "N":
+						case "N": //$NON-NLS-1$
 							buf1.append("null"); //$NON-NLS-1$
 							break;
-						case "U":
+						case "U": //$NON-NLS-1$
 							buf1.append("uninitialized_this"); //$NON-NLS-1$
 							break;
 						default:

--- a/org.eclipse.jdt.bcoview/src/org/eclipse/jdt/bcoview/asm/CommentedClassVisitor.java
+++ b/org.eclipse.jdt.bcoview/src/org/eclipse/jdt/bcoview/asm/CommentedClassVisitor.java
@@ -212,14 +212,19 @@ public class CommentedClassVisitor extends Textifier implements ICommentedClassV
 					}
 					break;
 				case FIELD_DESCRIPTOR:
-					if ("T".equals(desc)) { //$NON-NLS-1$
-						buf1.append("top"); //$NON-NLS-1$
-					} else if ("N".equals(desc)) { //$NON-NLS-1$
-						buf1.append("null"); //$NON-NLS-1$
-					} else if ("U".equals(desc)) { //$NON-NLS-1$
-						buf1.append("uninitialized_this"); //$NON-NLS-1$
-					} else {
-						buf1.append(getSimpleName(Type.getType(desc)));
+					switch (desc) {
+						case "T":
+							buf1.append("top"); //$NON-NLS-1$
+							break;
+						case "N":
+							buf1.append("null"); //$NON-NLS-1$
+							break;
+						case "U":
+							buf1.append("uninitialized_this"); //$NON-NLS-1$
+							break;
+						default:
+							buf1.append(getSimpleName(Type.getType(desc)));
+							break;
 					}
 					break;
 

--- a/org.eclipse.jdt.bcoview/src/org/eclipse/jdt/bcoview/views/BytecodeOutlineView.java
+++ b/org.eclipse.jdt.bcoview/src/org/eclipse/jdt/bcoview/views/BytecodeOutlineView.java
@@ -1634,15 +1634,21 @@ public class BytecodeOutlineView extends ViewPart implements IBytecodePart {
 			super("", AS_RADIO_BUTTON); //$NON-NLS-1$
 
 			String symbolicName = BytecodeOutlinePlugin.getDefault().getBundle().getSymbolicName();
-			if (orientation == VIEW_ORIENTATION_HORIZONTAL) {
-				setText(Messages.BytecodeOutlineView_toggle_horizontal_label);
-				setImageDescriptor(AbstractUIPlugin.imageDescriptorFromPlugin(symbolicName, "icons/th_horizontal.gif")); //$NON-NLS-1$
-			} else if (orientation == VIEW_ORIENTATION_VERTICAL) {
-				setText(Messages.BytecodeOutlineView_toggle_vertical_label);
-				setImageDescriptor(AbstractUIPlugin.imageDescriptorFromPlugin(symbolicName, "icons/th_vertical.gif")); //$NON-NLS-1$
-			} else if (orientation == VIEW_ORIENTATION_AUTOMATIC) {
-				setText(Messages.BytecodeOutlineView_toggle_automatic_label);
-				setImageDescriptor(AbstractUIPlugin.imageDescriptorFromPlugin(symbolicName, "icons/th_automatic.gif")); //$NON-NLS-1$
+			switch (orientation) {
+				case VIEW_ORIENTATION_HORIZONTAL:
+					setText(Messages.BytecodeOutlineView_toggle_horizontal_label);
+					setImageDescriptor(AbstractUIPlugin.imageDescriptorFromPlugin(symbolicName, "icons/th_horizontal.gif")); //$NON-NLS-1$
+					break;
+				case VIEW_ORIENTATION_VERTICAL:
+					setText(Messages.BytecodeOutlineView_toggle_vertical_label);
+					setImageDescriptor(AbstractUIPlugin.imageDescriptorFromPlugin(symbolicName, "icons/th_vertical.gif")); //$NON-NLS-1$
+					break;
+				case VIEW_ORIENTATION_AUTOMATIC:
+					setText(Messages.BytecodeOutlineView_toggle_automatic_label);
+					setImageDescriptor(AbstractUIPlugin.imageDescriptorFromPlugin(symbolicName, "icons/th_automatic.gif")); //$NON-NLS-1$
+					break;
+				default:
+					break;
 			}
 			actionOrientation = orientation;
 		}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
@@ -184,12 +184,18 @@ public class CoreJavaDocSnippetStringEvaluator {
 		String modifiedStr= str;
 		for (TagElement tag : tags) {
 			String name= tag.getTagName();
-			if (TagElement.TAG_HIGHLIGHT.equals(name)) {
-				handleSnippetHighlight(modifiedStr, tag, actionElements);
-			} else if (TagElement.TAG_REPLACE.equals(name)) {
-				modifiedStr= handleSnippetReplace(modifiedStr, tag, actionElements);
-			} else if (TagElement.TAG_LINK.equals(name)) {
-				handleSnippetLink(modifiedStr, tag, actionElements);
+			switch (name) {
+				case TagElement.TAG_HIGHLIGHT:
+					handleSnippetHighlight(modifiedStr, tag, actionElements);
+					break;
+				case TagElement.TAG_REPLACE:
+					modifiedStr= handleSnippetReplace(modifiedStr, tag, actionElements);
+					break;
+				case TagElement.TAG_LINK:
+					handleSnippetLink(modifiedStr, tag, actionElements);
+					break;
+				default:
+					break;
 			}
 		}
 		return getString(modifiedStr, actionElements);

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
@@ -1137,58 +1137,66 @@ public class CoreJavadocAccessImpl implements IJavadocAccess {
 				CharSequence inherited= fJavadocLookup.getInheritedMainDescription(fMethod);
 				return handleInherited(inherited);
 
-			} else if (TagElement.TAG_PARAM.equals(blockTagName)) {
-				List<? extends ASTNode> fragments= blockTag.fragments();
-				int size= fragments.size();
-				if (size > 0) {
-					Object first= fragments.get(0);
-					if (first instanceof SimpleName) {
-						String name= ((SimpleName) first).getIdentifier();
-						String[] parameterNames= fMethod.getParameterNames();
-						for (int i= 0; i < parameterNames.length; i++) {
-							if (name.equals(parameterNames[i])) {
-								CharSequence inherited= fJavadocLookup.getInheritedParamDescription(fMethod, i);
-								return handleInherited(inherited);
-							}
-						}
-					} else if (size > 2 && first instanceof TextElement) {
-						String firstText= ((TextElement) first).getText();
-						if ("<".equals(firstText)) { //$NON-NLS-1$
-							Object second= fragments.get(1);
-							Object third= fragments.get(2);
-							if (second instanceof SimpleName && third instanceof TextElement) {
-								String thirdText= ((TextElement) third).getText();
-								if (">".equals(thirdText)) { //$NON-NLS-1$
-									String name= ((SimpleName) second).getIdentifier();
-									ITypeParameter[] typeParameters= fMethod.getTypeParameters();
-									for (int i= 0; i < typeParameters.length; i++) {
-										ITypeParameter typeParameter= typeParameters[i];
-										if (name.equals(typeParameter.getElementName())) {
-											CharSequence inherited= getInheritedTypeParamDescription(i);
-											return handleInherited(inherited);
+			} else
+				switch (blockTagName) {
+					case TagElement.TAG_PARAM: {
+						List<? extends ASTNode> fragments= blockTag.fragments();
+						int size= fragments.size();
+						if (size > 0) {
+							Object first= fragments.get(0);
+							if (first instanceof SimpleName) {
+								String name= ((SimpleName) first).getIdentifier();
+								String[] parameterNames= fMethod.getParameterNames();
+								for (int i= 0; i < parameterNames.length; i++) {
+									if (name.equals(parameterNames[i])) {
+										CharSequence inherited= fJavadocLookup.getInheritedParamDescription(fMethod, i);
+										return handleInherited(inherited);
+									}
+								}
+							} else if (size > 2 && first instanceof TextElement) {
+								String firstText= ((TextElement) first).getText();
+								if ("<".equals(firstText)) { //$NON-NLS-1$
+									Object second= fragments.get(1);
+									Object third= fragments.get(2);
+									if (second instanceof SimpleName && third instanceof TextElement) {
+										String thirdText= ((TextElement) third).getText();
+										if (">".equals(thirdText)) { //$NON-NLS-1$
+											String name= ((SimpleName) second).getIdentifier();
+											ITypeParameter[] typeParameters= fMethod.getTypeParameters();
+											for (int i= 0; i < typeParameters.length; i++) {
+												ITypeParameter typeParameter= typeParameters[i];
+												if (name.equals(typeParameter.getElementName())) {
+													CharSequence inherited= getInheritedTypeParamDescription(i);
+													return handleInherited(inherited);
+												}
+											}
 										}
 									}
 								}
 							}
 						}
+						break;
 					}
-				}
-
-			} else if (TagElement.TAG_RETURN.equals(blockTagName)) {
-				CharSequence inherited= fJavadocLookup.getInheritedReturnDescription(fMethod);
-				return handleInherited(inherited);
-
-			} else if (TagElement.TAG_THROWS.equals(blockTagName) || TagElement.TAG_EXCEPTION.equals(blockTagName)) {
-				List<? extends ASTNode> fragments= blockTag.fragments();
-				if (fragments.size() > 0) {
-					Object first= fragments.get(0);
-					if (first instanceof Name) {
-						String name= ASTNodes.getSimpleNameIdentifier((Name) first);
-						CharSequence inherited= fJavadocLookup.getInheritedExceptionDescription(fMethod, name);
+					case TagElement.TAG_RETURN: {
+						CharSequence inherited= fJavadocLookup.getInheritedReturnDescription(fMethod);
 						return handleInherited(inherited);
 					}
+					case TagElement.TAG_THROWS:
+					case TagElement.TAG_EXCEPTION: {
+						List<? extends ASTNode> fragments= blockTag.fragments();
+						if (fragments.size() > 0) {
+							Object first= fragments.get(0);
+							if (first instanceof Name) {
+								String name= ASTNodes.getSimpleNameIdentifier((Name) first);
+								CharSequence inherited= fJavadocLookup.getInheritedExceptionDescription(fMethod, name);
+								return handleInherited(inherited);
+							}
+						}
+						break;
+					}
+					default:
+						break;
 				}
-			}
 		} catch (JavaModelException e) {
 			JavaManipulationPlugin.log(e);
 		}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/dialogs/StatusInfo.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/dialogs/StatusInfo.java
@@ -192,17 +192,23 @@ public class StatusInfo implements IStatus {
 	public String toString() {
 		StringBuilder buf = new StringBuilder();
 		buf.append("StatusInfo "); //$NON-NLS-1$
-		if (fSeverity == OK) {
-			buf.append("OK"); //$NON-NLS-1$
-		} else if (fSeverity == ERROR) {
-			buf.append("ERROR"); //$NON-NLS-1$
-		} else if (fSeverity == WARNING) {
-			buf.append("WARNING"); //$NON-NLS-1$
-		} else if (fSeverity == INFO) {
-			buf.append("INFO"); //$NON-NLS-1$
-		} else {
-			buf.append("severity="); //$NON-NLS-1$
-			buf.append(fSeverity);
+		switch (fSeverity) {
+			case OK:
+				buf.append("OK"); //$NON-NLS-1$
+				break;
+			case ERROR:
+				buf.append("ERROR"); //$NON-NLS-1$
+				break;
+			case WARNING:
+				buf.append("WARNING"); //$NON-NLS-1$
+				break;
+			case INFO:
+				buf.append("INFO"); //$NON-NLS-1$
+				break;
+			default:
+				buf.append("severity="); //$NON-NLS-1$
+				buf.append(fSeverity);
+				break;
 		}
 		buf.append(": "); //$NON-NLS-1$
 		buf.append(fStatusMessage);

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
@@ -2214,27 +2214,35 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 		IMethodBinding recursiveConstructor= null;
 
 		int type= selectedNode.getNodeType();
-		if (type == ASTNode.CLASS_INSTANCE_CREATION) {
-			ClassInstanceCreation creation= (ClassInstanceCreation) selectedNode;
-
-			ITypeBinding binding= creation.getType().resolveBinding();
-			if (binding != null) {
-				targetBinding= binding;
-				arguments= creation.arguments();
+		switch (type) {
+			case ASTNode.CLASS_INSTANCE_CREATION: {
+				ClassInstanceCreation creation= (ClassInstanceCreation) selectedNode;
+				ITypeBinding binding= creation.getType().resolveBinding();
+				if (binding != null) {
+					targetBinding= binding;
+					arguments= creation.arguments();
+				}
+				break;
 			}
-		} else if (type == ASTNode.SUPER_CONSTRUCTOR_INVOCATION) {
-			ITypeBinding typeBinding= Bindings.getBindingOfParentType(selectedNode);
-			if (typeBinding != null && !typeBinding.isAnonymous()) {
-				targetBinding= typeBinding.getSuperclass();
-				arguments= ((SuperConstructorInvocation) selectedNode).arguments();
+			case ASTNode.SUPER_CONSTRUCTOR_INVOCATION: {
+				ITypeBinding typeBinding= Bindings.getBindingOfParentType(selectedNode);
+				if (typeBinding != null && !typeBinding.isAnonymous()) {
+					targetBinding= typeBinding.getSuperclass();
+					arguments= ((SuperConstructorInvocation) selectedNode).arguments();
+				}
+				break;
 			}
-		} else if (type == ASTNode.CONSTRUCTOR_INVOCATION) {
-			ITypeBinding typeBinding= Bindings.getBindingOfParentType(selectedNode);
-			if (typeBinding != null && !typeBinding.isAnonymous()) {
-				targetBinding= typeBinding;
-				arguments= ((ConstructorInvocation) selectedNode).arguments();
-				recursiveConstructor= ASTResolving.findParentMethodDeclaration(selectedNode).resolveBinding();
+			case ASTNode.CONSTRUCTOR_INVOCATION: {
+				ITypeBinding typeBinding= Bindings.getBindingOfParentType(selectedNode);
+				if (typeBinding != null && !typeBinding.isAnonymous()) {
+					targetBinding= typeBinding;
+					arguments= ((ConstructorInvocation) selectedNode).arguments();
+					recursiveConstructor= ASTResolving.findParentMethodDeclaration(selectedNode).resolveBinding();
+				}
+				break;
 			}
+			default:
+				break;
 		}
 
 		if (selectedNode.getParent() instanceof EnumConstantDeclaration enumNode) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
@@ -910,14 +910,18 @@ public class SourceProvider {
 			return false;
 		Statement statement= statements.get(size - 1);
 		int nodeType= statement.getNodeType();
-		if (nodeType == ASTNode.IF_STATEMENT) {
-			IfStatement ifStatement= (IfStatement) statement;
-			return !(ifStatement.getThenStatement() instanceof Block)
-				&& !(ifStatement.getElseStatement() instanceof Block);
-		} else if (nodeType == ASTNode.FOR_STATEMENT) {
-			return !(((ForStatement)statement).getBody() instanceof Block);
-		} else if (nodeType == ASTNode.WHILE_STATEMENT) {
-			return !(((WhileStatement)statement).getBody() instanceof Block);
+		switch (nodeType) {
+			case ASTNode.IF_STATEMENT: {
+				IfStatement ifStatement= (IfStatement) statement;
+				return !(ifStatement.getThenStatement() instanceof Block)
+					&& !(ifStatement.getElseStatement() instanceof Block);
+			}
+			case ASTNode.FOR_STATEMENT:
+				return !(((ForStatement)statement).getBody() instanceof Block);
+			case ASTNode.WHILE_STATEMENT:
+				return !(((WhileStatement)statement).getBody() instanceof Block);
+			default:
+				break;
 		}
 		return false;
 	}

--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.16.500.qualifier
+Bundle-Version: 3.16.600.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitClasspathFixProcessor.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitClasspathFixProcessor.java
@@ -162,13 +162,24 @@ public class JUnitClasspathFixProcessor extends ClasspathFixProcessor {
 			res= JUNIT4;
 		} else if ("TestCase".equals(s) || "TestSuite".equals(s) || s.startsWith("junit.")) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			res= JUNIT3;
-		} else if ("Test".equals(s)) { //$NON-NLS-1$
-			res= JUNIT3 | JUNIT4 | JUNIT5;
-		} else if ("TestFactory".equals(s) || "Testable".equals(s) || "TestTemplate".equals(s) || "ParameterizedTest".equals(s) || "RepeatedTest".equals(s)) { //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-			res= JUNIT5;
-		} else if ("RunWith".equals(s)) { //$NON-NLS-1$
-			res= JUNIT4;
-		}
+		} else
+			switch (s) {
+				case "Test": //$NON-NLS-1$
+					res= JUNIT3 | JUNIT4 | JUNIT5;
+					break;
+				case "TestFactory": //$NON-NLS-1$
+				case "Testable": //$NON-NLS-1$
+				case "TestTemplate": //$NON-NLS-1$
+				case "ParameterizedTest": //$NON-NLS-1$
+				case "RepeatedTest": //$NON-NLS-1$
+					res= JUNIT5;
+					break;
+				case "RunWith": //$NON-NLS-1$
+					res= JUNIT4;
+					break;
+				default:
+					break;
+			}
 		if (res != 0) {
 			ArrayList<JUnitClasspathFixProposal> proposals= new ArrayList<>();
 			if ((res & JUNIT5) != 0 && JUnitStubUtility.is18OrHigher(project)) {

--- a/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/ui/dialogs/TypeInfoViewer.java
+++ b/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/ui/dialogs/TypeInfoViewer.java
@@ -887,20 +887,28 @@ public class TypeInfoViewer {
 		fTable.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyPressed(KeyEvent e) {
-				if (e.keyCode == SWT.DEL) {
-					deleteHistoryEntry();
-				} else if (e.keyCode == SWT.ARROW_DOWN) {
-					int index= fTable.getSelectionIndex();
-					if (index == fDashLineIndex - 1) {
-						e.doit= false;
-						setTableSelection(index + 2);
+				switch (e.keyCode) {
+					case SWT.DEL:
+						deleteHistoryEntry();
+						break;
+					case SWT.ARROW_DOWN: {
+						int index= fTable.getSelectionIndex();
+						if (index == fDashLineIndex - 1) {
+							e.doit= false;
+							setTableSelection(index + 2);
+						}
+						break;
 					}
-				} else if (e.keyCode == SWT.ARROW_UP) {
-					int index= fTable.getSelectionIndex();
-					if (fDashLineIndex != -1 && index == fDashLineIndex + 1) {
-						e.doit= false;
-						setTableSelection(index - 2);
+					case SWT.ARROW_UP: {
+						int index= fTable.getSelectionIndex();
+						if (fDashLineIndex != -1 && index == fDashLineIndex + 1) {
+							e.doit= false;
+							setTableSelection(index - 2);
+						}
+						break;
 					}
+					default:
+						break;
 				}
 			}
 		});

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/IndentAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/IndentAction.java
@@ -948,56 +948,65 @@ public class IndentAction extends TextEditorAction {
 		String commandIndent= EMPTY_STR;
 		if (isTextBlockStarting) {
 			if (!prevLineEndsWithComma) {
-				if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_ON_COLUMN) {
-					String newStr= indentation;
-					int length= IndentAction.measureLengthInSpaces(stringTocalculate, CodeFormatterUtil.getTabWidth(javaProject));
-					StringBuilder str= new StringBuilder();
-					if (getUseTabsOnlyForLeadingIndentations(javaProject)) {
-						int existing= IndentAction.measureLengthInSpaces(indentation, CodeFormatterUtil.getTabWidth(javaProject));
-						if (length - existing > 0) {
-							for (int i= 0; i < length - existing; i++) {
-								newStr+= IndentAction.SPACE_STR;
-							}
-						}
-					} else {
-						for (int i= 0; i < length; i++) {
-							str.append(IndentAction.SPACE_STR);
-						}
-						int units= Strings.computeIndentUnits(str.toString(), javaProject);
-						newStr= CodeFormatterUtil.createIndentString(units, javaProject);
-						int newLength= IndentManipulation.measureIndentInSpaces(newStr, CodeFormatterUtil.getTabWidth(javaProject));
-						if (newLength < length) {
-							if (DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue) || JavaCore.SPACE.equals(formatterTabValue)) {
-								for (int i= newLength; i < length; i++) {
+				switch (textBlockIndentationOption) {
+					case DefaultCodeFormatterConstants.INDENT_ON_COLUMN: {
+						String newStr= indentation;
+						int length= IndentAction.measureLengthInSpaces(stringTocalculate, CodeFormatterUtil.getTabWidth(javaProject));
+						StringBuilder str= new StringBuilder();
+						if (getUseTabsOnlyForLeadingIndentations(javaProject)) {
+							int existing= IndentAction.measureLengthInSpaces(indentation, CodeFormatterUtil.getTabWidth(javaProject));
+							if (length - existing > 0) {
+								for (int i= 0; i < length - existing; i++) {
 									newStr+= IndentAction.SPACE_STR;
 								}
-							} else if (JavaCore.TAB.equals(formatterTabValue)) {
-								newStr+= tabString;
+							}
+						} else {
+							for (int i= 0; i < length; i++) {
+								str.append(IndentAction.SPACE_STR);
+							}
+							int units= Strings.computeIndentUnits(str.toString(), javaProject);
+							newStr= CodeFormatterUtil.createIndentString(units, javaProject);
+							int newLength= IndentManipulation.measureIndentInSpaces(newStr, CodeFormatterUtil.getTabWidth(javaProject));
+							if (newLength < length) {
+								if (DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue) || JavaCore.SPACE.equals(formatterTabValue)) {
+									for (int i= newLength; i < length; i++) {
+										newStr+= IndentAction.SPACE_STR;
+									}
+								} else if (JavaCore.TAB.equals(formatterTabValue)) {
+									newStr+= tabString;
+								}
 							}
 						}
+						indentation= newStr;
+						break;
 					}
-					indentation= newStr;
-				} else if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_BY_ONE) {
-					if (JavaCore.TAB.equals(formatterTabValue)
-							|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
-						indentation+= tabString;
-					} else if (JavaCore.SPACE.equals(formatterTabValue)) {
-						indentation+= tabSpaceString;
+					case DefaultCodeFormatterConstants.INDENT_BY_ONE:
+						if (JavaCore.TAB.equals(formatterTabValue)
+								|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
+							indentation+= tabString;
+						} else if (JavaCore.SPACE.equals(formatterTabValue)) {
+							indentation+= tabSpaceString;
+						}
+						break;
+					case DefaultCodeFormatterConstants.INDENT_PRESERVE:
+						indentation= IndentAction.EMPTY_STR;
+						break;
+					case DefaultCodeFormatterConstants.INDENT_DEFAULT: {
+						String indentString= EMPTY_STR;
+						if (JavaCore.TAB.equals(formatterTabValue)
+								|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
+							indentString= tabString;
+						} else if (JavaCore.SPACE.equals(formatterTabValue)) {
+							indentString= tabSpaceString;
+						}
+						int count= getFormatterContinuationIndentation(javaProject);
+						for (int i= 0; i < count; i++) {
+							indentation+= indentString;
+						}
+						break;
 					}
-				} else if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_PRESERVE) {
-					indentation= IndentAction.EMPTY_STR;
-				} else if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_DEFAULT) {
-					String indentString= EMPTY_STR;
-					if (JavaCore.TAB.equals(formatterTabValue)
-							|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
-						indentString= tabString;
-					} else if (JavaCore.SPACE.equals(formatterTabValue)) {
-						indentString= tabSpaceString;
-					}
-					int count= getFormatterContinuationIndentation(javaProject);
-					for (int i= 0; i < count; i++) {
-						indentation+= indentString;
-					}
+					default:
+						break;
 				}
 			}
 		}
@@ -1026,56 +1035,65 @@ public class IndentAction extends TextEditorAction {
 		int textBlockIndentationOption= getTextBlockIndentation(javaProject);
 		String formatterTabValue= getFormatterTabValue(javaProject);
 		String stringTocalculate= fullStrNoTrim;
-		if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_ON_COLUMN) {
-			String newStr= indentation;
-			int length= IndentAction.measureLengthInSpaces(stringTocalculate, CodeFormatterUtil.getTabWidth(javaProject));
-			StringBuilder str= new StringBuilder();
-			if (getUseTabsOnlyForLeadingIndentations(javaProject)) {
-				int existing= IndentAction.measureLengthInSpaces(indentation, CodeFormatterUtil.getTabWidth(javaProject));
-				if (length - existing > 0) {
-					for (int i= 0; i < length - existing; i++) {
-						newStr+= IndentAction.SPACE_STR;
-					}
-				}
-			} else {
-				for (int i= 0; i < length; i++) {
-					str.append(IndentAction.SPACE_STR);
-				}
-				int units= Strings.computeIndentUnits(str.toString(), javaProject);
-				newStr= CodeFormatterUtil.createIndentString(units, javaProject);
-				int newLength= IndentManipulation.measureIndentInSpaces(newStr, CodeFormatterUtil.getTabWidth(javaProject));
-				if (newLength < length) {
-					if (DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue) || JavaCore.SPACE.equals(formatterTabValue)) {
-						for (int i= newLength; i < length; i++) {
+		switch (textBlockIndentationOption) {
+			case DefaultCodeFormatterConstants.INDENT_ON_COLUMN: {
+				String newStr= indentation;
+				int length= IndentAction.measureLengthInSpaces(stringTocalculate, CodeFormatterUtil.getTabWidth(javaProject));
+				StringBuilder str= new StringBuilder();
+				if (getUseTabsOnlyForLeadingIndentations(javaProject)) {
+					int existing= IndentAction.measureLengthInSpaces(indentation, CodeFormatterUtil.getTabWidth(javaProject));
+					if (length - existing > 0) {
+						for (int i= 0; i < length - existing; i++) {
 							newStr+= IndentAction.SPACE_STR;
 						}
-					} else if (JavaCore.TAB.equals(formatterTabValue)) {
-						newStr+= tabString;
+					}
+				} else {
+					for (int i= 0; i < length; i++) {
+						str.append(IndentAction.SPACE_STR);
+					}
+					int units= Strings.computeIndentUnits(str.toString(), javaProject);
+					newStr= CodeFormatterUtil.createIndentString(units, javaProject);
+					int newLength= IndentManipulation.measureIndentInSpaces(newStr, CodeFormatterUtil.getTabWidth(javaProject));
+					if (newLength < length) {
+						if (DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue) || JavaCore.SPACE.equals(formatterTabValue)) {
+							for (int i= newLength; i < length; i++) {
+								newStr+= IndentAction.SPACE_STR;
+							}
+						} else if (JavaCore.TAB.equals(formatterTabValue)) {
+							newStr+= tabString;
+						}
 					}
 				}
+				indentation= newStr;
+				break;
 			}
-			indentation= newStr;
-		} else if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_BY_ONE) {
-			if (JavaCore.TAB.equals(formatterTabValue)
-					|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
-				indentation+= tabString;
-			} else if (JavaCore.SPACE.equals(formatterTabValue)) {
-				indentation+= tabSpaceString;
+			case DefaultCodeFormatterConstants.INDENT_BY_ONE:
+				if (JavaCore.TAB.equals(formatterTabValue)
+						|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
+					indentation+= tabString;
+				} else if (JavaCore.SPACE.equals(formatterTabValue)) {
+					indentation+= tabSpaceString;
+				}
+				break;
+			case DefaultCodeFormatterConstants.INDENT_PRESERVE:
+				indentation= IndentAction.EMPTY_STR;
+				break;
+			case DefaultCodeFormatterConstants.INDENT_DEFAULT: {
+				String indentString= EMPTY_STR;
+				if (JavaCore.TAB.equals(formatterTabValue)
+						|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
+					indentString= tabString;
+				} else if (JavaCore.SPACE.equals(formatterTabValue)) {
+					indentString= tabSpaceString;
+				}
+				int count= getFormatterContinuationIndentation(javaProject);
+				for (int i= 0; i < count; i++) {
+					indentation+= indentString;
+				}
+				break;
 			}
-		} else if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_PRESERVE) {
-			indentation= IndentAction.EMPTY_STR;
-		} else if (textBlockIndentationOption == DefaultCodeFormatterConstants.INDENT_DEFAULT) {
-			String indentString= EMPTY_STR;
-			if (JavaCore.TAB.equals(formatterTabValue)
-					|| DefaultCodeFormatterConstants.MIXED.equals(formatterTabValue)) {
-				indentString= tabString;
-			} else if (JavaCore.SPACE.equals(formatterTabValue)) {
-				indentString= tabSpaceString;
-			}
-			int count= getFormatterContinuationIndentation(javaProject);
-			for (int i= 0; i < count; i++) {
-				indentation+= indentString;
-			}
+			default:
+				break;
 		}
 		return indentation;
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterModifyDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterModifyDialog.java
@@ -808,32 +808,37 @@ public class FormatterModifyDialog extends ModifyDialog {
 				 * visual tab size to the value piggy backed in the INDENTATION_SIZE
 				 * preference. See also CodeFormatterUtil.
 				 */
-				if (DefaultCodeFormatterConstants.MIXED.equals(tabPolicy)) {
-					if (JavaCore.SPACE.equals(fOldTabChar) || JavaCore.TAB.equals(fOldTabChar))
-						swapTabValues();
-					tabSizePref.setEnabled(true);
-					tabSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
-					indentSizePref.setEnabled(true);
-					indentSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_INDENTATION_SIZE);
-					onlyForLeadingPref.setEnabled(true);
-				} else if (JavaCore.SPACE.equals(tabPolicy)) {
-					if (DefaultCodeFormatterConstants.MIXED.equals(fOldTabChar))
-						swapTabValues();
-					tabSizePref.setEnabled(true);
-					tabSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_INDENTATION_SIZE);
-					indentSizePref.setEnabled(true);
-					indentSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
-					onlyForLeadingPref.setEnabled(false);
-				} else if (JavaCore.TAB.equals(tabPolicy)) {
-					if (DefaultCodeFormatterConstants.MIXED.equals(fOldTabChar))
-						swapTabValues();
-					tabSizePref.setEnabled(true);
-					tabSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
-					indentSizePref.setEnabled(false);
-					indentSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
-					onlyForLeadingPref.setEnabled(true);
-				} else {
-					Assert.isTrue(false);
+				switch (tabPolicy) {
+					case DefaultCodeFormatterConstants.MIXED:
+						if (JavaCore.SPACE.equals(fOldTabChar) || JavaCore.TAB.equals(fOldTabChar))
+							swapTabValues();
+						tabSizePref.setEnabled(true);
+						tabSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
+						indentSizePref.setEnabled(true);
+						indentSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_INDENTATION_SIZE);
+						onlyForLeadingPref.setEnabled(true);
+						break;
+					case JavaCore.SPACE:
+						if (DefaultCodeFormatterConstants.MIXED.equals(fOldTabChar))
+							swapTabValues();
+						tabSizePref.setEnabled(true);
+						tabSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_INDENTATION_SIZE);
+						indentSizePref.setEnabled(true);
+						indentSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
+						onlyForLeadingPref.setEnabled(false);
+						break;
+					case JavaCore.TAB:
+						if (DefaultCodeFormatterConstants.MIXED.equals(fOldTabChar))
+							swapTabValues();
+						tabSizePref.setEnabled(true);
+						tabSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
+						indentSizePref.setEnabled(false);
+						indentSizePref.setKey(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE);
+						onlyForLeadingPref.setEnabled(true);
+						break;
+					default:
+						Assert.isTrue(false);
+						break;
 				}
 				fOldTabChar= tabPolicy;
 			}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/ContentAssistPreference.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/ContentAssistPreference.java
@@ -221,32 +221,51 @@ public class ContentAssistPreference {
 
 		String p= event.getProperty();
 
-		if (AUTOACTIVATION.equals(p)) {
-			boolean enabled= store.getBoolean(AUTOACTIVATION);
-			assistant.enableAutoActivation(enabled);
-		} else if (AUTOACTIVATION_DELAY.equals(p)) {
-			int delay= store.getInt(AUTOACTIVATION_DELAY);
-			assistant.setAutoActivationDelay(delay);
-		} else if (PARAMETERS_FOREGROUND.equals(p)) {
-			Color c= getColor(store, PARAMETERS_FOREGROUND);
-			assistant.setContextInformationPopupForeground(c);
-			assistant.setContextSelectorForeground(c);
-		} else if (PARAMETERS_BACKGROUND.equals(p)) {
-			Color c= getColor(store, PARAMETERS_BACKGROUND);
-			assistant.setContextInformationPopupBackground(c);
-			assistant.setContextSelectorBackground(c);
-		} else if (AUTOINSERT.equals(p)) {
-			boolean enabled= store.getBoolean(AUTOINSERT);
-			assistant.enableAutoInsert(enabled);
-		} else if (PREFIX_COMPLETION.equals(p)) {
-			boolean enabled= store.getBoolean(PREFIX_COMPLETION);
-			assistant.enablePrefixCompletion(enabled);
-		} else if (USE_COLORED_LABELS.equals(p)) {
-			boolean enabled= store.getBoolean(USE_COLORED_LABELS);
-			assistant.enableColoredLabels(enabled);
-		} else if (DISABLE_COMPLETION_PROPOSAL_TRIGGER_CHARS.equals(p)) {
-			boolean disabled = store.getBoolean(DISABLE_COMPLETION_PROPOSAL_TRIGGER_CHARS);
-			assistant.enableCompletionProposalTriggerChars(!disabled);
+		switch (p) {
+			case AUTOACTIVATION: {
+				boolean enabled= store.getBoolean(AUTOACTIVATION);
+				assistant.enableAutoActivation(enabled);
+				break;
+			}
+			case AUTOACTIVATION_DELAY: {
+				int delay= store.getInt(AUTOACTIVATION_DELAY);
+				assistant.setAutoActivationDelay(delay);
+				break;
+			}
+			case PARAMETERS_FOREGROUND: {
+				Color c= getColor(store, PARAMETERS_FOREGROUND);
+				assistant.setContextInformationPopupForeground(c);
+				assistant.setContextSelectorForeground(c);
+				break;
+			}
+			case PARAMETERS_BACKGROUND: {
+				Color c= getColor(store, PARAMETERS_BACKGROUND);
+				assistant.setContextInformationPopupBackground(c);
+				assistant.setContextSelectorBackground(c);
+				break;
+			}
+			case AUTOINSERT: {
+				boolean enabled= store.getBoolean(AUTOINSERT);
+				assistant.enableAutoInsert(enabled);
+				break;
+			}
+			case PREFIX_COMPLETION: {
+				boolean enabled= store.getBoolean(PREFIX_COMPLETION);
+				assistant.enablePrefixCompletion(enabled);
+				break;
+			}
+			case USE_COLORED_LABELS: {
+				boolean enabled= store.getBoolean(USE_COLORED_LABELS);
+				assistant.enableColoredLabels(enabled);
+				break;
+			}
+			case DISABLE_COMPLETION_PROPOSAL_TRIGGER_CHARS: {
+				boolean disabled = store.getBoolean(DISABLE_COMPLETION_PROPOSAL_TRIGGER_CHARS);
+				assistant.enableCompletionProposalTriggerChars(!disabled);
+				break;
+			}
+			default:
+				break;
 		}
 
 		changeJavaProcessor(assistant, store, p);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocSnippetStringEvaluator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocSnippetStringEvaluator.java
@@ -168,12 +168,18 @@ public class JavaDocSnippetStringEvaluator {
 		String modifiedStr= str;
 		for (TagElement tag : tags) {
 			String name= tag.getTagName();
-			if (TagElement.TAG_HIGHLIGHT.equals(name)) {
-				handleSnippetHighlight(modifiedStr, tag, actionElements);
-			} else if (TagElement.TAG_REPLACE.equals(name)) {
-				modifiedStr= handleSnippetReplace(modifiedStr, tag, actionElements);
-			} else if (TagElement.TAG_LINK.equals(name)) {
-				handleSnippetLink(modifiedStr, tag, actionElements);
+			switch (name) {
+				case TagElement.TAG_HIGHLIGHT:
+					handleSnippetHighlight(modifiedStr, tag, actionElements);
+					break;
+				case TagElement.TAG_REPLACE:
+					modifiedStr= handleSnippetReplace(modifiedStr, tag, actionElements);
+					break;
+				case TagElement.TAG_LINK:
+					handleSnippetLink(modifiedStr, tag, actionElements);
+					break;
+				default:
+					break;
 			}
 		}
 		return getString( modifiedStr, actionElements);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/CPListLabelProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/CPListLabelProvider.java
@@ -138,181 +138,191 @@ public class CPListLabelProvider extends LabelProvider implements IStyledLabelPr
 	public String getCPListElementAttributeText(CPListElementAttribute attrib) {
 		String notAvailable= NewWizardMessages.CPListLabelProvider_none;
 		String key= attrib.getKey();
-		if (CPListElement.SOURCEATTACHMENT.equals(key)) {
-			String arg;
-			IPath path= (IPath) attrib.getValue();
-			if (path != null && !path.isEmpty()) {
-				if (attrib.getParent().getEntryKind() == IClasspathEntry.CPE_VARIABLE) {
-					arg= getVariableString(path);
-				} else {
-					arg= getPathString(path, path.getDevice() != null);
-				}
-			} else {
-				arg= notAvailable;
-			}
-			return Messages.format(NewWizardMessages.CPListLabelProvider_source_attachment_label, new String[] { arg });
-		} else if (CPListElement.OUTPUT.equals(key)) {
-			String arg= null;
-			IPath path= (IPath) attrib.getValue();
-			if (path != null) {
-				arg= BasicElementLabels.getPathLabel(path, false);
-			} else {
-				arg= NewWizardMessages.CPListLabelProvider_default_output_folder_label;
-			}
-			return Messages.format(NewWizardMessages.CPListLabelProvider_output_folder_label, new String[] { arg });
-		} else if (CPListElement.EXCLUSION.equals(key)) {
-			String arg= null;
-			IPath[] patterns= (IPath[]) attrib.getValue();
-			if (patterns != null && patterns.length > 0) {
-				int patternsCount= 0;
-				StringBuilder buf= new StringBuilder();
-				for (IPath p : patterns) {
-					if (p.segmentCount() > 0) {
-						String pattern= BasicElementLabels.getPathLabel(p, false);
-						if (patternsCount > 0) {
-							buf.append(NewWizardMessages.CPListLabelProvider_exclusion_filter_separator);
-						}
-						buf.append(pattern);
-						patternsCount++;
+		switch (key) {
+			case CPListElement.SOURCEATTACHMENT: {
+				String arg;
+				IPath path= (IPath) attrib.getValue();
+				if (path != null && !path.isEmpty()) {
+					if (attrib.getParent().getEntryKind() == IClasspathEntry.CPE_VARIABLE) {
+						arg= getVariableString(path);
+					} else {
+						arg= getPathString(path, path.getDevice() != null);
 					}
-				}
-				if (patternsCount > 0) {
-					arg= buf.toString();
 				} else {
 					arg= notAvailable;
 				}
-			} else {
-				arg= notAvailable;
+				return Messages.format(NewWizardMessages.CPListLabelProvider_source_attachment_label, new String[] { arg });
 			}
-			return Messages.format(NewWizardMessages.CPListLabelProvider_exclusion_filter_label, new String[] { arg });
-		} else if (CPListElement.INCLUSION.equals(key)) {
-			String arg= null;
-			IPath[] patterns= (IPath[]) attrib.getValue();
-			if (patterns != null && patterns.length > 0) {
-				int patternsCount= 0;
-				StringBuilder buf= new StringBuilder();
-				for (IPath p : patterns) {
-					if (p.segmentCount() > 0) {
-						String pattern= BasicElementLabels.getPathLabel(p, false);
-						if (patternsCount > 0) {
-							buf.append(NewWizardMessages.CPListLabelProvider_inclusion_filter_separator);
-						}
-						buf.append(pattern);
-						patternsCount++;
-					}
+			case CPListElement.OUTPUT: {
+				String arg= null;
+				IPath path= (IPath) attrib.getValue();
+				if (path != null) {
+					arg= BasicElementLabels.getPathLabel(path, false);
+				} else {
+					arg= NewWizardMessages.CPListLabelProvider_default_output_folder_label;
 				}
-				if (patternsCount > 0) {
-					arg= buf.toString();
+				return Messages.format(NewWizardMessages.CPListLabelProvider_output_folder_label, new String[] { arg });
+			}
+			case CPListElement.EXCLUSION: {
+				String arg= null;
+				IPath[] patterns= (IPath[]) attrib.getValue();
+				if (patterns != null && patterns.length > 0) {
+					int patternsCount= 0;
+					StringBuilder buf= new StringBuilder();
+					for (IPath p : patterns) {
+						if (p.segmentCount() > 0) {
+							String pattern= BasicElementLabels.getPathLabel(p, false);
+							if (patternsCount > 0) {
+								buf.append(NewWizardMessages.CPListLabelProvider_exclusion_filter_separator);
+							}
+							buf.append(pattern);
+							patternsCount++;
+						}
+					}
+					if (patternsCount > 0) {
+						arg= buf.toString();
+					} else {
+						arg= notAvailable;
+					}
 				} else {
 					arg= notAvailable;
 				}
-			} else {
-				arg= NewWizardMessages.CPListLabelProvider_all;
+				return Messages.format(NewWizardMessages.CPListLabelProvider_exclusion_filter_label, new String[] { arg });
 			}
-			return Messages.format(NewWizardMessages.CPListLabelProvider_inclusion_filter_label, new String[] { arg });
-		} else if (CPListElement.ACCESSRULES.equals(key)) {
-			IAccessRule[] rules= (IAccessRule[]) attrib.getValue();
-			int nRules= rules != null ? rules.length : 0;
-
-			int parentKind= attrib.getParent().getEntryKind();
-			if (parentKind == IClasspathEntry.CPE_PROJECT) {
-				Boolean combined= (Boolean) attrib.getParent().getAttribute(CPListElement.COMBINE_ACCESSRULES);
-				if (nRules > 0) {
-					if (combined) {
-						if (nRules == 1) {
-							return NewWizardMessages.CPListLabelProvider_project_access_rules_combined_singular;
-						} else {
-							return Messages.format(NewWizardMessages.CPListLabelProvider_project_access_rules_combined_plural, String.valueOf(nRules));
-						}
-					} else {
-						if (nRules == 1) {
-							return NewWizardMessages.CPListLabelProvider_project_access_rules_not_combined_singular;
-						} else {
-							return Messages.format(NewWizardMessages.CPListLabelProvider_project_access_rules_not_combined_plural, String.valueOf(nRules));
+			case CPListElement.INCLUSION: {
+				String arg= null;
+				IPath[] patterns= (IPath[]) attrib.getValue();
+				if (patterns != null && patterns.length > 0) {
+					int patternsCount= 0;
+					StringBuilder buf= new StringBuilder();
+					for (IPath p : patterns) {
+						if (p.segmentCount() > 0) {
+							String pattern= BasicElementLabels.getPathLabel(p, false);
+							if (patternsCount > 0) {
+								buf.append(NewWizardMessages.CPListLabelProvider_inclusion_filter_separator);
+							}
+							buf.append(pattern);
+							patternsCount++;
 						}
 					}
-				} else {
-					return NewWizardMessages.CPListLabelProvider_project_access_rules_no_rules;
-				}
-			} else if (parentKind == IClasspathEntry.CPE_CONTAINER) {
-				if (nRules > 1) {
-					return Messages.format(NewWizardMessages.CPListLabelProvider_container_access_rules_plural, String.valueOf(nRules));
-				} else if (nRules == 1) {
-					return NewWizardMessages.CPListLabelProvider_container_access_rules_singular;
-				} else {
-					return NewWizardMessages.CPListLabelProvider_container_no_access_rules;
-				}
-			} else {
-				if (nRules > 1) {
-					return Messages.format(NewWizardMessages.CPListLabelProvider_access_rules_enabled_plural, String.valueOf(nRules));
-				} else if (nRules == 1) {
-					return NewWizardMessages.CPListLabelProvider_access_rules_enabled_singular;
-				} else {
-					return NewWizardMessages.CPListLabelProvider_access_rules_disabled;
-				}
-			}
-		} else if (CPListElement.IGNORE_OPTIONAL_PROBLEMS.equals(key)) {
-			String arg;
-			if ("true".equals(attrib.getValue())) { //$NON-NLS-1$
-				arg= NewWizardMessages.CPListLabelProvider_ignore_optional_problems_yes;
-			} else {
-				arg= NewWizardMessages.CPListLabelProvider_ignore_optional_problems_no;
-			}
-			return Messages.format(NewWizardMessages.CPListLabelProvider_ignore_optional_problems_label, arg);
-		} else if (CPListElement.MODULE.equals(key)) {
-			Object value= attrib.getValue();
-			if (value instanceof ModuleEncapsulationDetail[]) {
-				boolean limitModules= false;
-				boolean modifiesEncaps= false;
-				for (ModuleEncapsulationDetail detail : (ModuleEncapsulationDetail[]) value) {
-					if (detail instanceof LimitModules) {
-						limitModules= true;
+					if (patternsCount > 0) {
+						arg= buf.toString();
 					} else {
-						modifiesEncaps= true;
+						arg= notAvailable;
+					}
+				} else {
+					arg= NewWizardMessages.CPListLabelProvider_all;
+				}
+				return Messages.format(NewWizardMessages.CPListLabelProvider_inclusion_filter_label, new String[] { arg });
+			}
+			case CPListElement.ACCESSRULES: {
+				IAccessRule[] rules= (IAccessRule[]) attrib.getValue();
+				int nRules= rules != null ? rules.length : 0;
+				int parentKind= attrib.getParent().getEntryKind();
+				if (parentKind == IClasspathEntry.CPE_PROJECT) {
+					Boolean combined= (Boolean) attrib.getParent().getAttribute(CPListElement.COMBINE_ACCESSRULES);
+					if (nRules > 0) {
+						if (combined) {
+							if (nRules == 1) {
+								return NewWizardMessages.CPListLabelProvider_project_access_rules_combined_singular;
+							} else {
+								return Messages.format(NewWizardMessages.CPListLabelProvider_project_access_rules_combined_plural, String.valueOf(nRules));
+							}
+						} else {
+							if (nRules == 1) {
+								return NewWizardMessages.CPListLabelProvider_project_access_rules_not_combined_singular;
+							} else {
+								return Messages.format(NewWizardMessages.CPListLabelProvider_project_access_rules_not_combined_plural, String.valueOf(nRules));
+							}
+						}
+					} else {
+						return NewWizardMessages.CPListLabelProvider_project_access_rules_no_rules;
+					}
+				} else if (parentKind == IClasspathEntry.CPE_CONTAINER) {
+					if (nRules > 1) {
+						return Messages.format(NewWizardMessages.CPListLabelProvider_container_access_rules_plural, String.valueOf(nRules));
+					} else if (nRules == 1) {
+						return NewWizardMessages.CPListLabelProvider_container_access_rules_singular;
+					} else {
+						return NewWizardMessages.CPListLabelProvider_container_no_access_rules;
+					}
+				} else {
+					if (nRules > 1) {
+						return Messages.format(NewWizardMessages.CPListLabelProvider_access_rules_enabled_plural, String.valueOf(nRules));
+					} else if (nRules == 1) {
+						return NewWizardMessages.CPListLabelProvider_access_rules_enabled_singular;
+					} else {
+						return NewWizardMessages.CPListLabelProvider_access_rules_disabled;
 					}
 				}
-				if (modifiesEncaps) {
-					if (limitModules)
-						return NewWizardMessages.CPListLabelProvider_modular_modifiesContentsAndEncapsulation_label;
-					return NewWizardMessages.CPListLabelProvider_modular_modifiesEncapsulation_label;
-				} else if (limitModules) {
-					return NewWizardMessages.CPListLabelProvider_modular_modifiesContents_label;
+			}
+			case CPListElement.IGNORE_OPTIONAL_PROBLEMS: {
+				String arg;
+				if ("true".equals(attrib.getValue())) { //$NON-NLS-1$
+					arg= NewWizardMessages.CPListLabelProvider_ignore_optional_problems_yes;
+				} else {
+					arg= NewWizardMessages.CPListLabelProvider_ignore_optional_problems_no;
 				}
-				return NewWizardMessages.CPListLabelProvider_modular_label;
-			} else {
-				return NewWizardMessages.CPListLabelProvider_not_modular_label;
+				return Messages.format(NewWizardMessages.CPListLabelProvider_ignore_optional_problems_label, arg);
 			}
-		} else if (CPListElement.TEST.equals(key)) {
-			String arg;
-			if ("true".equals(attrib.getValue())) { //$NON-NLS-1$
-				arg= NewWizardMessages.CPListLabelProvider_test_yes;
-			} else {
-				arg= NewWizardMessages.CPListLabelProvider_test_no;
+			case CPListElement.MODULE: {
+				Object value= attrib.getValue();
+				if (value instanceof ModuleEncapsulationDetail[]) {
+					boolean limitModules= false;
+					boolean modifiesEncaps= false;
+					for (ModuleEncapsulationDetail detail : (ModuleEncapsulationDetail[]) value) {
+						if (detail instanceof LimitModules) {
+							limitModules= true;
+						} else {
+							modifiesEncaps= true;
+						}
+					}
+					if (modifiesEncaps) {
+						if (limitModules)
+							return NewWizardMessages.CPListLabelProvider_modular_modifiesContentsAndEncapsulation_label;
+						return NewWizardMessages.CPListLabelProvider_modular_modifiesEncapsulation_label;
+					} else if (limitModules) {
+						return NewWizardMessages.CPListLabelProvider_modular_modifiesContents_label;
+					}
+					return NewWizardMessages.CPListLabelProvider_modular_label;
+				} else {
+					return NewWizardMessages.CPListLabelProvider_not_modular_label;
+				}
 			}
-			return Messages.format(attrib.getParent().getEntryKind() == IClasspathEntry.CPE_SOURCE
-					? NewWizardMessages.CPListLabelProvider_test_sources_label
-					: NewWizardMessages.CPListLabelProvider_test_dependency_label, arg);
-		} else if (CPListElement.WITHOUT_TEST_CODE.equals(key)) {
-			String arg;
-			if ("true".equals(attrib.getValue())) { //$NON-NLS-1$
-				arg= NewWizardMessages.CPListLabelProvider_test_yes;
-			} else {
-				arg= NewWizardMessages.CPListLabelProvider_test_no;
+			case CPListElement.TEST: {
+				String arg;
+				if ("true".equals(attrib.getValue())) { //$NON-NLS-1$
+					arg= NewWizardMessages.CPListLabelProvider_test_yes;
+				} else {
+					arg= NewWizardMessages.CPListLabelProvider_test_no;
+				}
+				return Messages.format(attrib.getParent().getEntryKind() == IClasspathEntry.CPE_SOURCE
+						? NewWizardMessages.CPListLabelProvider_test_sources_label
+						: NewWizardMessages.CPListLabelProvider_test_dependency_label, arg);
 			}
-			return Messages.format(NewWizardMessages.CPListLabelProvider_without_test_code_label, arg);
-		} else {
-			ClasspathAttributeConfiguration config= fAttributeDescriptors.get(key);
-			if (config != null) {
-				ClasspathAttributeAccess access= attrib.getClasspathAttributeAccess();
-				String nameLabel= config.getNameLabel(access);
-				String valueLabel= config.getValueLabel(access); // should be LTR marked
-				return Messages.format(NewWizardMessages.CPListLabelProvider_attribute_label, new String[] { nameLabel, valueLabel });
+			case CPListElement.WITHOUT_TEST_CODE: {
+				String arg;
+				if ("true".equals(attrib.getValue())) { //$NON-NLS-1$
+					arg= NewWizardMessages.CPListLabelProvider_test_yes;
+				} else {
+					arg= NewWizardMessages.CPListLabelProvider_test_no;
+				}
+				return Messages.format(NewWizardMessages.CPListLabelProvider_without_test_code_label, arg);
 			}
-			String arg= (String) attrib.getValue();
-			if (arg == null) {
-				arg= notAvailable;
+			default: {
+				ClasspathAttributeConfiguration config= fAttributeDescriptors.get(key);
+				if (config != null) {
+					ClasspathAttributeAccess access= attrib.getClasspathAttributeAccess();
+					String nameLabel= config.getNameLabel(access);
+					String valueLabel= config.getValueLabel(access); // should be LTR marked
+					return Messages.format(NewWizardMessages.CPListLabelProvider_attribute_label, new String[] { nameLabel, valueLabel });
+				}
+				String arg= (String) attrib.getValue();
+				if (arg == null) {
+					arg= notAvailable;
+				}
+				return Messages.format(NewWizardMessages.CPListLabelProvider_attribute_label, new String[] { key, arg });
 			}
-			return Messages.format(NewWizardMessages.CPListLabelProvider_attribute_label, new String[] { key, arg });
 		}
 	}
 
@@ -520,27 +530,32 @@ public class CPListLabelProvider extends LabelProvider implements IStyledLabelPr
 		} else if (element instanceof CPListElementAttribute) {
 			CPListElementAttribute attribute= (CPListElementAttribute) element;
 			String key= (attribute).getKey();
-			if (CPListElement.SOURCEATTACHMENT.equals(key)) {
-				return fRegistry.get(JavaPluginImages.DESC_OBJS_SOURCE_ATTACH_ATTRIB);
-			} else if (CPListElement.OUTPUT.equals(key)) {
-				return fRegistry.get(JavaPluginImages.DESC_OBJS_OUTPUT_FOLDER_ATTRIB);
-			} else if (CPListElement.EXCLUSION.equals(key)) {
-				return fRegistry.get(JavaPluginImages.DESC_OBJS_EXCLUSION_FILTER_ATTRIB);
-			} else if (CPListElement.INCLUSION.equals(key)) {
-				return fRegistry.get(JavaPluginImages.DESC_OBJS_INCLUSION_FILTER_ATTRIB);
-			} else if (CPListElement.ACCESSRULES.equals(key)) {
-				return fRegistry.get(JavaPluginImages.DESC_OBJS_ACCESSRULES_ATTRIB);
-			} else if (CPListElement.IGNORE_OPTIONAL_PROBLEMS.equals(key)) {
-				Image image= fRegistry.get(getCPListElementBaseImage(attribute.getParent(), false));
-				if (image != null) {
-					ImageDescriptor overlay= JavaPluginImages.DESC_OVR_IGNORE_OPTIONAL_PROBLEMS;
-					ImageDescriptor imageDescriptor= new DecorationOverlayIcon(image, overlay, IDecoration.BOTTOM_LEFT);
-					return fRegistry.get(imageDescriptor);
+			switch (key) {
+				case CPListElement.SOURCEATTACHMENT:
+					return fRegistry.get(JavaPluginImages.DESC_OBJS_SOURCE_ATTACH_ATTRIB);
+				case CPListElement.OUTPUT:
+					return fRegistry.get(JavaPluginImages.DESC_OBJS_OUTPUT_FOLDER_ATTRIB);
+				case CPListElement.EXCLUSION:
+					return fRegistry.get(JavaPluginImages.DESC_OBJS_EXCLUSION_FILTER_ATTRIB);
+				case CPListElement.INCLUSION:
+					return fRegistry.get(JavaPluginImages.DESC_OBJS_INCLUSION_FILTER_ATTRIB);
+				case CPListElement.ACCESSRULES:
+					return fRegistry.get(JavaPluginImages.DESC_OBJS_ACCESSRULES_ATTRIB);
+				case CPListElement.IGNORE_OPTIONAL_PROBLEMS: {
+					Image image= fRegistry.get(getCPListElementBaseImage(attribute.getParent(), false));
+					if (image != null) {
+						ImageDescriptor overlay= JavaPluginImages.DESC_OVR_IGNORE_OPTIONAL_PROBLEMS;
+						ImageDescriptor imageDescriptor= new DecorationOverlayIcon(image, overlay, IDecoration.BOTTOM_LEFT);
+						return fRegistry.get(imageDescriptor);
+					}
+					break;
 				}
-			} else {
-				ClasspathAttributeConfiguration config= fAttributeDescriptors.get(key);
-				if (config != null) {
-					return fRegistry.get(config.getImageDescriptor(attribute.getClasspathAttributeAccess()));
+				default: {
+					ClasspathAttributeConfiguration config= fAttributeDescriptors.get(key);
+					if (config != null) {
+						return fRegistry.get(config.getImageDescriptor(attribute.getClasspathAttributeAccess()));
+					}
+					break;
 				}
 			}
 			return  fSharedImages.getImage(ISharedImages.IMG_OBJS_CLASSPATH_VAR_ENTRY);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/LibrariesWorkbookPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/LibrariesWorkbookPage.java
@@ -782,63 +782,71 @@ public class LibrariesWorkbookPage extends BuildPathBasePage {
 				canEditEncoding= !attribute.isNonModifiable() && !attribute.isNotSupported();
 			}
 		}
-		if (CPListElement.SOURCEATTACHMENT.equals(key)) {
-			IClasspathEntry result= BuildPathDialogAccess.configureSourceAttachment(getShell(), selElement.getClasspathEntry(), canEditEncoding);
-			if (result != null) {
-				selElement.setAttribute(CPListElement.SOURCEATTACHMENT, result.getSourceAttachmentPath());
-				selElement.setAttribute(CPListElement.SOURCE_ATTACHMENT_ENCODING, SourceAttachmentBlock.getSourceAttachmentEncoding(result));
-				String[] changedAttributes= { CPListElement.SOURCEATTACHMENT, CPListElement.SOURCE_ATTACHMENT_ENCODING };
-				attributeUpdated(selElement, changedAttributes);
-				fLibrariesList.refresh(elem);
-				fLibrariesList.update(selElement); // image
-				fClassPathList.refresh(); // images
-				updateEnabledState();
-			}
-		} else if (CPListElement.ACCESSRULES.equals(key)) {
-			AccessRulesDialog dialog= new AccessRulesDialog(getShell(), selElement, fCurrJProject, fPageContainer != null);
-			int res= dialog.open();
-			if (res == Window.OK || res == AccessRulesDialog.SWITCH_PAGE) {
-				selElement.setAttribute(CPListElement.ACCESSRULES, dialog.getAccessRules());
-				String[] changedAttributes= { CPListElement.ACCESSRULES };
-				attributeUpdated(selElement, changedAttributes);
-
-				fLibrariesList.refresh(elem);
-				fClassPathList.dialogFieldChanged(); // validate
-				updateEnabledState();
-
-				if (res == AccessRulesDialog.SWITCH_PAGE) { // switch after updates and validation
-					dialog.performPageSwitch(fPageContainer);
+		switch (key) {
+			case CPListElement.SOURCEATTACHMENT: {
+				IClasspathEntry result= BuildPathDialogAccess.configureSourceAttachment(getShell(), selElement.getClasspathEntry(), canEditEncoding);
+				if (result != null) {
+					selElement.setAttribute(CPListElement.SOURCEATTACHMENT, result.getSourceAttachmentPath());
+					selElement.setAttribute(CPListElement.SOURCE_ATTACHMENT_ENCODING, SourceAttachmentBlock.getSourceAttachmentEncoding(result));
+					String[] changedAttributes= { CPListElement.SOURCEATTACHMENT, CPListElement.SOURCE_ATTACHMENT_ENCODING };
+					attributeUpdated(selElement, changedAttributes);
+					fLibrariesList.refresh(elem);
+					fLibrariesList.update(selElement); // image
+					fClassPathList.refresh(); // images
+					updateEnabledState();
 				}
+				break;
 			}
-		} else if (CPListElement.MODULE.equals(key)) {
-			boolean wasModular= selElement.getAttribute(CPListElement.MODULE) != null;
-			if (showModuleDialog(getShell(), elem)) {
-				String[] changedAttributes= { CPListElement.MODULE };
-				attributeUpdated(selElement, changedAttributes);
-				if (hasRootNodes()) {
-					boolean isModular= selElement.getAttribute(CPListElement.MODULE) != null;
-					RootNodeChange direction= RootNodeChange.fromOldAndNew(wasModular, isModular);
-					if (direction != RootNodeChange.NoChange) {
-						moveCPElementAcrossNode(fLibrariesList, selElement, direction);
+			case CPListElement.ACCESSRULES: {
+				AccessRulesDialog dialog= new AccessRulesDialog(getShell(), selElement, fCurrJProject, fPageContainer != null);
+				int res= dialog.open();
+				if (res == Window.OK || res == AccessRulesDialog.SWITCH_PAGE) {
+					selElement.setAttribute(CPListElement.ACCESSRULES, dialog.getAccessRules());
+					String[] changedAttributes= { CPListElement.ACCESSRULES };
+					attributeUpdated(selElement, changedAttributes);
+
+					fLibrariesList.refresh(elem);
+					fClassPathList.dialogFieldChanged(); // validate
+					updateEnabledState();
+
+					if (res == AccessRulesDialog.SWITCH_PAGE) { // switch after updates and validation
+						dialog.performPageSwitch(fPageContainer);
 					}
 				}
-				fLibrariesList.refresh(elem);
-				fClassPathList.dialogFieldChanged(); // validate
-				updateEnabledState();
+				break;
 			}
-		} else {
-			if (editCustomAttribute(getShell(), elem)) {
-				String[] changedAttributes= { key };
-				attributeUpdated(selElement, changedAttributes);
-				if(CPListElement.TEST.equals(key) || CPListElement.WITHOUT_TEST_CODE.equals(key)) {
-					fLibrariesList.refresh(elem.getParent());
-				} else {
+			case CPListElement.MODULE: {
+				boolean wasModular= selElement.getAttribute(CPListElement.MODULE) != null;
+				if (showModuleDialog(getShell(), elem)) {
+					String[] changedAttributes= { CPListElement.MODULE };
+					attributeUpdated(selElement, changedAttributes);
+					if (hasRootNodes()) {
+						boolean isModular= selElement.getAttribute(CPListElement.MODULE) != null;
+						RootNodeChange direction= RootNodeChange.fromOldAndNew(wasModular, isModular);
+						if (direction != RootNodeChange.NoChange) {
+							moveCPElementAcrossNode(fLibrariesList, selElement, direction);
+						}
+					}
 					fLibrariesList.refresh(elem);
+					fClassPathList.dialogFieldChanged(); // validate
+					updateEnabledState();
 				}
-				fClassPathList.dialogFieldChanged(); // validate
-				updateEnabledState();
-				checkAttributeEffect(key, fCurrJProject);
+				break;
 			}
+			default:
+				if (editCustomAttribute(getShell(), elem)) {
+					String[] changedAttributes= { key };
+					attributeUpdated(selElement, changedAttributes);
+					if(CPListElement.TEST.equals(key) || CPListElement.WITHOUT_TEST_CODE.equals(key)) {
+						fLibrariesList.refresh(elem.getParent());
+					} else {
+						fLibrariesList.refresh(elem);
+					}
+					fClassPathList.dialogFieldChanged(); // validate
+					updateEnabledState();
+					checkAttributeEffect(key, fCurrJProject);
+				}
+				break;
 		}
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/SourceContainerWorkbookPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/SourceContainerWorkbookPage.java
@@ -410,37 +410,50 @@ public class SourceContainerWorkbookPage extends BuildPathBasePage {
 
 	private void editAttributeEntry(CPListElementAttribute elem) {
 		String key= elem.getKey();
-		if (CPListElement.OUTPUT.equals(key)) {
-			CPListElement selElement=  elem.getParent();
-			OutputLocationDialog dialog= new OutputLocationDialog(getShell(), selElement, fClassPathList.getElements(), new Path(fOutputLocationField.getText()).makeAbsolute(), true);
-			if (dialog.open() == Window.OK) {
-				selElement.setAttribute(CPListElement.OUTPUT, dialog.getOutputLocation());
-				fFoldersList.refresh();
-				fClassPathList.dialogFieldChanged(); // validate
+		switch (key) {
+			case CPListElement.OUTPUT: {
+				CPListElement selElement=  elem.getParent();
+				OutputLocationDialog dialog= new OutputLocationDialog(getShell(), selElement, fClassPathList.getElements(), new Path(fOutputLocationField.getText()).makeAbsolute(), true);
+				if (dialog.open() == Window.OK) {
+					selElement.setAttribute(CPListElement.OUTPUT, dialog.getOutputLocation());
+					fFoldersList.refresh();
+					fClassPathList.dialogFieldChanged(); // validate
+				}
+				break;
 			}
-		} else if (CPListElement.EXCLUSION.equals(key) || CPListElement.INCLUSION.equals(key)) {
-			EditFilterWizard wizard= newEditFilterWizard(elem.getParent(), fFoldersList.getElements(), fOutputLocationField.getText());
-			OpenBuildPathWizardAction action= new OpenBuildPathWizardAction(wizard);
-			action.run();
-		} else if (CPListElement.IGNORE_OPTIONAL_PROBLEMS.equals(key)) {
-			String newValue= "true".equals(elem.getValue()) ? null : "true"; //$NON-NLS-1$ //$NON-NLS-2$
-			elem.setValue(newValue);
-			fFoldersList.refresh(elem);
-		} else if (CPListElement.TEST.equals(key)) {
-			String newValue= "true".equals(elem.getValue()) ? null : "true"; //$NON-NLS-1$ //$NON-NLS-2$
-			elem.setValue(newValue);
-			fFoldersList.refresh(elem.getParent());
-			fClassPathList.dialogFieldChanged(); // validate
-		} else if (CPListElement.WITHOUT_TEST_CODE.equals(key)) {
-			String newValue= "true".equals(elem.getValue()) ? null : "true"; //$NON-NLS-1$ //$NON-NLS-2$
-			elem.setValue(newValue);
-			fFoldersList.refresh(elem.getParent());
-		} else {
-			if (editCustomAttribute(getShell(), elem)) {
-				fFoldersList.refresh();
-				fClassPathList.dialogFieldChanged(); // validate
-				checkAttributeEffect(key, fCurrJProject);
+			case CPListElement.EXCLUSION:
+			case CPListElement.INCLUSION: {
+				EditFilterWizard wizard= newEditFilterWizard(elem.getParent(), fFoldersList.getElements(), fOutputLocationField.getText());
+				OpenBuildPathWizardAction action= new OpenBuildPathWizardAction(wizard);
+				action.run();
+				break;
 			}
+			case CPListElement.IGNORE_OPTIONAL_PROBLEMS: {
+				String newValue= "true".equals(elem.getValue()) ? null : "true"; //$NON-NLS-1$ //$NON-NLS-2$
+				elem.setValue(newValue);
+				fFoldersList.refresh(elem);
+				break;
+			}
+			case CPListElement.TEST: {
+				String newValue= "true".equals(elem.getValue()) ? null : "true"; //$NON-NLS-1$ //$NON-NLS-2$
+				elem.setValue(newValue);
+				fFoldersList.refresh(elem.getParent());
+				fClassPathList.dialogFieldChanged(); // validate
+				break;
+			}
+			case CPListElement.WITHOUT_TEST_CODE: {
+				String newValue= "true".equals(elem.getValue()) ? null : "true"; //$NON-NLS-1$ //$NON-NLS-2$
+				elem.setValue(newValue);
+				fFoldersList.refresh(elem.getParent());
+				break;
+			}
+			default:
+				if (editCustomAttribute(getShell(), elem)) {
+					fFoldersList.refresh();
+					fClassPathList.dialogFieldChanged(); // validate
+					checkAttributeEffect(key, fCurrJProject);
+				}
+				break;
 		}
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/WorkingSetModel.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/WorkingSetModel.java
@@ -622,26 +622,35 @@ public class WorkingSetModel {
 		if (!isAffected(event))
 			return;
 
-		if (IWorkingSetManager.CHANGE_WORKING_SET_CONTENT_CHANGE.equals(property)) {
-			IWorkingSet workingSet= (IWorkingSet)event.getNewValue();
-			IAdaptable[] elements= fElementMapper.refresh(workingSet);
-			if (elements != null) {
-				fireEvent(event);
+		switch (property) {
+			case IWorkingSetManager.CHANGE_WORKING_SET_CONTENT_CHANGE: {
+				IWorkingSet workingSet= (IWorkingSet)event.getNewValue();
+				IAdaptable[] elements= fElementMapper.refresh(workingSet);
+				if (elements != null) {
+					fireEvent(event);
+				}
+				break;
 			}
-		} else if (IWorkingSetManager.CHANGE_WORKING_SET_REMOVE.equals(property)) {
-			IWorkingSet workingSet= (IWorkingSet)event.getOldValue();
-			List<IWorkingSet> elements= new ArrayList<>(fActiveWorkingSets);
-			elements.remove(workingSet);
-			List<IWorkingSet> allElements= new ArrayList<>(Arrays.asList(getAllWorkingSets()));
-			allElements.remove(workingSet);
-			setWorkingSets(allElements.toArray(new IWorkingSet[allElements.size()]), fIsSortingEnabled, elements.toArray(new IWorkingSet[elements.size()]));
-		} else if (IWorkingSetManager.CHANGE_WORKING_SET_LABEL_CHANGE.equals(property)) {
-			IWorkingSet workingSet= (IWorkingSet)event.getNewValue();
-			if (isSortingEnabled() && Arrays.asList(getAllWorkingSets()).contains(workingSet)) {
-				setWorkingSets(getAllWorkingSets(), isSortingEnabled(), fActiveWorkingSets.toArray(new IWorkingSet[fActiveWorkingSets.size()]));
-			} else {
-				fireEvent(event);
+			case IWorkingSetManager.CHANGE_WORKING_SET_REMOVE: {
+				IWorkingSet workingSet= (IWorkingSet)event.getOldValue();
+				List<IWorkingSet> elements= new ArrayList<>(fActiveWorkingSets);
+				elements.remove(workingSet);
+				List<IWorkingSet> allElements= new ArrayList<>(Arrays.asList(getAllWorkingSets()));
+				allElements.remove(workingSet);
+				setWorkingSets(allElements.toArray(new IWorkingSet[allElements.size()]), fIsSortingEnabled, elements.toArray(new IWorkingSet[elements.size()]));
+				break;
 			}
+			case IWorkingSetManager.CHANGE_WORKING_SET_LABEL_CHANGE: {
+				IWorkingSet workingSet= (IWorkingSet)event.getNewValue();
+				if (isSortingEnabled() && Arrays.asList(getAllWorkingSets()).contains(workingSet)) {
+					setWorkingSets(getAllWorkingSets(), isSortingEnabled(), fActiveWorkingSets.toArray(new IWorkingSet[fActiveWorkingSets.size()]));
+				} else {
+					fireEvent(event);
+				}
+				break;
+			}
+			default:
+				break;
 		}
 
 	}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Applying the if/else to switch cleanup to the codebase because two additional cases are supported now.
Not in all cases the code is much clearer after applying the cleanup. However in these cases the code is definitely not very clear before as well. So in real world usages the feature to switch off the cleanup on specific code locations comes in handy.

## How to test
It should not change the way the code is processing. Might be in some corner cases switch is faster than if else chains.

Note:
There was a bug when processing "JUnitClasspathFixProcessor.java":
The comments for the strings have been removed and not reapplied. Not sure if that is a big deal as it can be applied automatically in a second step.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
