### PR TITLE
changing the visability Constants in the CallHierarchy

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchyCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchyCore.java
@@ -50,10 +50,9 @@ public class CallHierarchyCore {
 	public static final String PREF_HIDE_TEST_CODE = "PREF_HIDE_TEST_CODE";	//$NON-NLS-1$
 	public static final String PREF_SHOW_TEST_CODE_ONLY = "PREF_SHOW_TEST_CODE_ONLY";	//$NON-NLS-1$
 
-	private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
-	private static final String PREF_USE_FILTERS= "PREF_USE_FILTERS"; //$NON-NLS-1$
-	private static final String PREF_FILTERS_LIST= "PREF_FILTERS_LIST"; //$NON-NLS-1$
-
+    public static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
+    public static final String PREF_USE_FILTERS= "PREF_USE_FILTERS"; //$NON-NLS-1$
+    public static final String PREF_FILTERS_LIST= "PREF_FILTERS_LIST"; //$NON-NLS-1$
     private String defaultIgnoreFilters= "java.*,javax.*"; //$NON-NLS-1$
 
     private static CallHierarchyCore fgInstance;

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchy.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchy.java
@@ -17,6 +17,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.callhierarchy;
 
+import static org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyCore.PREF_FILTERS_LIST;
+import static org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyCore.PREF_HIDE_TEST_CODE;
+import static org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyCore.PREF_SHOW_ALL_CODE;
+import static org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyCore.PREF_SHOW_TEST_CODE_ONLY;
+import static org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyCore.PREF_USE_FILTERS;
+import static org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyCore.PREF_USE_IMPLEMENTORS;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -36,11 +43,8 @@ import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.util.StringMatcher;
 
-public class CallHierarchy {
 
-	private static final String PREF_USE_IMPLEMENTORS= "PREF_USE_IMPLEMENTORS"; //$NON-NLS-1$
-    private static final String PREF_USE_FILTERS = "PREF_USE_FILTERS"; //$NON-NLS-1$
-    private static final String PREF_FILTERS_LIST = "PREF_FILTERS_LIST"; //$NON-NLS-1$
+public class CallHierarchy {
 
     private static CallHierarchy fgInstance;
     private CallHierarchyCore fgCallHierarchyCore;
@@ -58,17 +62,17 @@ public class CallHierarchy {
 
     public void setShowAll(boolean value) {
         IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        settings.setValue(CallHierarchyCore.PREF_SHOW_ALL_CODE, value);
+        settings.setValue(PREF_SHOW_ALL_CODE, value);
     }
 
     public void setHideTestCode(boolean value) {
         IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        settings.setValue(CallHierarchyCore.PREF_HIDE_TEST_CODE, value);
+        settings.setValue(PREF_HIDE_TEST_CODE, value);
     }
 
     public void setShowTestCode(boolean value) {
         IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        settings.setValue(CallHierarchyCore.PREF_SHOW_TEST_CODE_ONLY, value);
+        settings.setValue(PREF_SHOW_TEST_CODE_ONLY, value);
     }
 
     public boolean isSearchUsingImplementorsEnabled() {
@@ -137,17 +141,17 @@ public class CallHierarchy {
 
     public boolean isShowAll() {
         IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        return settings.getBoolean(CallHierarchyCore.PREF_SHOW_ALL_CODE);
+        return settings.getBoolean(PREF_SHOW_ALL_CODE);
     }
 
     public boolean isHideTestCode() {
     	IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        return settings.getBoolean(CallHierarchyCore.PREF_HIDE_TEST_CODE);
+        return settings.getBoolean(PREF_HIDE_TEST_CODE);
     }
 
     public boolean isShowTestCode() {
     	IPreferenceStore settings = JavaPlugin.getDefault().getPreferenceStore();
-        return settings.getBoolean(CallHierarchyCore.PREF_SHOW_TEST_CODE_ONLY);
+        return settings.getBoolean(PREF_SHOW_TEST_CODE_ONLY);
     }
 
 


### PR DESCRIPTION
## What it does
It does not have any effect on the functionality, but it addresses and completes the suggestion from @jukzi which he made here: (https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1687)
Because the constants of which the visability is changed here are not part of PR #1687 , this PR is aimed at completing the suggestion made there.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
