### PR TITLE
custom folding regions

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,7 +20,7 @@ import org.junit.platform.suite.api.Suite;
 import org.eclipse.jdt.text.tests.codemining.CodeMiningTriggerTest;
 import org.eclipse.jdt.text.tests.codemining.ParameterNamesCodeMiningTest;
 import org.eclipse.jdt.text.tests.contentassist.ContentAssistTestSuite;
-import org.eclipse.jdt.text.tests.folding.FoldingTest;
+import org.eclipse.jdt.text.tests.folding.FoldingTestSuite;
 import org.eclipse.jdt.text.tests.semantictokens.SemanticTokensProviderTest;
 import org.eclipse.jdt.text.tests.spelling.SpellCheckEngineTestCase;
 import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
@@ -71,7 +71,7 @@ import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
 	JavaElementPrefixPatternMatcherTest.class,
 	CodeMiningTriggerTest.class,
 	ParameterNamesCodeMiningTest.class,
-	FoldingTest.class,
+	FoldingTestSuite.class,
 })
 public class JdtTextTestSuite {
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
@@ -1,0 +1,481 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Daniel Schmid and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Daniel Schmid - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.text.tests.folding;
+
+import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import org.eclipse.jface.text.IRegion;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+@RunWith(Parameterized.class)
+public class CustomFoldingRegionTest {
+	@Rule
+	public ProjectTestSetup projectSetup= new ProjectTestSetup();
+
+	private IJavaProject fJProject1;
+
+	private IPackageFragmentRoot fSourceFolder;
+
+	private IPackageFragment fPackageFragment;
+
+	@Parameter
+	public boolean extendedFoldingActive;
+
+	@Parameters(name = "Experimental folding active: {0}")
+	public static Object[] extendedFoldingElements() {
+		return new Object[] { true, false };
+	}
+
+	@Before
+	public void setUp() throws CoreException {
+		fJProject1= projectSetup.getProject();
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		fPackageFragment= fSourceFolder.createPackageFragment("org.example.test", false, null);
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED, true);
+		store.setValue(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED, extendedFoldingActive);
+	}
+
+
+	@After
+	public void tearDown() throws CoreException {
+		JavaProjectHelper.delete(fJProject1);
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setToDefault(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START);
+		store.setToDefault(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END);
+		store.setToDefault(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED);
+	}
+
+	@Test
+	public void testNoCustomFoldingRegions() throws Exception {
+		String str= """
+				package org.example.test;
+				public class Test {
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(0, projectionRanges.size());
+	}
+
+	@Test
+	public void testCustomFoldingRegionInsideAndOutsideClass() throws Exception {
+		String str= """
+				package org.example.test;
+				// region
+				// something else
+				// endregion
+				public class Test {
+					// region
+					// something else
+					// endregion
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(2, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 3);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 7);
+	}
+
+	@Test
+	public void testNestedCustomRegions() throws Exception {
+		String str= """
+				package org.example.test;
+
+				public class Test {
+					// region outer
+					// region inner
+
+					// endregion outer
+					// endregion inner
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(2, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 7);//outer
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//inner
+	}
+
+	@Test
+	public void testCustomRegionsDisabled() throws Exception {
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED, false);
+
+		String str= """
+				package org.example.test;
+
+				public class Test {
+					// region outer
+
+					// endregion inner
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(0, projectionRanges.size());
+	}
+
+	@Test
+	public void testNoCustomFoldingRegionsInMethod() throws Exception {
+		String str= """
+				package org.example.test;
+				public class Test {
+					void a(){
+
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(1, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 3);
+	}
+
+	@Test
+	public void testCustomFoldingRegionsInMethod() throws Exception {
+		String str= """
+				package org.example.test;
+				public class Test {
+					void a(){
+						// region
+
+						// endregion
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(2, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 5);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5);
+	}
+
+	@Test
+	public void testNoCustomFoldingRegionsSingleImport() throws Exception {
+		String str= """
+				package org.example.test;
+
+				import java.util.List;
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(0, projectionRanges.size());
+	}
+
+	@Test
+	public void testCustomFoldingRegionAroundSingleImport() throws Exception {
+		String str= """
+				package org.example.test;
+
+				// region imports
+				import java.util.List;
+				// endregion
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(1, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 4);
+	}
+
+	@Test
+	public void testCustomFoldingRegionAroundClasses() throws Exception {
+		String str= """
+				package org.example.test;
+
+				class A {
+
+				}
+
+				// region
+
+				class B {
+
+				}
+
+				class C {
+
+				}
+				// endregion
+
+				class D {
+
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(1, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 15);
+	}
+
+	@Test
+	public void testCustomFoldingRegionsMultipleLevels() throws Exception {
+		String str= """
+				package org.example.test;
+				// region outside class
+				public class Test {
+					// endregion should be ignored with old folding
+					// region outside method
+					void a(){
+						// endregion should be ignored
+						// region inside method
+						System.out.println("Hello World");
+						// endregion inside method
+					}
+					// endregion outside method
+				}
+				// endregion outside class
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(4, projectionRanges.size());
+		if (extendedFoldingActive) {
+			// folding with control structures does not consider top level classes
+			// hence the first region ends with the endregion comment inside the Test class
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 3);
+		}else {
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 13);//outside class
+		}
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 11);//outside method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 7, 9);//inside method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 9);//void a()
+	}
+
+	@Test
+	public void testCustomFoldingRegionsNotEndingTooEarly() throws Exception {
+		String str= """
+				package org.example.test;
+
+				public class Test {
+					void a(){
+						// region inside method
+					}
+					// endregion outside method
+				}
+				// endregion outside class
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(1, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//void a()
+	}
+
+	@Test
+	public void testCustomFoldingRegionsUsingSpecialCommentTypes() throws Exception {
+		String str= """
+				package org.example.test;
+
+				public class Test {
+					void a(){
+						/* region multiline
+						*/
+						/** region javadoc */
+						/** endregion javadoc */
+						/* endregion multiline
+						*/
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		if(extendedFoldingActive) {
+			assertEquals(5, projectionRanges.size());
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//void a()
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 5);// multiline (comment)
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 9);// multiline (folding region)
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);// javadoc
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 8, 9);// multiline (last comment)
+		} else {
+			assertEquals(3, projectionRanges.size());
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//void a()
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 9);// multiline
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);// javadoc
+		}
+	}
+
+	@Test
+	public void testCustomRegionsWithLocalClass() throws Exception {
+		String str= """
+				package org.example.test;
+
+				public class Test {
+					void a(){
+						// region
+						int i;
+
+						// endregion
+						class Inner{
+
+						}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(3, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 10);//void a()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 7);//region
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 8, 9);//class Inner
+	}
+
+	@Test
+	public void testNoCustomRegionAtDifferentLevelsWithOtherClass() throws Exception {
+		String str= """
+				package org.example.test;
+
+				public class Test{
+					// region outside
+					public class A {
+						public void helloWorld() {
+
+						}
+						// endregion inside
+					}
+
+					public class B {
+
+
+				    }
+
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(3, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 8);//class A
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//void helloWorld()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 11, 13);//class B
+	}
+
+	@Test
+	public void testCustomRegionsAroundFieldAndMethod() throws Exception {
+		String str= """
+				package org.example.test;
+
+				public class Test {
+					// region
+					int a;
+
+					void b(){
+
+					}
+					// endregion
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(2, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//region
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);//void b()
+	}
+
+	@Test
+	public void testDifferentConfiguration() throws Exception {
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START, "#regstart");
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END, "#regend");
+
+
+		String str= """
+				package org.example.test;
+				public class Test {
+					// region should be ignored
+					// #regstart this is the region
+					// #regend should end here
+					// endregion should be ignored
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(1, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);
+	}
+
+	@Test
+	public void testCommentsInEmptyBlocks() throws Exception {
+		String str= """
+				package org.example.test;
+				public class Test {
+					void a(){
+						{/* region 1*/}
+						System.out.println("Hello World");
+						{/* endregion 1*/}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(2, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 5);//void a()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5);//region 1
+	}
+
+	@Test
+	public void testNotFoldedWithinDifferentControlFlowStatements() throws Exception {
+		assumeTrue("Only enabled with extended folding", extendedFoldingActive);
+		String str= """
+				package org.example.test;
+				public class Test {
+					void a() {
+						// region
+						for (int i = 0; i < 10; i++) {
+							// endregion
+							// region
+						}
+						boolean b=false;
+						// region
+						while (b) {
+							// endregion
+						}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(3, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 12);//void a()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//void a()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 11);//void a()
+	}
+
+	@Test
+	public void testCustomRegionsWithElementAfterwards() throws Exception {
+		String str= """
+				package org.example.test;
+
+				public class Test {
+					// region
+
+					/* endregion */ void test(){}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(1, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);
+	}
+
+	private List<IRegion> getProjectionRangesOfFile(String str) throws Exception {
+		return FoldingTestUtils.getProjectionRangesOfFile(fPackageFragment, "Test.java", str);
+	}
+
+}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestSuite.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Daniel Schmid and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Daniel Schmid - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.text.tests.folding;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({
+	FoldingTest.class,
+	CustomFoldingRegionTest.class
+})
+public class FoldingTestSuite {
+}

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.34.100.qualifier
+Bundle-Version: 3.35.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.34.100-SNAPSHOT</version>
+  <version>3.35.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/DefaultJavaFoldingPreferenceBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/DefaultJavaFoldingPreferenceBlock.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,10 +15,10 @@ package org.eclipse.jdt.internal.ui.text.folding;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
@@ -28,6 +28,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -60,6 +61,12 @@ public class DefaultJavaFoldingPreferenceBlock implements IJavaFoldingPreference
 			fOverlayStore.setValue(fCheckBoxes.get(button), button.getSelection());
 		}
 	};
+	private Map<Text, String> fStringInputs= new HashMap<>();
+	private ModifyListener fModifyListener = e -> {
+		Text text = (Text)e.widget;
+		fOverlayStore.setValue(fStringInputs.get(text), text.getText());
+	};
+
 
 
 	public DefaultJavaFoldingPreferenceBlock() {
@@ -77,6 +84,10 @@ public class DefaultJavaFoldingPreferenceBlock implements IJavaFoldingPreference
 		overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_FOLDING_IMPORTS));
 		overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_FOLDING_HEADERS));
 		overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED));
+		overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_FOLDING_COLLAPSE_CUSTOM_REGIONS));
+		overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED));
+		overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START));
+		overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END));
 		return overlayKeys.toArray(new OverlayKey[overlayKeys.size()]);
 	}
 
@@ -88,32 +99,28 @@ public class DefaultJavaFoldingPreferenceBlock implements IJavaFoldingPreference
 		fOverlayStore.load();
 		fOverlayStore.start();
 
-		composite.setLayout(new GridLayout(1, false));
-		composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-
-		Composite inner= new Composite(composite, SWT.NONE);
 		GridLayout layout= new GridLayout(1, false);
-		layout.verticalSpacing= 10;
+		layout.verticalSpacing= 3;
 		layout.marginWidth= 0;
-		layout.marginHeight= 0;
-		inner.setLayout(layout);
-		inner.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		composite.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false));
 
-		Group initialFoldGroup = new Group(inner, SWT.NONE);
-		GridLayout initialFoldLayout = new GridLayout(1, false);
-		initialFoldLayout.marginWidth = 10;
-		initialFoldLayout.marginHeight = 10;
-		initialFoldGroup.setLayout(initialFoldLayout);
-		initialFoldGroup.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
-		initialFoldGroup.setText(FoldingMessages.DefaultJavaFoldingPreferenceBlock_title);
+		Composite outer= new Composite(composite, SWT.NONE);
+		outer.setLayout(layout);
+		outer.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-		addCheckBox(initialFoldGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_comments, PreferenceConstants.EDITOR_FOLDING_JAVADOC, 0);
-		addCheckBox(initialFoldGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_headers, PreferenceConstants.EDITOR_FOLDING_HEADERS, 0);
-		addCheckBox(initialFoldGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_innerTypes, PreferenceConstants.EDITOR_FOLDING_INNERTYPES, 0);
-		addCheckBox(initialFoldGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_methods, PreferenceConstants.EDITOR_FOLDING_METHODS, 0);
-		addCheckBox(initialFoldGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_imports, PreferenceConstants.EDITOR_FOLDING_IMPORTS, 0);
+		Group initialFoldingGroup= new Group(outer, SWT.NONE);
+		initialFoldingGroup.setLayout(layout);
+		initialFoldingGroup.setText(FoldingMessages.DefaultJavaFoldingPreferenceBlock_title);
+		initialFoldingGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
-		Group extendedFoldingGroup= new Group(inner, SWT.NONE);
+		addCheckBox(initialFoldingGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_comments, PreferenceConstants.EDITOR_FOLDING_JAVADOC, 0);
+		addCheckBox(initialFoldingGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_headers, PreferenceConstants.EDITOR_FOLDING_HEADERS, 0);
+		addCheckBox(initialFoldingGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_innerTypes, PreferenceConstants.EDITOR_FOLDING_INNERTYPES, 0);
+		addCheckBox(initialFoldingGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_methods, PreferenceConstants.EDITOR_FOLDING_METHODS, 0);
+		addCheckBox(initialFoldingGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_imports, PreferenceConstants.EDITOR_FOLDING_IMPORTS, 0);
+		addCheckBox(initialFoldingGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_customRegions, PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED, 0);
+
+		Group extendedFoldingGroup= new Group(outer, SWT.NONE);
 		GridLayout extendedFoldingLayout= new GridLayout(1, false);
 		extendedFoldingLayout.marginWidth= 10;
 		extendedFoldingLayout.marginHeight= 10;
@@ -126,16 +133,31 @@ public class DefaultJavaFoldingPreferenceBlock implements IJavaFoldingPreference
 		label.setLayoutData(gd);
 		label.setText(FoldingMessages.DefaultJavaFoldingPreferenceBlock_Warning_New_Feature);
 		addCheckBox(extendedFoldingGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_New, PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED, 0);
-		return inner;
+
+		Group customRegionGroup= new Group(outer, SWT.NONE);
+		customRegionGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+		GridLayout customRegionLayout= new GridLayout(2, false);
+		customRegionGroup.setLayout(customRegionLayout);
+		customRegionGroup.setText(FoldingMessages.DefaultJavaFoldingPreferenceBlock_custom_region_title);
+
+		addCheckBox(customRegionGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_customRegionsEnabled, PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED, 0, 2);
+		addStringInput(customRegionGroup, FoldingMessages.DefaultJavaFoldingPreferenceBlock_customRegionStart, PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START);
+		addStringInput(customRegionGroup, FoldingMessages.defaultJavaFoldingPreferenceBlock_customRegionEnd, PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END);
+
+		return outer;
 	}
 
 	private Button addCheckBox(Composite parent, String label, String key, int indentation) {
+		return addCheckBox(parent, label, key, indentation, 1);
+	}
+	private Button addCheckBox(Composite parent, String label, String key, int indentation, int horizontalSpan) {
 		Button checkBox= new Button(parent, SWT.CHECK);
 		checkBox.setText(label);
 
 		GridData gd= new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING);
 		gd.horizontalIndent= indentation;
-		gd.horizontalSpan= 1;
+		gd.horizontalSpan= horizontalSpan;
 		gd.grabExcessVerticalSpace= false;
 		checkBox.setLayoutData(gd);
 		checkBox.addSelectionListener(fCheckBoxListener);
@@ -145,13 +167,29 @@ public class DefaultJavaFoldingPreferenceBlock implements IJavaFoldingPreference
 		return checkBox;
 	}
 
+	private void addStringInput(Composite parent, String label, String key) {
+		Label labelElement = new Label(parent, SWT.LEFT);
+		labelElement.setText(label);
+		GridData labelGridData= new GridData(GridData.HORIZONTAL_ALIGN_BEGINNING);
+		labelGridData.horizontalSpan= 1;
+		labelGridData.grabExcessVerticalSpace= false;
+		labelElement.setLayoutData(labelGridData);
+
+		Text textInput = new Text(parent, SWT.SINGLE | SWT.BORDER);
+		textInput.setText(label);
+		textInput.addModifyListener(fModifyListener);
+
+		GridData textGridData= new GridData(SWT.FILL, SWT.BEGINNING, true, false);
+		textGridData.horizontalSpan= 1;
+		textGridData.grabExcessVerticalSpace= true;
+		textInput.setLayoutData(textGridData);
+
+		fStringInputs.put(textInput, key);
+	}
+
 	private void initializeFields() {
-		Iterator<Button> it= fCheckBoxes.keySet().iterator();
-		while (it.hasNext()) {
-			Button b= it.next();
-			String key= fCheckBoxes.get(b);
-			b.setSelection(fOverlayStore.getBoolean(key));
-		}
+		fCheckBoxes.forEach((b, key) -> b.setSelection(fOverlayStore.getBoolean(key)));
+		fStringInputs.forEach((text, key) -> text.setText(fOverlayStore.getString(key)));
 	}
 
 	/*

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/FoldingMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/FoldingMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2007 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,12 @@ final class FoldingMessages extends NLS {
 	public static String DefaultJavaFoldingPreferenceBlock_imports;
 	public static String DefaultJavaFoldingPreferenceBlock_New;
 	public static String DefaultJavaFoldingPreferenceBlock_headers;
+	public static String DefaultJavaFoldingPreferenceBlock_customRegions;
+
+	public static String DefaultJavaFoldingPreferenceBlock_custom_region_title;
+	public static String DefaultJavaFoldingPreferenceBlock_customRegionsEnabled;
+	public static String DefaultJavaFoldingPreferenceBlock_customRegionStart;
+	public static String defaultJavaFoldingPreferenceBlock_customRegionEnd;
 	public static String EmptyJavaFoldingPreferenceBlock_emptyCaption;
 	public static String JavaFoldingStructureProviderRegistry_warning_providerNotFound_resetToDefault;
 	public static String DefaultJavaFoldingPreferenceBlock_New_Setting_Title;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/FoldingMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/FoldingMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2006 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,13 @@ DefaultJavaFoldingPreferenceBlock_innerTypes= Inner &types
 DefaultJavaFoldingPreferenceBlock_methods= &Members
 DefaultJavaFoldingPreferenceBlock_imports= &Imports
 DefaultJavaFoldingPreferenceBlock_headers= &Header Comments
+DefaultJavaFoldingPreferenceBlock_customRegions= Custom folding regions
+
+DefaultJavaFoldingPreferenceBlock_custom_region_title= Custom folding regions
+DefaultJavaFoldingPreferenceBlock_customRegionsEnabled=Enable folding of custom regions
+DefaultJavaFoldingPreferenceBlock_customRegionStart=Region start comment text
+defaultJavaFoldingPreferenceBlock_customRegionEnd=Region end comment text
+
 DefaultJavaFoldingPreferenceBlock_New = &Activate feature
 DefaultJavaFoldingPreferenceBlock_New_Setting_Title = &Extended folding (Experimental)
 JavaFoldingStructureProviderRegistry_warning_providerNotFound_resetToDefault= The ''{0}'' folding provider could not be found. Resetting to the default folding provider.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -3483,6 +3483,46 @@ public class PreferenceConstants {
 	public static final String EDITOR_FOLDING_HEADERS= "editor_folding_default_headers"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that stores the value for custom region folding for the default folding provider.
+	 * <p>
+	 * Value is of type <code>Boolean</code>.
+	 * </p>
+	 *
+	 * @since 3.35
+	 */
+	public static final String EDITOR_FOLDING_COLLAPSE_CUSTOM_REGIONS= "editor_folding_default_custom_regions"; //$NON-NLS-1$
+
+	/**
+	 * A named preference that stores the value for enabling custom region folding for the default folding provider.
+	 * <p>
+	 * Value is of type <code>Boolean</code>.
+	 * </p>
+	 *
+	 * @since 3.35
+	 */
+	public static final String EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED= "editor_folding_custom_regions"; //$NON-NLS-1$
+
+	/**
+	 * A named preference that stores the value for the start indicator of custom folding regions for the default folding provider.
+	 * <p>
+	 * Value is of type <code>String</code>.
+	 * </p>
+	 *
+	 * @since 3.35
+	 */
+	public static final String EDITOR_FOLDING_CUSTOM_REGION_START= "editor_folding_custom_region_start"; //$NON-NLS-1$
+
+	/**
+	 * A named preference that stores the value for the end indicator of custom folding regions for the default folding provider.
+	 * <p>
+	 * Value is of type <code>String</code>.
+	 * </p>
+	 *
+	 * @since 3.35
+	 */
+	public static final String EDITOR_FOLDING_CUSTOM_REGION_END= "editor_folding_custom_region_end"; //$NON-NLS-1$
+
+	/**
 	 * A named preference that holds the methods or types whose methods are by default expanded with
 	 * constructors in the Call Hierarchy.
 	 * <p>
@@ -4310,6 +4350,11 @@ public class PreferenceConstants {
 		store.setDefault(PreferenceConstants.EDITOR_FOLDING_METHODS, false);
 		store.setDefault(PreferenceConstants.EDITOR_FOLDING_IMPORTS, true);
 		store.setDefault(PreferenceConstants.EDITOR_FOLDING_HEADERS, true);
+		store.setDefault(PreferenceConstants.EDITOR_FOLDING_COLLAPSE_CUSTOM_REGIONS, false);
+
+		store.setDefault(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED, false);
+		store.setDefault(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START, "region"); //$NON-NLS-1$
+		store.setDefault(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END, "endregion"); //$NON-NLS-1$
 
 		// properties file editor
 		store.setDefault(PreferenceConstants.PROPERTIES_FILE_COLORING_KEY_BOLD, false);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2024 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,11 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.text.folding;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -77,6 +79,7 @@ import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CatchClause;
+import org.eclipse.jdt.core.dom.Comment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.DoStatement;
 import org.eclipse.jdt.core.dom.EnhancedForStatement;
@@ -129,6 +132,10 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		private LinkedHashMap<JavaProjectionAnnotation, Position> fMap= new LinkedHashMap<>();
 		private IScanner fDefaultScanner; // this one may or not be the shared DefaultJavaFoldingStructureProvider.fSharedScanner
 		private IScanner fScannerForProject;
+
+		private Deque<Integer> fOpenCustomRegionStartPositions = new ArrayDeque<>();
+		private Set<IRegion> fCurrentCustomRegions = new HashSet<>();
+		private int fLastScannedIndex;
 
 		private FoldingStructureComputationContext(IDocument document, ProjectionAnnotationModel model, boolean allowCollapsing, IScanner scanner) {
 			Assert.isNotNull(document);
@@ -268,6 +275,17 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		public boolean collapseMembers() {
 			return fAllowCollapsing && fCollapseMembers;
 		}
+
+		/**
+		 * Returns <code>true</code> if custom regions should be collapsed.
+		 *
+		 * @return <code>true</code> if custom regions should be collapsed
+		 * @since 3.35
+		 */
+		public boolean collapseCustomRegions() {
+			return fAllowCollapsing && fCollapseCustomRegions;
+		}
+
 	}
 
 	/**
@@ -997,9 +1015,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	private IPropertyChangeListener fPropertyChangeListener = new IPropertyChangeListener() {
 	    @Override
 	    public void propertyChange(PropertyChangeEvent event) {
-	        if (PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED.equals(event.getProperty())) {
-	            fNewFolding = event.getNewValue().equals(Boolean.TRUE);
-	        }
+	        initializePreferences();
 	        initialize();
 	    }
 	};
@@ -1010,7 +1026,12 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	private boolean fCollapseInnerTypes= true;
 	private boolean fCollapseMembers= false;
 	private boolean fCollapseHeaderComments= true;
+	private boolean fCollapseCustomRegions= false;
 	private boolean fNewFolding;
+
+	private boolean fCustomFoldingRegionsEnabled;
+	private char[] fCustomFoldingRegionBegin;
+	private char[] fCustomFoldingRegionEnd;
 
 	/* filters */
 	/** Member filter, matches nested members (but not top-level types). */
@@ -1188,7 +1209,15 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	    fCollapseJavadoc = store.getBoolean(PreferenceConstants.EDITOR_FOLDING_JAVADOC);
 	    fCollapseMembers = store.getBoolean(PreferenceConstants.EDITOR_FOLDING_METHODS);
 	    fCollapseHeaderComments = store.getBoolean(PreferenceConstants.EDITOR_FOLDING_HEADERS);
-	    fNewFolding = store.getBoolean(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED);
+
+		String customFoldingRegionBegin= store.getString(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START);
+		String customFoldingRegionEnd= store.getString(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END);
+		fCustomFoldingRegionBegin=customFoldingRegionBegin.toCharArray();
+		fCustomFoldingRegionEnd=customFoldingRegionEnd.toCharArray();
+		fCustomFoldingRegionsEnabled = store.getBoolean(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED) &&
+				!customFoldingRegionBegin.isEmpty() && !customFoldingRegionEnd.isEmpty() &&
+				!customFoldingRegionBegin.startsWith(customFoldingRegionEnd) && !customFoldingRegionEnd.startsWith(customFoldingRegionBegin);
+		fNewFolding = store.getBoolean(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED);
 	}
 
 	private void update(FoldingStructureComputationContext ctx) {
@@ -1286,7 +1315,8 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	        String source = unit.getSource();
 	        if (source == null) return;
 
-	        ctx.getScanner().setSource(source.toCharArray());
+	        char[] sourceArray= source.toCharArray();
+			ctx.getScanner().setSource(sourceArray);
 	        ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
 	        parser.setBindingsRecovery(true);
 	        parser.setStatementsRecovery(true);
@@ -1296,16 +1326,145 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	        parser.setProject(unit.getJavaProject());
 	        parser.setSource(unit);
 	        Map<String, String> options = unit.getJavaProject().getOptions(true);
-		    options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_23);
-		    options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_23);
-		    options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_23);
+		    options.put(JavaCore.COMPILER_SOURCE, JavaCore.latestSupportedJavaVersion());
+		    options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.latestSupportedJavaVersion());
+		    options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.latestSupportedJavaVersion());
 		    options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED);
 	        parser.setCompilerOptions(options);
 
 	        CompilationUnit ast = (CompilationUnit) parser.createAST(null);
-	        ast.accept(new FoldingVisitor(ctx));
-	    } catch (JavaModelException | IllegalStateException e) {
-	    }
+	        FoldingVisitor visitor= new FoldingVisitor(ctx);
+			ast.accept(visitor);
+
+			if (fCustomFoldingRegionsEnabled) {
+				List<Comment> comments= ast.getCommentList();
+				int currentCommentIndex= 0;
+
+				// Go through all already discovered folding regions in order to compute custom regions
+				// Disjoint folding regions are processed sequentially.
+				// Nested folding regions are processed depth-first.
+
+				// stack containing the "current" nested folding regions
+				// the top of the stack is the innermost region
+				Deque<Position> currentFoldingPositions= new ArrayDeque<>();
+				// stack containing the position of "open" regions for each element in currentFoldingPositions
+				// i.e. regions where the start position has been found but no end position
+				// Whenever an element is added/removed from currentFoldingPositions, the same is done with openCustomRegionStartPositions
+				Deque<Deque<Integer>> openCustomRegionStartPositions= new ArrayDeque<>();
+				openCustomRegionStartPositions.add(new ArrayDeque<>());
+
+				for (Position nonCommentFoldingRegion : List.copyOf(ctx.fMap.values())) {
+
+					// process regions depth-first until reaching the current region
+					currentCommentIndex= processFoldingRegionsForCustomCommentFolding(
+							sourceArray, visitor, comments, currentCommentIndex,
+							currentFoldingPositions, openCustomRegionStartPositions, nonCommentFoldingRegion.getOffset()
+					);
+					if (currentCommentIndex >= comments.size()) {
+						return;
+					}
+
+					// process comments before current region starts
+					currentCommentIndex= checkCustomFoldingCommitsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peekLast(), nonCommentFoldingRegion.getOffset());
+
+					currentFoldingPositions.addLast(nonCommentFoldingRegion);
+					openCustomRegionStartPositions.addLast(new ArrayDeque<>());
+				}
+				// process all leftover comments at the end
+				currentCommentIndex= processFoldingRegionsForCustomCommentFolding(sourceArray, visitor, comments, currentCommentIndex, currentFoldingPositions, openCustomRegionStartPositions, Integer.MAX_VALUE);
+				checkCustomFoldingCommitsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peek(), Integer.MAX_VALUE);
+			}
+		} catch (JavaModelException | IllegalStateException e) {
+		}
+	}
+
+	/**
+	 * Pops regions before limit and checks for custom folding comments.
+	 *
+	 * @param sourceArray the content of the processed source file
+	 * @param visitor the {@link FoldingVisitor} used for adding folding regions
+	 * @param comments all comments in the source file
+	 * @param currentCommentIndex the index of the next comment to process
+	 * @param currentFoldingPositions stack of current nested folding regions
+	 * @param openCustomRegionStartPositions start positions of custom folding regions with the
+	 *            start position being found but the end positions still missing
+	 * @param limit only regions before this position are scanned
+	 * @return the new index of the next comment
+	 */
+	private int processFoldingRegionsForCustomCommentFolding(char[] sourceArray, FoldingVisitor visitor, List<Comment> comments, int currentCommentIndex,
+			Deque<Position> currentFoldingPositions, Deque<Deque<Integer>> openCustomRegionStartPositions, int limit) {
+		Position currentFoldingPosition= currentFoldingPositions.peekLast();
+		while (currentFoldingPosition != null && currentFoldingPosition.getOffset() + currentFoldingPosition.getLength() < limit) {
+			currentFoldingPositions.removeLast();
+			Deque<Integer> innerOpenStartPositions= openCustomRegionStartPositions.removeLast();
+
+			currentCommentIndex= checkCustomFoldingCommitsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, innerOpenStartPositions, currentFoldingPosition.getOffset() + currentFoldingPosition.getLength());
+
+			if (currentCommentIndex >= comments.size()) {
+				return currentCommentIndex;
+			}
+
+			currentFoldingPosition= currentFoldingPositions.peekLast();
+		}
+		return currentCommentIndex;
+	}
+
+
+	/**
+	 * Searches for custom folding comments before a specified position and adds corresponding folding annotations.
+	 *
+	 * @param sourceArray the content of the processed source file
+	 * @param visitor the {@link FoldingVisitor} used for adding folding annotations
+	 * @param comments all comments in the source file
+	 * @param currentCommentIndex the index of the first comment to process
+	 * @param innerOpenStartPositions start positions of custom folding regions with the start position being found but the end positions still missing
+	 * @param limit only regions before this position are scanned
+	 * @return the new index of the next comment to process (after limit)
+	 */
+	private int checkCustomFoldingCommitsBeforePosition(char[] sourceArray, FoldingVisitor visitor, List<Comment> comments, int currentCommentIndex,
+			Deque<Integer> innerOpenStartPositions, int limit) {
+		while (currentCommentIndex < comments.size() && comments.get(currentCommentIndex).getStartPosition() < limit) {
+			Comment comment= comments.get(currentCommentIndex);
+			checkCustomFolding(innerOpenStartPositions, sourceArray, visitor, comment);
+			currentCommentIndex++;
+		}
+		return currentCommentIndex;
+	}
+
+	private void checkCustomFolding(Deque<Integer> openCustomRegionStartPositions, char[] sourceArray, FoldingVisitor visitor, Comment comment) {
+		int skip= 2;
+		if (comment.isDocComment()) {
+			skip= 3;
+		}
+		int commentTextStart= skipLeadingWhitespace(sourceArray, comment.getStartPosition() + skip);
+		IRegion customFoldingRegion= checkCustomFolding(
+				openCustomRegionStartPositions, commentTextStart, sourceArray,
+				comment.getStartPosition(), comment.getStartPosition() + comment.getLength()
+		);
+		if (customFoldingRegion != null) {
+			if (includeLastLineInCustomFoldingRegion(sourceArray, customFoldingRegion.getOffset() + customFoldingRegion.getLength())) {
+				includelastLine= true;
+			}
+			visitor.createFoldingRegion(customFoldingRegion.getOffset(), customFoldingRegion.getLength(), fCollapseCustomRegions);
+		}
+	}
+
+	private boolean includeLastLineInCustomFoldingRegion(char[] sourceArray, int regionEnd) {
+		char firstCharacter = sourceArray[regionEnd];
+		if (firstCharacter == '\n' || firstCharacter == '\r') {
+			return true;
+		}
+		for (int i= regionEnd + 1; i < sourceArray.length; i++) {
+			char c= sourceArray[i];
+			if (c == '\n' || c == '\r') {
+				return true;
+			}
+			// allow custom regions comments defined in {/* ... */} without that causing the end to be shown
+			if (!Character.isWhitespace(c) && c != '}') {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private void processComments(FoldingStructureComputationContext ctx) {
@@ -1442,7 +1601,15 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 			if (element instanceof IParent) {
 				IParent parent= (IParent) element;
+				Deque<Integer> outerOpenRegions = ctx.fOpenCustomRegionStartPositions;
+				ctx.fOpenCustomRegionStartPositions = new ArrayDeque<>();
 				computeFoldingStructure(parent.getChildren(), ctx);
+				ctx.fOpenCustomRegionStartPositions = outerOpenRegions;
+			}
+			if (fCustomFoldingRegionsEnabled && element instanceof ISourceReference sourceRef) {
+				// mark as scanned until end after scanning all children
+				ISourceRange sourceRange= sourceRef.getSourceRange();
+				ctx.fLastScannedIndex = sourceRange.getLength()+sourceRange.getOffset();
 			}
 		}
 	}
@@ -1493,13 +1660,16 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			// comments
 			for (int i= 0; i < regions.length - 1; i++) {
 				includelastLine= true;
-				IRegion normalized= alignRegion(regions[i], ctx);
+				IRegion region= regions[i];
+				IRegion normalized= alignRegion(region, ctx);
 				if (normalized != null) {
 					Position position= createCommentPosition(normalized);
 					if (position != null) {
 						boolean commentCollapse;
 						if (i == 0 && (regions.length > 2 || ctx.hasHeaderComment()) && element == ctx.getFirstType()) {
 							commentCollapse= ctx.collapseHeaderComments();
+						} else if(ctx.fCurrentCustomRegions.contains(region)) {
+							commentCollapse= ctx.collapseCustomRegions();
 						} else {
 							commentCollapse= ctx.collapseJavadoc();
 						}
@@ -1588,24 +1758,40 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 				final int shift= range.getOffset();
 				IScanner scanner= ctx.getScanner();
+
+				if (fCustomFoldingRegionsEnabled &&
+						reference instanceof IJavaElement javaElement && javaElement.getParent() != null &&
+							javaElement.getParent() instanceof IParent parent && parent instanceof ISourceReference parentSourceReference) {
+						// check tokens between the last sibling (or the parent) and start of current sibling
+						ISourceRange parentSourceRange= parentSourceReference.getSourceRange();
+						if (ctx.fLastScannedIndex >= parentSourceRange.getOffset() && ctx.fLastScannedIndex < parentSourceRange.getOffset() + parentSourceRange.getLength()
+								&& ctx.fLastScannedIndex < range.getOffset()) {
+							scanner.resetTo(ctx.fLastScannedIndex, range.getOffset());
+							checkCustomFoldingUntilScannerEnd(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner);
+						}
+					}
+
+
 				scanner.resetTo(shift, shift + range.getLength());
 
 				int start= shift;
+
 				while (true) {
 
 					int token= scanner.getNextToken();
 					start= scanner.getCurrentTokenStartPosition();
 
 					switch (token) {
-						case ITerminalSymbols.TokenNameCOMMENT_JAVADOC:
-						case ITerminalSymbols.TokenNameCOMMENT_MARKDOWN:
-						case ITerminalSymbols.TokenNameCOMMENT_BLOCK: {
+						case ITerminalSymbols.TokenNameCOMMENT_JAVADOC, ITerminalSymbols.TokenNameCOMMENT_MARKDOWN, ITerminalSymbols.TokenNameCOMMENT_BLOCK: {
 							int end= scanner.getCurrentTokenEndPosition() + 1;
 							regions.add(new Region(start, end - start));
+							checkCustomFolding(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner, token, regions.size());
 							continue;
 						}
-						case ITerminalSymbols.TokenNameCOMMENT_LINE:
+						case ITerminalSymbols.TokenNameCOMMENT_LINE: {
+							checkCustomFolding(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner, token, regions.size());
 							continue;
+						}
 					}
 
 					break;
@@ -1613,12 +1799,113 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 				regions.add(new Region(start, shift + range.getLength() - start));
 
+				if (fCustomFoldingRegionsEnabled) {
+					if (reference instanceof IParent parent && !parent.hasChildren()) {
+						// if the element has no children, check content for custom folding region markers
+						checkCustomFoldingUntilScannerEnd(ctx, regions, new ArrayDeque<>(), scanner);
+					}
+					ctx.fLastScannedIndex= scanner.getCurrentTokenEndPosition();
+					if (reference instanceof IJavaElement javaElement && javaElement.getParent() != null &&
+							javaElement.getParent() instanceof IParent parent && parent instanceof ISourceReference parentSourceReference) {
+						IJavaElement[] siblings= parent.getChildren();
+						if (javaElement == siblings[siblings.length - 1]) {
+							// if the current element is the last sibling
+							// tokens after the current element and before the end of the parent are checked for custom folding region markers
+							int regionStart= range.getOffset() + range.getLength();
+							ISourceRange parentRange= parentSourceReference.getSourceRange();
+							int regionEnd= parentRange.getOffset() + parentRange.getLength();
+							scanner.resetTo(regionStart, regionEnd);
+							checkCustomFoldingUntilScannerEnd(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner);
+						}
+					}
+				}
+
 				IRegion[] result= new IRegion[regions.size()];
 				regions.toArray(result);
 				return result;
 		} catch (JavaModelException | InvalidInputException e) {
 		}
 		return new IRegion[0];
+	}
+
+	private void checkCustomFoldingUntilScannerEnd(FoldingStructureComputationContext ctx, List<IRegion> regions, Deque<Integer> openCustomRegionStartPositions, IScanner scanner) throws InvalidInputException {
+		for(int token = scanner.getNextToken(); token != ITerminalSymbols.TokenNameEOF; token=scanner.getNextToken()) {
+			if(isCommentToken(token)) {
+				checkCustomFolding(ctx, regions, openCustomRegionStartPositions, scanner, token, Math.max(regions.size() - 1, 0));
+			}
+		}
+	}
+
+	private boolean isCommentToken(int token) {
+		return token == ITerminalSymbols.TokenNameCOMMENT_BLOCK || token == ITerminalSymbols.TokenNameCOMMENT_JAVADOC || token == ITerminalSymbols.TokenNameCOMMENT_MARKDOWN || token == ITerminalSymbols.TokenNameCOMMENT_LINE;
+	}
+
+	private void checkCustomFolding(FoldingStructureComputationContext ctx, List<IRegion> regions, Deque<Integer> openCustomRegionStartPositions, IScanner scanner, int token, int regionArrayIndex) {
+		if (!fCustomFoldingRegionsEnabled) {
+			return;
+		}
+		int commentTextStart = findPossibleRegionCommentStart(scanner, token);
+
+		char[] source= scanner.getSource();
+		int currentTokenStartPosition= scanner.getCurrentTokenStartPosition();
+		int currentTokenEndPosition= scanner.getCurrentTokenEndPosition();
+
+		IRegion region= checkCustomFolding(openCustomRegionStartPositions, commentTextStart, source, currentTokenStartPosition, currentTokenEndPosition);
+		if (region != null) {
+			if (!includeLastLineInCustomFoldingRegion(source, currentTokenEndPosition)) {
+				includelastLine= false;
+				region= alignRegion(region, ctx);
+			}
+			regions.add(regionArrayIndex, region);
+			ctx.fCurrentCustomRegions.add(region);
+		}
+	}
+
+	private Region checkCustomFolding(Deque<Integer> openCustomRegionStartPositions, int commentTextStart, char[] source, int currentTokenStartPosition, int currentTokenEndPosition) {
+		int currentTokenLengthStartingAtCommentTextStart= currentTokenEndPosition - commentTextStart;
+
+		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCustomFoldingRegionBegin)) {
+			openCustomRegionStartPositions.add(currentTokenStartPosition);
+		}
+
+		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCustomFoldingRegionEnd) && !openCustomRegionStartPositions.isEmpty()) {
+			int end= currentTokenEndPosition;
+			Integer regionStart= openCustomRegionStartPositions.removeLast();
+			return new Region(regionStart, end - regionStart);
+
+		}
+		return null;
+	}
+
+	private int findPossibleRegionCommentStart(IScanner scanner, int token) {
+		char[] source= scanner.getSource();
+		int start= scanner.getCurrentTokenStartPosition();
+		int skip= switch (token) {
+			case ITerminalSymbols.TokenNameCOMMENT_LINE, ITerminalSymbols.TokenNameCOMMENT_BLOCK -> 2;
+			case ITerminalSymbols.TokenNameCOMMENT_JAVADOC, ITerminalSymbols.TokenNameCOMMENT_MARKDOWN -> 3;
+			default -> 0;
+		};
+		int newStart= start + skip;
+		return skipLeadingWhitespace(source, newStart);
+	}
+
+	private int skipLeadingWhitespace(char[] source, int start) {
+		while (Character.isWhitespace(source[start])) {
+			start++;
+		}
+		return start;
+	}
+
+	private boolean startsWith(char[] source, int offset, int length, char[] prefix) {
+		if (length < prefix.length) {
+			return false;
+		}
+		for(int i=0;i<prefix.length;i++) {
+			if (source[offset+i] != prefix[i]) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	private IRegion computeHeaderComment(FoldingStructureComputationContext ctx) throws JavaModelException {


### PR DESCRIPTION
Relevant issues: https://bugs.eclipse.org/bugs/show_bug.cgi?id=173796 (and there are also similar ones like https://bugs.eclipse.org/bugs/show_bug.cgi?id=258965 for CDT).

There is also a [Stack Overflow post](https://stackoverflow.com/q/13505413/10871900) asking for how to do that with quite a few upvotes so I'd say it seems like many people are interested in such a feature.

## What it does
This PR allows to add custom folding regions using comments.

I added new options to the preferences in `Java` > `Editor` > `Folding` (not that I changed this preference page to use `Group`s):  
![folding preference dialog including custom folding regions](https://github.com/user-attachments/assets/ffb58ff8-cde2-4053-94f8-28cfca492700)



If a comment containing the start region and a comment containing the end region are present in the same source file, a folding region is added allowing to collapse that section. 

![non-collapsed custom region](https://github.com/user-attachments/assets/5b2bcaa4-6d19-4896-994a-cdae2101191d)
![collapsed custom region](https://github.com/user-attachments/assets/bde0417a-5ef3-43e4-b2c8-01696ab6dc55)
![hovering over collapsed region indicator showing content](https://github.com/user-attachments/assets/531ead75-1f4c-4158-b69d-bf2c7425a5ac)

It would be possible to change the defaults from `region`/`endregion` to `#region`/`#endregion` or similar. I have decided for `// region`, `// endregion` as that seems less arbitrary. I don't really have an opinion about the best choice of defaults here.

This functionality is added both to the normal folding and the new folding based on the AST introduced in #1562. The folding using the AST uses existing folding annotations to compute the new ones.

~~This works even for elements of different levels~~ This is intentionally restricted since someone folding things from different elements is likely a mistake of the user (they probably don't want to fold something in the bodies of different methods or similar) as discussed in a devcall.

~~This PR also allows configuring folding per-project as requested in [this comment](https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1825#issuecomment-2565439652).~~ This has been moved to #1979

## How to test
- Create a Java source file
- Create a comment starting with the text `region`
- Create a comment starting with the text `endregion` after the `region` comment (but within the same block (e.g. method/class))
- Test similar things with the source file
- After editing the corresponding changes in `Java` > `Editor` > `Folding`, ~~it is necessary to reopen the source file.~~ the changes are automatically applied to open editors (and will also be used when opening a new editor).
  - It is also possible to change these preferences in the project properties. This also requires reopening the source file.

## Author checklist

- [X] I have thoroughly tested my changes
  - performance testing: https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1825#issuecomment-2562957272
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
