### PR TITLE
Modify string concat to text block cleanup to handle empty strings

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -156,7 +156,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					endPosition= getLineOffset(cUnit, lineNo + 1) == -1 ? cUnit.getLength() : getLineOffset(cUnit, lineNo + 1);
 					hasComments= hasComments || hasNLS(ASTNodes.getCommentsForRegion(cUnit, stringLiteral.getStartPosition(), endPosition - stringLiteral.getStartPosition()), cu);
 					String string= stringLiteral.getLiteralValue();
-					if (!string.isEmpty() && (fAllConcats || string.endsWith("\n") || i == extendedOperands.size() - 1)) { //$NON-NLS-1$
+					if (string.isEmpty() || fAllConcats || string.endsWith("\n") || i == extendedOperands.size() - 1) { //$NON-NLS-1$
 						continue;
 					}
 				}
@@ -315,8 +315,11 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			expressions.forEach(new Consumer<Expression>() {
 				@Override
 				public void accept(Expression t) {
-					String value= ((StringLiteral) t).getEscapedValue();
-					parts.addAll(unescapeBlock(value.substring(1, value.length() - 1)));
+					StringLiteral literal= (StringLiteral)t;
+					if (!literal.getLiteralValue().equals("\"\"")) { //$NON-NLS-1$
+						String value= literal.getEscapedValue();
+						parts.addAll(unescapeBlock(value.substring(1, value.length() - 1)));
+					}
 				}
 			});
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -117,14 +117,15 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			        Integer k = foo("" +\s
 			                  "abcdef\\n" +\s
 			                  "123456\\n" +\s
-			                  "klm");
+			                  "klm" +\s
+			                  "");
 			    }
 			    public void testAssignment() {
 			        Integer k = null;
 			        k = foo("" +\s
 			                  "abcdef\\n" +\s
 			                  "123456\\n" +\s
-			                  "klm");
+			                  "" + "klm");
 			    }
 			    public void testConcatInConstructor() {
 			        new StringBuffer("abc\\n" + "def\\n" + "ghi");


### PR DESCRIPTION
- add logic to StringConcatToTextBlockFixCore to handle the case where empty strings are appended
- modify tests in CleanUpTest15 to add some empty strings to existing tests
- for #1703

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See commit message and issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and test modifications.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
