### PR TITLE
Record classes are now handled the same as normal classes

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -381,6 +381,27 @@ public class ParameterNamesCodeMiningTest {
 	}
 
 	@Test
+	public void testRecordConstructorOneParameter() throws Exception {
+		String contents= """
+				public class Ant {
+			record Ca (int size){
+
+			}
+
+			Ca c = new Ca(0);
+
+		}
+		""";
+		ICompilationUnit compilationUnit= fPackage.createCompilationUnit("Ant.java", contents, true, new NullProgressMonitor());
+		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(compilationUnit);
+		fParameterNameCodeMiningProvider.setContext(editor);
+		JavaSourceViewer viewer= (JavaSourceViewer)editor.getViewer();
+		waitReconciled(viewer);
+
+		assertEquals(0, fParameterNameCodeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get().size());
+	}
+
+	@Test
 	public void testRecordConstructorOK() throws Exception {
 		String contents= "import java.util.Map;\n"
 				+ "public record Edge(int fromNodeId,\n"

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/CalleeJavaMethodParameterVisitor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/CalleeJavaMethodParameterVisitor.java
@@ -129,7 +129,7 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 
 	protected void collectParameterNamesCodeMinings(IMethodBinding mbinding, List<?> arguments, boolean isVarArgs) {
 		// synthetic method of a record
-		if (mbinding.getDeclaringClass().isRecord()) {
+		if (mbinding.getDeclaringClass().isRecord() && !skipParameterNamesCodeMinings(mbinding)) {
 			String[] parameterNames= mbinding.getParameterNames();
 			for (int i= 0; i < Math.min(arguments.size(), parameterNames.length); i++) {
 				if (!skipParameterNameCodeMining(parameterNames, arguments, i)) {
@@ -166,6 +166,10 @@ public class CalleeJavaMethodParameterVisitor extends HierarchicalASTVisitor {
 
 	private boolean skipParameterNamesCodeMinings(IMethod method) {
 		return method.getNumberOfParameters() <= 1;
+	}
+
+	private boolean skipParameterNamesCodeMinings(IMethodBinding methodBinding) {
+		return methodBinding.getParameterNames().length <= 1;
 	}
 
 	private boolean skipParameterNamesCodeMinings(IMethod method, String[] parameterNames) {


### PR DESCRIPTION
## What it does
Record classes are now handled the same way as normal classes. 
This bug fix was proposed here: https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1813

## Before
Record classes were not checked for the amount of parameters which their methods had. Normal classes where though. That posed the problem, that when only one argument was given, the code minings were shown for record classes but not for normal classes.

## How to test
Use this code snippet:
```` java
import java.util.Objects;

class Main {
	public static void main(String...args) {
		Car c = new Car(3);
		Cat car = new Cat(5);
		car.equals(c);
		car.doSomething(12, 13);
	}
}

 class Cat {
    private int size;

    public Cat(int size) {
        this.size = size;
    }
    public Cat(long age) {}

    public int getSize() {
        return size;
    }

    public void doSomething(int a, int b) {}
    @Override
    public boolean equals(Object obj) {
        if (this == obj) return true;
        if (obj == null || getClass() != obj.getClass()) return false;
        Cat cat = (Cat) obj;
        return size == cat.size;
    }

    @Override
    public int hashCode() {
        return Objects.hash(size);
    }

    @Override
    public String toString() {
        return "Cat{size=" + size + "}";
    }
}

public record Car(int side) {}

````

it will result in this:
![Screenshot 2024-11-29 113901](https://github.com/user-attachments/assets/e6c33830-1acd-4022-bc44-ea7186e170ef)

## After the changes
Record classes are checked for the number of parameters the same way as normal classes and methods are checked. For the discussion on when they should be checked please take a look at https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1813#issuecomment-2507666908  and feel free to tell us your opinion. 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
