### PR TITLE
Fix illegal name exception when inlining qualified field name

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test65_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test65_in.java
@@ -1,0 +1,11 @@
+package p;
+
+public class A {
+	public static void main(String[] args) {
+		String[] a= new String[0];
+		int length= a.length;
+		if (length > 0) {
+			System.out.println("Longer"); //$NON-NLS-1$
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test65_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test65_out.java
@@ -1,0 +1,10 @@
+package p;
+
+public class A {
+	public static void main(String[] args) {
+		String[] a= new String[0];
+		if (a.length > 0) {
+			System.out.println("Longer"); //$NON-NLS-1$
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
@@ -347,66 +347,6 @@ public class InlineTempTests extends GenericRefactoringTest {
 		helper1(5, 43, 5, 46);
 	}
 
-	public void test62() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(14, 13, 14, 14);
-	}
-
-	public void test63() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(11, 13, 11, 14);
-	}
-
-	public void test64() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(7, 13, 7, 14);
-	}
-
-	public void test53() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(12, 13, 12, 14);
-	}
-
-	public void test54() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(7, 13, 7, 14);
-	}
-
-	public void test55() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(11, 13, 11, 14);
-	}
-
-	public void test56() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(12, 13, 12, 14);
-	}
-
-	public void test57() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(9, 26, 9, 27);
-	}
-
-	public void test58() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(9, 26, 9, 27);
-	}
-
-	public void test59() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(11, 11, 11, 12);
-	}
-
-	public void test60() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(7, 13, 7, 14);
-	}
-
-	public void test61() throws Exception {
-		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
-		helper1(9, 13, 9, 14);
-	}
-
 	@Test
 	public void test41() throws Exception {
 		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=335173
@@ -477,6 +417,84 @@ public class InlineTempTests extends GenericRefactoringTest {
 	public void test52() throws Exception {
 		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=434747
 		helper1(4, 14, 4, 15);
+	}
+
+	@Test
+	public void test53() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(12, 13, 12, 14);
+	}
+
+	@Test
+	public void test54() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(7, 13, 7, 14);
+	}
+
+	@Test
+	public void test55() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(11, 13, 11, 14);
+	}
+
+	@Test
+	public void test56() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(12, 13, 12, 14);
+	}
+
+	@Test
+	public void test57() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(9, 26, 9, 27);
+	}
+
+	@Test
+	public void test58() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(9, 26, 9, 27);
+	}
+
+	@Test
+	public void test59() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(11, 11, 11, 12);
+	}
+
+	@Test
+	public void test60() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(7, 13, 7, 14);
+	}
+
+	@Test
+	public void test61() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(9, 13, 9, 14);
+	}
+
+	@Test
+	public void test62() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(14, 13, 14, 14);
+	}
+
+	@Test
+	public void test63() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(11, 13, 11, 14);
+	}
+
+	@Test
+	public void test64() throws Exception {
+		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=367536
+		helper1(7, 13, 7, 14);
+	}
+
+	@Test
+	public void test65() throws Exception {
+		//https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1705
+		helper1(6, 13, 6, 19);
 	}
 
 	//------


### PR DESCRIPTION
- fix InlineTempRefactoring.getAlternativeQualification() to not calculate qualified alternatives if not dealing with static reference
- fix InlineTempRefactoring.checkClashes() to handle when there are qualified alternatives
- add new test to InlineTempTests
- fixes #1705

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
