### PR TITLE
Fix extract method refactoring to recognize a member class collision

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -564,7 +564,7 @@ public class ExtractMethodRefactoring extends Refactoring {
 			if (obj instanceof IType resultType) {
 				try {
 					ASTNode typeDecl= null;
-					if (resultType.isLocal() || resultType.isAnonymous()) {
+					if (resultType.isLocal() || resultType.isAnonymous() || resultType.isMember()) {
 						ICompilationUnit icu= resultType.getCompilationUnit();
 						typeDecl= getTypeDeclaration(resultType, icu);
 					}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1758.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/invalidSelection/A_testIssue1758.java
@@ -1,0 +1,18 @@
+package invalidSelection;
+
+public class A_testIssue1758 {
+	public void foo() {
+		/*]*/int i;/*[*/
+	}
+}
+
+class SubClass {
+	void extracted() {
+	}
+
+	class InnerClass extends A_testIssue1758 {
+		void testMethod() {
+			extracted();
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -2735,4 +2735,9 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	public void testIssue1516() throws Exception {
 		invalidSelectionTest();
 	}
+
+	@Test
+	public void testIssue1758() throws Exception {
+		invalidSelectionTest();
+	}
 }


### PR DESCRIPTION
- modify ExtractMethodRefactoring.checkForMethodOverride() to also check for a member class
- add new test to ExtractMethodTests
- fixes #1758

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
