### PR TITLE
[23] many errors, some failure in AutomatedTestSuite with latest from JDT/Core

### DIFF
--- a/org.eclipse.jdt.ui.tests/test.xml
+++ b/org.eclipse.jdt.ui.tests/test.xml
@@ -35,6 +35,7 @@
       <property name="data-dir" value="${jdt-folder}"/>
       <property name="plugin-name" value="${plugin-name}"/>
       <property name="classname" value="org.eclipse.jdt.ui.tests.AutomatedSuite"/>
+      <property name="vmargs" value="-XX:CompileCommand=exclude,org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer::getExtendedRange" />
     </ant>
     
   </target>
@@ -349,7 +350,6 @@
     	--add-opens java.management/sun.management.spi=ALL-UNNAMED
     	--add-opens jdk.management/com.sun.management=ALL-UNNAMED
     	--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    	-XX:CompileCommand=exclude,org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer::getExtendedRange
     	" else="${java9vmargs}">
     	<javaversion atleast="17"/>
     </condition>


### PR DESCRIPTION
move jit-exclusion to the correct ant target (hopefully)

fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1639
