### PR TITLE
Move away of deprecated CopyProjectAction(Shell)

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/ReorgCopyAction.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/ReorgCopyAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -76,7 +76,7 @@ public class ReorgCopyAction extends SelectionDispatchAction {
 	}
 
 	private CopyProjectAction createWorkbenchAction(IStructuredSelection selection) {
-		CopyProjectAction action= new CopyProjectAction(getShell());
+		CopyProjectAction action= new CopyProjectAction(getSite());
 		action.selectionChanged(selection);
 		return action;
 	}


### PR DESCRIPTION
## What it does
Use CopyProjectAction(IShellProvider) instead.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
