### PR TITLE
it is now possible to expand the tree below in AbstractTreeViewer

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.33.200.qualifier
+Bundle-Version: 3.33.300.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.33.200-SNAPSHOT</version>
+  <version>3.33.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
@@ -642,10 +642,10 @@ public class TypeHierarchyViewPart extends ViewPart implements ITypeHierarchyVie
 		setMemberFilter(null);
 		internalSelectType(null, false); // clear selection
 		fIsEnableMemberFilter= false;
-		updateHierarchyViewer(true);
 		IType root= getSelectableType(fInputElements);
 		internalSelectType(root, true);
 		updateMethodViewer(root);
+		updateHierarchyViewer(true);
 		updateToolbarButtons();
 		updateToolTipAndDescription();
 		showMembersInHierarchy(false);


### PR DESCRIPTION
## What it does
This fixes the Problem that expanding the Tree in AbstractTreeViewer after the for loop failed on linux.  

![image](https://github.com/user-attachments/assets/e4897574-2d80-460d-9d7b-26bbea8cfb33)

It is important to see this PR together with https://github.com/eclipse-platform/eclipse.platform.ui/pull/2533. If ready to merge please merge this one before https://github.com/eclipse-platform/eclipse.platform.ui/pull/2533 because otherwise functionality will be lost on linux.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
