### PR TITLE
Fix push down to allow moving fields/methods to inner/local classes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
@@ -629,6 +629,19 @@ public final class PushDownRefactoringProcessor extends HierarchyProcessor {
 					continue;
 				if (!(element instanceof IMember))
 					continue;
+				IType[] destinationTypes= getAbstractDestinations(new NullProgressMonitor());
+				IMember elementMember= (IMember)element;
+				IType elementMemberType= elementMember.getDeclaringType();
+				boolean isMoveDestination= false;
+				for (IType destinationType : destinationTypes) {
+					if (destinationType.getFullyQualifiedName().equals(elementMemberType.getFullyQualifiedName())) {
+						isMoveDestination= true;
+						break;
+					}
+				}
+				if (isMoveDestination) {
+					continue;
+				}
 				IMember referencingMember= (IMember) element;
 				Object[] keys= { label, createLabel(referencingMember) };
 				String msg= Messages.format(RefactoringCoreMessages.PushDownRefactoring_referenced, keys);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test40/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test40/in/A.java
@@ -1,0 +1,13 @@
+package p;
+
+class A {
+	int f;
+
+	void mA() {
+		class B extends A {
+			public void mB() {
+				f = 0;
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test40/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test40/out/A.java
@@ -1,0 +1,13 @@
+package p;
+
+class A {
+	void mA() {
+		class B extends A {
+			int f;
+
+			public void mB() {
+				f = 0;
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
@@ -964,6 +964,24 @@ public class PushDownTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void test40() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1679
+		String[] selectedMethodNames= { };
+		String[][] selectedMethodSignatures= { new String[0] };
+		String[] selectedFieldNames= { "f" };
+		String[] namesOfMethodsToPushDown= selectedMethodNames;
+		String[][] signaturesOfMethodsToPushDown= selectedMethodSignatures;
+		String[] namesOfFieldsToPushDown= {};
+		String[] namesOfMethodsToDeclareAbstract= {};
+		String[][] signaturesOfMethodsToDeclareAbstract= {};
+
+		helper(selectedMethodNames, selectedMethodSignatures,
+				selectedFieldNames,
+				namesOfMethodsToPushDown, signaturesOfMethodsToPushDown,
+				namesOfFieldsToPushDown,
+				namesOfMethodsToDeclareAbstract, signaturesOfMethodsToDeclareAbstract, null, null);
+	}
+
+	@Test
 	public void testFail0() throws Exception {
 		String[] selectedMethodNames= {"f"};
 		String[][] selectedMethodSignatures= {new String[0]};


### PR DESCRIPTION
- add logic to PushDownRefactoringProcessor.checkReferencesToPushedDownMembers() to ignore members in the declaring CU that will end up being targets of the move (i.e. they extend the declaring class)
- add new test to PushDownTests
- fixes #1691

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
