### PR TITLE
Use new return-type of JC.getAllJavaSourceVersionsSupportedByCompiler()

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
@@ -1155,7 +1155,7 @@ public final class JavaModelUtil {
 				if(JavaCore.isJavaSourceVersionSupportedByCompiler(compliance)) {
 					return compliance;
 				}
-				return JavaCore.getFirstJavaSourceVersionSupportedByCompiler();
+				return JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first();
 			}
 		}
 
@@ -1192,7 +1192,7 @@ public final class JavaModelUtil {
 		} else if (desc.indexOf(JavaCore.VERSION_1_8) != -1) {
 			return JavaCore.VERSION_1_8;
 		}
-		return JavaCore.getFirstJavaSourceVersionSupportedByCompiler();
+		return JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first();
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
@@ -442,7 +442,7 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 		fJRE50InfoText= new Link(infoComposite, SWT.WRAP);
 		fJRE50InfoText.setFont(composite.getFont());
 		// set a text: not the real one, just for layouting
-		String versionLabel= getVersionLabel(JavaCore.getFirstJavaSourceVersionSupportedByCompiler());
+		String versionLabel= getVersionLabel(JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first());
 		fJRE50InfoText.setText(Messages.format(PreferencesMessages.ComplianceConfigurationBlock_jrecompliance_info_project, new String[] { versionLabel, versionLabel }));
 		fJRE50InfoText.setVisible(false);
 		fJRE50InfoText.addSelectionListener(new SelectionListener() {
@@ -1170,8 +1170,8 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 					reportPreview= WARNING;
 					assertAsId= ERROR;
 					enumAsId= ERROR;
-					source= JavaCore.getFirstJavaSourceVersionSupportedByCompiler();
-					target= JavaCore.getFirstJavaSourceVersionSupportedByCompiler();
+					source= JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first();
+					target= JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first();
 				}
 			}
 		} else {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
@@ -474,8 +474,8 @@ public class NewJavaProjectWizardPageOne extends WizardPage {
 			fInstalledJVMs= getWorkspaceJREs();
 			Arrays.sort(fInstalledJVMs, (i0, i1) -> {
 				if (i1 instanceof IVMInstall2 && i0 instanceof IVMInstall2) {
-					String cc0= JavaModelUtil.getCompilerCompliance((IVMInstall2) i0, JavaCore.getFirstJavaSourceVersionSupportedByCompiler());
-					String cc1= JavaModelUtil.getCompilerCompliance((IVMInstall2) i1, JavaCore.getFirstJavaSourceVersionSupportedByCompiler());
+					String cc0= JavaModelUtil.getCompilerCompliance((IVMInstall2) i0, JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first());
+					String cc1= JavaModelUtil.getCompilerCompliance((IVMInstall2) i1, JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first());
 					int result= JavaCore.compareJavaVersions(cc1, cc0);
 					if (result != 0)
 						return result;


### PR DESCRIPTION
## What it does

Leverage the new return-type of
JavaCore.getAllJavaSourceVersionsSupportedByCompiler(), adjusted in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
