### PR TITLE
Add new simplify boolean if/else cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/CleanUpNLSUtils.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/CleanUpNLSUtils.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.fix;
+
+import org.eclipse.jface.text.BadLocationException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.compiler.InvalidInputException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSScanner;
+
+public class CleanUpNLSUtils {
+
+	public static NLSLine scanCurrentLine(ICompilationUnit cu, ASTNode exp) {
+		CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
+		int startLine= cUnit.getLineNumber(exp.getStartPosition());
+		int lineStart= cUnit.getPosition(startLine, 0);
+		int endOfLine= cUnit.getPosition(startLine + 1, 0);
+		NLSLine[] lines;
+		try {
+			lines= NLSScanner.scan(cu.getBuffer().getText(lineStart, endOfLine - lineStart));
+			if (lines.length > 0) {
+				return lines[0];
+			}
+		} catch (IndexOutOfBoundsException | JavaModelException | InvalidInputException | BadLocationException e) {
+			e.printStackTrace();
+			// fall-through
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -73,6 +73,7 @@ public class MultiFixMessages extends NLS {
 	public static String CodeStyleCleanUp_PullUpAssignment_description;
 	public static String CodeStyleCleanUp_ElseIf_description;
 	public static String CodeStyleCleanUp_ReduceIndentation_description;
+	public static String CodeStyleCleanUp_SimplifyBooleanIfElse_description;
 	public static String CodeStyleCleanUp_Instanceof_description;
 	public static String CodeStyleCleanUp_numberSuffix_description;
 	public static String CodeStyleCleanUp_QualifyNonStaticMethod_description;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2005, 2023 IBM Corporation and others.
+# Copyright (c) 2005, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,7 @@ CodeStyleCleanUp_ExtractIncrement_description=Extract increment/decrement from s
 CodeStyleCleanUp_PullUpAssignment_description=Pull up assignment
 CodeStyleCleanUp_ElseIf_description=Combine nested 'if' statement in 'else' block to 'else if'
 CodeStyleCleanUp_ReduceIndentation_description=Reduce indentation
+CodeStyleCleanUp_SimplifyBooleanIfElse_description=Simplify boolean if/else to a single return if possible
 CodeStyleCleanUp_Instanceof_description=Use instanceof keyword instead of Class.isInstance()
 CodeStyleCleanUp_numberSuffix_description=Use uppercase for long literal suffix
 CodeFormatFix_RemoveTrailingWhitespace_changeDescription=Remove trailing whitespace

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SimplifyBooleanIfElseCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SimplifyBooleanIfElseCleanUpCore.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.fix;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.text.edits.TextEditGroup;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.BooleanLiteral;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IfStatement;
+import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
+import org.eclipse.jdt.core.dom.ReturnStatement;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
+import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
+import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
+import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+
+import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+
+public class SimplifyBooleanIfElseCleanUpCore extends AbstractMultiFix {
+
+	public SimplifyBooleanIfElseCleanUpCore() {
+		this(Collections.emptyMap());
+	}
+
+	public SimplifyBooleanIfElseCleanUpCore(final Map<String, String> options) {
+		super(options);
+	}
+
+	@Override
+	public CleanUpRequirements getRequirements() {
+		boolean requireAST= isEnabled(CleanUpConstants.SIMPLIFY_BOOLEAN_IF_ELSE);
+		return new CleanUpRequirements(requireAST, false, false, null);
+	}
+
+	@Override
+	public String[] getStepDescriptions() {
+		if (isEnabled(CleanUpConstants.SIMPLIFY_BOOLEAN_IF_ELSE)) {
+			return new String[] { MultiFixMessages.CodeStyleCleanUp_SimplifyBooleanIfElse_description };
+		}
+
+		return new String[0];
+	}
+
+	@Override
+	public String getPreview() {
+		StringBuilder bld= new StringBuilder();
+		if (isEnabled(CleanUpConstants.SIMPLIFY_BOOLEAN_IF_ELSE)) {
+			bld.append("return i > 0;\n"); //$NON-NLS-1$
+		} else {
+			bld.append("if (i > 0) {\n"); //$NON-NLS-1$
+			bld.append("    return true;\n"); //$NON-NLS-1$
+			bld.append("} else {\n"); //$NON-NLS-1$
+			bld.append("    return false;\n"); //$NON-NLS-1$
+			bld.append("}\n"); //$NON-NLS-1$
+		}
+
+		return bld.toString();
+	}
+
+	@Override
+	public boolean canFix(ICompilationUnit compilationUnit, IProblemLocation problem) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	public static enum SimplifyStatus {
+		INVALID, VALID_THEN_TRUE, VALID_ELSE_TRUE
+	}
+
+	public static SimplifyStatus verifyBooleanIfElse(final IfStatement ifStatement) {
+		if (ifStatement.getElseStatement() == null || ifStatement.getExpression() instanceof PatternInstanceofExpression) {
+			return SimplifyStatus.INVALID;
+		}
+
+		boolean thenValue= true;
+
+		Statement thenStatement= ifStatement.getThenStatement();
+		if (thenStatement instanceof ReturnStatement returnStatement) {
+			if (returnStatement.getExpression() instanceof BooleanLiteral literal) {
+				thenValue= literal.booleanValue();
+			}
+		} else if (thenStatement instanceof Block block && block.statements().size() == 1
+				&& block.statements().get(0) instanceof ReturnStatement returnStatement) {
+			if (returnStatement.getExpression() instanceof BooleanLiteral literal) {
+				thenValue= literal.booleanValue();
+			} else {
+				return SimplifyStatus.INVALID;
+			}
+		} else {
+			return SimplifyStatus.INVALID;
+		}
+
+		Statement elseStatement= ifStatement.getElseStatement();
+		if (elseStatement instanceof ReturnStatement returnStatement) {
+			if (returnStatement.getExpression() instanceof BooleanLiteral literal) {
+				if (literal.booleanValue() == thenValue) {
+					return SimplifyStatus.INVALID;
+				}
+			}
+		} else if (elseStatement instanceof Block block && block.statements().size() == 1
+				&& block.statements().get(0) instanceof ReturnStatement returnStatement) {
+			if (returnStatement.getExpression() instanceof BooleanLiteral literal) {
+				if (literal.booleanValue() == thenValue) {
+					return SimplifyStatus.INVALID;
+				}
+			} else {
+				return SimplifyStatus.INVALID;
+			}
+		} else {
+			return SimplifyStatus.INVALID;
+		}
+		return thenValue == true ? SimplifyStatus.VALID_THEN_TRUE : SimplifyStatus.VALID_ELSE_TRUE;
+	}
+
+	@Override
+	protected ICleanUpFix createFix(CompilationUnit unit) throws CoreException {
+		if (!isEnabled(CleanUpConstants.SIMPLIFY_BOOLEAN_IF_ELSE)) {
+			return null;
+		}
+
+		final List<CompilationUnitRewriteOperationWithSourceRange> rewriteOperations= new ArrayList<>();
+
+		unit.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(final IfStatement visited) {
+				SimplifyStatus status= verifyBooleanIfElse(visited);
+				if (status != SimplifyStatus.INVALID) {
+					rewriteOperations.add(new SimplifyBooleanIfElseOperation(visited, status));
+				}
+				return true;
+			}
+		});
+
+		if (rewriteOperations.isEmpty()) {
+			return null;
+		}
+
+		return new CompilationUnitRewriteOperationsFixCore(MultiFixMessages.CodeStyleCleanUp_SimplifyBooleanIfElse_description, unit,
+				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
+	}
+
+	@Override
+	protected ICleanUpFix createFix(CompilationUnit unit, IProblemLocation[] problems) throws CoreException {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	private static class SimplifyBooleanIfElseOperation extends CompilationUnitRewriteOperationWithSourceRange {
+		private final IfStatement visited;
+		private final SimplifyStatus status;
+
+		public SimplifyBooleanIfElseOperation(final IfStatement visited, final SimplifyStatus status) {
+			this.visited= visited;
+			this.status= status;
+		}
+
+		@Override
+		public void rewriteASTInternal(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+			ASTRewrite rewrite= cuRewrite.getASTRewrite();
+			TextEditGroup group= createTextEditGroup(MultiFixMessages.CodeStyleCleanUp_SimplifyBooleanIfElse_description, cuRewrite);
+
+			CompilationUnit cu= (CompilationUnit) visited.getRoot();
+			ICompilationUnit icu= (ICompilationUnit) cu.getJavaElement();
+			NLSLine nlsLine= CleanUpNLSUtils.scanCurrentLine(icu, visited.getExpression());
+			StringBuilder nlsBuffer= new StringBuilder();
+			if (nlsLine != null) {
+				NLSElement[] nlsElements= nlsLine.getElements();
+				for (int i= 0; i < nlsElements.length; ++i) {
+					NLSElement element= nlsElements[i];
+					if (element.hasTag()) {
+						nlsBuffer.append(" //$NON-NLS-" + (i + 1) + "$"); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}
+			}
+			ReturnStatement newReturn= null;
+			String ifExpression= icu.getBuffer().getText(visited.getExpression().getStartPosition(), visited.getExpression().getLength());
+			if (status == SimplifyStatus.VALID_THEN_TRUE) {
+				newReturn= (ReturnStatement) rewrite.createStringPlaceholder("return " + ifExpression + ";" + nlsBuffer.toString(), ASTNode.RETURN_STATEMENT); //$NON-NLS-1$ //$NON-NLS-2$
+			} else { // otherwise we need to reverse the if expression so it returns the right value
+				newReturn= (ReturnStatement) rewrite.createStringPlaceholder("return !(" + ifExpression + ");" + //$NON-NLS-1$ //$NON-NLS-2$
+						nlsBuffer.toString(), ASTNode.RETURN_STATEMENT);
+			}
+			rewrite.replace(visited, newReturn, group);
+		}
+
+	}
+
+}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
@@ -2113,6 +2113,17 @@ public class CleanUpConstants {
 	public static final String REDUCE_INDENTATION= "cleanup.reduce_indentation"; //$NON-NLS-1$
 
 	/**
+	 * Convert if/else that returns true or false based on condition to a single return statement if possible.
+	 * <p>
+	 * Possible values: {TRUE, FALSE}
+	 *
+	 * @see CleanUpOptions#TRUE
+	 * @see CleanUpOptions#FALSE
+	 * @since 4.35
+	 */
+	public static final String SIMPLIFY_BOOLEAN_IF_ELSE= "cleanup.simplify_boolean_if_else"; //$NON-NLS-1$
+
+	/**
 	 * Uses an {@code instanceof} expression to check an object against a hardcoded class.
 	 * <p>
 	 * Possible values: {TRUE, FALSE}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchFixCore.java
@@ -24,14 +24,11 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.text.edits.TextEditGroup;
 
-import org.eclipse.jface.text.BadLocationException;
-
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -64,11 +61,11 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.InterruptibleVisitor;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
-import org.eclipse.jdt.internal.corext.refactoring.nls.NLSScanner;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
+import org.eclipse.jdt.internal.ui.fix.CleanUpNLSUtils;
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 
 public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
@@ -383,7 +380,7 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 						&& constant.resolveConstantExpressionValue() != null) {
 					CompilationUnit cu= (CompilationUnit) variable.getRoot();
 					ICompilationUnit icu= (ICompilationUnit) cu.getJavaElement();
-					NLSLine nlsLine= scanCurrentLine(icu, variable);
+					NLSLine nlsLine= CleanUpNLSUtils.scanCurrentLine(icu, variable);
 					boolean hasTag= false;
 					if (nlsLine != null) {
 						for (NLSElement element : nlsLine.getElements()) {
@@ -399,23 +396,6 @@ public class SwitchFixCore extends CompilationUnitRewriteOperationsFixCore {
 					return new Variable(variable, Arrays.asList(constant), Arrays.asList(hasTag));
 				}
 
-				return null;
-			}
-
-			private NLSLine scanCurrentLine(ICompilationUnit cu, Expression exp) {
-				CompilationUnit cUnit= (CompilationUnit)exp.getRoot();
-				int startLine= cUnit.getLineNumber(exp.getStartPosition());
-				int lineStart= cUnit.getPosition(startLine, 0);
-				int endOfLine= cUnit.getPosition(startLine + 1, 0);
-				NLSLine[] lines;
-				try {
-					lines= NLSScanner.scan(cu.getBuffer().getText(lineStart, endOfLine - lineStart));
-					if (lines.length > 0) {
-						return lines[0];
-					}
-				} catch (IndexOutOfBoundsException | JavaModelException | InvalidInputException | BadLocationException e) {
-					// fall-through
-				}
 				return null;
 			}
 

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2023 IBM Corporation and others.
+ * Copyright (c) 2018, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -57,6 +57,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(PULL_UP_ASSIGNMENT, CleanUpOptions.FALSE);
 
 		options.setOption(ELSE_IF, CleanUpOptions.FALSE);
+		options.setOption(SIMPLIFY_BOOLEAN_IF_ELSE, CleanUpOptions.FALSE);
 		options.setOption(REDUCE_INDENTATION, CleanUpOptions.FALSE);
 		options.setOption(INSTANCEOF, CleanUpOptions.FALSE);
 		options.setOption(NUMBER_SUFFIX, CleanUpOptions.FALSE);
@@ -242,6 +243,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(PULL_UP_ASSIGNMENT, CleanUpOptions.FALSE);
 
 		options.setOption(ELSE_IF, CleanUpOptions.FALSE);
+		options.setOption(SIMPLIFY_BOOLEAN_IF_ELSE, CleanUpOptions.FALSE);
 		options.setOption(REDUCE_INDENTATION, CleanUpOptions.FALSE);
 		options.setOption(INSTANCEOF, CleanUpOptions.FALSE);
 		options.setOption(NUMBER_SUFFIX, CleanUpOptions.FALSE);

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7135,10 +7135,15 @@
             id="org.eclipse.jdt.ui.cleanup.else_if"
             runAfter="org.eclipse.jdt.ui.cleanup.variables">
       </cleanUp>
+       <cleanUp
+            class="org.eclipse.jdt.internal.ui.fix.SimplifyBooleanIfElseCleanUpCore"
+            id="org.eclipse.jdt.ui.cleanup.simplify_boolean_if_else"
+            runAfter="org.eclipse.jdt.ui.cleanup.else_if">
+      </cleanUp>
       <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.ReduceIndentationCleanUp"
             id="org.eclipse.jdt.ui.cleanup.reduce_indentation"
-            runAfter="org.eclipse.jdt.ui.cleanup.else_if">
+            runAfter="org.eclipse.jdt.ui.cleanup.simplify_boolean_if_else">
       </cleanUp>
       <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.ExpressionsCleanUp"

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ReduceIndentationCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ReduceIndentationCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -51,6 +51,8 @@ import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewr
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
+
+import org.eclipse.jdt.internal.ui.fix.SimplifyBooleanIfElseCleanUpCore.SimplifyStatus;
 
 /**
  * A fix that removes useless indentation when the opposite workflow falls through:
@@ -195,6 +197,12 @@ public class ReduceIndentationCleanUp extends AbstractMultiFix {
 				if (!(visited.getElseStatement() instanceof Block)
 						&& !ASTNodes.canHaveSiblings(visited)) {
 					return true;
+				}
+
+				if (isEnabled(CleanUpConstants.SIMPLIFY_BOOLEAN_IF_ELSE)) {
+					if (SimplifyBooleanIfElseCleanUpCore.verifyBooleanIfElse(visited) != SimplifyStatus.INVALID) {
+						return true;
+					}
 				}
 
 				if (visited.getElseStatement() != null && !ASTNodes.isInElse(visited)) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -64,6 +64,7 @@ public class CleanUpMessages extends NLS {
 	public static String CodeStyleTabPage_CheckboxName_ExtractIncrement;
 	public static String CodeStyleTabPage_CheckboxName_PullUpAssignment;
 	public static String CodeStyleTabPage_CheckboxName_ElseIf;
+	public static String CodeStyleTabPage_CheckboxName_SimplifyBooleanIfElse;
 	public static String CodeStyleTabPage_CheckboxName_ReduceIndentation;
 	public static String CodeStyleTabPage_CheckboxName_Instanceof;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2005, 2023 IBM Corporation and others.
+# Copyright (c) 2005, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ CodeStyleTabPage_RadioName_AlwaysUseBlocks=Al&ways
 CodeStyleTabPage_RadioName_NeverUseBlocks=Only if &necessary
 CodeStyleTabPage_CheckboxName_ElseIf=C&ombine nested 'if' statement in 'else' block to 'else if'
 CodeStyleTabPage_CheckboxName_ReduceIndentation=Reduce indentation when possible
+CodeStyleTabPage_CheckboxName_SimplifyBooleanIfElse=Simplify boolean if/else to single return if possible
 CodeStyleTabPage_GroupName_Expressions=Expressions
 CodeStyleTabPage_CheckboxName_ExtractIncrement=Extract increment/decrement from statement
 CodeStyleTabPage_CheckboxName_PullUpAssignment=Pull up assignment

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CodeStyleTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CodeStyleTabPage.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.internal.ui.fix.LambdaExpressionAndMethodRefCleanUp;
 import org.eclipse.jdt.internal.ui.fix.NumberSuffixCleanUp;
 import org.eclipse.jdt.internal.ui.fix.PullUpAssignmentCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ReduceIndentationCleanUp;
+import org.eclipse.jdt.internal.ui.fix.SimplifyBooleanIfElseCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.SwitchCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.VariableDeclarationCleanUpCore;
 
@@ -51,6 +52,7 @@ public final class CodeStyleTabPage extends AbstractCleanUpTabPage {
 				new NumberSuffixCleanUp(values),
 				new InstanceofCleanUp(values),
 				new VariableDeclarationCleanUpCore(values),
+				new SimplifyBooleanIfElseCleanUpCore(values),
 				new LambdaExpressionAndMethodRefCleanUp(values)
 		};
 	}
@@ -70,6 +72,9 @@ public final class CodeStyleTabPage extends AbstractCleanUpTabPage {
 
 		CheckboxPreference elseIf= createCheckboxPref(controlGroup, numColumns, CleanUpMessages.CodeStyleTabPage_CheckboxName_ElseIf, CleanUpConstants.ELSE_IF, CleanUpModifyDialog.FALSE_TRUE);
 		registerPreference(elseIf);
+
+		final CheckboxPreference simplifyIfElse= createCheckboxPref(controlGroup, numColumns, CleanUpMessages.CodeStyleTabPage_CheckboxName_SimplifyBooleanIfElse, CleanUpConstants.SIMPLIFY_BOOLEAN_IF_ELSE, CleanUpModifyDialog.FALSE_TRUE);
+		registerPreference(simplifyIfElse);
 
 		final CheckboxPreference reduceIndentationPref= createCheckboxPref(controlGroup, numColumns, CleanUpMessages.CodeStyleTabPage_CheckboxName_ReduceIndentation, CleanUpConstants.REDUCE_INDENTATION, CleanUpModifyDialog.FALSE_TRUE);
 		registerPreference(reduceIndentationPref);


### PR DESCRIPTION
- add new SimplifyBooleanIfElseCleanUpCore which reduces an if/else statement where the then statement is a boolean return statement and the else statement is an opposite boolean return statement
- add new tests to CleanUpTest
- add code to ReduceIndentationCleanUp to avoid collision with new clean up
- add new CleanUpNLSUtils class
- fixes #1632

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See feature issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
