### PR TITLE
Fix reading html content of a package fragment to not return null

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccess.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccess.java
@@ -184,8 +184,7 @@ public class CoreJavadocAccess {
 			return packageFragment.getAttachedJavadoc(null);
 
 		}
-
-		return null;
+		return ""; //$NON-NLS-1$
 	}
 
 


### PR DESCRIPTION
- in the case of a package fragement, when we search for Javadoc content and do not find any package info, just return the empty string so Javadoc hover will at least show the package name

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See commit message.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Add a Javadoc see reference to a package in the current project and click on the reference in the Java hover.  The package name should show up with icon and no content rather than nothing popping up.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
