### PR TITLE
Adapt to new return-type of IExecutionEnvironmentsManager.getSupportedExecutionEnvironments()

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -483,8 +484,9 @@ public class NewJavaProjectWizardPageOne extends WizardPage {
 				return Policy.getComparator().compare(i0.getName(), i1.getName());
 			});
 
-			List<IExecutionEnvironment> environments= JavaRuntime.getExecutionEnvironmentsManager().getSupportedExecutionEnvironments();
-			fInstalledEEs= environments.toArray(IExecutionEnvironment[]::new);
+			IExecutionEnvironment[] environments= JavaRuntime.getExecutionEnvironmentsManager().getSupportedExecutionEnvironments().toArray(IExecutionEnvironment[]::new);
+			Collections.reverse(Arrays.asList(environments));
+			fInstalledEEs= environments;
 		}
 
 		public Control createControl(Composite composite) {
@@ -605,7 +607,8 @@ public class NewJavaProjectWizardPageOne extends WizardPage {
 		private String getDefaultEEName() {
 			IVMInstall defaultVM= JavaRuntime.getDefaultVMInstall();
 
-			List<IExecutionEnvironment> environments= JavaRuntime.getExecutionEnvironmentsManager().getSupportedExecutionEnvironments();
+			List<IExecutionEnvironment> environments= new ArrayList<>(JavaRuntime.getExecutionEnvironmentsManager().getSupportedExecutionEnvironments());
+			Collections.reverse(environments);
 			if (defaultVM != null) {
 				for (IExecutionEnvironment environment : environments) {
 					IVMInstall eeDefaultVM= environment.getDefaultVM();


### PR DESCRIPTION
## What it does

Adapt to new return-type of `IExecutionEnvironmentsManager.getSupportedExecutionEnvironments()`, changed in
https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/474.

~Without that change being submitted, this PR's build cannot succeed (and without this, an I-Build with the other PR applied cannot succeed too).~ Without that change this PR leads to wrong display orders of the EEs.


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
