### PR TITLE
Fix inlining method with anonymous class and qualified this reference

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -268,7 +268,7 @@ class SourceAnalyzer  {
 			if (fTypeCounter == 0) {
 				Expression receiver= node.getExpression();
 				if (receiver == null) {
-					if (node.resolveTypeBinding().isLocal())
+					if (node.resolveTypeBinding().isLocal() && !node.resolveTypeBinding().isAnonymous())
 						fImplicitReceivers.add(node);
 				}
 			}
@@ -326,6 +326,12 @@ class SourceAnalyzer  {
 		public boolean visit(ThisExpression node) {
 			if (fTypeCounter == 0) {
 				fImplicitReceivers.add(node);
+			}
+			if (node.getQualifier() instanceof Name qualifier) {
+				IBinding binding= qualifier.resolveBinding();
+				if (binding instanceof ITypeBinding) {
+					fImplicitReceivers.add(node);
+				}
 			}
 			return true;
 		}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/receiver_in/TestQualifiedAnonymousReceiver.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/receiver_in/TestQualifiedAnonymousReceiver.java
@@ -1,0 +1,22 @@
+package receiver_in;
+
+public class TestQualifiedAnonymousReceiver {
+	int x = 10;
+
+	void superClassMethod() {
+		System.out.println(x);
+	}
+
+	static void callingMethod(TestQualifiedAnonymousReceiver instance) {
+		/*]*/instance.methodToBeInlined();/*[*/
+	}
+
+	void methodToBeInlined() {
+		int k = 0;
+		new Object() {
+			void execute() {
+				TestQualifiedAnonymousReceiver.this.superClassMethod();
+			}
+		}.execute();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/receiver_out/TestQualifiedAnonymousReceiver.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/receiver_out/TestQualifiedAnonymousReceiver.java
@@ -1,0 +1,27 @@
+package receiver_out;
+
+public class TestQualifiedAnonymousReceiver {
+	int x = 10;
+
+	void superClassMethod() {
+		System.out.println(x);
+	}
+
+	static void callingMethod(TestQualifiedAnonymousReceiver instance) {
+		/*]*/int k = 0;
+		new Object() {
+			void execute() {
+				instance.superClassMethod();
+			}
+		}.execute();/*[*/
+	}
+
+	void methodToBeInlined() {
+		int k = 0;
+		new Object() {
+			void execute() {
+				TestQualifiedAnonymousReceiver.this.superClassMethod();
+			}
+		}.execute();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -956,6 +956,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void testQualifiedAnonymousReceiver() throws Exception {
+		performReceiverTest();
+	}
+
+	@Test
 	public void testThisReceiver() throws Exception {
 		performReceiverTestInlineMethod();
 	}


### PR DESCRIPTION
- fix SourceAnalyzer to denote a qualified this receiver if the qualifier is a type and also to not denote an anonymous class instantiation for implicit receiver
- add new test to InlineMethodTests
- fixes #1780

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
