### PR TITLE
Deal with unsupported target options in compiler preferences

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
@@ -804,6 +804,27 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 		String source= getValue(PREF_SOURCE_COMPATIBILITY);
 		String target= getValue(PREF_CODEGEN_TARGET_PLATFORM);
 
+		String firstSupported = JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first();
+
+		// compliance must be supported
+		if (JavaModelUtil.isVersionLessThan(compliance, firstSupported)) {
+			String warning = Messages.format(PreferencesMessages.ComplianceConfigurationBlock_unsupported_compliance, new String[] { firstSupported });
+			setValue(PREF_COMPLIANCE, firstSupported);
+			status.setWarning(warning);
+		}
+		// source must be supported
+		if (JavaModelUtil.isVersionLessThan(source, firstSupported)) {
+			String warning = Messages.format(PreferencesMessages.ComplianceConfigurationBlock_unsupported_source, new String[] { firstSupported });
+			setValue(PREF_SOURCE_COMPATIBILITY, firstSupported);
+			status.setWarning(warning);
+		}
+		// target must be supported
+		if (JavaModelUtil.isVersionLessThan(target, firstSupported)) {
+			String warning = Messages.format(PreferencesMessages.ComplianceConfigurationBlock_unsupported_target, new String[] { firstSupported });
+			setValue(PREF_CODEGEN_TARGET_PLATFORM, firstSupported);
+			status.setWarning(warning);
+		}
+
 		// compliance must not be smaller than source or target
 		if (JavaModelUtil.isVersionLessThan(compliance, source)) {
 			status.setError(PreferencesMessages.ComplianceConfigurationBlock_src_greater_compliance);
@@ -1158,7 +1179,9 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 		if (options == null)
 			return DISABLED;
 		String complianceOption= options.get(JavaCore.COMPILER_COMPLIANCE);
-		if (JavaCore.compareJavaVersions(complianceOption, JavaCore.VERSION_10) > 0) {
+		if (JavaCore.compareJavaVersions(complianceOption, JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first()) < 0) {
+			return DISABLED;
+		} else if (JavaCore.compareJavaVersions(complianceOption, JavaCore.VERSION_10) > 0) {
 			return checkDefaults(PREFS_COMPLIANCE_11_OR_HIGHER, options);
 		} else {
 			return checkDefaults(PREFS_COMPLIANCE, options);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
@@ -554,6 +554,9 @@ public final class PreferencesMessages extends NLS {
 	public static String ComplianceConfigurationBlock_compliance_follows_EE_with_EE_label;
 	public static String ComplianceConfigurationBlock_compliance_group_label;
 	public static String ComplianceConfigurationBlock_classfiles_group_label;
+	public static String ComplianceConfigurationBlock_unsupported_compliance;
+	public static String ComplianceConfigurationBlock_unsupported_source;
+	public static String ComplianceConfigurationBlock_unsupported_target;
 	public static String CodeStylePreferencePage_title;
 	public static String CodeTemplatesPreferencePage_title;
 	public static String NameConventionConfigurationBlock_field_label;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -618,6 +618,9 @@ ComplianceConfigurationBlock_compliance_group_label=JDK Compliance
 ComplianceConfigurationBlock_classfiles_group_label=Classfile Generation
 ComplianceConfigurationBlock_classfile_greater_compliance=Classfile compatibility must be equal or less than compliance level.
 ComplianceConfigurationBlock_classfile_greater_source=Classfile compatibility must be equal or greater than source compatibility.
+ComplianceConfigurationBlock_unsupported_compliance=Compliance level was changed to minimal supported {0}.
+ComplianceConfigurationBlock_unsupported_source=Source level was changed to minimal supported {0}.
+ComplianceConfigurationBlock_unsupported_target=Target level was changed to minimal supported {0}.
 
 ComplianceConfigurationBlock_jrecompliance_info=When selecting {0} compliance, make sure to have a compatible JRE installed and activated (currently {1}). <a href="1" >Configure...</a>
 ComplianceConfigurationBlock_jrecompliance_info_project=When selecting {0} compliance, make sure to have a compatible JRE installed and activated (currently {1}). Configure the <a href="1" >''Installed JREs''</a> and <a href="2" >''Execution Environments''</a>, or change the JRE on the <a href="3" >''Java Build Path''</a>.


### PR DESCRIPTION
After we dropped support of Java < 1.8 compliance level, we still have to deal with projects that have these setting stored in preferences.

- Make sure we don't allow use unsupported compliance from JRE < 1.8
- Make sure we update value of compliance/source and target to first supported version

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1465
