### PR TITLE
[23] JEP 467: Render markdown doc comments

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="3.23.0",
  org.eclipse.core.filesystem;bundle-version="1.10.0",
  org.eclipse.core.filebuffers;bundle-version="3.8.0",
- org.eclipse.search.core;bundle-version="3.16.0"
+ org.eclipse.search.core;bundle-version="3.16.0",
+ org.commonmark;bundle-version="0.22.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.jdt.core.manipulation,
  org.eclipse.jdt.core.refactoring,

--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.31.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="1.10.0",
  org.eclipse.core.filebuffers;bundle-version="3.8.0",
  org.eclipse.search.core;bundle-version="3.16.0",
- org.commonmark;bundle-version="0.22.0"
+ org.commonmark;bundle-version="0.22.0",
+ org.commonmark-gfm-tables;bundle-version="0.22.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.jdt.core.manipulation,
  org.eclipse.jdt.core.refactoring,

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.manipulation.internal.javadoc;
+
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.dom.Javadoc;
+
+public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
+
+	public CoreMarkdownAccessImpl(IJavaElement element, Javadoc javadoc, String source) {
+		super(element, javadoc, source);
+	}
+
+	public CoreMarkdownAccessImpl(IJavaElement element, Javadoc javadoc, String source, JavadocLookup lookup) {
+		super(element, javadoc, source, lookup);
+	}
+
+	@Override
+	protected String removeDocLineIntros(String textWithStars) {
+		String lineBreakGroup= "(\\r\\n?|\\n)"; //$NON-NLS-1$
+		String noBreakSpace= "[^\r\n&&\\s]"; //$NON-NLS-1$
+		return textWithStars.replaceAll(lineBreakGroup + noBreakSpace + "///" /*+ noBreakSpace + '?'*/, "$1"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Override
+	protected String getBlockTagStart() {
+		return "\n"+super.getBlockTagStart(); //$NON-NLS-1$
+	}
+
+	@Override
+	public String toHTML() {
+		String content = super.toHTML();
+		Parser parser = Parser.builder().build();
+		Node document = parser.parse(content);
+		HtmlRenderer renderer = HtmlRenderer.builder().build();
+		return renderer.render(document);
+	}
+
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -13,42 +13,108 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.manipulation.internal.javadoc;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.node.Document;
 import org.commonmark.node.Node;
+import org.commonmark.node.Paragraph;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
 
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.TagElement;
+import org.eclipse.jdt.core.dom.TextElement;
 
 public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 
+	private Parser fParser;
+	private HtmlRenderer fRenderer;
+	private int fBlockDepth= 0;
+
 	public CoreMarkdownAccessImpl(IJavaElement element, Javadoc javadoc, String source) {
 		super(element, javadoc, source);
+		init();
 	}
-
 	public CoreMarkdownAccessImpl(IJavaElement element, Javadoc javadoc, String source, JavadocLookup lookup) {
 		super(element, javadoc, source, lookup);
+		init();
+	}
+
+	private void init() {
+		List<Extension> extensions= List.of(TablesExtension.create());
+		fParser= Parser.builder().extensions(extensions).build();
+		fRenderer= HtmlRenderer.builder().extensions(extensions).build();
 	}
 
 	@Override
-	protected String removeDocLineIntros(String textWithStars) {
+	protected String removeDocLineIntros(String textWithSlashes) {
 		String lineBreakGroup= "(\\r\\n?|\\n)"; //$NON-NLS-1$
 		String noBreakSpace= "[^\r\n&&\\s]"; //$NON-NLS-1$
-		return textWithStars.replaceAll(lineBreakGroup + noBreakSpace + "///" /*+ noBreakSpace + '?'*/, "$1"); //$NON-NLS-1$ //$NON-NLS-2$
+		return textWithSlashes.replaceAll(lineBreakGroup + noBreakSpace + "*///" /*+ noBreakSpace + '?'*/, "$1"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	@Override
+	protected void handleLink(List<? extends ASTNode> fragments) {
+		if (fragments.size() == 2 && fragments.get(0) instanceof TextElement) {
+			// super method expects the reference as first fragment, optional label as second fragment
+			fragments= Arrays.asList(fragments.get(1), fragments.get(0));
+		}
+		super.handleLink(fragments);
 	}
 
 	@Override
 	protected String getBlockTagStart() {
+		this.fBlockDepth++;
 		return "\n"+super.getBlockTagStart(); //$NON-NLS-1$
 	}
 
 	@Override
-	public String toHTML() {
-		String content = super.toHTML();
-		Parser parser = Parser.builder().build();
-		Node document = parser.parse(content);
-		HtmlRenderer renderer = HtmlRenderer.builder().build();
-		return renderer.render(document);
+	protected String getBlockTagEnd() {
+		if (this.fBlockDepth > 0)
+			this.fBlockDepth--;
+		return super.getBlockTagEnd();
 	}
 
+	@Override
+	protected void handleContentElements(List<? extends ASTNode> nodes, boolean skipLeadingWhitespace, TagElement tagElement) {
+		int start= fBuf.length();
+		super.handleContentElements(nodes, skipLeadingWhitespace, tagElement);
+		if (this.fBlockDepth > 0) {
+			// inside an HTML block the markdown content must be rendered now
+			String generated= fBuf.substring(start); // extract new part of fBuf
+			Node node= fParser.parse(generated);
+			if (node.getFirstChild() instanceof Paragraph para && para.getNext() == null) {
+				// inside block replace single paragraph with its children
+				node= eliminateContainerNode(para);
+			}
+			String rendered= fRenderer.render(node);
+			fBuf.replace(start, fBuf.length(), rendered); // replace new part with its rendered version
+		}
+	}
+
+	/** Return a new Document containing all children of the given container node. */
+	protected Node eliminateContainerNode(Node container) {
+		List<Node> children= new ArrayList<>();
+		for (Node child= container.getFirstChild(); child != null; child= child.getNext()) {
+			children.add(child);
+		}
+		Document doc= new Document();
+		for (Node child2 : children) {
+			doc.appendChild(child2);
+		}
+		return doc;
+	}
+
+	@Override
+	public String toHTML() {
+		String content= super.toHTML();
+		Node document= fParser.parse(content);
+		return fRenderer.render(document);
+	}
 }

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/JavadocLookup.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/JavadocLookup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,12 @@ public class JavadocLookup {
 	public static final IJavadocContentFactory DEFAULT_FACTORY= new IJavadocContentFactory() {
 		@Override
 		public IJavadocAccess createJavadocAccess(IJavaElement element, Javadoc javadoc, String source, JavadocLookup lookup) {
+			if (source.startsWith("///")) { //$NON-NLS-1$
+				if (lookup == null)
+					return new CoreMarkdownAccessImpl(element, javadoc, source);
+				else
+					return new CoreMarkdownAccessImpl(element, javadoc, source, lookup);
+			}
 			if (lookup == null)
 				return new CoreJavadocAccessImpl(element, javadoc, source);
 			else

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
@@ -32,6 +32,7 @@ import org.eclipse.jdt.ui.tests.callhierarchy.CallHierarchyContentProviderTest;
 import org.eclipse.jdt.ui.tests.core.CoreTestSuite;
 import org.eclipse.jdt.ui.tests.core.CoreTests;
 import org.eclipse.jdt.ui.tests.hover.JavadocHoverTests;
+import org.eclipse.jdt.ui.tests.hover.MarkdownCommentTests;
 import org.eclipse.jdt.ui.tests.hover.PackageJavadocTests;
 import org.eclipse.jdt.ui.tests.jarexport.JarExportTests;
 import org.eclipse.jdt.ui.tests.model.ContentProviderTests;
@@ -82,6 +83,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 	JarExportTests.class,
 	PackageJavadocTests.class,
 	JavadocHoverTests.class,
+	MarkdownCommentTests.class,
 	SmokeViewsTest.class
 })
 public class AutomatedSuite {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -1,0 +1,545 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.hover;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import org.eclipse.jface.text.Region;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.ISourceReference;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+
+import org.eclipse.jdt.ui.tests.core.CoreTests;
+import org.eclipse.jdt.ui.tests.core.rules.Java17ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+import org.eclipse.jdt.internal.ui.text.java.hover.JavadocBrowserInformationControlInput;
+import org.eclipse.jdt.internal.ui.text.java.hover.JavadocHover;
+
+public class MarkdownCommentTests extends CoreTests {
+
+	@Rule
+	public ProjectTestSetup pts= new Java17ProjectTestSetup("TestSetupProject", true);
+
+	private IJavaProject fJProject1;
+
+	// copies from CoreJavaElementLinks
+	private static final char LINK_SEPARATOR= '\u2602';
+	private static final char LINK_BRACKET_REPLACEMENT= '\u2603';
+
+	// copies from JavaElement:
+	static final char JEM_JAVAPROJECT= '=';
+	static final char JEM_PACKAGEFRAGMENTROOT= '/';
+	static final char JEM_PACKAGEFRAGMENT= '<';
+	static final char JEM_FIELD= '^';
+	static final char JEM_METHOD= '~';
+	static final char JEM_COMPILATIONUNIT= '{';
+	static final char JEM_TYPE= LINK_BRACKET_REPLACEMENT; // replacement for '['
+
+	@Before
+	public void setUp() throws Exception {
+		fJProject1= pts.getProject();
+		JavaProjectHelper.addSourceContainer(fJProject1, "src");
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		JavaProjectHelper.clear(fJProject1, pts.getDefaultClasspath());
+	}
+
+	protected ICompilationUnit getWorkingCopy(String path, String source, WorkingCopyOwner owner) throws JavaModelException {
+		ICompilationUnit workingCopy= (ICompilationUnit) JavaCore.create(getFile(path));
+		if (owner != null)
+			workingCopy= workingCopy.getWorkingCopy(owner, null/*no progress monitor*/);
+		else
+			workingCopy.becomeWorkingCopy(null/*no progress monitor*/);
+		workingCopy.getBuffer().setContents(source);
+		workingCopy.makeConsistent(null/*no progress monitor*/);
+		return workingCopy;
+	}
+
+	protected IFile getFile(String path) {
+		IWorkspaceRoot root= ResourcesPlugin.getWorkspace().getRoot();
+		return root.getFile(new Path(path));
+	}
+
+	private String makeEncodedClassUri(String pack, String cuName, String clazz) {
+		try {
+			StringBuilder buf= new StringBuilder();
+			buf.append(LINK_SEPARATOR);
+			buf.append(JEM_JAVAPROJECT).append("TestSetupProject");
+			buf.append(JEM_PACKAGEFRAGMENTROOT).append("src");
+			buf.append(JEM_PACKAGEFRAGMENT).append(pack);
+			buf.append(JEM_COMPILATIONUNIT).append(cuName).append(".java");
+			buf.append(JEM_TYPE).append(clazz);
+			URI uri= new URI("eclipse-javadoc", buf.toString(), null);
+			return uri.toASCIIString();
+		} catch (URISyntaxException e) {
+			fail(e);
+			return null;
+		}
+	}
+
+	/** Create a javadoc link to the specified method. */
+	private String makeEncodedMethodUri(String pack, String cuName, String clazz, String selector, String... parameters) {
+		return makeEncodedMethodUri(false, pack, cuName, clazz, selector, parameters);
+	}
+	/** Create a javadoc link for the specified method.
+	 * @param asScopeURI when {@code true} the link is intended as a scope prefix for {@link #makeEncodedRelativeUri(String, String...)}.
+	 */
+	private String makeEncodedMethodUri(boolean asScopeURI, String pack, String cuName, String clazz, String selector, String... parameters) {
+		try {
+			StringBuilder buf= new StringBuilder();
+			buf.append(LINK_SEPARATOR);
+			buf.append(JEM_JAVAPROJECT).append("TestSetupProject");
+			buf.append(JEM_PACKAGEFRAGMENTROOT).append("src");
+			buf.append(JEM_PACKAGEFRAGMENT).append(pack);
+			buf.append(JEM_COMPILATIONUNIT).append(cuName).append(".java");
+			buf.append(JEM_TYPE).append(clazz);
+
+			if (asScopeURI) {
+				buf.append(JEM_METHOD);
+			} else {
+				buf.append(LINK_SEPARATOR);
+				buf.append(LINK_SEPARATOR);
+			}
+			buf.append(selector);
+			for (String parameter : parameters) {
+				if (asScopeURI) {
+					buf.append(JEM_METHOD);
+				} else {
+					buf.append(LINK_SEPARATOR);
+				}
+				buf.append(parameter);
+			}
+			URI uri= new URI("eclipse-javadoc", buf.toString(), null);
+			return uri.toASCIIString();
+		} catch (URISyntaxException e) {
+			fail(e);
+			return null;
+		}
+	}
+
+	/** Create a javadoc link to the element specified by moreWords as seen from the scope specified by scopeURI. */
+	private String makeEncodedRelativeUri(String scopeURI, String... moreWords) {
+		try {
+			StringBuilder buf= new StringBuilder(scopeURI);
+			for (String parameter : moreWords) {
+				buf.append(LINK_SEPARATOR).append(parameter);
+			}
+			URI uri= new URI(buf.toString());
+			return uri.toASCIIString();
+		} catch (URISyntaxException e) {
+			fail(e);
+			return null;
+		}
+	}
+
+	private <T extends ISourceReference & IJavaElement> String getHoverHtmlContent(ICompilationUnit cu, T element) throws JavaModelException {
+		ISourceRange range= element.getNameRange();
+		JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(
+				new IJavaElement[] { element },
+				cu,
+				new Region(range.getOffset(), range.getLength()),
+				null);
+		return hoverInfo.getHtml();
+	}
+
+	/** Strips standard head and tail of actualContent for convenient assertEquals() comparison. */
+	private void assertHtmlContent(String expectedContent, String actualContent) {
+		int start= actualContent.indexOf("<a class='header'");
+		String headerTail= "</div></h5><br><p>";
+		start= actualContent.indexOf(headerTail, start);
+		int end= actualContent.lastIndexOf("</body></html>");
+		assertEquals(expectedContent, actualContent.substring(start+headerTail.length(), end));
+	}
+
+	@Test
+	public void testBasicFormatting() throws Exception {
+		String source= """
+				package p;
+				/// ## TestClass
+				///
+				/// Paragraph
+				///
+				/// - item 1
+				/// - _item 2_
+				public class TestClass {
+					/// ### m()
+					///
+					/// Paragraph with _emphasis_
+					/// - item 1
+					/// - item 2
+					/// @param i an _integer_ !
+					void m(int i) {
+					}
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/TestClass.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		IType type= cu.getType("TestClass");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+
+		assertHtmlContent("""
+				<h2>TestClass</h2>
+				<p>Paragraph</p>
+				<ul>
+				<li>item 1</li>
+				<li><em>item 2</em></li>
+				</ul>
+				""",
+				actualHtmlContent);
+
+		IMethod elem= type.getMethods()[0];
+		actualHtmlContent= getHoverHtmlContent(cu, elem);
+
+		assertHtmlContent("""
+				<h3>m()</h3>
+				<p>Paragraph with <em>emphasis</em></p>
+				<ul>
+				<li>item 1</li>
+				<li>item 2</li>
+				</ul>
+				<dl><dt>Parameters:</dt><dd><b>i</b> an <em>integer</em> !</dd></dl>
+				""",
+				actualHtmlContent);
+	}
+
+	@Test
+	public void testItemAtEnd() throws Exception {
+		String source= """
+				package p;
+				/// - item 1
+				/// - item 2
+				public class TestClass {
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/TestClass.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		IType type= cu.getType("TestClass");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+		assertHtmlContent("""
+				<ul>
+				<li>item 1</li>
+				<li>item 2</li>
+				</ul>
+				""",
+				actualHtmlContent);
+	}
+
+	@Test
+	public void testMarkdownLink1() throws Exception {
+		String source= """
+				package p;
+				/// ## TestClass
+				///
+				/// Please have a _look at [#m1(int)]_ if you like.
+				public class TestClass {
+					public void m1(int i) {}
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/TestClass.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		String expectedURI= makeEncodedMethodUri("p", "TestClass", "TestClass", "m1", "int");
+		String expectedHtmlContent= """
+				<h2>TestClass</h2>
+				<p>Please have a <em>look at <code><a href='URI'>m1(int)</a></code></em> if you like.</p>
+				"""
+				.replace("URI", expectedURI);
+
+		IType type= cu.getType("TestClass");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+		assertHtmlContent(expectedHtmlContent, actualHtmlContent);
+	}
+
+	@Test
+	public void testMarkdownLink2() throws Exception {
+		String source= """
+				package p;
+				/// ## TestClass
+				///
+				/// Please have a _look at [method 1][#m1(int)]_ if you like.
+				public class TestClass {
+					public void m1(int i) {}
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/TestClass.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		String expectedURI= makeEncodedMethodUri("p", "TestClass", "TestClass", "m1", "int");
+		String expectedHtmlContent= """
+				<h2>TestClass</h2>
+				<p>Please have a <em>look at <code><a href='URI'>method 1</a></code></em> if you like.</p>
+				"""
+				.replace("URI", expectedURI);
+
+		IType type= cu.getType("TestClass");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+		assertHtmlContent(expectedHtmlContent, actualHtmlContent);
+	}
+
+	@Test
+	public void testSpec01Links() throws CoreException {
+		String source= """
+				package p;
+				public class Spec01Links {
+
+					/// - a module [java.base/]
+					/// - a package [java.util]
+					/// - a class [String]
+					/// - a field [String#CASE_INSENSITIVE_ORDER]
+					/// - a method [String#chars()]
+					public void plainLinks() {
+
+					}
+
+					/// - [the `java.base` module][java.base/]
+					/// - [the `java.util` package][java.util]
+					/// - [a class][String]
+					/// - [a field][String#CASE_INSENSITIVE_ORDER]
+					/// - [a method][String#chars()]
+					public void linksDisplayString() {
+
+					}
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Spec01Links.java", source, null);
+		assertNotNull("Spec01Links.java", cu);
+		IType type= cu.getType("Spec01Links");
+
+		String plainLinksURI= makeEncodedMethodUri(true, "p", "Spec01Links", "Spec01Links", "plainLinks");
+		String moduleURI= makeEncodedRelativeUri(plainLinksURI, "java.base/");
+		String packageURI= makeEncodedRelativeUri(plainLinksURI, "java.util");
+		String classURI= makeEncodedRelativeUri(plainLinksURI, "String");
+		String fieldURI= makeEncodedRelativeUri(plainLinksURI, "String", "CASE_INSENSITIVE_ORDER");
+		String methodURI= makeEncodedRelativeUri(plainLinksURI, "String", "chars", "");
+		String expectedHtmlContent= """
+				<ul>
+				<li>a module <code><a href='MODULE_URI'>java.base/</a></code></li>
+				<li>a package <code><a href='PACKAGE_URI'>java.util</a></code></li>
+				<li>a class <code><a href='CLASS_URI'>String</a></code></li>
+				<li>a field <code><a href='FIELD_URI'>String.CASE_INSENSITIVE_ORDER</a></code></li>
+				<li>a method <code><a href='METHOD_URI'>String.chars()</a></code></li>
+				</ul>
+				"""
+				.replace("MODULE_URI", moduleURI)
+				.replace("PACKAGE_URI", packageURI)
+				.replace("CLASS_URI", classURI)
+				.replace("FIELD_URI", fieldURI)
+				.replace("METHOD_URI", methodURI);
+
+		IMethod method= type.getMethod("plainLinks", new String[0]);
+		String actualHtmlContent= getHoverHtmlContent(cu, method);
+		assertHtmlContent(expectedHtmlContent, actualHtmlContent);
+
+		expectedHtmlContent= """
+				<ul>
+				<li><code><a href='MODULE_URI'>the <code>java.base</code> module</a></code></li>
+				<li><code><a href='PACKAGE_URI'>the <code>java.util</code> package</a></code></li>
+				<li><code><a href='CLASS_URI'>a class</a></code></li>
+				<li><code><a href='FIELD_URI'>a field</a></code></li>
+				<li><code><a href='METHOD_URI'>a method</a></code></li>
+				</ul>
+				"""
+				.replace("MODULE_URI", moduleURI)
+				.replace("PACKAGE_URI", packageURI)
+				.replace("CLASS_URI", classURI)
+				.replace("FIELD_URI", fieldURI)
+				.replace("METHOD_URI", methodURI)
+				.replaceAll("plainLinks", "linksDisplayString"); // rebase all links to be relative to linksDisplayString
+		method= type.getMethod("linksDisplayString", new String[0]);
+		actualHtmlContent= getHoverHtmlContent(cu, method);
+		assertHtmlContent(expectedHtmlContent, actualHtmlContent);
+	}
+
+	@Test
+	public void testSpec02Table() throws CoreException {
+		String source= """
+				package p;
+
+				/// | Latin | Greek |
+				/// |-------|-------|
+				/// | a     | alpha |
+				/// | b     | beta  |
+				/// | c     | gamma |
+				public class Spec02Table {
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Spec02Table.java", source, null);
+		assertNotNull("Spec02Table.java", cu);
+
+		IType type= cu.getType("Spec02Table");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+		assertHtmlContent("""
+				<table>
+				<thead>
+				<tr>
+				<th>Latin</th>
+				<th>Greek</th>
+				</tr>
+				</thead>
+				<tbody>
+				<tr>
+				<td>a</td>
+				<td>alpha</td>
+				</tr>
+				<tr>
+				<td>b</td>
+				<td>beta</td>
+				</tr>
+				<tr>
+				<td>c</td>
+				<td>gamma</td>
+				</tr>
+				</tbody>
+				</table>
+				""",
+				actualHtmlContent);
+	}
+
+	@Test
+	public void testSpec03Tags() throws CoreException {
+		String source= """
+				package p;
+				class Super {
+					/// super doc
+					public void m(int i) {}
+				}
+				public class Spec03Tags extends Super {
+
+					/// {@inheritDoc}
+					/// In addition, this methods calls [#wait()].
+					///
+					/// @param i the index
+					public void m(int i) {}
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Spec03Tags.java", source, null);
+		assertNotNull("Spec03Tags.java", cu);
+
+		String mURI= makeEncodedMethodUri(true, "p", "Spec03Tags", "Spec03Tags","m", "I");
+		String waitURI= makeEncodedRelativeUri(mURI, "", "wait", "");
+		String superURI= makeEncodedClassUri("p", "Spec03Tags", "Super");
+		String superMURI= makeEncodedMethodUri(true, "p", "Spec03Tags", "Super","m", "I");
+		String expectedContent= """
+				<p>super doc
+				In addition, this methods calls <code><a href='METHOD_URI'>wait()</a></code>.<div><b>Overrides:</b> <a href='SUPER_M_URI'>m(...)</a> in <a href='SUPER_URI'>Super</a></div></p>
+				<dl><dt>Parameters:</dt><dd><b>i</b> the index</dd></dl>
+				"""
+				.replace("METHOD_URI", waitURI)
+				.replace("SUPER_M_URI", superMURI)
+				.replace("SUPER_URI", superURI);
+
+		IType type= cu.getType("Spec03Tags");
+		IMethod method= type.getMethod("m", new String[] { "I" });
+		String actualHtmlContent= getHoverHtmlContent(cu, method);
+		assertHtmlContent(expectedContent, actualHtmlContent);
+	}
+
+	@Test
+	@Ignore("https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2808")
+	public void testSpec04Code() throws CoreException {
+		String source= """
+				/// The following code span contains literal text, and not a JavaDoc tag:
+				/// `{@inheritDoc}`
+				///
+				/// In the following indented code block, `@Override` is an annotation,
+				/// and not a JavaDoc tag:
+				///
+				///     @Override
+				///     public void m() ...
+				///
+				/// Likewise, in the following fenced code block, `@Override` is an annotation,
+				/// and not a JavaDoc tag:
+				///
+				/// ```
+				/// @Override
+				/// public void m() ...
+				/// ```
+				public class Spec04Code {
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Spec04Code.java", source, null);
+		assertNotNull("Spec04Code.java", cu);
+
+		String expectedContent= """
+				<p>The following code span contains literal text, and not a JavaDoc tag:
+				<code>{@inheritDoc}</code></p>
+				<p>In the following indented code block, <code>@Override</code> is an annotation,
+				and not a JavaDoc tag:</p>
+				<pre><code>@Override
+				public void m() ...</code></pre>
+				<p>Likewise, in the following fenced code block, <code>@Override</code> is an annotation,
+				and not a JavaDoc tag:</p>
+				<pre><code>@Override
+				public void m() ...</code></pre>
+				""";
+		IType type= cu.getType("Spec04Code");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+		assertHtmlContent(expectedContent, actualHtmlContent);
+	}
+
+	@Test
+	public void testSpec05TextInTag() throws CoreException {
+		String source= """
+				import java.util.List;
+
+				public class Spec05TextInTag {
+					/// @param l   the list, or `null` if no list is available
+					public void m(List<String> l) {}
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Spec05TextInTag.java", source, null);
+		assertNotNull("Spec05TextInTag.java", cu);
+
+		IType type= cu.getType("Spec05TextInTag");
+		IMethod method= type.getMethods()[0];
+		String actualHtmlContent= getHoverHtmlContent(cu, method);
+		assertHtmlContent("""
+				<dl><dt>Parameters:</dt><dd><b>l</b> the list, or <code>null</code> if no list is available</dd></dl>
+				""",
+				actualHtmlContent);
+	}
+}


### PR DESCRIPTION
Reverts eclipse-jdt/eclipse.jdt.ui#1585

add dependency org.commonmark incl. extension for tables
    use it for rendering
        markdown variant is detected by inspecting the raw javadoc text, might be replaced by new API in DOM
    minimal tests incl. examples from the specification in https://openjdk.org/jeps/467

fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1472