### PR TITLE
Fix clicking on a ParametrizedTest

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.13.400.qualifier
+Bundle-Version: 3.13.500.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
@@ -482,7 +482,7 @@ public class TestRunSession implements ITestRunSession {
 		int index0= treeEntry.indexOf(',');
 		String id= treeEntry.substring(0, index0);
 
-		StringBuffer testNameBuffer= new StringBuffer(100);
+		StringBuilder testNameBuffer= new StringBuilder(100);
 		int index1= scanTestName(treeEntry, index0 + 1, testNameBuffer);
 		String testName= testNameBuffer.toString().trim();
 
@@ -493,11 +493,11 @@ public class TestRunSession implements ITestRunSession {
 		boolean isDynamicTest;
 		String parentId;
 		String displayName;
-		StringBuffer displayNameBuffer= new StringBuffer(100);
+		StringBuilder displayNameBuffer= new StringBuilder(100);
 		String[] parameterTypes;
-		StringBuffer parameterTypesBuffer= new StringBuffer(200);
+		StringBuilder parameterTypesBuffer= new StringBuilder(200);
 		String uniqueId;
-		StringBuffer uniqueIdBuffer= new StringBuffer(200);
+		StringBuilder uniqueIdBuffer= new StringBuilder(200);
 		int index3= treeEntry.indexOf(',', index2 + 1);
 		if (index3 == -1) {
 			testCount= Integer.parseInt(treeEntry.substring(index2 + 1));
@@ -519,7 +519,7 @@ public class TestRunSession implements ITestRunSession {
 			}
 
 			int index6= scanTestName(treeEntry, index5 + 1, displayNameBuffer);
-			displayName= displayNameBuffer.toString().trim();
+			displayName= displayNameBuffer.toString().replace('\0', ' ').trim();
 			if (displayName.equals(testName)) {
 				displayName= null;
 			}
@@ -592,7 +592,7 @@ public class TestRunSession implements ITestRunSession {
 	 *
 	 * @return the index of the next ','
 	 */
-	private int scanTestName(String s, int start, StringBuffer testName) {
+	private int scanTestName(String s, int start, StringBuilder testName) {
 		boolean inQuote= false;
 		int i= start;
 		for (; i < s.length(); i++) {

--- a/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.runtime
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.runtime;singleton:=true
-Bundle-Version: 3.7.500.qualifier
+Bundle-Version: 3.7.600.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/org.eclipse.jdt.junit.runtime/pom.xml
+++ b/org.eclipse.jdt.junit.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit.runtime</artifactId>
-  <version>3.7.500-SNAPSHOT</version>
+  <version>3.7.600-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RemoteTestRunner.java
+++ b/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RemoteTestRunner.java
@@ -386,15 +386,19 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 		fLoader = newInstance;
 	}
 
-	private void readPackageNames(String pkgNameFile) throws IOException {
-		try(BufferedReader br= new BufferedReader(new InputStreamReader(new FileInputStream(new File(pkgNameFile)), StandardCharsets.UTF_8))) {
+	private String[] readLines(String fileName) throws IOException {
+		try(BufferedReader br= new BufferedReader(new InputStreamReader(new FileInputStream(new File(fileName)), StandardCharsets.UTF_8))) {
 			String line;
 			Vector<String> list= new Vector<>();
 			while ((line= br.readLine()) != null) {
 				list.add(line);
 			}
-			fPackageNames= list.toArray(new String[list.size()]);
+			return list.toArray(new String[list.size()]);
 		}
+	}
+
+	private void readPackageNames(String pkgNameFile) throws IOException {
+		fPackageNames= readLines(pkgNameFile);
 		if (fDebugMode) {
 			System.out.println("Packages:"); //$NON-NLS-1$
 			for (String fPackageName : fPackageNames) {
@@ -404,14 +408,7 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 	}
 
 	private void readTestNames(String testNameFile) throws IOException {
-		try(BufferedReader br= new BufferedReader(new InputStreamReader(new FileInputStream(new File(testNameFile)), StandardCharsets.UTF_8))) {
-			String line;
-			Vector<String> list= new Vector<>();
-			while ((line= br.readLine()) != null) {
-				list.add(line);
-			}
-			fTestClassNames= list.toArray(new String[list.size()]);
-		}
+		fTestClassNames= readLines(testNameFile);
 		if (fDebugMode) {
 			System.out.println("Tests:"); //$NON-NLS-1$
 			for (String fTestClassName : fTestClassNames) {
@@ -421,14 +418,7 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 	}
 
 	private void readFailureNames(String testFailureFile) throws IOException {
-		try(BufferedReader br= new BufferedReader(new InputStreamReader(new FileInputStream(new File(testFailureFile)), StandardCharsets.UTF_8))) {
-			String line;
-			Vector<String> list= new Vector<>();
-			while ((line= br.readLine()) != null) {
-				list.add(line);
-			}
-			fFailureNames= list.toArray(new String[list.size()]);
-		}
+		fFailureNames = readLines(testFailureFile);
 		if (fDebugMode) {
 			System.out.println("Failures:"); //$NON-NLS-1$
 			for (String fFailureName : fFailureNames) {
@@ -510,7 +500,7 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 	 * @param testName individual method to be run
 	 * @param execution executor
 	 */
-	public void runTests(String[] testClassNames, String testName, TestExecution execution) {
+	private void runTests(String[] testClassNames, String testName, TestExecution execution) {
 		ITestReference[] suites= fLoader.loadTests(loadClasses(testClassNames), testName, fFailureNames, fPackageNames, fIncludeExcludeTags, fUniqueId, this);
 
 		// count all testMethods and inform ITestRunListeners
@@ -754,7 +744,7 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 	    fWriter.flush();
 	}
 
-	public void runTests(TestExecution execution) {
+	private void runTests(TestExecution execution) {
 		runTests(fTestClassNames, fTestName, execution);
 	}
 

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -450,14 +450,14 @@ public class TestViewer {
 
 		if (children.length > 0 && children[0] instanceof TestCaseElement tce && tce.isDynamicTest()) {
 			// a group of parameterized tests
-			return new OpenTestAction(fTestRunnerPart, (TestCaseElement) children[0], null);
+			return new OpenTestAction(fTestRunnerPart, tce, tce.getParameterTypes());
 		}
 		if (children.length == 0) {
 			// check if we have applied the workaround for: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/945
 			TestCaseElement child= testSuite.getSingleDynamicChild();
 			if (child != null) {
 				// a parameterized test that ran only one test
-				return new OpenTestAction(fTestRunnerPart, child, null);
+				return new OpenTestAction(fTestRunnerPart, child, child.getParameterTypes());
 			}
 		}
 

--- a/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
+++ b/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.ui.unittest.junit.feature"
       label="%featureName"
-      version="1.1.500.qualifier"
+      version="1.1.600.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.ui.unittest.junit.feature/pom.xml
+++ b/org.eclipse.jdt.ui.unittest.junit.feature/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt.feature</groupId>
   <artifactId>org.eclipse.jdt.ui.unittest.junit.feature</artifactId>
-  <version>1.1.500-SNAPSHOT</version>
+  <version>1.1.600-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <build>
      <plugins>

--- a/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.unittest.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui.unittest.junit;singleton:=true
-Bundle-Version: 1.1.500.qualifier
+Bundle-Version: 1.1.600.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.unittest.junit.JUnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui.unittest.junit/pom.xml
+++ b/org.eclipse.jdt.ui.unittest.junit/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.unittest.junit</artifactId>
-  <version>1.1.500-SNAPSHOT</version>
+  <version>1.1.600-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitRemoteTestRunnerClient.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitRemoteTestRunnerClient.java
@@ -424,7 +424,7 @@ public class JUnitRemoteTestRunnerClient extends RemoteTestRunnerClient {
 			}
 
 			int index6 = scanTestName(fixedTreeEntry, index5 + 1, displayNameBuffer);
-			displayName = displayNameBuffer.toString().trim();
+			displayName = displayNameBuffer.toString().replace('\0', ' ').trim();
 			if (displayName.equals(testName)) {
 				displayName = null;
 			}

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/ui/JUnitTestViewSupport.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/ui/JUnitTestViewSupport.java
@@ -89,7 +89,7 @@ public class JUnitTestViewSupport implements ITestViewSupport {
 		int index = testName.indexOf('(');
 		// test factory method
 		if (index > 0) {
-			return new OpenTestAction(shell, testSuite.getTestName(), testName.substring(0, index),
+			return new OpenTestAction(shell, getClassName(testSuite), testName.substring(0, index),
 					getParameterTypes(testSuite), true, testSuite.getTestRunSession());
 		}
 
@@ -259,18 +259,32 @@ public class JUnitTestViewSupport implements ITestViewSupport {
 	 * @return a parameter type array
 	 */
 	private String[] getParameterTypes(ITestElement test) {
-		String testName = test.getDisplayName();
+		final String testName = test.getDisplayName();
 		if (testName != null) {
-			int index = testName.lastIndexOf("method:"); //$NON-NLS-1$
+			final int index = testName.lastIndexOf("method:"); //$NON-NLS-1$
 			if (index != -1) {
-				index = testName.indexOf('(', index);
-				if (index > 0) {
-					int closeIndex = testName.indexOf(')', index);
-					if (closeIndex > 0) {
-						String params = testName.substring(index + 1, closeIndex);
-						return params.split(","); //$NON-NLS-1$
-					}
+				String[] result = extractParameters(testName, index);
+				if (result != null) {
+					return result;
 				}
+			}
+		}
+		final String testUniqData = test.getData();
+		if (testUniqData != null) {
+			final int testTemplateIdx = testUniqData.indexOf("test-template:"); //$NON-NLS-1$
+			if (testTemplateIdx >= 0) {
+				return extractParameters(testUniqData, testTemplateIdx);
+			}
+		}
+		return null;
+	}
+
+	private String[] extractParameters(String testDescription, int startIndex) {
+		final int index = testDescription.indexOf('(', startIndex);
+		if (index > 0) {
+			final int closeIndex = testDescription.indexOf(')', index);
+			if (closeIndex > 0) {
+				return testDescription.substring(index + 1, closeIndex).split(","); //$NON-NLS-1$
 			}
 		}
 		return null;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
When we click on the 'grouping' element for a ParametrizedTest, the code tries to find the method without the parameter types, but the search actually tries to find a parameter-less method with the same name.


## How to test

1. Have a JUnit test:
```
	@ParameterizedTest
	@ValueSource(ints = {1,2,3})
	void x(int l) {
		fail("Not yet implemented");
	}

	@ParameterizedTest
	@ValueSource(ints = {4})
	void y(int l) {
		fail("Not yet implemented");
	}
 
	@TestFactory
	Collection<DynamicTest> dynamicTestsWithCollection() {
		return Arrays.asList(DynamicTest.dynamicTest("First test", () -> {
			fail("Bad luck");
		}), DynamicTest.dynamicTest("Second test", () -> {
			fail("Bad luck");
		})
		);
	}

	@ParameterizedTest
	@MethodSource("testArgs")
	void testInvisibleCharacters(String msg) {
        }

	private static List<String> testArgs() {
		return List.of("aaa\u0000MISSING", "bbb\u0000MISSING");
	}


```
2. Run the tests, 
3. In the test results, try to click on `x(int)` or `y(int)`
4. A dialog came up complaining of the missing method, instead of navigating to the actual code.
5. Check that the test cases under `testInvisibleCharacters` shows as `aaa MISSING` and `bbb MISSING` instead of `aaa` and `bbb` 

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
