### PR TITLE
Fix extract method to recognize name collision with a sub-class

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -581,6 +581,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String ExtractMethodAnalyzer_leftHandSideOfAssignment;
 
+	public static String ExtractMethodAnalyzer_method_will_override_call_in_subclass;
+
 	public static String ExtractMethodAnalyzer_no_valid_destination_type;
 
 	public static String ExtractMethodAnalyzer_invalid_selection;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -145,6 +145,7 @@ ExtractMethodAnalyzer_single_expression_or_set=Can only extract a single express
 ExtractMethodAnalyzer_cannot_extract_null_type=Cannot extract null expression.
 ExtractMethodAnalyzer_cannot_extract_break=Cannot extract a break statement.
 ExtractMethodAnalyzer_cannot_extract_continue=Cannot extract a continue statement.
+ExtractMethodAnalyzer_method_will_override_call_in_subclass=New method name may cause logic change in class: ''{0}'' that sub-classes target.
 ExtractMethodAnalyzer_no_valid_destination_type=No valid destination type exists.
 ExtractMethodAnalyzer_resource_in_try_with_resources=Cannot extract a resource declared in a 'try-with-resources' statement.
 ExtractMethodAnalyzer_resource_used_in_try_with_resources=Cannot extract a resource used in a 'try-with-resources' statement.

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -549,6 +549,9 @@ public class ExtractMethodRefactoring extends Refactoring {
 		}
 		String typeName= type.getQualifiedName();
 		SearchPattern pattern = SearchPattern.createPattern(typeName, IJavaSearchConstants.TYPE, IJavaSearchConstants.IMPLEMENTORS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+		if (pattern == null) {
+			return status;
+		}
 		TypeExtendsSearchRequestor requestor= new TypeExtendsSearchRequestor();
 		try {
 			search(pattern, SearchEngine.createJavaSearchScope(new IJavaElement[] {type.getJavaElement().getJavaProject()}), requestor);

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -54,9 +54,11 @@ import org.eclipse.ltk.core.refactoring.participants.ResourceChangeChecker;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
@@ -85,6 +87,7 @@ import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.ReturnStatement;
@@ -112,6 +115,13 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 import org.eclipse.jdt.core.refactoring.IJavaRefactorings;
 import org.eclipse.jdt.core.refactoring.descriptors.ExtractMethodDescriptor;
 import org.eclipse.jdt.core.refactoring.descriptors.JavaRefactoringDescriptor;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchMatch;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
 
 import org.eclipse.jdt.internal.core.manipulation.BindingLabelProviderCore;
 import org.eclipse.jdt.internal.core.manipulation.JavaElementLabelsCore;
@@ -122,6 +132,7 @@ import org.eclipse.jdt.internal.core.refactoring.descriptors.RefactoringSignatur
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.BodyDeclarationRewrite;
 import org.eclipse.jdt.internal.corext.dom.LinkedNodeFinder;
@@ -480,6 +491,111 @@ public class ExtractMethodRefactoring extends Refactoring {
 		return fUsedNames;
 	}
 
+	private class TypeExtendsSearchRequestor extends SearchRequestor {
+
+		public List<SearchMatch> results= new ArrayList<>();
+
+		public List<SearchMatch> getResults() {
+			return results;
+		}
+
+		@Override
+		public void acceptSearchMatch(SearchMatch match) throws CoreException {
+			if (match.getAccuracy() == SearchMatch.A_ACCURATE) {
+				results.add(match);
+			}
+		}
+
+	}
+
+	private void search(SearchPattern searchPattern, IJavaSearchScope scope, SearchRequestor requestor) throws CoreException {
+		new SearchEngine().search(
+			searchPattern,
+			new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()},
+			scope,
+			requestor,
+			null);
+	}
+
+	private class CheckMethodConflictVisitor extends ASTVisitor {
+		private final String fMethodNameToCheck;
+
+		public CheckMethodConflictVisitor(String methodName) {
+			this.fMethodNameToCheck= methodName;
+		}
+
+		@Override
+		public boolean visit(MethodInvocation node) {
+			if (node.getName().getFullyQualifiedName().equals(fMethodNameToCheck) && node.getExpression() == null) {
+				throw new AbortSearchException();
+			}
+			return true;
+		}
+	}
+
+	protected RefactoringStatus checkForMethodOverride() {
+
+		RefactoringStatus status= new RefactoringStatus();
+		ITypeBinding type= null;
+		if (fDestination instanceof AbstractTypeDeclaration) {
+			final AbstractTypeDeclaration decl= (AbstractTypeDeclaration) fDestination;
+			type= decl.resolveBinding();
+		} else if (fDestination instanceof AnonymousClassDeclaration) {
+			final AnonymousClassDeclaration decl= (AnonymousClassDeclaration) fDestination;
+			type= decl.resolveBinding();
+		}
+		if (type == null) {
+			return status;
+		}
+		String typeName= type.getQualifiedName();
+		SearchPattern pattern = SearchPattern.createPattern(typeName, IJavaSearchConstants.TYPE, IJavaSearchConstants.IMPLEMENTORS, SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE);
+		TypeExtendsSearchRequestor requestor= new TypeExtendsSearchRequestor();
+		try {
+			search(pattern, SearchEngine.createJavaSearchScope(new IJavaElement[] {type.getJavaElement().getJavaProject()}), requestor);
+		} catch (CoreException e) {
+			return status;
+		}
+		List<SearchMatch> results= requestor.getResults();
+		for (SearchMatch result : results) {
+			Object obj= result.getElement();
+			if (obj instanceof IType resultType) {
+				try {
+					ASTNode typeDecl= null;
+					if (resultType.isLocal() || resultType.isAnonymous()) {
+						ICompilationUnit icu= resultType.getCompilationUnit();
+						typeDecl= getTypeDeclaration(resultType, icu);
+					}
+					if (typeDecl != null) {
+						CheckMethodConflictVisitor visitor= new CheckMethodConflictVisitor(fMethodName);
+						try {
+							typeDecl.accept(visitor);
+						} catch (AbortSearchException e) {
+							status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.ExtractMethodAnalyzer_method_will_override_call_in_subclass, resultType.getFullyQualifiedName('.'))));
+						}
+					}
+				} catch (JavaModelException e) {
+					// do nothing
+				}
+			}
+		}
+		return status;
+	}
+
+	private ASTNode getTypeDeclaration(IType iType, ICompilationUnit icu) throws JavaModelException {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setSource(icu);
+		parser.setResolveBindings(true);
+		CompilationUnit compilationUnit= (CompilationUnit) parser.createAST(null);
+		ASTNode perform= NodeFinder.perform(compilationUnit, iType.getSourceRange());
+		if (perform instanceof TypeDeclaration && ((TypeDeclaration) perform).resolveBinding() != null) {
+			return perform;
+		} else if (perform instanceof AnonymousClassDeclaration && ((AnonymousClassDeclaration) perform).resolveBinding() != null) {
+			return perform;
+		}
+		return null;
+	}
+
 	@Override
 	public RefactoringStatus checkFinalConditions(IProgressMonitor pm) throws CoreException {
 		pm.beginTask(RefactoringCoreMessages.ExtractMethodRefactoring_checking_new_name, 2);
@@ -488,6 +604,7 @@ public class ExtractMethodRefactoring extends Refactoring {
 		RefactoringStatus result= checkMethodName();
 		result.merge(checkParameterNames());
 		result.merge(checkVarargOrder());
+		result.merge(checkForMethodOverride());
 		pm.worked(1);
 		if (pm.isCanceled())
 			throw new OperationCanceledException();

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1516.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1516.java
@@ -1,0 +1,23 @@
+package invalidSelection;
+
+public class A_testIssue1516 {
+
+	public void extracted() {
+		System.out.println("c");
+	}
+
+	public void foo() {
+		class D extends B {
+			public void t() {
+				extracted();
+			}
+		}
+	}
+
+}
+
+class B {
+	public void s() {
+		/*]*/System.out.println("b");/*[*/
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -2730,4 +2730,9 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	public void testIssue1357_2() throws Exception {
 		validSelectionTestChecked();
 	}
+
+	@Test
+	public void testIssue1516() throws Exception {
+		invalidSelectionTest();
+	}
 }


### PR DESCRIPTION
- modify ExtractMethodRefactoring to test if the new method name collides with an existing method name being used by a class that sub-classes the one creating the new method
- add new test to ExtractMethodtests
- fixes #1516

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
