### PR TITLE
Move away of deprecated org.eclipse.jface.internal.text.html.SubstitutionTextReader

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDoc2HTMLTextReader.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDoc2HTMLTextReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,8 +22,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.text.readers.SubstitutionReader;
+
 import org.eclipse.jface.internal.text.html.HTMLPrinter;
-import org.eclipse.jface.internal.text.html.SubstitutionTextReader;
 
 import org.eclipse.jdt.core.dom.TagElement;
 
@@ -31,7 +32,7 @@ import org.eclipse.jdt.core.dom.TagElement;
 /**
  * Processes JavaDoc tags.
  */
-public class JavaDoc2HTMLTextReader extends SubstitutionTextReader {
+public class JavaDoc2HTMLTextReader extends SubstitutionReader {
 
 
 	static private class Pair {


### PR DESCRIPTION
## What it does
Switches from using deprecated internal class to using API

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
