### PR TITLE
Add logic to useless return/continue cleanups to prevent logic change

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -17110,6 +17110,72 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testIssue1638() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String input= """
+			package test1;
+
+			public class E1 {
+			    public void doNotRemoveUselessReturn(boolean arg) {
+				    if (arg) {
+					    return;
+					} else {
+						System.out.println("here");
+					}
+			    }
+
+			    public void doNotRemoveUselessContinue(boolean arg) {
+					while (arg) {
+						arg = bar();
+						if (arg) {
+							continue;
+						} else {
+							System.out.println("Hello World");
+						}
+					}
+			    }
+
+				public boolean bar() {
+					return true;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E1.java", input, false, null);
+
+		enable(CleanUpConstants.REMOVE_USELESS_CONTINUE);
+		enable(CleanUpConstants.REMOVE_USELESS_RETURN);
+		enable(CleanUpConstants.REDUCE_INDENTATION);
+
+		String output= """
+			package test1;
+
+			public class E1 {
+			    public void doNotRemoveUselessReturn(boolean arg) {
+				    if (arg) {
+					    return;
+					}
+			        System.out.println("here");
+			    }
+
+			    public void doNotRemoveUselessContinue(boolean arg) {
+					while (arg) {
+						arg = bar();
+						if (arg) {
+							continue;
+						}
+			            System.out.println("Hello World");
+					}
+			    }
+
+				public boolean bar() {
+					return true;
+				}
+			}
+			""";
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { output });
+	}
+
+	@Test
 	public void testUnloopedWhile() throws Exception {
 		// Given
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessContinueCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessContinueCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -148,6 +148,16 @@ public class UselessContinueCleanUp extends AbstractMultiFix {
 								|| parent instanceof ForStatement
 								|| parent instanceof DoStatement) {
 							return true;
+						}
+
+						if (parent instanceof IfStatement ifStatement && ifStatement.getElseStatement() != null
+								&& node.getLocationInParent() != IfStatement.ELSE_STATEMENT_PROPERTY) {
+							if (isEnabled(CleanUpConstants.REDUCE_INDENTATION)) {
+								Statement elseStatement= ifStatement.getElseStatement();
+								if (!(elseStatement instanceof Block elseBlock) || elseBlock.statements().size() == 1) {
+									return false;
+								}
+							}
 						}
 
 						if (parent instanceof MethodDeclaration) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -147,6 +147,16 @@ public class UselessReturnCleanUp extends AbstractMultiFix {
 						if (parent instanceof WhileStatement || parent instanceof EnhancedForStatement
 								|| parent instanceof ForStatement || parent instanceof DoStatement) {
 							return false;
+						}
+
+						if (parent instanceof IfStatement ifStatement && ifStatement.getElseStatement() != null
+								&& node.getLocationInParent() != IfStatement.ELSE_STATEMENT_PROPERTY) {
+							if (isEnabled(CleanUpConstants.REDUCE_INDENTATION)) {
+								Statement elseStatement= ifStatement.getElseStatement();
+								if (!(elseStatement instanceof Block elseBlock) || elseBlock.statements().size() == 1) {
+									return false;
+								}
+							}
 						}
 
 						if (parent instanceof Statement) {


### PR DESCRIPTION
- add logic to UselessContinueCleanUp and UselessReturnCleanUp so they do not remove a return or continue statement if it is in an if then and there is an else with a single statement and the user has also specified to reduce indentation
- add new test to CleanUpTest
- fixes #1638

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
