### PR TITLE
Fix PullUp refactoring to handle implemented interfaces

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.21.200.qualifier
+Bundle-Version: 1.21.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PullUpRefactoringProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PullUpRefactoringProcessor.java
@@ -1647,7 +1647,10 @@ public class PullUpRefactoringProcessor extends HierarchyProcessor {
 							final AbstractTypeDeclaration declaration= ASTNodeSearchUtil.getAbstractTypeDeclarationNode(destination, rewrite.getRoot());
 							ModifierRewrite.create(rewriter, declaration).setModifiers(declaration.getModifiers() | Modifier.ABSTRACT, rewrite.createCategorizedGroupDescription(RefactoringCoreMessages.PullUpRefactoring_make_target_abstract, SET_PULL_UP));
 						}
-						final TypeVariableMaplet[] mapping= TypeVariableUtil.subTypeToSuperType(getDeclaringType(), destination);
+						TypeVariableMaplet[] mapping= TypeVariableUtil.subTypeToSuperType(getDeclaringType(), destination);
+						if (mapping.length == 0 && destination.isInterface()) {
+							mapping= TypeVariableUtil.subTypeToImplementedType(getDeclaringType(), destination);
+						}
 						final SubMonitor subsub= sub.newChild(1);
 						final AbstractTypeDeclaration declaration= ASTNodeSearchUtil.getAbstractTypeDeclarationNode(destination, rewrite.getRoot());
 						ImportRewriteContext context= new ContextSensitiveImportRewriteContext(declaration, rewrite.getImportRewrite());

--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.15.500.qualifier
+Bundle-Version: 3.15.600.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.15.500-SNAPSHOT</version>
+  <version>3.15.600-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testGenericsTypeParameterRename/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testGenericsTypeParameterRename/in/A.java
@@ -1,0 +1,11 @@
+package p;
+
+public class A {
+    public interface Bar<T> { }
+
+    public interface Base<T> { }
+
+    public class B<T,U> implements Base<U> {
+    	public void m(Bar<U> bar) { }// pull method foo up to interface Base
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testGenericsTypeParameterRename/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testGenericsTypeParameterRename/out/A.java
@@ -1,0 +1,14 @@
+package p;
+
+public class A {
+    public interface Bar<T> { }
+
+    public interface Base<T> {
+
+		void m(Bar<T> bar); }
+
+    public class B<T,U> implements Base<U> {
+    	@Override
+		public void m(Bar<U> bar) { }// pull method foo up to interface Base
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -275,4 +275,24 @@ public class PullUpTests1d8 extends PullUpTests {
 		assertEqualLines("MainImpl", getFileContents(getOutputTestFileName("MainImpl")), cuMainImpl.getSource());
 		assertEqualLines("OtherImpl", getFileContents(getOutputTestFileName("OtherImpl")), cuOtherImpl.getSource());
 	}
+
+	@Test
+	public void testGenericsTypeParameterRename() throws Exception {
+		String[] selectedMethodNames= { "m" };
+		String[][] selectedMethodSignatures= { new String[] { "QBar<QU;>;" } };
+		String[] selectedFieldNames= {};
+		String[] namesOfMethodsToPullUp= {};
+		String[][] signaturesOfMethodsToPullUp= {};
+		String[] namesOfFieldsToPullUp= {};
+		String[] namesOfMethodsToDeclareAbstract= { "m" };
+		String[][] signaturesOfMethodsToDeclareAbstract= { new String[] { "QBar<QU;>;" } };
+
+		declareAbstractHelper(selectedMethodNames, selectedMethodSignatures,
+				selectedFieldNames,
+				new String[0], namesOfMethodsToPullUp,
+				signaturesOfMethodsToPullUp,
+				namesOfFieldsToPullUp, namesOfMethodsToDeclareAbstract,
+				signaturesOfMethodsToDeclareAbstract, new String[0], false, false, 0);
+	}
+
 }


### PR DESCRIPTION
- add new methods to TypeVariableUtil to get mappings for an implemented interface
- add calls to get new mappings when the mappings are empty for inherited methods
- add new test to PullUpTests1d8
- fixes #1532

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test or issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
