### PR TITLE
[23] Compiler compliance level 23 missing (BETA) label

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
@@ -272,14 +272,23 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 
 		ArrayList<String> allJavaProjectVersions = new ArrayList<>(JavaCore.getAllJavaSourceVersionsSupportedByCompiler());
 		Collections.reverse(allJavaProjectVersions);
+
 		final String[] complianceVersions= allJavaProjectVersions.toArray(String[]::new);
-		final String[] complianceLabels= complianceVersions;
+
+		for (int i= 0; i < allJavaProjectVersions.size(); i++) {
+			String version= allJavaProjectVersions.get(i);
+			if (isBetaVersion(version)) {
+				allJavaProjectVersions.set(i, version + " (BETA)"); //$NON-NLS-1$
+				break;
+			}
+		}
+		final String[] complianceLabels= allJavaProjectVersions.toArray(String[]::new); // 2nd copy in case (BETA) was added
 
 		final String[] targetVersions= complianceVersions;
-		final String[] targetLabels= targetVersions;
+		final String[] targetLabels= complianceLabels;
 
 		final String[] sourceVersions= complianceVersions;
-		final String[] sourceLabels= sourceVersions;
+		final String[] sourceLabels= complianceLabels;
 
 		final ScrolledPageContent sc1 = new ScrolledPageContent(folder);
 		Composite composite= sc1.getBody();
@@ -684,9 +693,7 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 				}
 			}
 
-//			TODO: Comment once Java SE 23 has been shipped:
-			String selectedCompliance= getValue(PREF_COMPLIANCE);
-			if (JavaCore.VERSION_23.equals(selectedCompliance)) {
+			if (isBetaVersion(getValue(PREF_COMPLIANCE))) {
 				fJRE50InfoText.setText(
 						"This is an implementation of an early-draft specification developed under the Java Community Process (JCP) and is made available for testing and evaluation purposes only. The code is not compatible with any specification of the JCP."); //$NON-NLS-1$
 				isVisible= true;
@@ -696,6 +703,10 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 			fJRE50InfoImage.setImage(isVisible ? image : null);
 			fJRE50InfoImage.getParent().layout();
 		}
+	}
+
+	protected boolean isBetaVersion(String compliance) {
+		return JavaCore.VERSION_23.equals(compliance);
 	}
 
 	private String addsExportToSystemModule() {


### PR DESCRIPTION
Manually add the "(BETA)" suffix to a version label, if it's still in BETA status.

Tried to make it so only one location needs to be edited to leave BETA and later reenter for 24 etc.

fixes #1588 