### PR TITLE
Text block conversion support for indexOf()

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -487,6 +487,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 		private Map<ExpressionStatement, ChangeStringBufferToTextBlock> conversions= new HashMap<>();
 		private static final String APPEND= "append"; //$NON-NLS-1$
 		private static final String TO_STRING= "toString"; //$NON-NLS-1$
+		private static final String INDEX_OF= "indexOf"; //$NON-NLS-1$
 		private BodyDeclaration fLastBodyDecl;
 		private final Set<String> fExcludedNames;
 		private final Set<IBinding> fRemovedDeclarations= new HashSet<>();
@@ -503,6 +504,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			private int lastStatementEnd;
 			private IBinding varBinding;
 			private List<MethodInvocation> toStringList= new ArrayList<>();
+			private List<MethodInvocation> indexOfList= new ArrayList<>();
 			private List<SimpleName> argList= new ArrayList<>();
 
 			public CheckValidityVisitor(int lastStatementEnd, IBinding varBinding) {
@@ -520,6 +522,10 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 
 			public List<MethodInvocation> getToStringList() {
 				return toStringList;
+			}
+
+			public List<MethodInvocation> getIndexOfList() {
+				return indexOfList;
 			}
 
 			public List<SimpleName> getArgList() {
@@ -546,6 +552,10 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 							if (invocation.getName().getFullyQualifiedName().equals(TO_STRING)) {
 								valid= true;
 								toStringList.add(invocation);
+								return true;
+							} else if (invocation.getName().getFullyQualifiedName().equals(INDEX_OF)) {
+								valid= true;
+								indexOfList.add(invocation);
 								return true;
 							} else {
 								valid= false;
@@ -645,6 +655,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					if (exp instanceof MethodInvocation) {
 						class MethodVisitor extends ASTVisitor {
 							private boolean valid= false;
+							private boolean indexOfSeen= false;
 							public boolean isValid() {
 								return valid;
 							}
@@ -653,11 +664,19 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 								if (simpleName.getFullyQualifiedName().equals(APPEND) && simpleName.getLocationInParent() == MethodInvocation.NAME_PROPERTY) {
 									return true;
 								}
-								if (simpleName.getLocationInParent() == MethodInvocation.EXPRESSION_PROPERTY && simpleName.getFullyQualifiedName().equals(originalVarName.getFullyQualifiedName())
-										&& ((MethodInvocation)simpleName.getParent()).getName().getFullyQualifiedName().equals(APPEND)) {
-									extractConcatenatedAppends(simpleName);
-									valid= true;
-									return false;
+								if (simpleName.getLocationInParent() == MethodInvocation.EXPRESSION_PROPERTY && simpleName.getFullyQualifiedName().equals(originalVarName.getFullyQualifiedName())) {
+									if (((MethodInvocation)simpleName.getParent()).getName().getFullyQualifiedName().equals(APPEND)) {
+										if (!indexOfSeen) {
+											extractConcatenatedAppends(simpleName);
+											valid= true;
+										} else {
+											valid= false;
+										}
+										return false;
+									} else if (((MethodInvocation)simpleName.getParent()).getName().getFullyQualifiedName().equals(INDEX_OF)) {
+										indexOfSeen= true;
+										return false;
+									}
 								}
 								return true;
 							}
@@ -724,12 +743,13 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			List<Statement> statements= new ArrayList<>(statementList);
 			List<StringLiteral> literals= new ArrayList<>(fLiterals);
 			List<MethodInvocation> toStringList= new ArrayList<>(checkValidityVisitor.getToStringList());
+			List<MethodInvocation> indexOfList= new ArrayList<>(checkValidityVisitor.getIndexOfList());
 			List<SimpleName> argList= new ArrayList<>(checkValidityVisitor.getArgList());
 			BodyDeclaration bodyDecl= ASTNodes.getFirstAncestorOrNull(node, BodyDeclaration.class);
 			if (statements.get(0) instanceof VariableDeclarationStatement) {
 				fRemovedDeclarations.add(originalVarName.resolveBinding());
 			}
-			ChangeStringBufferToTextBlock operation= new ChangeStringBufferToTextBlock(toStringList, argList, statements, literals,
+			ChangeStringBufferToTextBlock operation= new ChangeStringBufferToTextBlock(toStringList, indexOfList, argList, statements, literals,
 					fRemovedDeclarations.contains(originalVarName.resolveBinding()) ? assignmentToConvert : null, fExcludedNames, fLastBodyDecl, nonNLS);
 			fLastBodyDecl= bodyDecl;
 			fOperations.add(operation);
@@ -864,6 +884,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 	public static class ChangeStringBufferToTextBlock extends CompilationUnitRewriteOperation {
 
 		private final List<MethodInvocation> fToStringList;
+		private final List<MethodInvocation> fIndexOfList;
 		private final List<SimpleName> fArgList;
 		private final List<Statement> fStatements;
 		private final List<StringLiteral> fLiterals;
@@ -873,9 +894,10 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 		private final boolean fNonNLS;
 		private ExpressionStatement fAssignmentToConvert;
 
-		public ChangeStringBufferToTextBlock(final List<MethodInvocation> toStringList, final List<SimpleName> argList, List<Statement> statements,
-				List<StringLiteral> literals, ExpressionStatement assignmentToConvert, Set<String> excludedNames, BodyDeclaration lastBodyDecl, boolean nonNLS) {
+		public ChangeStringBufferToTextBlock(final List<MethodInvocation> toStringList, final List<MethodInvocation> indexOfList, final List<SimpleName> argList,
+				List<Statement> statements, List<StringLiteral> literals, ExpressionStatement assignmentToConvert, Set<String> excludedNames, BodyDeclaration lastBodyDecl, boolean nonNLS) {
 			this.fToStringList= toStringList;
+			this.fIndexOfList= indexOfList;
 			this.fArgList= argList;
 			this.fStatements= statements;
 			this.fLiterals= literals;
@@ -976,6 +998,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			buf.append("\"\"\""); //$NON-NLS-1$
 			AST ast= fStatements.get(0).getAST();
 			if (fToStringList.size() == 1 &&
+					fIndexOfList.isEmpty() &&
 					!fNonNLS &&
 					ASTNodes.getLeadingComments(fStatements.get(0)).size() == 0 &&
 					(fToStringList.get(0).getLocationInParent() == Assignment.RIGHT_HAND_SIDE_PROPERTY ||
@@ -1023,6 +1046,15 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				for (MethodInvocation toStringCall : fToStringList) {
 					SimpleName name= ast.newSimpleName(newVarName);
 					rewrite.replace(toStringCall, name, group);
+				}
+				for (MethodInvocation indexOfCall : fIndexOfList) {
+					MethodInvocation newCall= ast.newMethodInvocation();
+					newCall.setName(ast.newSimpleName("indexOf")); //$NON-NLS-1$
+					SimpleName caller= ast.newSimpleName(newVarName);
+					newCall.setExpression(caller);
+					List<Expression> arguments= indexOfCall.arguments();
+					newCall.arguments().add(rewrite.createCopyTarget(arguments.get(0)));
+					rewrite.replace(indexOfCall, newCall, group);
 				}
 				for (SimpleName arg : fArgList) {
 					SimpleName name= ast.newSimpleName(newVarName);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -401,6 +401,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			        buf10.append("     * foo\\n");
 			        buf10.append("     */");
 			        write(buf10);
+			        StringBuilder buf11 = new StringBuilder();
+			        buf11.append("abcd\\n");
+			        buf11.append("efgh\\n");
+			        buf11.append("ijkl\\n");
+			        buf11.append("mnop\\n");
+			        int index = buf11.indexOf("fg");
+			        System.out.println(buf11.toString());
 			    }
 			    private void write(CharSequence c) {
 			        System.out.println(c);
@@ -522,6 +529,14 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			                 */\\
 			            \""";
 			        write(str8);
+			        String str9 = \"""
+			            abcd
+			            efgh
+			            ijkl
+			            mnop
+			            \""";
+			        int index = str9.indexOf("fg");
+			        System.out.println(str9);
 			    }
 			    private void write(CharSequence c) {
 			        System.out.println(c);
@@ -789,6 +804,16 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			        buf.append("abcdef\\n");
 			        buf.append("123456\\n"); //$NON-NLS-1$
 			        buf.append("ghijkl\\n");
+			        buf.append(3);
+			        String x = buf.toString();
+			    }
+
+			    public void testIndexOfInBetween() {
+			        StringBuffer buf = new StringBuffer();
+			        buf.append("abcdef\\n");
+			        buf.append("123456\\n");
+			        buf.append("ghijkl\\n");
+			        int index = buf.indexOf("123");
 			        buf.append(3);
 			        String x = buf.toString();
 			    }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds support to the StringBuilder/StringBuffer to text block cleanup/quick assist so that a call to indexOf() gets converted to a call to String.indexOf() on the converted text block.  Until now, additional method calls to the StringBuilder/StringBuffer that weren't append() or toString() resulted in not converting to the text block.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See #1703 or the new test cases added.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
