### PR TITLE
Fix inline method to check for super class reference into static method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -49,6 +49,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String CallInliner_field_initializer_simple;
 
+	public static String CallInliner_incompatible_super_call_for_static_method;
+
 	public static String CallInliner_multiDeclaration;
 
 	public static String CallInliner_receiver_type;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -57,6 +57,7 @@ import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
@@ -249,6 +250,13 @@ class SourceAnalyzer  {
 			return true;
 		}
 		@Override
+		public boolean visit(SuperFieldAccess node) {
+			if (fTypeCounter == 0) {
+				fHasSuperFieldAccess= true;
+			}
+			return true;
+		}
+		@Override
 		public boolean visit(SuperConstructorInvocation node) {
 			if (fTypeCounter == 0) {
 				fHasSuperMethodInvocation= true;
@@ -404,6 +412,7 @@ class SourceAnalyzer  {
 
 	private boolean fArrayAccess;
 	private boolean fHasSuperMethodInvocation;
+	private boolean fHasSuperFieldAccess;
 
 	private List<SimpleName> fTypesToImport;
 	private List<SimpleName> fStaticsToImport;
@@ -573,6 +582,10 @@ class SourceAnalyzer  {
 
 	public boolean hasSuperMethodInvocation() {
 		return fHasSuperMethodInvocation;
+	}
+
+	public boolean hasSuperFieldAccess() {
+		return fHasSuperFieldAccess;
 	}
 
 	private ASTNode[] getStatements() {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
@@ -236,6 +236,10 @@ public class SourceProvider {
 		return fAnalyzer.hasSuperMethodInvocation();
 	}
 
+	public boolean hasSuperFieldAccess() {
+		return fAnalyzer.hasSuperFieldAccess();
+	}
+
 	public boolean mustEvaluateReturnedExpression() {
 		return fMustEvalReturnedExpression;
 	}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -217,6 +217,7 @@ CallInliner_multiDeclaration=Cannot inline method used as an initializer in a mu
 CallInliner_simple_functions=Inlining is only possible on simple functions (consisting of a single return statement), or functions used in an assignment.
 CallInliner_field_initializer_simple=In field initializers inlining is only supported for simple functions (e.g. functions consisting of a single return statement).
 CallInliner_field_initialize_new_local=Cannot inline field initializer because new local variable is required.
+CallInliner_incompatible_super_call_for_static_method=Cannot inline super class reference into a static method.
 CallInliner_super_into_this_expression=Cannot inline a super invocation into a this expression.
 CallInliner_field_initialize_write_parameter=Cannot inline field initializer because one of the method parameters is used as an assignment target and will require new local variable.
 CallInliner_field_initialize_self_reference=Cannot inline method. Method references the field to be initialized.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/Test_issue_1529_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/Test_issue_1529_1.java
@@ -1,0 +1,16 @@
+package invalid;
+
+class A{
+    void bar() {}
+}
+
+class B extends A {
+    void foo() {
+        super.bar();
+    }
+
+    static void err(B b) {
+        b./*]*/foo()/*[*/;
+    }
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/Test_issue_1529_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/Test_issue_1529_2.java
@@ -1,0 +1,16 @@
+package invalid;
+
+class A {
+    public int x;
+}
+
+class B extends A {
+    void foo() {
+        super.x = 8;
+    }
+
+    static void err(B b) {
+        b./*]*/foo()/*[*/;
+    }
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -487,6 +487,16 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_1529_1() throws Exception {
+		performInvalidTest();
+	}
+
+	@Test
+	public void test_issue_1529_2() throws Exception {
+		performInvalidTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- add new check in CallInliner which checks for trying to inline code with a super reference into a static method
- add new hasSuperFieldAccess() method to SourceAnalyzer
- add new tests to InlineMethodTests
- fixes #1529

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
