### PR TITLE
Fix if/else to switch to handle null scenarios

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest12.java
@@ -1131,36 +1131,41 @@ public class E {
 
     public void bug1(String i1) {
         int i = 0;
-        switch (i1) {
-            case E.VALUE0 : {
-                int integer1 = 0;
-                i = integer1;
-                break;
-            }
-            case E.VALUE1 : {
-                char integer1 = 'a';
-                i = integer1;
-                break;
-            }
-            case E.VALUE2 : {
-                char integer1 = 'b';
-                i = integer1;
-                break;
-            }
-            case "5" : //$NON-NLS-1$
-            case "five" :
-            case "another string" : //$NON-NLS-1$
-             {
-                char integer1 = 'c';
-                i = integer1;
-                break;
-            }
-            default :
-                if (computeit(i1) || i1.equals(E.VALUE3)) {
-                //
-                //
+        if (i1 != null) {
+            switch (i1) {
+                case E.VALUE0 : {
+                    int integer1 = 0;
+                    i = integer1;
+                    break;
                 }
-                break;
+                case E.VALUE1 : {
+                    char integer1 = 'a';
+                    i = integer1;
+                    break;
+                }
+                case E.VALUE2 : {
+                    char integer1 = 'b';
+                    i = integer1;
+                    break;
+                }
+                case "5" : //$NON-NLS-1$
+                case "five" :
+                case "another string" : //$NON-NLS-1$
+                 {
+                    char integer1 = 'c';
+                    i = integer1;
+                    break;
+                }
+                default :
+                    if (computeit(i1) || i1.equals(E.VALUE3)) {
+                    //
+                    //
+                    }
+                    break;
+            }
+        } else if (computeit(i1) || i1.equals(E.VALUE3)) {
+        //
+        //
         }
     }
 
@@ -1221,29 +1226,34 @@ public class E {
 
 	public void bug1(MYENUM i1) {
 		int i = 0;
-		switch (i1) {
-            case MYENUM.VALUE0 : {
-                int integer1 = 0;
-                i = integer1;
-                break;
-            }
-            case MYENUM.VALUE1 : {
-                char integer1 = 'a';
-                i = integer1;
-                break;
-            }
-            case MYENUM.VALUE2 : {
-                char integer1 = 'b';
-                i = integer1;
-                break;
-            }
-            default :
-                if (computeit(i1) || i1 == MYENUM.VALUE3) {
-                	//
-                	//
+		if (i1 != null) {
+            switch (i1) {
+                case VALUE0 : {
+                    int integer1 = 0;
+                    i = integer1;
+                    break;
                 }
-                break;
-        }
+                case VALUE1 : {
+                    char integer1 = 'a';
+                    i = integer1;
+                    break;
+                }
+                case VALUE2 : {
+                    char integer1 = 'b';
+                    i = integer1;
+                    break;
+                }
+                default :
+                    if (computeit(i1) || i1 == MYENUM.VALUE3) {
+                    	//
+                    	//
+                    }
+                    break;
+            }
+        } else if (computeit(i1) || i1 == MYENUM.VALUE3) {
+			//
+			//
+		}
 	}
 
 	private boolean computeit(MYENUM i) {


### PR DESCRIPTION
- for < JVM 21 add an if/else that checks for null
- for JVM 21 and up, add case null
- modified SwitchFixCore and modified tests in CleanUpTest12 to also not qualify enums if the switch value is an enum
- fixes #1714

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
