### PR TITLE
Prevent potential `ClassCastException` in 'add service provider' quickfix

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -2650,7 +2650,7 @@ public class LocalCorrectionsSubProcessor {
 
 	public static void addServiceProviderProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) throws CoreException {
 		ASTNode node= problem.getCoveredNode(context.getASTRoot());
-		if (!(node instanceof Name) && !(node.getParent() instanceof ProvidesDirective)) {
+		if (!(node instanceof Name) || !(node.getParent() instanceof ProvidesDirective)) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1598

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Switch `&&` to `||` to prevent a `ClassCastException` in the case that the parent node is not a `ProvidesDirective`.

## How to test
Set a debug point before the line that was changed, and modify the AST so that the parent node is not a `ProvidesDirective`. The method should return on the line after the line that was changed.

I don't have a method to reproduce this without modifying variables in memory, since the bug relies on a faulty error range or AST being generated by the compiler.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
