### PR TITLE
[23] FoldingStructureComputationContext should respect the project compliance level for parsing

### DIFF
--- a/org.eclipse.jdt.astview.feature/feature.xml
+++ b/org.eclipse.jdt.astview.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.astview.feature"
       label="Java AST View"
-      version="1.2.300.qualifier"
+      version="1.2.350.qualifier"
       provider-name="Eclipse.org"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.astview
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.astview; singleton:=true
-Bundle-Version: 1.6.200.qualifier
+Bundle-Version: 1.6.250.qualifier
 Bundle-Activator: org.eclipse.jdt.astview.ASTViewPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.21.200.qualifier
+Bundle-Version: 1.21.250.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.text.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.text.tests;singleton:=true
-Bundle-Version: 3.14.500.qualifier
+Bundle-Version: 3.14.550.qualifier
 Bundle-Activator: org.eclipse.jdt.text.tests.JdtTextTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.text.tests/pom.xml
+++ b/org.eclipse.jdt.text.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.text.tests</artifactId>
-  <version>3.14.500-SNAPSHOT</version>
+  <version>3.14.550-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests; singleton:=true
-Bundle-Version: 3.15.500.qualifier
+Bundle-Version: 3.15.550.qualifier
 Bundle-Activator: org.eclipse.jdt.testplugin.JavaTestPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.ui.tests/pom.xml
+++ b/org.eclipse.jdt.ui.tests/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests</artifactId>
-  <version>3.15.500-SNAPSHOT</version>
+  <version>3.15.550-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -52,7 +52,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.WorkingCopyOwner;
 
 import org.eclipse.jdt.ui.tests.core.CoreTests;
-import org.eclipse.jdt.ui.tests.core.rules.Java17ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.Java23ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 
 import org.eclipse.jdt.internal.ui.text.java.hover.JavadocBrowserInformationControlInput;
@@ -61,7 +61,7 @@ import org.eclipse.jdt.internal.ui.text.java.hover.JavadocHover;
 public class MarkdownCommentTests extends CoreTests {
 
 	@Rule
-	public ProjectTestSetup pts= new Java17ProjectTestSetup("TestSetupProject", true);
+	public ProjectTestSetup pts= new Java23ProjectTestSetup("TestSetupProject", false);
 
 	private IJavaProject fJProject1;
 

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.33.0.qualifier
+Bundle-Version: 3.33.50.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.33.0-SNAPSHOT</version>
+  <version>3.33.50-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <profile>
       <id>build-individual-bundles</id>
       <properties>
-      	<eclipse-p2-repo.url>http://download.eclipse.org/eclipse/updates/Y-builds</eclipse-p2-repo.url>
+      	<eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.33-Y-builds</eclipse-p2-repo.url>
       	<skipAPIAnalysis>true</skipAPIAnalysis>
       </properties>
       <repositories>


### PR DESCRIPTION
Since https://bugs.eclipse.org/73400 folding tries to use a shared scanner (for performance reasons). But that shared scanner may be inappropriately configured.

To minimize interference with https://bugs.eclipse.org/73400 I created a separate field `FoldingStructureComputationContext.fScannerForProject` which is used if a difference between project compliance and workspace defaults is detected.

fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1634
