### PR TITLE
Clarify message when refactoring rename not possible

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/refactoringui.properties
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/refactoringui.properties
@@ -202,7 +202,7 @@ MoveMembersInputPage_no_binary=Cannot move members to binary types
 RenameJavaElementAction_exception=An unexpected exception occurred. See the error log for more details
 RenameJavaElementAction_not_available=Operation unavailable on the current selection.\nSelect a Java project, source folder, resource, package, compilation unit, type, field, method, parameter or a local variable
 RenameJavaElementAction_name=Rename
-RenameJavaElementAction_started_rename_in_file=Element could not be resolved, started 'Rename in file'
+RenameJavaElementAction_started_rename_in_file=Rename refactoring not possible, started 'Text rename in file'
 
 MoveAction_text=&Move...
 


### PR DESCRIPTION
- for #1531

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Clarifies message when refactoring rename is not possible and instead we allow a lightweight text rename in file.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
