### PR TITLE
JarWriter3: fix Potential resource leak, deprecate for removal

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.33.0.qualifier
+Bundle-Version: 3.33.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.33.0-SNAPSHOT</version>
+  <version>3.33.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarPackageData.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarPackageData.java
@@ -883,7 +883,7 @@ public class JarPackageData {
 	 *
 	 * @deprecated Use {@link #createJarWriter3(Shell)} instead
 	 */
-	@Deprecated
+	@Deprecated(forRemoval= true, since= "2024-12")
 	public JarWriter2 createJarWriter(Shell parent) throws CoreException {
 		return new JarWriter2(this, parent);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter.java
@@ -57,7 +57,7 @@ import org.eclipse.jdt.internal.ui.jarpackager.JarPackagerUtil;
  *
  * @deprecated use {@link org.eclipse.jdt.ui.jarpackager.JarWriter3 JarWriter3} instead.
  */
-@Deprecated
+@Deprecated(forRemoval= true, since= "2024-12")
 public class JarWriter {
 	private JarOutputStream fJarOutputStream;
 	private JarPackageData fJarPackage;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter2.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter2.java
@@ -57,7 +57,7 @@ import org.eclipse.jdt.internal.ui.jarpackager.JarPackagerUtil;
  *
  * @deprecated Use {@link JarWriter3} instead which leverages new {@link org.eclipse.core.filesystem.EFS EFS} support
  */
-@Deprecated
+@Deprecated(forRemoval= true, since= "2024-12")
 public class JarWriter2 {
 
 	private JarOutputStream fJarOutputStream;


### PR DESCRIPTION
Stream was not closed on IOException

fixes warning:
 "Potential resource leak: '<unassigned Closeable value>' may not be
closed"

