### PR TITLE
Add outer class checking to Pull Up Refactoring

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1573,6 +1573,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String PullUpRefactoring_final_fields;
 
+	public static String PullUpRefactoring_inaccessible_outer_fields;
+
 	public static String PullUpRefactoring_incompatible_langauge_constructs;
 
 	public static String PullUpRefactoring_incompatible_language_constructs1;
@@ -2496,6 +2498,7 @@ public final class RefactoringCoreMessages extends NLS {
 	public static String UseSupertypeWherePossibleRefactoring_name;
 
 	public static String ChangeSignatureRefactoring_lambda_expression;
+
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, RefactoringCoreMessages.class);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -676,6 +676,7 @@ PullUpRefactoring_Type_variable3_not_available=The type parameters ''{0}'', ''{1
 PullUpRefactoring_Type_variables_not_available=Several type parameters cannot be mapped to the super type ''{0}''
 PullUpRefactoring_non_final_pull_up_to_interface=Moving non-final fields to an interface will result in compile errors if they are not initialized on creation or in constructors
 PullUpRefactoring_incompatible_langauge_constructs=Moving ''{0}'' which contains annotations to destination type ''{1}'' will result in compile errors, since the destination is not J2SE 5.0 compatible.
+PullUpRefactoring_inaccessible_outer_fields=Cannot pull up ''{0}'' to ''{1}'' due to outer class reference to ''{2}'' that will be inaccessible after move  
 PullUpRefactoring_incompatible_language_constructs1=Moving ''{0}'' which contains varargs to destination type ''{1}'' will result in compile errors, since the destination is not J2SE 5.0 compatible.
 PullUpRefactoring_moving_static_method_to_interface=Moving ''{0}'' which is declared ''static'' will result in compile errors, since the interface method is hidden by the static method.
 PullUpRefactoring_moving_fromto_default_package=Moving ''{0}'' will result in compile errors, since source or target is in default package.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test61/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test61/in/A.java
@@ -1,0 +1,18 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+		
+	}
+	public class Outer {
+		static int x;
+		public void f() {}
+		
+		public class B extends C {
+			public void foo() {
+				y = 7;
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test61/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test61/out/A.java
@@ -1,0 +1,19 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+
+		public void foo() {
+			y = 7;
+		}
+		
+	}
+	public class Outer {
+		static int x;
+		public void f() {}
+		
+		public class B extends C {
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test62/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test62/in/A.java
@@ -1,0 +1,18 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+		
+	}
+	public class Outer {
+		static int x;
+		public void f() {}
+		
+		public class B extends C {
+			public void foo() {
+				Outer.x = 7;
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test62/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test62/out/A.java
@@ -1,0 +1,19 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+
+		public void foo() {
+			Outer.x = 7;
+		}
+		
+	}
+	public class Outer {
+		static int x;
+		public void f() {}
+		
+		public class B extends C {
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail30/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail30/in/A.java
@@ -1,0 +1,18 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class B2 {
+		
+	}
+	public class Outer {
+		int x;
+		public void f() {}
+		
+		public class B extends B2 {
+			public void foo() {
+				System.out.println(x);
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail31/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail31/in/A.java
@@ -1,0 +1,18 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+		
+	}
+	public class Outer {
+		int x;
+		public void f() {}
+		
+		public class B extends C {
+			public void foo() {
+				Outer.this.x = 3;
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail32/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail32/in/A.java
@@ -1,0 +1,18 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+		
+	}
+	public class Outer {
+		int x;
+		public void f() {}
+		
+		public class B extends C {
+			public void foo() {
+				f();
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail33/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail33/in/A.java
@@ -1,0 +1,18 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+		
+	}
+	public class Outer {
+		int x;
+		public void f() {}
+		
+		public class B extends C {
+			public void foo() {
+				Outer.this.f();
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail34/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail34/in/A.java
@@ -1,0 +1,18 @@
+package p;
+
+public class A {
+	public int y = 1;
+	public class C {
+		
+	}
+	public class Outer {
+		static int x;
+		public void f() {}
+		
+		public class B extends C {
+			public void foo() {
+				x = 7;
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1483,6 +1483,16 @@ public class PullUpTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void test61() throws Exception {
+		helper1(new String[] { "foo" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
+	@Test
+	public void test62() throws Exception {
+		helper1(new String[] { "foo" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
+	@Test
 	public void testFail0() throws Exception {
 //		printTestDisabledMessage("6538: searchDeclarationsOf* incorrect");
 		helper2(new String[] { "m" }, new String[][] { new String[0] }, true, false, 0);
@@ -1820,6 +1830,31 @@ public class PullUpTests extends GenericRefactoringTest {
 	@Test
 	public void testFail29() throws Exception {
 		helper2(new String[] { "stop" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
+	@Test
+	public void testFail30() throws Exception {
+		helper2(new String[] { "foo" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
+	@Test
+	public void testFail31() throws Exception {
+		helper2(new String[] { "foo" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
+	@Test
+	public void testFail32() throws Exception {
+		helper2(new String[] { "foo" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
+	@Test
+	public void testFail33() throws Exception {
+		helper2(new String[] { "foo" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
+	@Test
+	public void testFail34() throws Exception {
+		helper2(new String[] { "foo" }, new String[][] { new String[0] }, true, false, 0);
 	}
 
 	//----------------------------------------------------------


### PR DESCRIPTION
- add new checking if PullUpRefactoringProcessor to check for an inner class referring to an outer class field or method that will be inaccessible after the pull up
- add new tests to PullUpTests
- fixes #1533

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
