### PR TITLE
Fix push down to replace super references where appropriate

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
@@ -909,7 +909,6 @@ public final class PushDownRefactoringProcessor extends HierarchyProcessor {
 							ASTNode argsCopy= typeArgs.createCopyTarget(originalArgsList.get(0), originalArgsList.get(originalTypeList.size() - 1));
 							newMethodInvocation.arguments().add(argsCopy);
 						}
-						newMethodInvocation.setExpression(ast.newThisExpression());
 						astRewrite.replace(node, newMethodInvocation, group);
 						return false;
 					}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test41/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test41/in/A.java
@@ -1,0 +1,17 @@
+package p;
+
+class A {
+	int f;
+
+	void m() {
+	}
+
+	void mA() {
+		class B extends A {
+			public void mB() {
+				super.m();
+				super.f = 0;
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test41/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test41/out/A.java
@@ -6,7 +6,7 @@ class A {
 			int f;
 
 			public void mB() {
-				this.m();
+				m();
 				this.f = 0;
 			}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test41/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/test41/out/A.java
@@ -1,0 +1,17 @@
+package p;
+
+class A {
+	void mA() {
+		class B extends A {
+			int f;
+
+			public void mB() {
+				this.m();
+				this.f = 0;
+			}
+
+			void m() {
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
@@ -964,8 +964,26 @@ public class PushDownTests extends GenericRefactoringTest {
 	}
 
 	@Test
-	public void test40() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1679
+	public void test40() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1691
 		String[] selectedMethodNames= { };
+		String[][] selectedMethodSignatures= { new String[0] };
+		String[] selectedFieldNames= { "f" };
+		String[] namesOfMethodsToPushDown= selectedMethodNames;
+		String[][] signaturesOfMethodsToPushDown= selectedMethodSignatures;
+		String[] namesOfFieldsToPushDown= {};
+		String[] namesOfMethodsToDeclareAbstract= {};
+		String[][] signaturesOfMethodsToDeclareAbstract= {};
+
+		helper(selectedMethodNames, selectedMethodSignatures,
+				selectedFieldNames,
+				namesOfMethodsToPushDown, signaturesOfMethodsToPushDown,
+				namesOfFieldsToPushDown,
+				namesOfMethodsToDeclareAbstract, signaturesOfMethodsToDeclareAbstract, null, null);
+	}
+
+	@Test
+	public void test41() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1692
+		String[] selectedMethodNames= { "m" };
 		String[][] selectedMethodSignatures= { new String[0] };
 		String[] selectedFieldNames= { "f" };
 		String[] namesOfMethodsToPushDown= selectedMethodNames;


### PR DESCRIPTION
- modify PushDownRefactoringProcessor to replace any super method invocations and super field accesses to the members being pushed down if they are in a destination of the moved members
- add new test to PushDownTests
- fixes #1692

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
