### PR TITLE
[23] Highlight 'module' in module imports

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractSemanticHighlightingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractSemanticHighlightingTest.java
@@ -36,6 +36,7 @@ import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.SourceViewer;
 
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
 
@@ -66,6 +67,14 @@ public class AbstractSemanticHighlightingTest {
 			fEditor= (JavaEditor) EditorTestHelper.openInEditor(ResourceTestHelper.findFile(fTestFilename), true);
 			fSourceViewer= EditorTestHelper.getSourceViewer(fEditor);
 			assertTrue(EditorTestHelper.joinReconciler(fSourceViewer, 0, 10000, 100));
+		}
+
+		public void updateCompliance(String compliance, boolean enablePreview) {
+			fJavaProject.setOption(JavaCore.COMPILER_SOURCE, compliance);
+			fJavaProject.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, compliance);
+			fJavaProject.setOption(JavaCore.COMPILER_COMPLIANCE, compliance);
+			fJavaProject.setOption(JavaCore.COMPILER_RELEASE, JavaCore.ENABLED);
+			fJavaProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, enablePreview ? JavaCore.ENABLED: JavaCore.DISABLED);
 		}
 
 		protected String getTestFilename() {
@@ -147,7 +156,7 @@ public class AbstractSemanticHighlightingTest {
 	protected void setUpSemanticHighlighting(String semanticHighlighting) {
 		enableSemanticHighlighting(semanticHighlighting);
 		EditorTestHelper.forceReconcile(fSourceViewer);
-		assertTrue(EditorTestHelper.joinReconciler(fSourceViewer, 0, 10000, 100));
+		assertTrue(EditorTestHelper.joinReconciler(fSourceViewer, 0, -1, 100));
 		EditorTestHelper.runEventQueue(100);
 	}
 

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractSemanticHighlightingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractSemanticHighlightingTest.java
@@ -156,7 +156,7 @@ public class AbstractSemanticHighlightingTest {
 	protected void setUpSemanticHighlighting(String semanticHighlighting) {
 		enableSemanticHighlighting(semanticHighlighting);
 		EditorTestHelper.forceReconcile(fSourceViewer);
-		assertTrue(EditorTestHelper.joinReconciler(fSourceViewer, 0, -1, 100));
+		assertTrue(EditorTestHelper.joinReconciler(fSourceViewer, 0, 10000, 100));
 		EditorTestHelper.runEventQueue(100);
 	}
 

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/Java23SemanticHighlightingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/Java23SemanticHighlightingTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Stephan Herrmann - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.text.tests;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jface.text.Position;
+
+import org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightingsCore;
+
+public class Java23SemanticHighlightingTest extends AbstractSemanticHighlightingTest {
+
+	@Rule
+	public SemanticHighlightingTestSetup shts= new SemanticHighlightingTestSetup( "/SHTest/src/Java23.java");
+
+	@Before
+	public void updateCompliance() {
+		shts.updateCompliance("23", true);
+	}
+
+	@Test
+	public void restrictedKeywordHighlighting() throws Exception {
+		setUpSemanticHighlighting(SemanticHighlightingsCore.RESTRICTED_KEYWORDS);
+		Position[] expected= new Position[] {
+				createPosition(0, 7, 6), // module (import modifier)
+				createPosition(3, 1, 6), // sealed
+				createPosition(3, 8, 6), // record
+				createPosition(6, 1, 10),// non-sealed
+				createPosition(8, 2, 3), // var
+		};
+		Position[] actual= getSemanticHighlightingPositions();
+		assertEqualPositions(expected, actual);
+	}
+}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
@@ -53,6 +53,7 @@ import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
 	SpellCheckEngineTestCase.class,
 	SemanticHighlightingTest.class,
 	AutoboxingSemanticHighlightingTest.class,
+	Java23SemanticHighlightingTest.class,
 	NewForLoopJavaContextTest.class,
 	IteratorForLoopJavaContextTest.class,
 	ArrayWithTempVarForLoopJavaContextTest.class,

--- a/org.eclipse.jdt.text.tests/testResources/semanticHighlightingTest1/Java23.java
+++ b/org.eclipse.jdt.text.tests/testResources/semanticHighlightingTest1/Java23.java
@@ -1,0 +1,11 @@
+import module java.base;
+
+public class Java23 {
+	sealed record SampleRecord(String left, String right) {
+		
+	}
+	non-sealed interface NSI {}
+	void m() {
+		var var = "Hello";
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightingReconciler.java
@@ -212,24 +212,27 @@ public class SemanticHighlightingReconciler implements IJavaReconcilingListener,
 		@Override
 		public boolean visit(Modifier node) {
 			AST ast= node.getAST();
+			int offset= node.getStartPosition();
+			int length = 0;
+			ModifierKeyword keyword= node.getKeyword();
 			if (ASTHelper.isSealedTypeSupportedInAST(ast)) {
-				ModifierKeyword keyword= node.getKeyword();
-				int offset= node.getStartPosition();
-				int length;
 				if (keyword == ModifierKeyword.SEALED_KEYWORD) {
 					length= 6;
 				} else if (keyword == ModifierKeyword.NON_SEALED_KEYWORD) {
 					length= 10;
-				} else {
-					return true;
 				}
-				if (offset > -1 && length > 0) {
-					for (int i= 0; i < fJobSemanticHighlightings.length; i++) {
-						SemanticHighlighting semanticHighlighting= fJobSemanticHighlightings[i];
-						if (semanticHighlighting instanceof RestrictedIdentifiersHighlighting) {
-							addPosition(offset, length, fJobHighlightings[i]);
-							return false;
-						}
+			}
+			if (length == 0 && ast.apiLevel() >= AST.JLS23) {
+				if (keyword == ModifierKeyword.MODULE_KEYWORD) {
+					length= 6;
+				}
+			}
+			if (offset > -1 && length > 0) {
+				for (int i= 0; i < fJobSemanticHighlightings.length; i++) {
+					SemanticHighlighting semanticHighlighting= fJobSemanticHighlightings[i];
+					if (semanticHighlighting instanceof RestrictedIdentifiersHighlighting) {
+						addPosition(offset, length, fJobHighlightings[i]);
+						return false;
 					}
 				}
 			}


### PR DESCRIPTION
Add semantic highlighting for 'module' in an module import declaration (as "Restricted Identifier").

fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1589
