### PR TITLE
fix usage of asserts where order or condition is missleading

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/templates/TemplateCompletionTests.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/templates/TemplateCompletionTests.java
@@ -14,7 +14,6 @@ package org.eclipse.jdt.text.tests.templates;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -102,9 +101,7 @@ public class TemplateCompletionTests {
 		List<ICompletionProposal> proposals= computeCompletionProposals(cu, completionIndex);
 
 		boolean fail= proposals.stream().anyMatch(p -> "new_class - create new class".equals(p.getDisplayString()));
-		if (fail) {
-			fail("Proposal '" + propDisplay + "' should not exist");
-		}
+		org.junit.Assert.assertFalse("Proposal '" + propDisplay + "' should not exist", fail);
 	}
 
 	@Test

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/templates/TemplateCompletionTests.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/templates/TemplateCompletionTests.java
@@ -13,6 +13,7 @@
 package org.eclipse.jdt.text.tests.templates;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -101,7 +102,7 @@ public class TemplateCompletionTests {
 		List<ICompletionProposal> proposals= computeCompletionProposals(cu, completionIndex);
 
 		boolean fail= proposals.stream().anyMatch(p -> "new_class - create new class".equals(p.getDisplayString()));
-		org.junit.Assert.assertFalse("Proposal '" + propDisplay + "' should not exist", fail);
+		assertFalse("Proposal '" + propDisplay + "' should not exist", fail);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractConstantTests1d7.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractConstantTests1d7.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.refactoring;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
@@ -61,7 +62,7 @@ public class ExtractConstantTests1d7 extends ExtractConstantTests {
 
 		assertNotNull("precondition was supposed to fail", result);
 		if(checkMsg)
-			org.junit.Assert.assertEquals(errorMsg, result.getEntryMatchingSeverity(RefactoringStatus.FATAL).getMessage());
+			assertEquals(errorMsg, result.getEntryMatchingSeverity(RefactoringStatus.FATAL).getMessage());
 	}
 	//--- TESTS
 

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractConstantTests1d7.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractConstantTests1d7.java
@@ -14,7 +14,6 @@
 package org.eclipse.jdt.ui.tests.refactoring;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,7 +61,7 @@ public class ExtractConstantTests1d7 extends ExtractConstantTests {
 
 		assertNotNull("precondition was supposed to fail", result);
 		if(checkMsg)
-			assertTrue(errorMsg.equals(result.getEntryMatchingSeverity(RefactoringStatus.FATAL).getMessage()));
+			org.junit.Assert.assertEquals(errorMsg, result.getEntryMatchingSeverity(RefactoringStatus.FATAL).getMessage());
 	}
 	//--- TESTS
 

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceFactoryTestsBase.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceFactoryTestsBase.java
@@ -15,6 +15,7 @@
 package org.eclipse.jdt.ui.tests.refactoring;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -164,8 +165,8 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 		int		begin= source.indexOf(SELECTION_START_HERALD) + SELECTION_START_HERALD.length();
 		int		end= source.indexOf(SELECTION_END_HERALD);
 
-		org.junit.Assert.assertFalse("No selection start comment in input source file!", begin < SELECTION_START_HERALD.length());
-		org.junit.Assert.assertFalse("No selection end comment in input source file!", end < 0);
+		assertFalse("No selection start comment in input source file!", begin < SELECTION_START_HERALD.length());
+		assertFalse("No selection end comment in input source file!", end < 0);
 
 		return new SourceRange(begin, end-begin);
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceFactoryTestsBase.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceFactoryTestsBase.java
@@ -164,10 +164,8 @@ public class IntroduceFactoryTestsBase extends GenericRefactoringTest {
 		int		begin= source.indexOf(SELECTION_START_HERALD) + SELECTION_START_HERALD.length();
 		int		end= source.indexOf(SELECTION_END_HERALD);
 
-		if (begin < SELECTION_START_HERALD.length())
-			fail("No selection start comment in input source file!");
-		if (end < 0)
-			fail("No selection end comment in input source file!");
+		org.junit.Assert.assertFalse("No selection start comment in input source file!", begin < SELECTION_START_HERALD.length());
+		org.junit.Assert.assertFalse("No selection end comment in input source file!", end < 0);
 
 		return new SourceRange(begin, end-begin);
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
@@ -12,6 +12,7 @@
 
 package org.eclipse.jdt.ui.tests.refactoring;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -154,14 +155,14 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testMethodNotFound() throws Exception {
 		//Method cannot be found
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 0, 2, 1);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_on_this_selection);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_on_this_selection);
 	}
 
 	@Test
 	public void testIsConstructor() throws Exception {
 		//Check if Constructor
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 12, 2, 15);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_constructors);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_constructors);
 	}
 
 	@Test
@@ -197,42 +198,42 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testRecursive() throws Exception {
 		//MethodInvocation in MethodDeclaration with object of the same Class in parameter
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 3, 10, 3, 13);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testRecursive2() throws Exception {
 		//recursive invocation after invoking a method that returns a new instance of the same class
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 6, 10, 6, 13);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testRecursive3() throws Exception {
 		//simple recursive invocation of instance method
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 17, 2, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testInheritance() throws Exception {
 		//Refactor of method that overrides method of supertype (Selection is set to MethodDeclaration)
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 4, 19, 4, 22);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation);
 	}
 
 	@Test
 	public void testInheritance2() throws Exception {
 		//Refactor of method in super type that has child type overriding the method -> should fail
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SuperClass", "p.SubClass" }, 3, 19, 3, 22);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_method_is_overridden_in_subtype);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_method_is_overridden_in_subtype);
 	}
 
 	@Test
 	public void testInheritance3() throws Exception {
 		//Selecting SuperMethodInvocation -> should fail
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 5, 26, 5, 29);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_super_method_invocations);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_super_method_invocations);
 	}
 
 	@Test
@@ -240,14 +241,14 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 		//Refactor method without parameters on the lowest hierarchy level ->
 		//After refactoring it is static but has the same signature as parent type method -> should fail
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 4, 19, 4, 22);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_hiding_method_of_parent_type);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_hiding_method_of_parent_type);
 	}
 
 	@Test
 	public void testInheritance5() throws Exception {
 		//Inheritance with Recursion
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 4, 10, 4, 13);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
@@ -261,7 +262,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testDuplicateMethod() throws Exception {
 		//Selected method has instance usage and there is an existing method that is equal to the selected method after being refactored
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 5, 19, 5, 22);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_duplicate_method_signature);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_duplicate_method_signature);
 	}
 
 	@Test
@@ -275,7 +276,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testMethodAlreadyStatic() throws Exception {
 		//Selected method is already static
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 24, 2, 27);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_method_already_static);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_method_already_static);
 	}
 
 	@Test
@@ -347,14 +348,14 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testGenericDeclaration9() throws Exception {
 		//check for wildcardTypes as bounds (T extends List<?>)
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 7, 17, 7, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound);
 	}
 
 	@Test
 	public void testGenericDeclaration10() throws Exception {
 		//check for wildcardTypes as bounds (T extends Map<? extends Runnable, ? extends Throwable>)
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 7, 17, 7, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound);
 	}
 
 	@Test
@@ -411,7 +412,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testVariousInstanceCases() throws Exception {
 		//Various cases of instance access in many different forms
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 14, 17, 14, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access);
 	}
 
 	@Test
@@ -446,7 +447,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testSuperMethodReference() throws Exception {
 		//Selected method is used in SuperMethodReference -> Should throw error
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SuperClass", "p.SubClass" }, 4, 19, 4, 22);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test
@@ -467,7 +468,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testExplicitSuperMethodInvocation() throws Exception {
 		//MethodDeclaration uses explcit SuperMethodInvocation to call method of parent type -> semantic change not allowed
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 3, 17, 3, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation);
 	}
 
 	@Test
@@ -481,7 +482,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testSuperFieldAccess() throws Exception {
 		//MethodDeclaration uses SuperFieldAccess -> throws warning but is possible
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 6, 17, 6, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access);
 	}
 
 	@Test
@@ -493,7 +494,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	@Test
 	public void testSourceNotAvailable() throws Exception {
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 3, 20, 3, 27);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_source_not_available_for_selected_method);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_source_not_available_for_selected_method);
 	}
 
 	@Test
@@ -514,7 +515,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testConvertMethodReferenceToLambda() throws Exception {
 		//MethodReference needs to be co0nverted to lambda because refactored method accepts two parameters
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 10, 10, 10, 13);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test
@@ -527,28 +528,28 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testMethodReference() throws Exception {
 		//TypeMethodReference
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 8, 10, 8, 13);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test
 	public void testMethodReference2() throws Exception {
 		//ExpressionMethodReference in anonymous class -> Refactoring not allowed in anonymous class and method references also not allowed
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 4, 26, 4, 29);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_local_or_anonymous_types);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_local_or_anonymous_types);
 	}
 
 	@Test
 	public void testMethodReference3() throws Exception {
 		//ExpressionMethodReference with recursion
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 17, 2, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testMethodReference4() throws Exception {
 		//ExpressionMethodReference
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 8, 17, 8, 20);
-		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
+		assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
@@ -154,14 +154,14 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testMethodNotFound() throws Exception {
 		//Method cannot be found
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 0, 2, 1);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage().equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_on_this_selection));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_on_this_selection);
 	}
 
 	@Test
 	public void testIsConstructor() throws Exception {
 		//Check if Constructor
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 12, 2, 15);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage().equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_constructors));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_constructors);
 	}
 
 	@Test
@@ -197,46 +197,42 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testRecursive() throws Exception {
 		//MethodInvocation in MethodDeclaration with object of the same Class in parameter
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 3, 10, 3, 13);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testRecursive2() throws Exception {
 		//recursive invocation after invoking a method that returns a new instance of the same class
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 6, 10, 6, 13);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testRecursive3() throws Exception {
 		//simple recursive invocation of instance method
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 17, 2, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testInheritance() throws Exception {
 		//Refactor of method that overrides method of supertype (Selection is set to MethodDeclaration)
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 4, 19, 4, 22);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation);
 	}
 
 	@Test
 	public void testInheritance2() throws Exception {
 		//Refactor of method in super type that has child type overriding the method -> should fail
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SuperClass", "p.SubClass" }, 3, 19, 3, 22);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage().equals(RefactoringCoreMessages.MakeStaticRefactoring_method_is_overridden_in_subtype));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_method_is_overridden_in_subtype);
 	}
 
 	@Test
 	public void testInheritance3() throws Exception {
 		//Selecting SuperMethodInvocation -> should fail
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 5, 26, 5, 29);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage().equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_super_method_invocations));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_super_method_invocations);
 	}
 
 	@Test
@@ -244,14 +240,14 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 		//Refactor method without parameters on the lowest hierarchy level ->
 		//After refactoring it is static but has the same signature as parent type method -> should fail
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 4, 19, 4, 22);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage().equals(RefactoringCoreMessages.MakeStaticRefactoring_hiding_method_of_parent_type));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_hiding_method_of_parent_type);
 	}
 
 	@Test
 	public void testInheritance5() throws Exception {
 		//Inheritance with Recursion
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 4, 10, 4, 13);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage().equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
@@ -265,8 +261,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testDuplicateMethod() throws Exception {
 		//Selected method has instance usage and there is an existing method that is equal to the selected method after being refactored
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 5, 19, 5, 22);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_duplicate_method_signature));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_duplicate_method_signature);
 	}
 
 	@Test
@@ -280,8 +275,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testMethodAlreadyStatic() throws Exception {
 		//Selected method is already static
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 24, 2, 27);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_method_already_static));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_method_already_static);
 	}
 
 	@Test
@@ -353,16 +347,14 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testGenericDeclaration9() throws Exception {
 		//check for wildcardTypes as bounds (T extends List<?>)
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 7, 17, 7, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound);
 	}
 
 	@Test
 	public void testGenericDeclaration10() throws Exception {
 		//check for wildcardTypes as bounds (T extends Map<? extends Runnable, ? extends Throwable>)
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 7, 17, 7, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_wildCardTypes_as_bound);
 	}
 
 	@Test
@@ -419,8 +411,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testVariousInstanceCases() throws Exception {
 		//Various cases of instance access in many different forms
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 14, 17, 14, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access);
 	}
 
 	@Test
@@ -455,8 +446,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testSuperMethodReference() throws Exception {
 		//Selected method is used in SuperMethodReference -> Should throw error
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SuperClass", "p.SubClass" }, 4, 19, 4, 22);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test
@@ -477,8 +467,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testExplicitSuperMethodInvocation() throws Exception {
 		//MethodDeclaration uses explcit SuperMethodInvocation to call method of parent type -> semantic change not allowed
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 3, 17, 3, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_explicit_super_method_invocation);
 	}
 
 	@Test
@@ -492,8 +481,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testSuperFieldAccess() throws Exception {
 		//MethodDeclaration uses SuperFieldAccess -> throws warning but is possible
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.SubClass", "p.SuperClass" }, 6, 17, 6, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_selected_method_uses_super_field_access);
 	}
 
 	@Test
@@ -505,8 +493,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	@Test
 	public void testSourceNotAvailable() throws Exception {
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 3, 20, 3, 27);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_source_not_available_for_selected_method));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_source_not_available_for_selected_method);
 	}
 
 	@Test
@@ -527,8 +514,7 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testConvertMethodReferenceToLambda() throws Exception {
 		//MethodReference needs to be co0nverted to lambda because refactored method accepts two parameters
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 10, 10, 10, 13);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test
@@ -541,32 +527,28 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testMethodReference() throws Exception {
 		//TypeMethodReference
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 8, 10, 8, 13);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test
 	public void testMethodReference2() throws Exception {
 		//ExpressionMethodReference in anonymous class -> Refactoring not allowed in anonymous class and method references also not allowed
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 4, 26, 4, 29);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_local_or_anonymous_types));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_local_or_anonymous_types);
 	}
 
 	@Test
 	public void testMethodReference3() throws Exception {
 		//ExpressionMethodReference with recursion
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 2, 17, 2, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_recursive_methods);
 	}
 
 	@Test
 	public void testMethodReference4() throws Exception {
 		//ExpressionMethodReference
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 8, 17, 8, 20);
-		assertTrue(status.getEntryWithHighestSeverity().getMessage()
-				.equals(RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references));
+		org.junit.Assert.assertEquals(status.getEntryWithHighestSeverity().getMessage(), RefactoringCoreMessages.MakeStaticRefactoring_not_available_for_method_references);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/WrappingSystemTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/WrappingSystemTest.java
@@ -14,9 +14,9 @@
 package org.eclipse.jdt.junit.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 import java.util.List;
@@ -213,10 +213,9 @@ public class WrappingSystemTest implements ILaunchesListener2 {
 			int millisecondTimeout, boolean lastItemHasImage) throws PartInitException {
 		long startTime = System.currentTimeMillis();
 		while (stillWaiting(numExpectedTableLines, lastItemHasImage)) {
-			if (System.currentTimeMillis() - startTime > millisecondTimeout)
-				fail("Timeout waiting for " + numExpectedTableLines
-						+ " lines in table. Present: " + getNumTableItems() + " items.\n"
-						+ "The 2nd vm has " + (hasNotTerminated() ? "not " : "") + "terminated.");
+			assertFalse("Timeout waiting for " + numExpectedTableLines
+					+ " lines in table. Present: " + getNumTableItems() + " items.\n"
+					+ "The 2nd vm has " + (hasNotTerminated() ? "not " : "") + "terminated.", System.currentTimeMillis() - startTime > millisecondTimeout);
 			dispatchEvents();
 		}
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/TypeInfoTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/TypeInfoTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.ui.tests.core;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -297,7 +298,7 @@ public class TypeInfoTest {
 
 		filter= new TypeInfoFilter("Test", scope, 0, null);
 		assertEquals("Test", filter.getNamePattern());
-		assertEquals(null, filter.getPackagePattern());
+		assertNull(filter.getPackagePattern());
    }
 
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -255,7 +255,7 @@ public class JavadocHoverTests extends CoreTests {
 
 			// value should be expanded:
 			int index= actualHtmlContent.indexOf("<pre>{");
-			org.junit.Assert.assertNotEquals(-1, index);
+			assertNotEquals(-1, index);
 			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
 			assertEquals("sequence doesn't match", expectedCodeSequence, actualSnippet);
 		}
@@ -319,7 +319,7 @@ public class JavadocHoverTests extends CoreTests {
 
 			// value should be expanded:
 			int index= actualHtmlContent.indexOf("<pre><code>");
-			org.junit.Assert.assertNotEquals(-1, index);
+			assertNotEquals(-1, index);
 			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
 			assertEquals("sequence doesn't match", actualSnippet, expectedCodeSequence);
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -15,7 +15,6 @@
 package org.eclipse.jdt.ui.tests.hover;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -204,7 +203,7 @@ public class JavadocHoverTests extends CoreTests {
 
 			// value should be expanded:
 			int index= actualHtmlContent.indexOf("<pre><code>");
-			assertFalse(index == -1);
+			org.junit.Assert.assertNotEquals(-1, index);
 			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
 			assertEquals("sequence doesn't match", expectedCodeSequence, actualSnippet);
 		}
@@ -255,7 +254,7 @@ public class JavadocHoverTests extends CoreTests {
 
 			// value should be expanded:
 			int index= actualHtmlContent.indexOf("<pre>{");
-			assertFalse(index == -1);
+			org.junit.Assert.assertNotEquals(-1, index);
 			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
 			assertEquals("sequence doesn't match", expectedCodeSequence, actualSnippet);
 		}
@@ -319,7 +318,7 @@ public class JavadocHoverTests extends CoreTests {
 
 			// value should be expanded:
 			int index= actualHtmlContent.indexOf("<pre><code>");
-			assertFalse(index == -1);
+			org.junit.Assert.assertNotEquals(-1, index);
 			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
 			assertEquals("sequence doesn't match", actualSnippet, expectedCodeSequence);
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -15,6 +15,7 @@
 package org.eclipse.jdt.ui.tests.hover;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -203,7 +204,7 @@ public class JavadocHoverTests extends CoreTests {
 
 			// value should be expanded:
 			int index= actualHtmlContent.indexOf("<pre><code>");
-			org.junit.Assert.assertNotEquals(-1, index);
+			assertNotEquals(-1, index);
 			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
 			assertEquals("sequence doesn't match", expectedCodeSequence, actualSnippet);
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -4780,7 +4780,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SubstringCleanUp_description)));
 	}
@@ -5600,7 +5600,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.VALUEOF_RATHER_THAN_INSTANTIATION);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(
 						MultiFixMessages.ValueOfRatherThanInstantiationCleanup_description_float_with_valueof,
@@ -5663,7 +5663,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.VALUEOF_RATHER_THAN_INSTANTIATION);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.ValueOfRatherThanInstantiationCleanup_description_float_with_float_value)));
 	}
@@ -5789,7 +5789,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_COMPARISON);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveComparisonCleanUp_description)));
 	}
@@ -6080,7 +6080,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_PARSING);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveParsingCleanUp_description)));
 	}
@@ -6788,7 +6788,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -7320,7 +7320,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -7841,7 +7841,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -8390,7 +8390,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -9047,7 +9047,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -9674,7 +9674,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -10235,7 +10235,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -10834,7 +10834,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
 
@@ -10935,7 +10935,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PRIMITIVE_RATHER_THAN_WRAPPER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.PrimitiveRatherThanWrapperCleanUp_description)));
 	}
@@ -11976,7 +11976,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.OperandFactorizationCleanUp_description)));
 	}
@@ -12269,7 +12269,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.TernaryOperatorCleanUp_description)));
 	}
@@ -12493,7 +12493,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.StrictlyEqualOrDifferentCleanUp_description)));
 	}
@@ -12820,7 +12820,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.BOOLEAN_VALUE_RATHER_THAN_COMPARISON);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.BooleanValueRatherThanComparisonCleanUp_description)));
 	}
 
@@ -13293,7 +13293,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.RedundantComparisonStatementCleanup_description)));
 	}
@@ -13699,7 +13699,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.UNREACHABLE_BLOCK);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.UnreachableBlockCleanUp_description)));
 	}
@@ -14423,7 +14423,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.MERGE_CONDITIONAL_BLOCKS);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.MergeConditionalBlocksCleanup_description_if_suite, MultiFixMessages.MergeConditionalBlocksCleanup_description_inner_if)));
 	}
@@ -15668,7 +15668,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PULL_OUT_IF_FROM_IF_ELSE);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.PullOutIfFromIfElseCleanUp_description)));
 	}
 
@@ -16062,7 +16062,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.REDUNDANT_COMPARATOR);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.RedundantComparatorCleanUp_description)));
 	}
@@ -16293,7 +16293,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.ARRAY_WITH_CURLY);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.ArrayWithCurlyCleanup_description)));
 	}
@@ -16610,7 +16610,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.RETURN_EXPRESSION);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.ReturnExpressionCleanUp_description)));
 	}
@@ -16750,7 +16750,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_BOOLEAN_IF_ELSE);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_SimplifyBooleanIfElse_description)));
 	}
@@ -16830,7 +16830,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.REDUCE_INDENTATION);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_SimplifyBooleanIfElse_description)));
 	}
@@ -17524,7 +17524,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.UNLOOPED_WHILE);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.UnloopedWhileCleanUp_description)));
 	}
@@ -20225,7 +20225,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.REDUCE_INDENTATION);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_ReduceIndentation_description)));
 	}
@@ -22429,7 +22429,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SINGLE_USED_FIELD);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SingleUsedFieldCleanUp_description_new_local_var_declaration,
 						MultiFixMessages.SingleUsedFieldCleanUp_description_old_field_declaration, MultiFixMessages.SingleUsedFieldCleanUp_description_uses_of_the_var)));
@@ -22492,7 +22492,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SINGLE_USED_FIELD);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SingleUsedFieldCleanUp_description_new_local_var_declaration,
 						MultiFixMessages.SingleUsedFieldCleanUp_description_old_field_declaration, MultiFixMessages.SingleUsedFieldCleanUp_description_uses_of_the_var)));
@@ -22533,7 +22533,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SINGLE_USED_FIELD);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SingleUsedFieldCleanUp_description_new_local_var_declaration,
 						MultiFixMessages.SingleUsedFieldCleanUp_description_old_field_declaration, MultiFixMessages.SingleUsedFieldCleanUp_description_uses_of_the_var)));
@@ -22596,7 +22596,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SINGLE_USED_FIELD);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SingleUsedFieldCleanUp_description_new_local_var_declaration,
 						MultiFixMessages.SingleUsedFieldCleanUp_description_old_field_declaration, MultiFixMessages.SingleUsedFieldCleanUp_description_uses_of_the_var)));
@@ -22637,7 +22637,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SINGLE_USED_FIELD);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SingleUsedFieldCleanUp_description_new_local_var_declaration,
 						MultiFixMessages.SingleUsedFieldCleanUp_description_old_field_declaration, MultiFixMessages.SingleUsedFieldCleanUp_description_uses_of_the_var)));
@@ -22686,7 +22686,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SINGLE_USED_FIELD);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SingleUsedFieldCleanUp_description_new_local_var_declaration,
 						MultiFixMessages.SingleUsedFieldCleanUp_description_old_field_declaration, MultiFixMessages.SingleUsedFieldCleanUp_description_uses_of_the_var)));
@@ -22725,7 +22725,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.SINGLE_USED_FIELD);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.SingleUsedFieldCleanUp_description_new_local_var_declaration,
 						MultiFixMessages.SingleUsedFieldCleanUp_description_old_field_declaration, MultiFixMessages.SingleUsedFieldCleanUp_description_uses_of_the_var)));
@@ -23798,7 +23798,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.STATIC_INNER_CLASS);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.StaticInnerClassCleanUp_description)));
 	}
@@ -23848,7 +23848,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.STATIC_INNER_CLASS);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.StaticInnerClassCleanUp_description)));
 	}
@@ -23914,7 +23914,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.STATIC_INNER_CLASS);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.StaticInnerClassCleanUp_description)));
 	}
@@ -24695,7 +24695,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.STRINGBUILDER);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.StringBuilderCleanUp_description)));
 	}
@@ -24978,7 +24978,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PLAIN_REPLACEMENT);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.PlainReplacementCleanUp_description)));
 	}
@@ -25078,7 +25078,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.PLAIN_REPLACEMENT);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.PlainReplacementCleanUp_description)));
 	}
@@ -25449,7 +25449,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.CONTROLFLOW_MERGE);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.ControlFlowMergeCleanUp_description)));
 	}
@@ -25818,7 +25818,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.ONE_IF_RATHER_THAN_DUPLICATE_BLOCKS_THAT_FALL_THROUGH);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(MultiFixMessages.OneIfRatherThanDuplicateBlocksThatFallThroughCleanUp_description)));
 	}
 
@@ -26654,7 +26654,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.EXTRACT_INCREMENT);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_ExtractIncrement_description)));
 	}
@@ -27202,7 +27202,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.INSTANCEOF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_Instanceof_description)));
 	}
@@ -28784,7 +28784,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.INVERT_EQUALS);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.InvertEqualsCleanUp_description)));
 	}
@@ -28937,7 +28937,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.STANDARD_COMPARISON);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.StandardComparisonCleanUp_description)));
 	}
@@ -30049,7 +30049,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.CONSTANTS_FOR_SYSTEM_PROPERTY_JAVA_SPECIFICATION_VERSION);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(Messages.format(ConstantsCleanUp_description,UpdateProperty.FILE_SEPARATOR.toString()),
 						Messages.format(ConstantsCleanUp_description,UpdateProperty.PATH_SEPARATOR.toString()),
@@ -30113,7 +30113,7 @@ public class CleanUpTest extends CleanUpTestCase {
 		enable(CleanUpConstants.CONSTANTS_FOR_SYSTEM_PROPERTY_BOXED);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(Messages.format(ConstantsCleanUp_description,UpdateProperty.FILE_SEPARATOR.toString()),
 						Messages.format(ConstantsCleanUp_description,UpdateProperty.PATH_SEPARATOR.toString()),

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest11.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest11.java
@@ -566,7 +566,7 @@ public class CleanUpTest11 extends CleanUpTestCase {
 		enable(CleanUpConstants.USE_STRING_IS_BLANK);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected }, new HashSet<>(Arrays.asList(FixMessages.UseStringIsBlankCleanUp_description)));
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
@@ -1072,7 +1072,7 @@ public class CleanUpTest12 extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_Switch_description)));
 	}
@@ -1170,7 +1170,7 @@ public class E {
 }
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_Switch_description)));
 	}
@@ -1252,7 +1252,7 @@ public class E {
 }
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.CodeStyleCleanUp_Switch_description)));
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -273,7 +273,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.PatternMatchingForInstanceofCleanup_description)));
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d4.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d4.java
@@ -75,7 +75,7 @@ public class CleanUpTest1d4 extends CleanUpTestCase {
 				+ "    private static final long serialVersionUID = 1L;\n" //
 				+ "}\n";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpectedIgnoreHashValue(new ICompilationUnit[] {cu}, new String[] {expected});
 	}
 
@@ -116,7 +116,7 @@ public class CleanUpTest1d4 extends CleanUpTestCase {
 				+ "    }\n" //
 				+ "}\n";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpectedIgnoreHashValue(new ICompilationUnit[] {cu}, new String[] {expected});
 	}
 
@@ -197,7 +197,7 @@ public class CleanUpTest1d4 extends CleanUpTestCase {
 				+ "    }\n" //
 				+ "}\n";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpectedIgnoreHashValue(new ICompilationUnit[] {cu}, new String[] {expected});
 	}
 
@@ -235,7 +235,7 @@ public class CleanUpTest1d4 extends CleanUpTestCase {
 				+ "    };\n" //
 				+ "}\n";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpectedIgnoreHashValue(new ICompilationUnit[] {cu}, new String[] {expected});
 	}
 
@@ -286,7 +286,7 @@ public class CleanUpTest1d4 extends CleanUpTestCase {
 				+ "    }\n" //
 				+ "}\n";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpectedIgnoreHashValue(new ICompilationUnit[] {cu}, new String[] {expected});
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -119,7 +119,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] {cu}, new String[] {expected}, null);
 	}
 
@@ -471,7 +471,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.AddAllCleanup_description)));
 	}
@@ -2560,7 +2560,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		enable(CleanUpConstants.USE_AUTOBOXING);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.AutoboxingCleanup_description)));
 	}
@@ -2844,7 +2844,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		enable(CleanUpConstants.USE_UNBOXING);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.UnboxingCleanup_description)));
 	}
@@ -3197,7 +3197,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 			enable(CleanUpConstants.REMOVE_UNNECESSARY_ARRAY_CREATION);
 
 			// Then
-			assertNotEquals("The class must be changed", given, expected);
+			assertNotEquals("The class must be changed", expected, given);
 			assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 					new HashSet<>(Arrays.asList(FixMessages.UnusedCodeFix_RemoveUnnecessaryArrayCreation_description)));
 		} catch (Exception e) {
@@ -3245,7 +3245,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 			enable(CleanUpConstants.REMOVE_UNNECESSARY_ARRAY_CREATION);
 
 			// Then
-			assertNotEquals("The class must be changed", given, expected);
+			assertNotEquals("The class must be changed", expected, given);
 			assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 					new HashSet<>(Arrays.asList(FixMessages.UnusedCodeFix_RemoveUnnecessaryArrayCreation_description)));
 		} catch (Exception e) {
@@ -3356,7 +3356,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		enable(CleanUpConstants.REMOVE_UNNECESSARY_ARRAY_CREATION);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(FixMessages.UnusedCodeFix_RemoveUnnecessaryArrayCreation_description)));
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d6.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d6.java
@@ -271,7 +271,7 @@ public class CleanUpTest1d6 extends CleanUpTestCase {
 		enable(CleanUpConstants.CONSTANTS_FOR_SYSTEM_PROPERTY_BOXED);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(Messages.format(ConstantsCleanUp_description,UpdateProperty.FILE_SEPARATOR.toString()),
 						Messages.format(ConstantsCleanUp_description,UpdateProperty.PATH_SEPARATOR.toString()),

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d7.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d7.java
@@ -568,7 +568,7 @@ public class CleanUpTest1d7 extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.TryWithResourceCleanup_description)));
 	}
@@ -959,7 +959,7 @@ public class CleanUpTest1d7 extends CleanUpTestCase {
 		enable(CleanUpConstants.MULTI_CATCH);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.MultiCatchCleanUp_description)));
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -1916,7 +1916,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -1967,7 +1967,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -2096,7 +2096,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -2155,7 +2155,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu, cu1 }, new String[] { expected, given1 },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -2211,7 +2211,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu, cu1 }, new String[] { expected, given1 },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -2267,7 +2267,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu, cu1 }, new String[] { expected, given1 },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -2323,7 +2323,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu, cu1 }, new String[] { expected, given1 },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -2399,7 +2399,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.SIMPLIFY_LAMBDA_EXPRESSION_AND_METHOD_REF);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.LambdaExpressionAndMethodRefCleanUp_description)));
 	}
@@ -3198,7 +3198,7 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		enable(CleanUpConstants.COMPARING_ON_CRITERIA);
 
 		// Then
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.ComparingOnCriteriaCleanUp_description)));
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest9.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest9.java
@@ -216,7 +216,7 @@ public class CleanUpTest9 extends CleanUpTestCase {
 			}
 			""";
 
-		assertNotEquals("The class must be changed", given, expected);
+		assertNotEquals("The class must be changed", expected, given);
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
 				new HashSet<>(Arrays.asList(MultiFixMessages.TryWithResourceCleanup_description)));
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/NewTypeWizardTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/NewTypeWizardTest.java
@@ -18,7 +18,6 @@ package org.eclipse.jdt.ui.tests.wizardapi;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -145,7 +144,7 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -187,9 +186,9 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			import java.util.ArrayList;
-			
+
 			/**
 			 * Type
 			 */
@@ -241,14 +240,14 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			import pack.A;
-			
+
 			/**
 			 * Type
 			 */
 			public class E extends A<String> {
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -303,14 +302,14 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			import pack.A;
-			
+
 			/**
 			 * Type
 			 */
 			public class E extends A<String> {
-			
+
 			    /**
 			     * Constructor
 			     */
@@ -318,12 +317,12 @@ public class NewTypeWizardTest {
 			        super(t);
 			    }
 			    /* class body */
-			
+
 			    /**
 			     * Method
 			     */
 			    public static void main(String[] args) {
-			
+
 			    }
 			}
 			""";
@@ -370,9 +369,9 @@ public class NewTypeWizardTest {
 
 		String expected= """
 			package pack;
-			
+
 			import java.util.ArrayList;
-			
+
 			public class A<T> {
 			    /**
 			     * Type
@@ -380,7 +379,7 @@ public class NewTypeWizardTest {
 			    public class E<S> extends ArrayList<S> {
 			        /* class body */
 			    }
-			
+
 			    public abstract void foo(T t);
 			}
 			""";
@@ -423,11 +422,11 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			import java.io.File;
 			import java.util.List;
 			import java.util.Map;
-			
+
 			/**
 			 * Type
 			 */
@@ -486,16 +485,16 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			import java.util.Map;
-			
+
 			import pack.A;
-			
+
 			/**
 			 * Type
 			 */
 			public class E extends A {
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -526,9 +525,9 @@ public class NewTypeWizardTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str1= """
 			package test1;
-			
+
 			import java.util.Map;
-			
+
 			public class B {
 			}
 			""";
@@ -558,18 +557,18 @@ public class NewTypeWizardTest {
 
 		String expected= """
 			package test1;
-			
+
 			import java.util.Map;
-			
+
 			import pack.A;
-			
+
 			public class B {
-			
+
 			    /**
 			     * Type
 			     */
 			    public class E extends A {
-			
+
 			        /**
 			         * Overridden
 			         */
@@ -612,9 +611,9 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			import java.util.List;
-			
+
 			/**
 			 * Type
 			 */
@@ -652,7 +651,7 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -690,7 +689,7 @@ public class NewTypeWizardTest {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -811,9 +810,9 @@ public class NewTypeWizardTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
 			package test1;
-			
+
 			public class Foo1 {
-			
+
 			}
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("Foo1.java", str, false, null);
@@ -823,9 +822,9 @@ public class NewTypeWizardTest {
 		pack1= fSourceFolder.createPackageFragment("test2", false, null);
 		String str1= """
 			package test2;
-			
+
 			public class Foo3 {
-			
+
 			}
 			""";
 		pack1.createCompilationUnit("Foo3.java", str1, false, null);
@@ -849,7 +848,7 @@ public class NewTypeWizardTest {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String test= """
 			package test1;
-			
+
 			public final class A{
 			}
 			""";
@@ -873,8 +872,8 @@ public class NewTypeWizardTest {
 
 		IStatus status= wizardPage.getSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(expected.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(expected, status.getMessage());
 	}
 
 	private static ITypeBinding getTypeBinding(ICompilationUnit cu) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/NewTypeWizardTest17.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/NewTypeWizardTest17.java
@@ -15,7 +15,7 @@
 package org.eclipse.jdt.ui.tests.wizardapi;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Hashtable;
@@ -122,14 +122,14 @@ public class NewTypeWizardTest17 {
 		fpack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String test= """
 			package test;
-			
+
 			public sealed class Shape permits Square {
 			}
 			""";
 		fSealedSuperCls= fpack1.createCompilationUnit("Shape.java", test, false, null);
 		test= """
 			package test;
-			
+
 			public non-sealed class Square extends Shape {
 			}
 			""";
@@ -137,14 +137,14 @@ public class NewTypeWizardTest17 {
 		fSealedClsBinding= getTypeBinding(fSealedSuperCls);
 		test= """
 			package test;
-			
+
 			public sealed interface IShape permits ISquare {
 			}
 			""";
 		fSealedSuperInterface= fpack1.createCompilationUnit("IShape.java", test, false, null);
 		test= """
 			package test;
-			
+
 			public non-sealed interface ISquare extends IShape {
 			}
 			""";
@@ -159,14 +159,14 @@ public class NewTypeWizardTest17 {
 		fMpack1= fMSourceFolder.createPackageFragment("test1", false, null);
 		String test= """
 			package test;
-			
+
 			public sealed class Shape permits Square {
 			}
 			""";
 		fMSealedSuperCls= fMpack1.createCompilationUnit("Shape.java", test, false, null);
 		test= """
 			package test;
-			
+
 			public non-sealed class Square extends Shape {
 			}
 			""";
@@ -174,14 +174,14 @@ public class NewTypeWizardTest17 {
 		fMSealedClsBinding= getTypeBinding(fMSealedSuperCls);
 		test= """
 			package test;
-			
+
 			public sealed interface IShape permits ISquare {
 			}
 			""";
 		fMSealedSuperInterface= fMpack1.createCompilationUnit("IShape.java", test, false, null);
 		test= """
 			package test;
-			
+
 			public non-sealed interface ISquare extends IShape {
 			}
 			""";
@@ -204,8 +204,8 @@ public class NewTypeWizardTest17 {
 
 	private void createModuleInfo() throws Exception {
 		String test= """
-			
-			
+
+
 			module modTest1 {
 				exports test1;
 			}
@@ -220,8 +220,8 @@ public class NewTypeWizardTest17 {
 		fMSourceFolder= JavaProjectHelper.addSourceContainer(fJProjectM2, "src");
 		fMpack1= fMSourceFolder.createPackageFragment("test3", false, null);
 		String test= """
-			
-			
+
+
 			module modTest2 {
 				requires modTest2;
 			}
@@ -276,8 +276,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperClassInDifferentPackage.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperClassInDifferentPackage, status.getMessage());
 	}
 
 	// Throw error if the sealed super interface is in different package to the new class
@@ -301,8 +301,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperInterfaceInDifferentPackage.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperInterfaceInDifferentPackage, status.getMessage());
 	}
 
 	// Throw error if the sealed super interface is in different package to the new interface
@@ -325,8 +325,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_interface_SealedSuperInterfaceInDifferentPackage.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_interface_SealedSuperInterfaceInDifferentPackage, status.getMessage());
 	}
 
 	// Successfully Create non-sealed class which has sealed super class
@@ -350,17 +350,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccNonSealed, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -371,7 +371,7 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -386,7 +386,7 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			public sealed class Shape permits Square, E {
 			}
 			""";
@@ -414,17 +414,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccNonSealed, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -435,7 +435,7 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -450,7 +450,7 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			public sealed interface IShape permits ISquare, E {
 			}
 			""";
@@ -479,17 +479,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccFinal, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -500,7 +500,7 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -515,7 +515,7 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			public sealed class Shape permits Square, E {
 			}
 			""";
@@ -543,17 +543,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccFinal, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -564,7 +564,7 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -579,7 +579,7 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			public sealed interface IShape permits ISquare, E {
 			}
 			""";
@@ -606,17 +606,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedInterface_extend_superinterface_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedInterface_extend_superinterface_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccNonSealed, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -627,7 +627,7 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
@@ -642,7 +642,7 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			public sealed interface IShape permits ISquare, IE {
 			}
 			""";
@@ -677,8 +677,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperClassInDifferentProject.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperClassInDifferentProject, status.getMessage());
 	}
 
 	// Throw error if the sealed super interface is in different project to the new class
@@ -703,8 +703,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperInterfaceInDifferentProject.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperInterfaceInDifferentProject, status.getMessage());
 	}
 
 	// Throw error if the sealed super interface is in different project to the new interface
@@ -728,8 +728,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_interface_SealedSuperInterfaceInDifferentProject.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_interface_SealedSuperInterfaceInDifferentProject, status.getMessage());
 	}
 
 
@@ -761,17 +761,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccNonSealed, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -782,9 +782,9 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test2;
-			
+
 			import test1.Shape;
-			
+
 			/**
 			 * Type
 			 */
@@ -799,9 +799,9 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			import test2.E;
-			
+
 			public sealed class Shape permits Square, E {
 			}
 			""";
@@ -832,17 +832,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccNonSealed, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -853,9 +853,9 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test2;
-			
+
 			import test1.IShape;
-			
+
 			/**
 			 * Type
 			 */
@@ -870,9 +870,9 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			import test2.E;
-			
+
 			public sealed interface IShape permits ISquare, E {
 			}
 			""";
@@ -904,17 +904,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_extend_superclass_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccFinal, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -925,9 +925,9 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test2;
-			
+
 			import test1.Shape;
-			
+
 			/**
 			 * Type
 			 */
@@ -942,9 +942,9 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			import test2.E;
-			
+
 			public sealed class Shape permits Square, E {
 			}
 			""";
@@ -975,17 +975,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedClass_implement_superinterface_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccFinal, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -996,9 +996,9 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test2;
-			
+
 			import test1.IShape;
-			
+
 			/**
 			 * Type
 			 */
@@ -1013,9 +1013,9 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			import test2.E;
-			
+
 			public sealed interface IShape permits ISquare, E {
 			}
 			""";
@@ -1045,17 +1045,17 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedInterface_extend_superinterface_notSelected_message.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_SealedFinalNonSealedInterface_extend_superinterface_notSelected_message, status.getMessage());
 		int modifiers= wizardPage.getModifiers();
 		wizardPage.setModifiers(modifiers | Flags.AccNonSealed, true);
 		status= wizardPage.getSealedModifierStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.OK);
+		assertEquals(IStatus.OK, status.getSeverity());
 
 		wizardPage.createType(null);
 
@@ -1066,9 +1066,9 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test2;
-			
+
 			import test1.IShape;
-			
+
 			/**
 			 * Type
 			 */
@@ -1083,9 +1083,9 @@ public class NewTypeWizardTest17 {
 
 		expected= """
 			package test;
-			
+
 			import test2.IE;
-			
+
 			public sealed interface IShape permits ISquare, IE {
 			}
 			""";
@@ -1120,8 +1120,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperClassInDifferentModule.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperClassInDifferentModule, status.getMessage());
 	}
 
 	// Throw error if the sealed super interface is in different module to the new class
@@ -1146,8 +1146,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperInterfaceInDifferentModule.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_class_SealedSuperInterfaceInDifferentModule, status.getMessage());
 	}
 
 	// Throw error if the sealed super interface is in different module to the new interface
@@ -1171,8 +1171,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSealedSuperInterfaceStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(NewWizardMessages.NewTypeWizardPage_error_interface_SealedSuperInterfaceInDifferentModule.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(NewWizardMessages.NewTypeWizardPage_error_interface_SealedSuperInterfaceInDifferentModule, status.getMessage());
 	}
 
 	@Test
@@ -1182,7 +1182,7 @@ public class NewTypeWizardTest17 {
 		fpack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String test= """
 			package test;
-			
+
 			public record Rec1(int x){
 			}
 			""";
@@ -1209,8 +1209,8 @@ public class NewTypeWizardTest17 {
 
 		IStatus status= wizardPage.getSuperClassStatus();
 		assertNotNull(status);
-		assertTrue(status.getSeverity() == IStatus.ERROR);
-		assertTrue(expected.equals(status.getMessage()));
+		assertEquals(IStatus.ERROR, status.getSeverity());
+		assertEquals(expected, status.getMessage());
 	}
 
 	@Test
@@ -1242,12 +1242,12 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
 			public record Rec1() {
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -1255,7 +1255,7 @@ public class NewTypeWizardTest17 {
 			    public boolean equals(Object arg0) {
 			        return false;
 			    }
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -1263,7 +1263,7 @@ public class NewTypeWizardTest17 {
 			    public int hashCode() {
 			        return 0;
 			    }
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -1271,7 +1271,7 @@ public class NewTypeWizardTest17 {
 			    public String toString() {
 			        return null;
 			    }
-			
+
 			}""" ;
 
 		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
@@ -1306,12 +1306,12 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
 			public record Rec1() {
-			
+
 			}""" ;
 
 		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
@@ -1346,19 +1346,19 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
 			public record Rec1() {
-			
+
 			    /**
 			     * Method
 			     */
 			    public static void main(String[] args) {
-			
+
 			    }
-			
+
 			}""" ;
 
 		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
@@ -1393,12 +1393,12 @@ public class NewTypeWizardTest17 {
 			 * File
 			 */
 			package test1;
-			
+
 			/**
 			 * Type
 			 */
 			public record Rec1() {
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -1406,7 +1406,7 @@ public class NewTypeWizardTest17 {
 			    public boolean equals(Object arg0) {
 			        return false;
 			    }
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -1414,7 +1414,7 @@ public class NewTypeWizardTest17 {
 			    public int hashCode() {
 			        return 0;
 			    }
-			
+
 			    /**
 			     * Overridden
 			     */
@@ -1422,14 +1422,14 @@ public class NewTypeWizardTest17 {
 			    public String toString() {
 			        return null;
 			    }
-			
+
 			    /**
 			     * Method
 			     */
 			    public static void main(String[] args) {
-			
+
 			    }
-			
+
 			}""" ;
 
 		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
junit asserts generate an error message based on the parameters presented. So when the fixed part and the actual part of an equal assertion is wrong it creates a wrong message about what was expected. The assertion still "works" because in an equal comparison the order does not matter regarding the failure of the junit test but the error message is wrong. 
Another case is when you do the comparison inside of an assertion to check for true. That way junit is inable to generate a useful error message.

This PR fixes some of these issues. It has been generated by using the "Autorefactor" cleanup at
https://github.com/carstenartur/AutoRefactor/tree/master
Afaik this cleanup will not make it into jdt.ui any longer.

I looked at it while checking what could help to migrate tests to junit5. 
Since the change was applied to no longer support old java versions in a lot of code of jdt.ui test environments are a mess with wrong name for the testenvironment to be used.

## How to test
Nothing should change but the messages should be better in case of an issue.

## Author checklist

- [] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
