### PR TITLE
Show only tests

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchyCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchyCore.java
@@ -46,10 +46,13 @@ import org.eclipse.jdt.internal.ui.util.StringMatcher;
 
 public class CallHierarchyCore {
 
-    private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
-    private static final String PREF_USE_FILTERS= "PREF_USE_FILTERS"; //$NON-NLS-1$
-    private static final String PREF_FILTERS_LIST= "PREF_FILTERS_LIST"; //$NON-NLS-1$
-    private static final String PREF_FILTER_TESTCODE= "PREF_FILTER_TESTCODE"; //$NON-NLS-1$
+	public static final String PREF_SHOW_ALL_CODE = "PREF_SHOW_ALL_CODE";	//$NON-NLS-1$
+	public static final String PREF_HIDE_TEST_CODE = "PREF_HIDE_TEST_CODE";	//$NON-NLS-1$
+	public static final String PREF_SHOW_TEST_CODE_ONLY = "PREF_SHOW_TEST_CODE_ONLY";	//$NON-NLS-1$
+
+	private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
+	private static final String PREF_USE_FILTERS= "PREF_USE_FILTERS"; //$NON-NLS-1$
+	private static final String PREF_FILTERS_LIST= "PREF_FILTERS_LIST"; //$NON-NLS-1$
 
     private String defaultIgnoreFilters= "java.*,javax.*"; //$NON-NLS-1$
 
@@ -69,9 +72,17 @@ public class CallHierarchyCore {
         return Boolean.parseBoolean(JavaManipulation.getPreference(PREF_USE_IMPLEMENTORS, null));
     }
 
-    public boolean isFilterTestCode() {
-        return Boolean.parseBoolean(JavaManipulation.getPreference(PREF_FILTER_TESTCODE, null));
+    public boolean isShowTestCode() {
+        return Boolean.parseBoolean(JavaManipulation.getPreference(PREF_SHOW_TEST_CODE_ONLY, null));
     }
+
+    public boolean isShowAll() {
+		return Boolean.parseBoolean(JavaManipulation.getPreference(PREF_SHOW_ALL_CODE, null));
+    }
+
+	public boolean isHideTestCode() {
+		return Boolean.parseBoolean(JavaManipulation.getPreference(PREF_HIDE_TEST_CODE, null));
+	}
 
     public Collection<IJavaElement> getImplementingMethods(IMethod method) {
         if (isSearchUsingImplementorsEnabled()) {
@@ -196,10 +207,8 @@ public class CallHierarchyCore {
         		}
         	}
         }
-
         return false;
     }
-
     public boolean isFilterEnabled() {
         return Boolean.parseBoolean(JavaManipulation.getPreference(PREF_USE_FILTERS, null));
     }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallSearchResultCollector.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallSearchResultCollector.java
@@ -72,19 +72,21 @@ class CallSearchResultCollector {
      * Method isIgnored.
      * @return boolean
      */
-    private boolean isIgnored(IMember enclosingElement) {
-        String fullyQualifiedName = getTypeOfElement(enclosingElement)
-                                        .getFullyQualifiedName();
+	private boolean isIgnored(IMember enclosingElement) {
+		String fullyQualifiedName= getTypeOfElement(enclosingElement).getFullyQualifiedName();
 
-		if (CallHierarchyCore.getDefault().isFilterTestCode()) {
-			IClasspathEntry classpathEntry= determineClassPathEntry(enclosingElement);
-			if (classpathEntry != null && classpathEntry.isTest()) {
-				return true;
-			}
+		if (CallHierarchyCore.getDefault().isShowAll()) {
+			return false;
 		}
+		IClasspathEntry classpathEntry= determineClassPathEntry(enclosingElement);
 
-        return CallHierarchyCore.getDefault().isIgnored(fullyQualifiedName);
-    }
+		if (classpathEntry != null) {
+			boolean isTest= classpathEntry.isTest();
+			return CallHierarchyCore.getDefault().isHideTestCode() && isTest
+					|| CallHierarchyCore.getDefault().isShowTestCode() && !isTest;
+		}
+		return CallHierarchyCore.getDefault().isIgnored(fullyQualifiedName);
+	}
 
 	private static IClasspathEntry determineClassPathEntry(Object element) {
 		if (element instanceof IJavaElement) {

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchy.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchy.java
@@ -37,10 +37,10 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.util.StringMatcher;
 
 public class CallHierarchy {
-    private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
+
+	private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
     private static final String PREF_USE_FILTERS = "PREF_USE_FILTERS"; //$NON-NLS-1$
     private static final String PREF_FILTERS_LIST = "PREF_FILTERS_LIST"; //$NON-NLS-1$
-    private static final String PREF_FILTER_TESTCODE= "PREF_FILTER_TESTCODE"; //$NON-NLS-1$
 
     private static CallHierarchy fgInstance;
     private CallHierarchyCore fgCallHierarchyCore;
@@ -53,13 +53,26 @@ public class CallHierarchy {
         if (fgInstance == null) {
             fgInstance = new CallHierarchy();
         }
-
         return fgInstance;
+    }
+
+    public void setShowAll(boolean value) {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        settings.setValue(CallHierarchyCore.PREF_SHOW_ALL_CODE, value);
+    }
+
+    public void setHideTestCode(boolean value) {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        settings.setValue(CallHierarchyCore.PREF_HIDE_TEST_CODE, value);
+    }
+
+    public void setShowTestCode(boolean value) {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        settings.setValue(CallHierarchyCore.PREF_SHOW_TEST_CODE_ONLY, value);
     }
 
     public boolean isSearchUsingImplementorsEnabled() {
         IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-
         return settings.getBoolean(PREF_USE_IMPLEMENTORS);
     }
 
@@ -68,19 +81,6 @@ public class CallHierarchy {
 
         settings.setValue(PREF_USE_IMPLEMENTORS, enabled);
     }
-
-    public boolean isFilterTestCode() {
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-
-        return settings.getBoolean(PREF_FILTER_TESTCODE);
-    }
-
-    public void setFilterTestCode(boolean enabled) {
-        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-
-        settings.setValue(PREF_FILTER_TESTCODE, enabled);
-    }
-
 
     public Collection<IJavaElement> getImplementingMethods(IMethod method) {
         return fgCallHierarchyCore.getImplementingMethods(method);
@@ -134,6 +134,22 @@ public class CallHierarchy {
         IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
         return settings.getBoolean(PREF_USE_FILTERS);
     }
+
+    public boolean isShowAll() {
+        IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        return settings.getBoolean(CallHierarchyCore.PREF_SHOW_ALL_CODE);
+    }
+
+    public boolean isHideTestCode() {
+    	IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        return settings.getBoolean(CallHierarchyCore.PREF_HIDE_TEST_CODE);
+    }
+
+    public boolean isShowTestCode() {
+    	IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
+        return settings.getBoolean(CallHierarchyCore.PREF_SHOW_TEST_CODE_ONLY);
+    }
+
 
     public void setFilterEnabled(boolean filterEnabled) {
         IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.java
@@ -66,6 +66,11 @@ public final class CallHierarchyMessages extends NLS {
 	public static String ShowExpandWithConstructorsDialogAction_text;
 	public static String ShowFilterDialogAction_text;
 	public static String FiltersDialog_filter;
+
+	public static String FiltersDialog_ShowAllCode;
+	public static String FiltersDialog_HideTestCode;
+	public static String FiltersDialog_TestCodeOnly;
+
 	public static String FiltersDialog_filterOnNames;
 	public static String FiltersDialog_filterOnNamesSubCaption;
 	public static String FiltersDialog_maxCallDepth;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
@@ -62,6 +62,11 @@ ShowSearchInDialogAction_text= Search &In...
 SearchInDialog_title= Search In
 ShowExpandWithConstructorsDialogAction_text=E&xpand with Constructors...
 ShowFilterDialogAction_text= &Filters...
+
+FiltersDialog_HideTestCode = Hide Test Code
+FiltersDialog_ShowAllCode = Show All Code
+FiltersDialog_TestCodeOnly = Test Code only
+
 FiltersDialog_filter= Filter Calls
 FiltersDialog_filterOnNames= &Name filter patterns (matching names will be hidden):
 FiltersDialog_filterOnNamesSubCaption= Patterns are separated by commas (* = any string, ? = any character)

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/FiltersDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/FiltersDialog.java
@@ -40,8 +40,9 @@ class FiltersDialog extends StatusDialog {
     private Button fFilterOnNames;
     private Text fNames;
     private Text fMaxCallDepth;
-    private Button fFilterTestCode;
-
+    private Button fShowAll;
+    private Button fHideTest;
+    private Button fShowTest;
 
     protected FiltersDialog(Shell parentShell) {
         super(parentShell);
@@ -112,10 +113,34 @@ class FiltersDialog extends StatusDialog {
     }
 
     private void createTestCodeArea(Composite parent) {
-        fFilterTestCode = createCheckbox(parent,
-                CallHierarchyMessages.FiltersDialog_filterTestCode, true);
-    }
+		Composite radioGroup= new Composite(parent, SWT.NONE);
+		GridLayout layout= new GridLayout();
+		layout.numColumns= 1;
+		radioGroup.setLayout(layout);
 
+		fShowAll= new Button(radioGroup, SWT.RADIO);
+		fShowAll.setText(CallHierarchyMessages.FiltersDialog_ShowAllCode);
+
+		fHideTest= new Button(radioGroup, SWT.RADIO);
+		fHideTest.setText(CallHierarchyMessages.FiltersDialog_HideTestCode);
+
+		fShowTest= new Button(radioGroup, SWT.RADIO);
+		fShowTest.setText(CallHierarchyMessages.FiltersDialog_TestCodeOnly);
+		setSelection();
+
+		GridData gridData= new GridData();
+		gridData.horizontalIndent= 0;
+		fShowAll.setLayoutData(gridData);
+		fHideTest.setLayoutData(gridData);
+		fShowTest.setLayoutData(gridData);
+	}
+
+    private void setSelection() {
+		fShowAll.setSelection(CallHierarchy.getDefault().isShowAll());
+		fHideTest.setSelection(CallHierarchy.getDefault().isHideTestCode());
+		fShowTest.setSelection(CallHierarchy.getDefault().isShowTestCode());
+
+    }
 
     /**
      * Creates a check box button with the given parent and text.
@@ -157,27 +182,33 @@ class FiltersDialog extends StatusDialog {
     }
 
     /**
-     * Updates the given filter from the UI state.
-     */
-    private void updateFilterFromUI() {
-        int maxCallDepth = Integer.parseInt(this.fMaxCallDepth.getText());
+	 * Updates the given filter from the UI state.
+	 */
+	private void updateFilterFromUI() {
+		int maxCallDepth= Integer.parseInt(this.fMaxCallDepth.getText());
 
-        CallHierarchyUI.getDefault().setMaxCallDepth(maxCallDepth);
-        CallHierarchy.getDefault().setFilters(fNames.getText());
-        CallHierarchy.getDefault().setFilterEnabled(fFilterOnNames.getSelection());
-        CallHierarchy.getDefault().setFilterTestCode(fFilterTestCode.getSelection());
-    }
+		CallHierarchyUI.getDefault().setMaxCallDepth(maxCallDepth);
+		CallHierarchy.getDefault().setFilters(fNames.getText());
+		CallHierarchy.getDefault().setFilterEnabled(fFilterOnNames.getSelection());
 
-    /**
-     * Updates the UI state from the given filter.
-     */
-    private void updateUIFromFilter() {
-      fMaxCallDepth.setText(String.valueOf(CallHierarchyUI.getDefault().getMaxCallDepth()));
-      fNames.setText(CallHierarchy.getDefault().getFilters());
-      fFilterOnNames.setSelection(CallHierarchy.getDefault().isFilterEnabled());
-      fFilterTestCode.setSelection(CallHierarchy.getDefault().isFilterTestCode());
-      updateEnabledState();
-    }
+		CallHierarchy.getDefault().setShowAll(fShowAll.getSelection());
+		CallHierarchy.getDefault().setHideTestCode(fHideTest.getSelection());
+		CallHierarchy.getDefault().setShowTestCode(fShowTest.getSelection());
+	}
+
+	/**
+	 * Updates the UI state from the given filter.
+	 */
+	private void updateUIFromFilter() {
+		fMaxCallDepth.setText(String.valueOf(CallHierarchyUI.getDefault().getMaxCallDepth()));
+		fNames.setText(CallHierarchy.getDefault().getFilters());
+		fFilterOnNames.setSelection(CallHierarchy.getDefault().isFilterEnabled());
+
+		setSelection();
+		
+		updateEnabledState();
+	}
+
 
 	/**
      * Updates the filter from the UI state.


### PR DESCRIPTION
## What it does
Add a new option to only show the test code when filtering the Call Hierarchy. The option was missing before since one could only either show all code or show only non-test code.

## Before
![image](https://github.com/user-attachments/assets/a6056ef7-5142-44d8-a3e9-7fa8305fc932)

## After
![image](https://github.com/user-attachments/assets/13ad4d51-611f-47bf-8af8-70c3f0941d50)

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
