### PR TITLE
Finer check to trigger cast when converting to methodRef

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -974,7 +974,9 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 					while (parentTypeBinding != null) {
 						IMethodBinding[] parentTypeMethods= parentTypeBinding.getDeclaredMethods();
 						for (IMethodBinding parentTypeMethod : parentTypeMethods) {
-							if (parentTypeMethod.getName().equals(parentBinding.getName()) && !parentTypeMethod.isEqualTo(parentBinding)) {
+							if (parentTypeMethod.getName().equals(parentBinding.getName())
+									&& parentTypeMethod.getParameterTypes().length == args.size()
+									&& !parentTypeMethod.isEqualTo(parentBinding)) {
 								needCast= true;
 								break;
 							}


### PR DESCRIPTION
In some cases (eg JDT-LS
AnonymousClassCreationToLambdaTest.testConvertToLambda12 with Javac backend), a cast is needlessly added just because a method with same name exists.
Also check the number of arguments to decide whether to add a cast or not.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Improve the check to decide whether to cast the expression after "Extract to lambda" with method ref to take arguments count as criterion

## How to test

Run JDT-LS test AnonymousClassCreationToLambdaTest.testConvertToLambda12 with Javac backend, because of https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/issues/821 (which doesn't seem to be much of a bug), the behavior is different and a cast is added because the check matches the (package visible) `removeIf(Predicate, int, int)` method. But this method doesn't apply in this context.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
