### PR TITLE
Fix move refactor to recognize super class name collision

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test80/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test80/in/A.java
@@ -1,0 +1,21 @@
+package p1;
+
+class A {
+	B b;
+
+	void method() {
+		System.out.println("A class method");
+	}
+}
+
+class ParentClass {
+	void method() {
+		System.out.println("ParentClass method");
+	}
+}
+
+class B extends ParentClass {
+	void test() {
+		method();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test80/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test80/out/A.java
@@ -1,0 +1,21 @@
+package p1;
+
+class A {
+	B b;
+}
+
+class ParentClass {
+	void method() {
+		System.out.println("ParentClass method");
+	}
+}
+
+class B extends ParentClass {
+	void test() {
+		super.method();
+	}
+
+	void method() {
+		System.out.println("A class method");
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -708,6 +708,13 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 	public void test79() throws Exception {
 		helper1(new String[] { "A" }, "A", 11, 17, 11, 18, FIELD, "b", true, true);
 	}
+
+	@Test
+	public void test80() throws Exception {
+		helper1(new String[] { "A" }, "A", 6, 10, 6, 16, FIELD, "b", true, true);
+	}
+
+
 	// Move mA1 to field fB, do not inline delegator
 	@Test
 	public void test3() throws Exception {


### PR DESCRIPTION
- fix MoveInstanceMethodProcessor to recognize when a member being moved has same name as a member of a super class of the target and change existing references to use super qualifier
- add new test to MoveInstanceMethodTests
- fixes #1676

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
