### PR TITLE
add a plain junit5 test to show junit5 tests are now possible

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
@@ -24,6 +24,8 @@ import org.eclipse.jdt.testplugin.TestOptions;
 
 import org.eclipse.jdt.core.JavaCore;
 
+import org.eclipse.jdt.internal.common.VisitorTest;
+
 import org.eclipse.jdt.ui.tests.browsing.PackagesViewContentProviderTests;
 import org.eclipse.jdt.ui.tests.browsing.PackagesViewContentProviderTests2;
 import org.eclipse.jdt.ui.tests.browsing.PackagesViewDeltaTests;
@@ -53,6 +55,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
  */
 @Suite
 @SelectClasses({
+	VisitorTest.class,
 	CoreTests.class,
 	CoreTestSuite.class,
 	QuickFixTestSuite.class,


### PR DESCRIPTION

## What it does
It adds existing junit5 tests in the sourcetree to the build configuration. Theses tests could not be executed until recently the suites have been migrated from junit4 to junit5. This patch adds the tests to be executed as part of the build.

## How to test
count the number of tests and check if "VisitorTest" is now part of the test execution.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
