### PR TITLE
Fix unused suppressed warnings quick fix counts

### DIFF
--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/SuppressWarningsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/SuppressWarningsBaseSubProcessor.java
@@ -245,21 +245,11 @@ public abstract class SuppressWarningsBaseSubProcessor<T> {
 			T proposal= createFixCorrectionProposal(fix, cleanUp, IProposalRelevance.REMOVE_ANNOTATION, context);
 			proposals.add(proposal);
 		}
-		fix= UnusedSuppressWarningsFixCore.createAllFix(context.getASTRoot(), literal);
-		if (fix != null) {
-			Map<String, String> options= new Hashtable<>();
-			options.put(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS, CleanUpOptions.TRUE);
-			UnusedSuppressWarningsCleanUp cleanUp= new UnusedSuppressWarningsCleanUp(options);
-			cleanUp.setLiteral(literal);
-			T proposal= createFixCorrectionProposal(fix, cleanUp, IProposalRelevance.REMOVE_ANNOTATION, context);
-			proposals.add(proposal);
-		}
 		fix= UnusedSuppressWarningsFixCore.createAllFix(context.getASTRoot(), null);
 		if (fix != null) {
 			Map<String, String> options= new Hashtable<>();
 			options.put(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS, CleanUpOptions.TRUE);
 			UnusedSuppressWarningsCleanUp cleanUp= new UnusedSuppressWarningsCleanUp(options);
-			cleanUp.setLiteral(literal);
 			T proposal= createFixCorrectionProposal(fix, cleanUp, IProposalRelevance.REMOVE_ANNOTATION, context);
 			proposals.add(proposal);
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
@@ -3050,7 +3050,6 @@ public class QuickFixTest1d8 extends QuickFixTest {
 						return false;
 					}
 
-					@SuppressWarnings("unchecked")
 					public boolean simplifyNLS(String x) {
 						return true;
 					}
@@ -3060,27 +3059,6 @@ public class QuickFixTest1d8 extends QuickFixTest {
 					}
 				}
 				""";
-
-		String expected3= """
-				package test1;
-				public class E {
-					public boolean simplifyNormal(int x) {
-						return true;
-					}
-
-					public boolean simplifyCompoundIf(int x) {
-						return false;
-					}
-
-					public boolean simplifyNLS(String x) {
-						return true;
-					}
-
-					public boolean simplifyAll() {
-						return false;
-					}
-				}
-				""";
-		assertExpectedExistInProposals(proposals, new String[] {expected1, expected2, expected3});
+		assertExpectedExistInProposals(proposals, new String[] {expected1, expected2});
 	}
 }


### PR DESCRIPTION
- add new logic for UnusedSuppressWarningsCleanUp.computeNumberOfFixes() that screens the problems for the current literal or returns 1 if removing all unused tokens
- fix SuppressWarningsBaseSubProcessor to remove the call to remove all instances of current literal since the computeNumberOfFixes() call in the clean up will offer an option to do this automatically
- fix the test in QuickFixTest1d8
- fixes #1719

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
