### PR TITLE
[23] Markdown doc comments with codeblock don't parse Javadoc tags afterwards #2989

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -808,4 +808,95 @@ public class MarkdownCommentTests extends CoreTests {
 				""";
 		assertHtmlContent(expectedContent, actualHtmlContent);
 	}
+	@Test
+	public void testGH2980() throws CoreException {
+		String source= """
+				package p;
+
+				public class X {
+					/// This is a test Javadoc for method test1()
+					/// ```java
+					/// test1(42);
+					/// ```
+					/// @param a some parameter for test1
+					public void test1(int a) {}
+					///
+					/// This is a test Javadoc for method test2()
+					/// 'test2(0)'
+					/// @param b some parameter for test1
+					public void test2(int b) {}
+					/// This is a test Javadoc for method test3()
+					/// ```java
+					/// int r = test3();
+					/// System.out.println(r);
+					/// ```
+					/// @return an int value
+					public int test3() {
+						return 0;
+					}
+					/// This is a test Javadoc for method test4()
+					/// Invocation method 1:
+					/// ```java
+					/// int r = test4();
+					/// System.out.println(r);
+					/// ```
+					/// Invocation method 2:
+					/// ```java
+					/// System.out.println(test4());
+					/// ```
+					/// @return an int value
+					/// @param i an int param
+					public int test4(int i) {
+						return 0;
+					}
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/X.java", source, null);
+		assertNotNull("X.java", cu);
+
+		IType type= cu.getType("X");
+
+		IMethod method= type.getMethods()[0];
+		String actualHtmlContent= getHoverHtmlContent(cu, method);
+		String expectedContent= """
+					<p>This is a test Javadoc for method test1()</p>
+					<pre><code class="language-java">test1(42);
+					</code></pre>
+					<dl><dt>Parameters:</dt><dd><b>a</b> some parameter for test1</dd></dl>
+					""";
+		assertHtmlContent(expectedContent, actualHtmlContent);
+
+		method= type.getMethods()[1];
+		actualHtmlContent= getHoverHtmlContent(cu, method);
+		expectedContent= """
+					<p>This is a test Javadoc for method test2()
+					'test2(0)'</p>
+					<dl><dt>Parameters:</dt><dd><b>b</b> some parameter for test1</dd></dl>
+					""";
+		assertHtmlContent(expectedContent, actualHtmlContent);
+
+		method= type.getMethods()[2];
+		actualHtmlContent= getHoverHtmlContent(cu, method);
+		expectedContent= """
+					<p>This is a test Javadoc for method test3()</p>
+					<pre><code class="language-java">int r = test3();
+					System.out.println(r);
+					</code></pre>
+					<dl><dt>Returns:</dt><dd>an int value</dd></dl>
+					""";
+		method= type.getMethods()[3];
+		actualHtmlContent= getHoverHtmlContent(cu, method);
+		expectedContent= """
+					<p>This is a test Javadoc for method test4()
+					Invocation method 1:</p>
+					<pre><code class="language-java">int r = test4();
+					System.out.println(r);
+					</code></pre>
+					<p>Invocation method 2:</p>
+					<pre><code class="language-java">System.out.println(test4());
+					</code></pre>
+					<dl><dt>Parameters:</dt><dd><b>i</b> an int param</dd><dt>Returns:</dt><dd>an int value</dd></dl>
+					""";
+		assertHtmlContent(expectedContent, actualHtmlContent);
+	}
 }


### PR DESCRIPTION
 Test case for the jdt.core fix

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2980

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
