### PR TITLE
Bump qualifier of org.eclipse.jdt.ui

### DIFF
--- a/org.eclipse.jdt.ui/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.ui/forceQualifierUpdate.txt
@@ -21,3 +21,4 @@ Comparator errors in I20231127-0750
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1979
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+Pick up changes from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770


### PR DESCRIPTION
## What it does

Pick up changes from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770

Fixes comparator errors of tonight's I-build:
https://download.eclipse.org/eclipse/downloads/drops4/I20240806-1800/buildlogs/comparatorlogs/buildtimeComparatorUnanticipated.log.txt

@iloveeclipse can you please review?

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
