### PR TITLE
Enhance StringBuffer/StringBuilder to text block cleanup/quickfix

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -76,20 +76,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \"\" + //$NON-NLS-1$\n");
-        buf.append("            \"public void foo() {\\n\" + //$NON-NLS-1$\n");
-        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" + //$NON-NLS-1$\n");
-        buf.append("            \"}\\n\"; //$NON-NLS-1$ // comment 2\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x = "" + //$NON-NLS-1$
+			            "public void foo() {\\n" + //$NON-NLS-1$
+			            "    System.out.println(\\"abc\\");\\n" + //$NON-NLS-1$
+			            "}\\n"; //$NON-NLS-1$ // comment 2
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("x");
+		int index= str1.indexOf("x");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 1);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -127,20 +128,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \"\" +\n");
-        buf.append("            \"public void foo() { \\n\" +\n");
-        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" +\n");
-        buf.append("            \"}\\n\"; // comment 2\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x = "" +
+			            "public void foo() { \\n" +
+			            "    System.out.println(\\"abc\\");\\n" +
+			            "}\\n"; // comment 2
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("System");
+		int index= str1.indexOf("System");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -178,20 +180,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \"\" +\n");
-        buf.append("            \"public void foo() { \\n\" +\n");
-        buf.append("            \"    System.out.println(\\\"\\\"\\\"abc\\\"\\\"\\\");\\n\" +\n");
-        buf.append("            \"}\\n\"; // comment 2\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x = "" +
+			            "public void foo() { \\n" +
+			            "    System.out.println(\\"\\"\\"abc\\"\\"\\");\\n" +
+			            "}\\n"; // comment 2
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("System");
+		int index= str1.indexOf("System");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -229,20 +232,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \"\" +\n");
-        buf.append("            \"abcdef\" +\n");
-        buf.append("            \"ghijkl\\\"\\\"\\\"123\\\"\\\"\\\"\" +\n");
-        buf.append("            \"mnop\";\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x = "" +
+			            "abcdef" +
+			            "ghijkl\\"\\"\\"123\\"\\"\\"" +
+			            "mnop";
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("abcdef");
+		int index= str1.indexOf("abcdef");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -279,26 +283,27 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        StringBuffer buf= new StringBuffer(\"intro string\\n\");\n");
-		buf.append("        buf.append(\"public void foo() {\\n\");\n");
-		buf.append("        buf.append(\"    return null;\\n\");\n");
-		buf.append("        buf.append(\"}\\n\");\n");
-		buf.append("        buf.append(\"\\n\");\n");
-		buf.append("        System.out.println(buf.toString());\n");
-		buf.append("        System.out.println(buf.toString() + \"abc\");\n");
-		buf.append("        // comment 2\n");
-		buf.append("        buf = new StringBuffer(\"intro string 2\\n\");\n");
-		buf.append("        buf.append(\"some string\\n\");\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        StringBuffer buf= new StringBuffer("intro string\\n");
+			        buf.append("public void foo() {\\n");
+			        buf.append("    return null;\\n");
+			        buf.append("}\\n");
+			        buf.append("\\n");
+			        System.out.println(buf.toString());
+			        System.out.println(buf.toString() + "abc");
+			        // comment 2
+			        buf = new StringBuffer("intro string 2\\n");
+			        buf.append("some string\\n");
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf");
+		int index= str1.indexOf("buf");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -343,23 +348,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        StringBuilder buf3= new StringBuilder();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
-		buf.append("        buf3.append(\"    return null;\\n\");\n");
-		buf.append("        buf3.append(\"}\\n\");\n");
-		buf.append("        buf3.append(\"\\n\");\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n");
+			        buf3.append("    return null;\\n");
+			        buf3.append("}\\n");
+			        buf3.append("\\n");
+			        // comment 1
+			        String k = buf3.toString();
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf");
+		int index= str1.indexOf("buf");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -399,23 +405,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        StringBuilder buf3= new StringBuilder();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"    return null;\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"}\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"\\n\"); //$NON-NLS-1$\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n"); //$NON-NLS-1$
+			        buf3.append("    return null;\\n"); //$NON-NLS-1$
+			        buf3.append("}\\n"); //$NON-NLS-1$
+			        buf3.append("\\n"); //$NON-NLS-1$
+			        // comment 1
+			        String k = buf3.toString();
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf3");
+		int index= str1.indexOf("buf3");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 4);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -456,23 +463,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        StringBuilder buf3= new StringBuilder();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"    return null;\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"}\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"\\n\"); //$NON-NLS-1$\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n"); //$NON-NLS-1$
+			        buf3.append("    return null;\\n"); //$NON-NLS-1$
+			        buf3.append("}\\n"); //$NON-NLS-1$
+			        buf3.append("\\n"); //$NON-NLS-1$
+			        // comment 1
+			        String k = buf3.toString();
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("StringBuilder");
+		int index= str1.indexOf("StringBuilder");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 4);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -513,17 +521,18 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \"foo \\n\" + \"bar  \" + \"baz\" + \"biz\";\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x = "foo \\n" + "bar  " + "baz" + "biz";
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("x");
+		int index= str1.indexOf("x");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -564,17 +573,18 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \"foo \\n\" + \"bar  \" + \"baz\" + \"biz\";\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x = "foo \\n" + "bar  " + "baz" + "biz";
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("x");
+		int index= str1.indexOf("x");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -615,21 +625,22 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x =\"\\tif (true) {\\n\" +\n");
-		buf.append("                \"\\t\\tstuff();\\n\" +\n");
-		buf.append("                \"\\t} else\\n\" +\n");
-		buf.append("                \"\\t\\tnoStuff\";\n");
-		buf.append("        System.out.println(x);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x ="\\tif (true) {\\n" +
+			                "\\t\\tstuff();\\n" +
+			                "\\t} else\\n" +
+			                "\\t\\tnoStuff";
+			        System.out.println(x);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("x");
+		int index= str1.indexOf("x");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -669,26 +680,27 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        StringBuilder buf3= new StringBuilder();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"    return null;\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"}\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"\\n\"); //$NON-NLS-1$\n");
-		buf.append("        // comment 1\n");
-		buf.append("        write(buf3);\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("    private void write(CharSequence c) {\n");
-		buf.append("        System.out.println(c);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n"); //$NON-NLS-1$
+			        buf3.append("    return null;\\n"); //$NON-NLS-1$
+			        buf3.append("}\\n"); //$NON-NLS-1$
+			        buf3.append("\\n"); //$NON-NLS-1$
+			        // comment 1
+			        write(buf3);
+			       \s
+			    }
+			    private void write(CharSequence c) {
+			        System.out.println(c);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf3");
+		int index= str1.indexOf("buf3");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 4);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -732,24 +744,25 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        StringBuilder buf3= new StringBuilder();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
-		buf.append("        buf3.append(\"    return null;\\n\");\n");
-		buf.append("        buf3.append(\"}\\n\");\n");
-		buf.append("        buf3.append(\"\\n\");\n");
-		buf.append("        // comment 1\n");
-		buf.append("        int index = buf3.indexOf(\"null\");\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n");
+			        buf3.append("    return null;\\n");
+			        buf3.append("}\\n");
+			        buf3.append("\\n");
+			        // comment 1
+			        int index = buf3.indexOf("null");
+			        String k = buf3.toString();
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("StringBuilder");
+		int index= str1.indexOf("StringBuilder");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 4);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -777,6 +790,70 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 	}
 
 	@Test
+	public void testConcatToTextBlock14() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n");
+			        buf3.append("    return null;\\n");
+			        buf3.append("}\\n");
+			        buf3.append("\\n");
+			        // comment 1
+			        int index = buf3.indexOf("null");
+			        bufFunc(buf3);
+			       \s
+			    }
+			    public void bufFunc(StringBuilder x) {
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("StringBuilder");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 4);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		String expected= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        StringBuilder buf3= new StringBuilder(\"""
+						public void foo() {
+						    return null;
+						}
+					\t
+						\""");
+			        // comment 1
+			        int index = buf3.indexOf("null");
+			        bufFunc(buf3);
+			       \s
+			    }
+			    public void bufFunc(StringBuilder x) {
+			    }
+			}
+			""";
+
+		assertProposalExists(proposals, FixMessages.StringConcatToTextBlockFix_convert_msg);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
 	public void testNoConcatToTextBlock1() throws Exception {
 		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
 		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
@@ -791,19 +868,20 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \n");
-        buf.append("            \"abcdef\" +\n");
-        buf.append("            \"ghijkl\";\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x =\s
+			            "abcdef" +
+			            "ghijkl";
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("abcdef");
+		int index= str1.indexOf("abcdef");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -826,20 +904,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \n");
-        buf.append("            \"abcdef\" +\n");
-        buf.append("            \"ghijkl\" +\n");
-        buf.append("            String.valueOf(true);\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x =\s
+			            "abcdef" +
+			            "ghijkl" +
+			            String.valueOf(true);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("abcdef");
+		int index= str1.indexOf("abcdef");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -862,20 +941,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \n");
-        buf.append("            \"abcdef\" +\n");
-        buf.append("            \"ghijkl\" +\n");
-        buf.append("            3;\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        // comment 1
+			        String x =\s
+			            "abcdef" +
+			            "ghijkl" +
+			            3;
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("abcdef");
+		int index= str1.indexOf("abcdef");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -898,20 +978,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo(String a) {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \n");
-        buf.append("            \"abcdef\" +\n");
-        buf.append("            \"ghijkl\" +\n");
-        buf.append("            a;\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo(String a) {
+			        // comment 1
+			        String x =\s
+			            "abcdef" +
+			            "ghijkl" +
+			            a;
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("abcdef");
+		int index= str1.indexOf("abcdef");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -934,21 +1015,22 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void noToString() {\n");
-		buf.append("        StringBuilder buf3= new StringBuilder();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
-		buf.append("        buf3.append(\"    return null;\\n\");\n");
-		buf.append("        buf3.append(\"}\\n\");\n");
-		buf.append("        buf3.append(\"\\n\");\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void noToString() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n");
+			        buf3.append("    return null;\\n");
+			        buf3.append("}\\n");
+			        buf3.append("\\n");
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf3");
+		int index= str1.indexOf("buf3");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -971,23 +1053,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void extraAppend() {\n");
-		buf.append("        StringBuilder buf3= new StringBuilder();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
-		buf.append("        buf3.append(\"    return null;\\n\");\n");
-		buf.append("        buf3.append(\"}\\n\");\n");
-		buf.append("        buf3.append(\"\\n\");\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        buf3.append(\"extra stuff\\n\");\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void extraAppend() {
+			        StringBuilder buf3= new StringBuilder();
+			        buf3.append("public void foo() {\\n");
+			        buf3.append("    return null;\\n");
+			        buf3.append("}\\n");
+			        buf3.append("\\n");
+			        String k = buf3.toString();
+			        buf3.append("extra stuff\\n");
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf3");
+		int index= str1.indexOf("buf3");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1010,22 +1093,23 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void combinedAppendWithNLS() {\n");
-		buf.append("        StringBuffer buf3= new StringBuffer();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"    return null;\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"}\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"\\n\").append(\"extra append\\n\"); //$NON-NLS-1$ //$NON-NLS-2$\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void combinedAppendWithNLS() {
+			        StringBuffer buf3= new StringBuffer();
+			        buf3.append("public void foo() {\\n"); //$NON-NLS-1$
+			        buf3.append("    return null;\\n"); //$NON-NLS-1$
+			        buf3.append("}\\n"); //$NON-NLS-1$
+			        buf3.append("\\n").append("extra append\\n"); //$NON-NLS-1$ //$NON-NLS-2$
+			        String k = buf3.toString();
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf3");
+		int index= str1.indexOf("buf3");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1048,32 +1132,33 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void inconsistentNLSMarkers() {\n");
-		buf.append("        StringBuffer buf3= new StringBuffer();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\"); //$NON-NLS-1$\n");
-		buf.append("        buf3.append(\"    return null;\\n\");\n");
-		buf.append("        buf3.append(\"}\\n\");\n");
-		buf.append("        buf3.append(\"\\n\");\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("    public void indexOfInside() {\n");
-		buf.append("        StringBuffer buf3= new StringBuffer();\n");
-		buf.append("        buf3.append(\"public void foo() {\\n\");\n");
-		buf.append("        buf3.append(\"    return null;\\n\");\n");
-		buf.append("        buf3.append(\"}\\n\");\n");
-		buf.append("        int index = buf3.indexOf(\"foo\");\n");
-		buf.append("        buf3.append(\"\\n\");\n");
-		buf.append("        String k = buf3.toString();\n");
-		buf.append("        \n");
-		buf.append("    }\n");
-		buf.append("}\n");
-	ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void inconsistentNLSMarkers() {
+			        StringBuffer buf3= new StringBuffer();
+			        buf3.append("public void foo() {\\n"); //$NON-NLS-1$
+			        buf3.append("    return null;\\n");
+			        buf3.append("}\\n");
+			        buf3.append("\\n");
+			        String k = buf3.toString();
+			       \s
+			    }
+			    public void indexOfInside() {
+			        StringBuffer buf3= new StringBuffer();
+			        buf3.append("public void foo() {\\n");
+			        buf3.append("    return null;\\n");
+			        buf3.append("}\\n");
+			        int index = buf3.indexOf("foo");
+			        buf3.append("\\n");
+			        String k = buf3.toString();
+			       \s
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("buf3");
+		int index= str1.indexOf("buf3");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1096,20 +1181,21 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void inconsistentNLS() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String x = \"\" + //$NON-NLS-1$\n");
-        buf.append("            \"public void foo() {\\n\" +\n");
-        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" + //$NON-NLS-1$\n");
-        buf.append("            \"}\\n\"; //$NON-NLS-1$ // comment 2\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void inconsistentNLS() {
+			        // comment 1
+			        String x = "" + //$NON-NLS-1$
+			            "public void foo() {\\n" +
+			            "    System.out.println(\\"abc\\");\\n" + //$NON-NLS-1$
+			            "}\\n"; //$NON-NLS-1$ // comment 2
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("x");
+		int index= str1.indexOf("x");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 1);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1132,22 +1218,23 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void inconsistentNLS() {\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String y = \"something\";\n");
-		buf.append("        String x = \"\" +\n");
-        buf.append("            \"public void foo() {\\n\" +\n");
-        buf.append("            \"    System.out.println(\\\"abc\\\");\\n\" +\n");
-        buf.append("                  y + \n");
-        buf.append("            \"}\\n\"; //$NON-NLS-1$ // comment 2\n");
-        buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void inconsistentNLS() {
+			        // comment 1
+			        String y = "something";
+			        String x = "" +
+			            "public void foo() {\\n" +
+			            "    System.out.println(\\"abc\\");\\n" +
+			                  y +\s
+			            "}\\n"; //$NON-NLS-1$ // comment 2
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("x");
+		int index= str1.indexOf("x");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 1);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1170,23 +1257,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/***********\\n\" +\n");
-		buf.append("                \" * simple {} \\n\" +\n");
-		buf.append("                \" * copyright\\n\" +\n");
-		buf.append("                statement +\n");
-		buf.append("                \" * notice {0}\\n\" +\n");
-		buf.append("                \"***********/\\n\"; // comment 2\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/***********\\n" +
+			                " * simple {} \\n" +
+			                " * copyright\\n" +
+			                statement +
+			                " * notice {0}\\n" +
+			                "***********/\\n"; // comment 2
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1232,23 +1320,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/******************************\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
-		buf.append("                statement +\n");
-		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" ******************************/\\n\"; //$NON-NLS-1$\n");
-		buf.append("        System.out.println(copyright);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/******************************\\n" + //$NON-NLS-1$
+			                " * simple   \\n" + //$NON-NLS-1$
+			                statement +
+			                " * copyright\\n" + //$NON-NLS-1$
+			                " ******************************/\\n"; //$NON-NLS-1$
+			        System.out.println(copyright);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1294,22 +1383,23 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/***************************************************\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
-		buf.append("                statement;\n");
-		buf.append("        System.out.println(copyright);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/***************************************************\\n" + //$NON-NLS-1$
+			                " * simple   \\n" + //$NON-NLS-1$
+			                " * copyright\\n" + //$NON-NLS-1$
+			                statement;
+			        System.out.println(copyright);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1353,22 +1443,23 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/*********************\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
-		buf.append("                statement + \" * notice\\n\" + \"*********************/\\n\"; //comment 2 //$NON-NLS-1$ //$NON-NLS-2$\n");
-		buf.append("        System.out.println(copyright);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/*********************\\n" + //$NON-NLS-1$
+			                " * simple   \\n" + //$NON-NLS-1$
+			                " * copyright\\n" + //$NON-NLS-1$
+			                statement + " * notice\\n" + "*********************/\\n"; //comment 2 //$NON-NLS-1$ //$NON-NLS-2$
+			        System.out.println(copyright);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1415,16 +1506,17 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo(String name, String id) {\n");
-		buf.append("        String title = \"Name: \" + name + \" ID: \" + id;\n");
-		buf.append("        System.out.println(title);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("title");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo(String name, String id) {
+			        String title = "Name: " + name + " ID: " + id;
+			        System.out.println(title);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("title");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1461,19 +1553,20 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo(String name, String id) {\n");
-		buf.append("        String title = \"Name: \" +\n");
-		buf.append("                          name + \n");
-		buf.append("                          \" ID: \" + \n");
-		buf.append("                          id;\n");
-		buf.append("        System.out.println(title);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("title");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo(String name, String id) {
+			        String title = "Name: " +
+			                          name +\s
+			                          " ID: " +\s
+			                          id;
+			        System.out.println(title);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("title");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1510,23 +1603,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/*******************************\\n\" +\n");
-		buf.append("                \" * simple   \\n\" +\n");
-		buf.append("                \" * copyright %\\n\" +\n");
-		buf.append("                statement +\n");
-		buf.append("                \" * notice\\n\" +\n");
-		buf.append("                \" *******************************/\\n\"; // comment 2\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/*******************************\\n" +
+			                " * simple   \\n" +
+			                " * copyright %\\n" +
+			                statement +
+			                " * notice\\n" +
+			                " *******************************/\\n"; // comment 2
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1569,23 +1663,24 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/******************************\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
-		buf.append("                statement +\n");
-		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" ******************************/\\n\"; //$NON-NLS-1$\n");
-		buf.append("        System.out.println(copyright);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/******************************\\n" + //$NON-NLS-1$
+			                " * simple   \\n" + //$NON-NLS-1$
+			                statement +
+			                " * copyright\\n" + //$NON-NLS-1$
+			                " ******************************/\\n"; //$NON-NLS-1$
+			        System.out.println(copyright);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1628,22 +1723,23 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/***************************************************\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
-		buf.append("                statement;\n");
-		buf.append("        System.out.println(copyright);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/***************************************************\\n" + //$NON-NLS-1$
+			                " * simple   \\n" + //$NON-NLS-1$
+			                " * copyright\\n" + //$NON-NLS-1$
+			                statement;
+			        System.out.println(copyright);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1684,22 +1780,23 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        String statement= \" * statement\\n\";\n");
-		buf.append("        // comment 1\n");
-		buf.append("        String copyright=\n");
-		buf.append("                \"/*********************\\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * simple   \\n\" + //$NON-NLS-1$\n");
-		buf.append("                \" * copyright\\n\" + //$NON-NLS-1$\n");
-		buf.append("                statement + \" * notice\\n\" + \"*********************/\\n\"; //comment 2 //$NON-NLS-1$ //$NON-NLS-2$\n");
-		buf.append("        System.out.println(copyright);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("simple");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo() {
+			        String statement= " * statement\\n";
+			        // comment 1
+			        String copyright=
+			                "/*********************\\n" + //$NON-NLS-1$
+			                " * simple   \\n" + //$NON-NLS-1$
+			                " * copyright\\n" + //$NON-NLS-1$
+			                statement + " * notice\\n" + "*********************/\\n"; //comment 2 //$NON-NLS-1$ //$NON-NLS-2$
+			        System.out.println(copyright);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("simple");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1743,16 +1840,17 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo(String name, String id) {\n");
-		buf.append("        String title = \"Name: \" + name + \" ID: \" + id;\n");
-		buf.append("        System.out.println(title);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("title");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo(String name, String id) {
+			        String title = "Name: " + name + " ID: " + id;
+			        System.out.println(title);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("title");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -1786,19 +1884,20 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public void foo(String name, String id) {\n");
-		buf.append("        String title = \"Name: \" +\n");
-		buf.append("                          name + \n");
-		buf.append("                          \" ID: \" + \n");
-		buf.append("                          id;\n");
-		buf.append("        System.out.println(title);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
-		int index= buf.indexOf("title");
+		String str1= """
+			package test;
+			public class Cls {
+			    public void foo(String name, String id) {
+			        String title = "Name: " +
+			                          name +\s
+			                          " ID: " +\s
+			                          id;
+			        System.out.println(title);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+		int index= str1.indexOf("title");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 6);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -409,10 +409,17 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			        buf11.append("mnop\\n");
 			        int index = buf11.indexOf("fg");
 			        System.out.println(buf11.toString());
+			        StringBuffer buf12 = new StringBuffer("abcd\\n");
+			        buf12.append("efgh\\n");
+			        buf12.append("ijkl\\n");
+			        buf12.append("mnopq\\n");
+			        bufFunc(buf12);
 			    }
 			    private void write(CharSequence c) {
 			        System.out.println(c);
 			    }
+			    private void bufFunc(StringBuffer buf) {
+				}
 			}""";
 
 		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
@@ -538,10 +545,19 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			            \""";
 			        int index = str9.indexOf("fg");
 			        System.out.println(str9);
+			        StringBuffer buf12 = new StringBuffer(\"""
+			            abcd
+			            efgh
+			            ijkl
+			            mnopq
+			            \""");
+			        bufFunc(buf12);
 			    }
 			    private void write(CharSequence c) {
 			        System.out.println(c);
 			    }
+			    private void bufFunc(StringBuffer buf) {
+				}
 			}""";
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);


### PR DESCRIPTION
- modify StringConcatToTextBlockFixCore to support the case where the StringBuilder/StringBuffer is passed as an argument and in that case do not replace the StringBuilder/StringBuffer but change it to initialize with a text block
- add new tests to AssistQuickFixTest15 and CleanUpTest15
- fixes #1841

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.  Allows conversion of more tests to use text block.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run clean up on file mentioned in issue or see new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
