### PR TITLE
Remove api filter related to org.eclipse.jdt.ui.text.IJavaPartitions.…

### DIFF
--- a/org.eclipse.jdt.core.manipulation/.settings/.api_filters
+++ b/org.eclipse.jdt.core.manipulation/.settings/.api_filters
@@ -31,12 +31,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="proposals/org/eclipse/jdt/ui/text/IJavaPartitions.java" type="org.eclipse.jdt.ui.text.IJavaPartitions">
-        <filter id="403767336">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.ui.text.IJavaPartitions"/>
-                <message_argument value="JAVA_MARKDOWN_COMMENT"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.21.300.qualifier
+Bundle-Version: 1.21.400.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin


### PR DESCRIPTION
…JAVA_MARKDOWN_COMMENT

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Remove api filter which is not needed, just cause build failures


## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
