### PR TITLE
remove setproperty for jdt.bug.367669

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/jarexport/FatJarExportTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/jarexport/FatJarExportTests.java
@@ -114,7 +114,6 @@ public class FatJarExportTests {
 
 	@BeforeClass
 	public static void setUpTest() {
-		System.setProperty("jdt.bug.367669", "non-null");
 	}
 
 	private IJavaProject fProject;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/jarexport/PlainJarExportTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/jarexport/PlainJarExportTests.java
@@ -65,7 +65,6 @@ public class PlainJarExportTests {
 
 	@BeforeClass
 	public static void setUpTest() {
-		System.setProperty("jdt.bug.367669", "non-null");
 	}
 
 	private IJavaProject fProject;


### PR DESCRIPTION
System.setProperty("jdt.bug.367669", "non-null");

see
https://git.eclipse.org/c/jdt/eclipse.jdt.core.git/commit/?id=df26c679ec361eae61785b6b440639645b574764

https://bugs.eclipse.org/bugs/show_bug.cgi?id=367669

https://git.eclipse.org/c/jdt/eclipse.jdt.ui.git/commit/?id=7bbe9b200e2038f2a18dd4bf9b010385f95ab3de

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
