### PR TITLE
Bug 310510 - fix move to new type so extraneous import not added

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInnerToTopRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -303,8 +303,17 @@ public final class MoveInnerToTopRefactoring extends Refactoring {
 				final ITypeBinding binding= node.resolveBinding();
 				if (binding != null) {
 					final ITypeBinding declaring= binding.getDeclaringClass();
-					if (declaring != null && !Bindings.equals(declaring, fTypeBinding.getDeclaringClass()) && !Bindings.equals(binding, fTypeBinding) && fSourceRewrite.getRoot().findDeclaringNode(binding) != null && Modifier.isStatic(binding.getModifiers()))
+					if (declaring != null && !Bindings.equals(declaring, fTypeBinding.getDeclaringClass()) && !Bindings.equals(binding, fTypeBinding) && fSourceRewrite.getRoot().findDeclaringNode(binding) != null && Modifier.isStatic(binding.getModifiers())) {
+						ITypeBinding temp= binding;
+						while (temp != null && temp.isMember()) {
+							ITypeBinding declaringType= temp.getDeclaringClass();
+							if (Bindings.equals(declaringType, fTypeBinding)) {
+								return super.visit(node);
+							}
+							temp= declaringType;
+						}
 						addTypeQualification(node, fSourceRewrite, fGroup);
+					}
 				}
 			}
 			return super.visit(node);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel/testBug310510/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel/testBug310510/in/A.java
@@ -1,0 +1,10 @@
+package p;
+
+class A {
+	static class Inner {
+		Q q;
+
+		static class Q {
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel/testBug310510/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel/testBug310510/out/A.java
@@ -1,0 +1,4 @@
+package p;
+
+class A {
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel/testBug310510/out/Inner.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel/testBug310510/out/Inner.java
@@ -1,0 +1,7 @@
+package p;
+class Inner {
+	Q q;
+
+	static class Q {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel16/test_Bug572639_2/out/Layout.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInnerToTopLevel16/test_Bug572639_2/out/Layout.java
@@ -11,13 +11,13 @@ import java.util.Map;
 
 public interface Layout /*permits Layout.PrimitiveLayout, Layout.ListLayout, Layout.StructLayout*/ {
     default boolean isPrimitive() {
-      return this instanceof Layout.PrimitiveLayout;
+      return this instanceof PrimitiveLayout;
     }
     default boolean isList() {
-      return this instanceof Layout.ListLayout;
+      return this instanceof ListLayout;
     }
     default boolean isStruct() {
-      return this instanceof Layout.StructLayout;
+      return this instanceof StructLayout;
     }
     boolean nullable();
     default Map<String, Layout> fields() {
@@ -30,56 +30,56 @@ public interface Layout /*permits Layout.PrimitiveLayout, Layout.ListLayout, Lay
       throw new IllegalArgumentException("no element");
     }
 
-    static Layout.PrimitiveLayout u1(boolean nullable) {
+    static PrimitiveLayout u1(boolean nullable) {
       return new PrimitiveLayout(nullable, boolean.class);
     }
-    static Layout.PrimitiveLayout byte8(boolean nullable) {
+    static PrimitiveLayout byte8(boolean nullable) {
       return new PrimitiveLayout(nullable, byte.class);
     }
-    static Layout.PrimitiveLayout short16(boolean nullable) {
+    static PrimitiveLayout short16(boolean nullable) {
       return new PrimitiveLayout(nullable, short.class);
     }
-    static Layout.PrimitiveLayout char16(boolean nullable) {
+    static PrimitiveLayout char16(boolean nullable) {
       return new PrimitiveLayout(nullable, char.class);
     }
-    static Layout.PrimitiveLayout int32(boolean nullable) {
+    static PrimitiveLayout int32(boolean nullable) {
       return new PrimitiveLayout(nullable, int.class);
     }
-    static Layout.PrimitiveLayout float32(boolean nullable) {
+    static PrimitiveLayout float32(boolean nullable) {
       return new PrimitiveLayout(nullable, float.class);
     }
-    static Layout.PrimitiveLayout double64(boolean nullable) {
+    static PrimitiveLayout double64(boolean nullable) {
       return new PrimitiveLayout(nullable, double.class);
     }
-    static Layout.PrimitiveLayout long64(boolean nullable) {
+    static PrimitiveLayout long64(boolean nullable) {
       return new PrimitiveLayout(nullable, long.class);
     }
 
-    static Layout.ListLayout list(boolean nullable, Layout layout) {
+    static ListLayout list(boolean nullable, Layout layout) {
       return new ListLayout(nullable, layout);
     }
-    static Layout.ListLayout string(boolean nullable) {
+    static ListLayout string(boolean nullable) {
       return list(true, char16(nullable));
     }
 
-    static Layout.Field field(String name, Layout layout) {
+    static Field field(String name, Layout layout) {
       return new Field(name, layout);
     }
-    static Layout.StructLayout struct(boolean nullable, Layout.Field... fields) {
+    static StructLayout struct(boolean nullable, Field... fields) {
       return new StructLayout(nullable, Arrays.stream(fields).collect(toMap(Field::name, Field::layout, (_1, _2) -> null, LinkedHashMap::new)));
     }
 
     private static String toString(String space, Layout layout) {
-      if (layout instanceof Layout.PrimitiveLayout primitiveLayout) {
+      if (layout instanceof PrimitiveLayout primitiveLayout) {
         return primitiveLayout.toString();
       }
-      if (layout instanceof Layout.ListLayout listLayout) {
-        if (listLayout.element instanceof Layout.PrimitiveLayout elementLayout && elementLayout.type == char.class) {
+      if (layout instanceof ListLayout listLayout) {
+        if (listLayout.element instanceof PrimitiveLayout elementLayout && elementLayout.type == char.class) {
           return "string(" + elementLayout.nullable + ")";
         }
         return "list(" + listLayout.nullable + ", " + toString(space, listLayout.element);
       }
-      if (layout instanceof Layout.StructLayout structLayout) {
+      if (layout instanceof StructLayout structLayout) {
         if (structLayout.fields.isEmpty()) {
           return "struct(" + structLayout.nullable + ")";
         }

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInnerToTopLevelTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInnerToTopLevelTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -430,6 +430,11 @@ public class MoveInnerToTopLevelTests extends GenericRefactoringTest {
 	@Test
 	public void test44() throws Exception {
 		validatePassingTest("A", "B", "p", new String[] { "A"}, new String[] { "p"}, "a", true, true, true, true);
+	}
+
+	@Test
+	public void testBug310510() throws Exception {
+		validatePassingTest("A", "Inner", new String[]{"A"}, new String[]{"p"}, null, false, false);
 	}
 
 	// static context: https://bugs.eclipse.org/bugs/show_bug.cgi?id=385237


### PR DESCRIPTION
- fix MoveInnerToTopRefactoring.TypeReferenceQualifier visitor to not add qualifier to fields of member types that will end up being moved so to prevent call to addImport() to acquire Type
- add new test to MoveInnerToTopLevelTests
- fixes #1658

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
