### PR TITLE
Add override checking to Move static member

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/Bindings.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/Bindings.java
@@ -1062,7 +1062,7 @@ public class Bindings {
 
 	//---- Helper methods to convert a method ---------------------------------------------
 
-	private static boolean sameParameters(IMethodBinding method, IMethod candidate) throws JavaModelException {
+	public static boolean sameParameters(IMethodBinding method, IMethod candidate) throws JavaModelException {
 		ITypeBinding[] methodParamters= method.getParameterTypes();
 		String[] candidateParameters= candidate.getParameterTypes();
 		if (methodParamters.length != candidateParameters.length)

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1453,6 +1453,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String MoveMembersRefactoring_only_public_static_18;
 
+	public static String MoveMembersRefactoring_override_ref;
+
 	public static String MoveMembersRefactoring_read_only;
 
 	public static String MoveMembersRefactoring_referenceUpdate;
@@ -2498,7 +2500,6 @@ public final class RefactoringCoreMessages extends NLS {
 	public static String UseSupertypeWherePossibleRefactoring_name;
 
 	public static String ChangeSignatureRefactoring_lambda_expression;
-
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, RefactoringCoreMessages.class);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -700,6 +700,7 @@ MoveMembersRefactoring_member_will_be_public=Moved member will be public in the 
 MoveMembersRefactoring_multi_var_fields=Only field declarations with single variable declaration fragments can be moved.
 MoveMembersRefactoring_only_public_static=Only 'public static' types and 'public static final' fields with variable initializers can be moved to an interface.
 MoveMembersRefactoring_only_public_static_18=Only 'public static' types, 'public static' methods and 'public static final' fields with variable initializers can be moved to an interface.
+MoveMembersRefactoring_override_ref=Moving member to ''{0}'' will override references to ''{1}'' from ''{2}''
 MoveMembersRefactoring_Object=Move is not allowed on members declared in 'java.lang.Object'.
 MoveMembersRefactoring_binary=Pull up is not allowed on members of binary types.
 MoveMembersRefactoring_read_only=Pull up is not allowed on members of read-only types.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail25/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail25/in/A.java
@@ -1,0 +1,5 @@
+package p;
+
+public class A {
+	static int m = 3;
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail25/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail25/in/B.java
@@ -1,0 +1,12 @@
+package p;
+
+class C {
+	static int m = 7;
+}
+
+public class B extends C {
+	
+	public void foo() {
+		System.out.println(m);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail26/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail26/in/A.java
@@ -1,0 +1,7 @@
+package p;
+
+public class A {
+	static int m() {
+		return 3;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail26/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/testFail26/in/B.java
@@ -1,0 +1,14 @@
+package p;
+
+class C {
+	static int m() {
+		return 7;
+	}
+}
+
+public class B extends C {
+	
+	public void foo() {
+		System.out.println(m());
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
@@ -707,6 +707,24 @@ public class MoveMembersTests extends GenericRefactoringTest {
 				RefactoringStatus.FATAL, "p.B");
 	}
 
+	@Test
+	public void testFail25() throws Exception { // test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1530
+		// Move a static field that will override another field in the hierarchy that is referenced
+		fieldMethodTypeHelper_failing(new String[] {"m"},
+				new String[0], new String[][] {new String[0]},
+				new String[0],
+				RefactoringStatus.ERROR, "p.B");
+	}
+
+	@Test
+	public void testFail26() throws Exception { // test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1530
+		// Move a static method that will override another method in the hierarchy that is referenced
+		fieldMethodTypeHelper_failing(new String[0],
+				new String[] {"m"}, new String[][] {new String[0]},
+				new String[0],
+				RefactoringStatus.ERROR, "p.B");
+	}
+
 	// Delegate creation
 
 	@Test


### PR DESCRIPTION
- add logic to MoveStaticMembersProcessor to test if moving the member will override a reference to a member of the same name that the target class is referencing
- add new tests to MoveMemberTests
- fixes #1530

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
