### PR TITLE
Updated bundles with comparator errors

### DIFF
--- a/org.eclipse.jdt.core.manipulation/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.manipulation/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1979
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.13.400.qualifier
+Bundle-Version: 3.13.500.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit.core/forceQualifierUpdate.txt
@@ -5,3 +5,4 @@ Bug 527899 [9] Implement JEP 280: Indify String Concatenation
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/org.eclipse.jdt.junit/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit/forceQualifierUpdate.txt
@@ -16,3 +16,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/16
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.33.200.qualifier
+Bundle-Version: 3.33.300.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.ui/forceQualifierUpdate.txt
@@ -22,3 +22,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/19
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1979
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 Pick up changes from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.33.200-SNAPSHOT</version>
+  <version>3.33.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>


### PR DESCRIPTION
Changes to ecj are for handling of switch on String.

See: https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
