### PR TITLE
Implementation of #508 (Confusing "No JRE" in search header).

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchMessages.properties
@@ -168,31 +168,31 @@ JavaElementAction_operationUnavailable_interface= The operation is unavailable o
 JavaElementLine_error_nobuffer=Element has no buffer: ''{0}''
 
 WorkspaceScope= workspace
-WorkspaceScopeNoJRE= workspace (no JRE)
+WorkspaceScopeNoJRE= workspace (omitting JRE)
 
 SingleWorkingSetScope= working set ''{0}''
-SingleWorkingSetScopeNoJRE= working set ''{0}'' (no JRE)
+SingleWorkingSetScopeNoJRE= working set ''{0}'' (omitting JRE)
 DoubleWorkingSetScope= working sets ''{0}'', ''{1}''
-DoubleWorkingSetScopeNoJRE= working set ''{0}'', ''{1}'' (no JRE)
+DoubleWorkingSetScopeNoJRE= working set ''{0}'', ''{1}'' (omitting JRE)
 WorkingSetsScope= working set ''{0}'', ''{1}'', ...
-WorkingSetsScopeNoJRE= working set ''{0}'', ''{1}'', ... (no JRE)
+WorkingSetsScopeNoJRE= working set ''{0}'', ''{1}'', ... (omitting JRE)
 
 SingleSelectionScope= ''{0}''
-SingleSelectionScopeNoJRE= ''{0}'' (no JRE)
+SingleSelectionScopeNoJRE= ''{0}'' (omitting JRE)
 DoubleSelectionScope= ''{0}'', ''{1}''
-DoubleSelectionScopeNoJRE= ''{0}'', ''{1}'' (no JRE)
+DoubleSelectionScopeNoJRE= ''{0}'', ''{1}'' (omitting JRE)
 SelectionScope= ''{0}'', ''{1}'', ...
-SelectionScopeNoJRE= ''{0}'', ''{1}'', ... (no JRE)
+SelectionScopeNoJRE= ''{0}'', ''{1}'', ... (omitting JRE)
 
 EnclosingProjectsScope=projects ''{0}'', ''{1}'', ...
-EnclosingProjectsScopeNoJRE=projects ''{0}'', ''{1}'', ... (no JRE)
+EnclosingProjectsScopeNoJRE=projects ''{0}'', ''{1}'', ... (omitting JRE)
 EnclosingProjectScope=project ''{0}''
-EnclosingProjectScopeNoJRE=project ''{0}'' (no JRE)
+EnclosingProjectScopeNoJRE=project ''{0}'' (omitting JRE)
 EnclosingProjectsScope2=projects ''{0}'', ''{1}''
-EnclosingProjectsScope2NoJRE=projects ''{0}'', ''{1}'' (no JRE)
+EnclosingProjectsScope2NoJRE=projects ''{0}'', ''{1}'' (omitting JRE)
 
 ProjectScope= project ''{0}''
-ProjectScopeNoJRE= project ''{0}'' (no JRE)
+ProjectScopeNoJRE= project ''{0}'' (omitting JRE)
 HierarchyScope= hierarchy of ''{0}''
 
 JavaSearchResultPage_sortByName=Name


### PR DESCRIPTION
## What it does
Fixes #508 

## How to test
Do a Java search where JRE is not included. Part of the search header text is now "omitting JRE" instead of "no JRE".

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
