### PR TITLE
Tweak new logic for useless return or useless continue clean-up

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessContinueCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessContinueCleanUp.java
@@ -154,7 +154,7 @@ public class UselessContinueCleanUp extends AbstractMultiFix {
 								&& node.getLocationInParent() != IfStatement.ELSE_STATEMENT_PROPERTY) {
 							if (isEnabled(CleanUpConstants.REDUCE_INDENTATION)) {
 								Statement elseStatement= ifStatement.getElseStatement();
-								if (!(elseStatement instanceof Block elseBlock) || elseBlock.statements().size() == 1) {
+								if (elseStatement != null) {
 									return false;
 								}
 							}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
@@ -153,7 +153,7 @@ public class UselessReturnCleanUp extends AbstractMultiFix {
 								&& node.getLocationInParent() != IfStatement.ELSE_STATEMENT_PROPERTY) {
 							if (isEnabled(CleanUpConstants.REDUCE_INDENTATION)) {
 								Statement elseStatement= ifStatement.getElseStatement();
-								if (!(elseStatement instanceof Block elseBlock) || elseBlock.statements().size() == 1) {
+								if (elseStatement != null) {
 									return false;
 								}
 							}


### PR DESCRIPTION
- do not check how many statements are in the else clause, just that there is an else clause

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See #1638.  The logic didn't handle the case where there are multipe statements in the else clause.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See #1638 and add an additional println statement to the else.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
