### PR TITLE
Provide name for parameters in 1-arg methods when using code minings

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
@@ -46,6 +47,7 @@ import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
@@ -54,6 +56,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
 
@@ -381,7 +384,17 @@ public class ParameterNamesCodeMiningTest {
 	}
 
 	@Test
-	public void testRecordConstructorOneParameter() throws Exception {
+	public void testRecordConstructorOneParameterPreferenceFalse() throws Exception {
+		assertParameterNamesShown(false, 0);
+	}
+
+	@Test
+	public void testRecordConstructorOneParameterPreferenceTrue() throws Exception {
+		assertParameterNamesShown(true, 1);
+	}
+
+	private void assertParameterNamesShown(boolean preferenceValue, int expectedShownNames) throws JavaModelException, PartInitException, InterruptedException, ExecutionException {
+		PreferenceConstants.getPreferenceStore().setValue(PreferenceConstants.EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAME_SINGLE_ARG, preferenceValue);
 		String contents= """
 				public class Ant {
 			record Ca (int size){
@@ -398,7 +411,7 @@ public class ParameterNamesCodeMiningTest {
 		JavaSourceViewer viewer= (JavaSourceViewer)editor.getViewer();
 		waitReconciled(viewer);
 
-		assertEquals(0, fParameterNameCodeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get().size());
+		assertEquals(expectedShownNames, fParameterNameCodeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get().size());
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/CalleeJavaMethodParameterVisitor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/CalleeJavaMethodParameterVisitor.java
@@ -165,11 +165,15 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 	}
 
 	private boolean skipParameterNamesCodeMinings(IMethod method) {
-		return method.getNumberOfParameters() <= 1;
+		boolean showNamesOfSingleArguments= PreferenceConstants.getPreferenceStore().getBoolean(PreferenceConstants.EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAME_SINGLE_ARG);
+		return !showNamesOfSingleArguments && method.getNumberOfParameters() == 1
+				|| method.getNumberOfParameters() == 0;
 	}
 
 	private boolean skipParameterNamesCodeMinings(IMethodBinding methodBinding) {
-		return methodBinding.getParameterNames().length <= 1;
+		boolean showNamesOfSingleArguments= PreferenceConstants.getPreferenceStore().getBoolean(PreferenceConstants.EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAME_SINGLE_ARG);
+		return !showNamesOfSingleArguments && methodBinding.getParameterNames().length == 1
+				|| methodBinding.getParameterNames().length == 0;
 	}
 
 	private boolean skipParameterNamesCodeMinings(IMethod method, String[] parameterNames) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorCodeMiningConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorCodeMiningConfigurationBlock.java
@@ -81,6 +81,9 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 	private static final Key PREF_DEFAULT_FILTER_FOR_PARAMETER_NAMES= getJDTUIKey(
 			PreferenceConstants.EDITOR_JAVA_CODEMINING_DEFAULT_FILTER_FOR_PARAMETER_NAMES);
 
+	private static final Key PREF_SHOW_ONE_PARAMETER= getJDTUIKey(
+			PreferenceConstants.EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAME_SINGLE_ARG);
+
 	private static final String SETTINGS_SECTION_NAME= "JavaEditorCodeMiningConfigurationBlock"; //$NON-NLS-1$
 
 	private static final String[] TRUE_FALSE= new String[] { "true", "false" }; //$NON-NLS-1$ //$NON-NLS-2$
@@ -101,7 +104,7 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 	public static Key[] getAllKeys() {
 		return new Key[] { PREF_CODEMINING_ENABLED, PREF_SHOW_CODEMINING_AT_LEAST_ONE, PREF_SHOW_REFERENCES, PREF_SHOW_REFERENCES_ON_TYPES, PREF_SHOW_REFERENCES_ON_FIELDS,
 				PREF_SHOW_REFERENCES_ON_METHODS,
-				PREF_SHOW_IMPLEMENTATIONS, PREF_SHOW_PARAMETER_NAMES, PREF_IGNORE_INEXACT_MATCHES, PREF_FILTER_IMPLIED_PARAMETER_NAMES, PREF_DEFAULT_FILTER_FOR_PARAMETER_NAMES };
+				PREF_SHOW_IMPLEMENTATIONS, PREF_SHOW_PARAMETER_NAMES, PREF_IGNORE_INEXACT_MATCHES, PREF_FILTER_IMPLIED_PARAMETER_NAMES, PREF_DEFAULT_FILTER_FOR_PARAMETER_NAMES, PREF_SHOW_ONE_PARAMETER };
 	}
 
 	@Override
@@ -227,6 +230,9 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 				PreferencesMessages.JavaEditorCodeMiningConfigurationBlock_defaultFilterForParameterNames_label,
 				PREF_DEFAULT_FILTER_FOR_PARAMETER_NAMES, TRUE_FALSE, extraIndent, section);
 
+		fFilteredPrefTree.addCheckBox(inner,
+				PreferencesMessages.JavaEditorCodeMiningShowOneParameter_label,
+				PREF_SHOW_ONE_PARAMETER, TRUE_FALSE, extraIndent, section);
 	}
 
 	private void updateEnableStates() {
@@ -244,8 +250,11 @@ public class JavaEditorCodeMiningConfigurationBlock extends OptionsConfiguration
 			// Show implementations checkboxes
 			getCheckBox(PREF_SHOW_IMPLEMENTATIONS).getSelection();
 			boolean showParameterNames= getCheckBox(PREF_SHOW_PARAMETER_NAMES).getSelection();
+
 			getCheckBox(PREF_FILTER_IMPLIED_PARAMETER_NAMES).setEnabled(showParameterNames);
 			getCheckBox(PREF_DEFAULT_FILTER_FOR_PARAMETER_NAMES).setEnabled(showParameterNames);
+			getCheckBox(PREF_SHOW_ONE_PARAMETER).setEnabled(showParameterNames);
+
 		} else {
 			atLeastOneCheckBox.setEnabled(false);
 			ignoreInexactReferenceMatches.setEnabled(false);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
@@ -913,6 +913,7 @@ public final class PreferencesMessages extends NLS {
 	public static String JavaEditorCodeMiningConfigurationBlock_showParameterNames_label;
 	public static String JavaEditorCodeMiningConfigurationBlock_filterImpliedParameterNames_label;
 	public static String JavaEditorCodeMiningConfigurationBlock_defaultFilterForParameterNames_label;
+	public static String JavaEditorCodeMiningShowOneParameter_label;
 
 	public static String JavaLaunchingConfigurationBlock_application_name_fully_qualified_label;
 	public static String JavaLaunchingConfigurationBlock_applet_name_fully_qualified_label;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -1038,6 +1038,7 @@ JavaEditorCodeMiningConfigurationBlock_showImplementations_label=Show &implement
 JavaEditorCodeMiningConfigurationBlock_showParameterNames_label=Show method &parameter names
 JavaEditorCodeMiningConfigurationBlock_defaultFilterForParameterNames_label=&Default filter for some specified methods and method parameter names (e.g. compare())
 JavaEditorCodeMiningConfigurationBlock_filterImpliedParameterNames_label=Filter parameter &names that are implied by parameter
+JavaEditorCodeMiningShowOneParameter_label=Show code minings when method has one parameter
 
 #Launching preferences
 JavaLaunchingConfigurationBlock_application_name_fully_qualified_label=Use fully qualified name for new Java Application

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -3940,6 +3940,17 @@ public class PreferenceConstants {
 	public static final String EDITOR_JAVA_CODEMINING_DEFAULT_FILTER_FOR_PARAMETER_NAMES = "java.codemining.defalt.filter.for.parameterNames"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that stores the value if a method with one parameter should be shown with code minings or if the code minings are
+	 * only shown for 2+ parameters
+	 * <p>
+	 * Value is of type <code>Boolean</code>.
+	 * </p>
+	 *
+	 * @since 3.34
+	 */
+	public static final String EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAME_SINGLE_ARG = "java.codemining.show.one.parameter"; //$NON-NLS-1$
+
+	/**
 	 * A named preference that stores the value for "Filter matching parameter names" when showing parameter names
 	 * in codemining.  This will filter out parameter names when the passed parameter name implies the parameter name.
 	 * For example, if the parameter name is "format" and the parameter passed is "stringFormat".
@@ -4374,6 +4385,7 @@ public class PreferenceConstants {
 		store.setDefault(EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAMES, false);
 		store.setDefault(EDITOR_JAVA_CODEMINING_FILTER_IMPLIED_PARAMETER_NAMES, true);
 		store.setDefault(EDITOR_JAVA_CODEMINING_DEFAULT_FILTER_FOR_PARAMETER_NAMES, true);
+		store.setDefault(EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAME_SINGLE_ARG, true);
 
 		// Javadoc hover & view
 		JavaElementLinks.initDefaultPreferences(store);


### PR DESCRIPTION
## What it does
This PR will enable the possability to show code minings in all Methods, also those who expect just one argument.

## Before: 
When a method only had one parameter, it was eligible for code minings, except if it was from a record class.  As you can see in the screenshot and snippet, the code minings are shown for car but not for Cat.

```java

import java.util.Objects;

class Main {
	public static void main(String...args) {
		Car c = new Car(3);
		Cat car = new Cat(5);
		car.equals(c);
		car.doSomething(12, 13);
	}
}

 class Cat {
    private int size;

    public Cat(int size) {
        this.size = size;
    }
    public Cat(long age) {}

    public int getSize() {
        return size;
    }

    public void doSomething(int a, int b) {}
    @Override
    public boolean equals(Object obj) {
        if (this == obj) return true;
        if (obj == null || getClass() != obj.getClass()) return false;
        Cat cat = (Cat) obj;
        return size == cat.size;
    }

    @Override
    public int hashCode() {
        return Objects.hash(size);
    }

    @Override
    public String toString() {
        return "Cat{size=" + size + "}";
    }
}

public record Car(int side) {}
```

![image](https://github.com/user-attachments/assets/e3c61d4a-ee0b-4f04-890a-c360964740e7)


@mickaelistria Is there a reason, why it always checks if there are more than one parameter? Because if not, I think it would be beneficial if the code minings are always shown. 


## After this change
Code minings are always shown no matter how many Parameters there are.


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
