### PR TITLE
Fix generate hashcode to add this expression when needed

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -471,7 +471,7 @@ public final class GenerateHashCodeEqualsOperation implements IWorkspaceRunnable
 				if (field.getType().isArray()) {
 					body.statements().add(createAddArrayHashCode(field));
 				} else if (fUseJ7HashEquals) {
-					j7Invoc.arguments().add(fAst.newSimpleName(field.getName()));
+					j7Invoc.arguments().add(getThisAccessForHashCode(field.getName()));
 				} else if (field.getType().isPrimitive()) {
 					Statement[] sts= createAddSimpleHashCode(field.getType(), this::getThisAccessForHashCode, field.getName(), false);
 					body.statements().addAll(Arrays.asList(sts));


### PR DESCRIPTION
- fix GenerateHashCodeEqualsOperation.createHashCodeMethod() to add this specifier for fields that match local variables generated
- add new test to GenerateHashCodeEqualsTest
- fixes #1560

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
