### PR TITLE
[23] search filter dialog should show "In Imports" option for module searches

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/JavaMatchFilter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/JavaMatchFilter.java
@@ -330,6 +330,7 @@ class ImportFilter extends JavaMatchFilter {
 					case IJavaElement.METHOD:
 					case IJavaElement.FIELD:
 					case IJavaElement.PACKAGE_FRAGMENT:
+					case IJavaElement.JAVA_MODULE:
 						isApplicable= true;
 						break;
 					default:


### PR DESCRIPTION
+ ~~also enables a filter if applicable to only one from multi-selection~~

Seeing that filter applicability consistently uses "and" semantics for multi selections also for other filters I reverted that part.

fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1604

