### PR TITLE
Move filters Button in Call Hierarchy view to the top level Bar

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.33.100.qualifier
+Bundle-Version: 3.33.200.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.33.100-SNAPSHOT</version>
+  <version>3.33.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyFiltersActionGroup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyFiltersActionGroup.java
@@ -21,12 +21,9 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
-import org.eclipse.jface.window.Window;
 
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.actions.ActionGroup;
-
-import org.eclipse.jdt.internal.ui.JavaPluginImages;
 
 /**
  * Action group to add the filter actions to a view part's toolbar
@@ -36,19 +33,6 @@ import org.eclipse.jdt.internal.ui.JavaPluginImages;
  * </p>
  */
 public class CallHierarchyFiltersActionGroup extends ActionGroup {
-
-    class ShowFilterDialogAction extends Action {
-        ShowFilterDialogAction() {
-            setText(CallHierarchyMessages.ShowFilterDialogAction_text);
-            setImageDescriptor(JavaPluginImages.DESC_ELCL_FILTER);
-			setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_FILTER);
-        }
-
-        @Override
-		public void run() {
-            openFiltersDialog();
-        }
-    }
 
     class ShowExpandWithConstructorsDialogAction extends Action {
     	ShowExpandWithConstructorsDialogAction() {
@@ -82,7 +66,7 @@ public class CallHierarchyFiltersActionGroup extends ActionGroup {
 
     private void fillViewMenu(IMenuManager viewMenu) {
         viewMenu.add(new Separator("filters")); //$NON-NLS-1$
-        viewMenu.add(new ShowFilterDialogAction());
+        viewMenu.add(new ShowCallHierarchyFilterDialogAction(fPart, null));
         viewMenu.add(new ShowExpandWithConstructorsDialogAction());
     }
 
@@ -92,15 +76,6 @@ public class CallHierarchyFiltersActionGroup extends ActionGroup {
     }
 
     // ---------- dialog related code ----------
-
-    private void openFiltersDialog() {
-        FiltersDialog dialog= new FiltersDialog(
-            fPart.getViewSite().getShell());
-
-        if(Window.OK == dialog.open()) {
-        	fPart.refresh();
-        }
-    }
 
     private void openExpandWithConstructorsDialog() {
     	Shell parentShell= fPart.getViewSite().getShell();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyViewPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyViewPart.java
@@ -244,6 +244,7 @@ public class CallHierarchyViewPart extends ViewPart implements ICallHierarchyVie
 	private IPartListener2 fPartListener;
 	private boolean fIsPinned;
 	private PinCallHierarchyViewAction fPinViewAction;
+	private ShowCallHierarchyFilterDialogAction fFiltersAction;
 
 
     public CallHierarchyViewPart() {
@@ -1024,6 +1025,7 @@ public class CallHierarchyViewPart extends ViewPart implements ICallHierarchyVie
 		}
         toolBar.add(fHistoryDropDownAction);
         toolBar.add(fPinViewAction);
+        toolBar.add(fFiltersAction);
     }
 
     private void makeActions() {
@@ -1048,6 +1050,8 @@ public class CallHierarchyViewPart extends ViewPart implements ICallHierarchyVie
         fExpandWithConstructorsAction= new ExpandWithConstructorsAction(this, fCallHierarchyViewer);
         fRemoveFromViewAction= new RemoveFromViewAction(this, fCallHierarchyViewer);
         fPinViewAction= new PinCallHierarchyViewAction(this);
+        fFiltersAction = new ShowCallHierarchyFilterDialogAction(this, CallHierarchyMessages.ShowFilterDialogAction_text);
+
         fToggleOrientationActions = new ToggleOrientationAction[] {
                 new ToggleOrientationAction(this, VIEW_ORIENTATION_VERTICAL),
                 new ToggleOrientationAction(this, VIEW_ORIENTATION_HORIZONTAL),

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/ShowCallHierarchyFilterDialogAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/ShowCallHierarchyFilterDialogAction.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Vector Informatik GmbH and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Vector Informatik GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.callhierarchy;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.window.Window;
+
+import org.eclipse.jdt.internal.ui.JavaPluginImages;
+
+class ShowCallHierarchyFilterDialogAction extends Action {
+	private CallHierarchyViewPart fPart;
+
+	public ShowCallHierarchyFilterDialogAction(CallHierarchyViewPart view, String tooltipText) {
+		super();
+		fPart= view;
+
+		setToolTipText(tooltipText);
+
+		setText(CallHierarchyMessages.ShowFilterDialogAction_text);
+		setImageDescriptor(JavaPluginImages.DESC_ELCL_FILTER);
+		setDisabledImageDescriptor(JavaPluginImages.DESC_DLCL_FILTER);
+	}
+
+	@Override
+	public void run() {
+		openFiltersDialog();
+	}
+
+	private void openFiltersDialog() {
+		FiltersDialog dialog= new FiltersDialog(
+				fPart.getViewSite().getShell());
+
+		if (Window.OK == dialog.open()) {
+			fPart.refresh();
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Before the changes the filters could only be accessed through the "View Menu" (three dots), which is inconvenient considering that the filters button is rather important and frequently used.
After the changes the filters can be accessed by clicking on the icon in the top level bar as well as the old way through the view menu.

## Before
![image](https://github.com/user-attachments/assets/d3cee259-fe69-4d4a-bbab-bb1f94a7b396)
## After
![Ticket1_bearbeitet](https://github.com/user-attachments/assets/a29e5298-3283-4e7e-89da-baf7ab4c0179)


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
