### PR TITLE
Remove empty hamcrest-core 2.x from 'JUnit 4/5' classpath container

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.13.300.qualifier
+Bundle-Version: 3.13.400.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
@@ -304,9 +304,6 @@ public class BuildPathSupport {
 	public static final JUnitPluginDescription JUNIT4_PLUGIN= new JUnitPluginDescription(
 			"org.junit", new VersionRange("[4.13.0,5.0.0)"), null, "org.junit_4.*.jar", "org.junit.source", "source-bundle/", JUnitPreferencesConstants.JUNIT4_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
-	private static final JUnitPluginDescription HAMCREST_CORE_PLUGIN= new JUnitPluginDescription(
-			"org.hamcrest.core", new VersionRange("[2.2.0,3.1.0)"), null, "org.hamcrest.core_2.*.jar", "org.hamcrest.core.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_CORE_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-
 	private static final JUnitPluginDescription HAMCREST_PLUGIN= new JUnitPluginDescription(
 			"org.hamcrest", new VersionRange("[2.2.0,3.1.0)"), null, "org.hamcrest_2.*.jar", "org.hamcrest.source", "source-bundle/", JUnitPreferencesConstants.HAMCREST_JAVADOC); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 
@@ -419,13 +416,6 @@ public class BuildPathSupport {
 	 */
 	public static IClasspathEntry getJUnit4as3LibraryEntry() {
 		return JUNIT4_AS_3_PLUGIN.getLibraryEntry();
-	}
-
-	/**
-	 * @return the org.hamcrest.core library, or <code>null</code> if not available
-	 */
-	public static IClasspathEntry getHamcrestCoreLibraryEntry() {
-		return HAMCREST_CORE_PLUGIN.getLibraryEntry();
 	}
 
 	/**

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
@@ -121,7 +121,6 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 		case JUNIT4:
 			entriesList.add(BuildPathSupport.getJUnit4LibraryEntry());
 			entriesList.add(BuildPathSupport.getHamcrestLibraryEntry());
-			entriesList.add(BuildPathSupport.getHamcrestCoreLibraryEntry());
 			break;
 		case JUNIT5:
 			boolean vintage = isVintage(attributes);
@@ -145,7 +144,6 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 				entriesList.add(BuildPathSupport.getJUnit4LibraryEntry());
 			}
 			entriesList.add(BuildPathSupport.getHamcrestLibraryEntry());
- 			entriesList.add(BuildPathSupport.getHamcrestCoreLibraryEntry());
 			// errors will be reported above
 			entriesList.removeIf(e -> e == null);
 			break;


### PR DESCRIPTION
## What it does
Since hamcrest version 2 the 'hamcrest-core' artifact only exists to redirect to the new 'hamcrest' artifact containing all of hamcrest. Therefore 'hamcrest-core' does only contains meteadata but no classes. For the 'JUnit 4/5' classpath container it is therefore useless in version 2 and later.

References:
- https://hamcrest.org/JavaHamcrest/distributables.html#previous-versions-of-hamcrest
- https://github.com/hamcrest/JavaHamcrest/releases/tag/v2.1

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
