### PR TITLE
Update InlineTempRefactoring logic for adding method type parameters

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RefactoringAnalyzeUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/rename/RefactoringAnalyzeUtil.java
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 
 import org.eclipse.text.edits.TextEdit;
 
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -132,6 +133,18 @@ public class RefactoringAnalyzeUtil {
 	public static RefactoringStatus checkNewSource(CompilationUnitChange change, ICompilationUnit originalCu, CompilationUnit oldCuNode, IProgressMonitor pm) throws CoreException {
 		RefactoringStatus result= new RefactoringStatus();
 		String newCuSource= change.getPreviewContent(new NullProgressMonitor());
+		CompilationUnit newCuNode= new RefactoringASTParser(IASTSharedValues.SHARED_AST_LEVEL).parse(newCuSource, originalCu, true, true, pm);
+		IProblem[] newProblems= getIntroducedCompileProblems(newCuNode, oldCuNode);
+		for (IProblem problem : newProblems) {
+			if (problem.isError())
+				result.addEntry(new RefactoringStatusEntry(RefactoringStatus.ERROR, problem.getMessage(), new JavaStringStatusContext(newCuSource, SourceRangeFactory.create(problem))));
+		}
+		return result;
+	}
+
+	public static RefactoringStatus checkNewSource(IDocument change, ICompilationUnit originalCu, CompilationUnit oldCuNode, IProgressMonitor pm) {
+		RefactoringStatus result= new RefactoringStatus();
+		String newCuSource= change.get();
 		CompilationUnit newCuNode= new RefactoringASTParser(IASTSharedValues.SHARED_AST_LEVEL).parse(newCuSource, originalCu, true, true, pm);
 		IProblem[] newProblems= getIntroducedCompileProblems(newCuNode, oldCuNode);
 		for (IProblem problem : newProblems) {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test31_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test31_out.java
@@ -5,11 +5,11 @@ import java.util.Map;
 
 class A extends Sup<String> {
 	public A(Map<String, Integer> map) {
-		method(Collections.<String, Integer>emptyMap(/*nada*/));
-		method2(Collections.<String, Integer>emptyMap(/*nada*/));
-		method3(Collections.<String, Integer>emptyMap(/*nada*/));
-		new A(Collections.<String, Integer>emptyMap(/*nada*/));
-		super.sup(Collections.<String, Integer>emptyMap(/*nada*/));
+		method(Collections.emptyMap(/*nada*/));
+		method2(Collections.emptyMap(/*nada*/));
+		method3(Collections.emptyMap(/*nada*/));
+		new A(Collections.emptyMap(/*nada*/));
+		super.sup(Collections.emptyMap(/*nada*/));
 		
 		Map<String, Integer> emptyMap2= Collections.emptyMap(/*nada*/);
 		emptyMap2= Collections.emptyMap(/*nada*/);

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -290,7 +290,6 @@ public class InlineTempTests extends GenericRefactoringTest {
 	}
 
 	@Test
-	@Ignore //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1565
 	public void test31() throws Exception{
 		helper1(8, 30, 8, 30);
 	}


### PR DESCRIPTION
- modify the getModifiedInitializerSource() logic to mark locations where type parameters might need to be added to a method invocation
- in checkFinalConditions() apply all changes and calculate the positions of the marked locations then compile the new source to find all introduced problems in the new source
- if any type match problems are introduced at the marked locations, redo the refactoring and add type parameters in these locations
- re-enable InlineTempTests.test31
- fixes #1573

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run InlineTempTests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
