### PR TITLE
Fix unused variable cleanup to work with unused pattern/lambda vars

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/RenameUnusedVariableCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/RenameUnusedVariableCleanUpCore.java
@@ -134,7 +134,7 @@ public class RenameUnusedVariableCleanUpCore extends AbstractMultiFix {
 
 	@Override
 	public boolean canFix(ICompilationUnit compilationUnit, IProblemLocation problem) {
-		if (UnusedCodeFixCore.isUnusedMember(problem) || UnusedCodeFixCore.isUnusedLambdaParameter(problem))
+		if (RenameUnusedVariableFixCore.isUnusedMember(problem) || RenameUnusedVariableFixCore.isUnusedLambdaParameter(problem))
 			return isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_LOCAL_VARIABLES);
 
 		return false;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
@@ -237,7 +237,7 @@ public class UnusedCodeCleanUpCore extends AbstractMultiFix {
 		if (UnusedCodeFixCore.isUnusedImport(problem))
 			return isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_IMPORTS);
 
-		if (UnusedCodeFixCore.isUnusedMember(problem) || UnusedCodeFixCore.isUnusedLambdaParameter(problem))
+		if (UnusedCodeFixCore.isUnusedMember(problem))
 			return isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_MEMBERS) && isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_METHODS) ||
 				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_MEMBERS) && isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_CONSTRUCTORS) ||
 				isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_MEMBERS) && isEnabled(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_TYPES) ||

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest22.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest22.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2020, 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix;
+
+import java.util.Hashtable;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+
+import org.eclipse.jdt.ui.tests.core.rules.Java22ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+/**
+ * Tests the cleanup features related to Java 22.
+ */
+public class CleanUpTest22 extends CleanUpTestCase {
+	@Rule
+	public ProjectTestSetup projectSetup= new Java22ProjectTestSetup();
+
+	@Override
+	protected IJavaProject getProject() {
+		return projectSetup.getProject();
+	}
+
+	@Override
+	protected IClasspathEntry[] getDefaultClasspath() throws CoreException {
+		return projectSetup.getDefaultClasspath();
+	}
+
+	@Test
+	public void testUnusedCleanUpUnnamedVariable() throws Exception {
+		Hashtable<String, String> options= JavaCore.getOptions();
+		options.put(JavaCore.COMPILER_PB_UNUSED_LAMBDA_PARAMETER, JavaCore.WARNING);
+		options.put(JavaCore.COMPILER_PB_UNUSED_LOCAL, JavaCore.WARNING);
+		JavaCore.setOptions(options);
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class E {
+				private interface J {
+					public void run(String a, String b);
+				}
+				record R(int i, long l) {}
+				public void test () {
+				  	J j = (a, b) -> System.out.println(a);
+					j.run("a", "b");
+					R r = new R(1, 1);
+					switch (r) {
+					case R(_, long l) -> {}
+					case R r2 -> {}
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.REMOVE_UNUSED_CODE_LOCAL_VARIABLES);
+
+		sample= """
+			package test1;
+
+			public class E {
+				private interface J {
+					public void run(String a, String b);
+				}
+				record R(int i, long l) {}
+				public void test () {
+				  	J j = (a, _) -> System.out.println(a);
+					j.run("a", "b");
+					R r = new R(1, 1);
+					switch (r) {
+					case R(_, long _) -> {}
+					case R _ -> {}
+					}
+				}
+			}
+			""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTestCaseSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTestCaseSuite.java
@@ -33,6 +33,7 @@ import org.junit.platform.suite.api.Suite;
 	CleanUpTest14.class,
 	CleanUpTest15.class,
 	CleanUpTest16.class,
+	CleanUpTest22.class,
 	CleanUpAnnotationTest.class,
 	SaveParticipantTest.class,
 	CleanUpActionTest.class,

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7550,6 +7550,11 @@
             id="org.eclipse.jdt.ui.cleanup.unboxing"
             runAfter="org.eclipse.jdt.ui.cleanup.autoboxing">
       </cleanUp>
+      <cleanUp
+            class="org.eclipse.jdt.internal.ui.fix.RenameUnusedVariableCleanUpCore"
+            id="org.eclipse.jdt.ui.cleanup.rename_unused"
+            runAfter="org.eclipse.jdt.ui.cleanup.unboxing">
+      </cleanUp>
    </extension>
 
   <extension


### PR DESCRIPTION
- add checks to UnusedCodeFixCore to not create a remove member operation in the case of unused pattern variables and unused lambda parameters when Java is 22 and up
- add RenameUnusedVariableCleanUpCore to JDT UI plug.xml
- add new CleanUpTest22
- fixes #1782

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
