### PR TITLE
[Dark Theme] Fix for bg color of bread crumb in editor

### DIFF
--- a/org.eclipse.jdt.ui/css/e4-dark_jdt_syntaxhighlighting.css
+++ b/org.eclipse.jdt.ui/css/e4-dark_jdt_syntaxhighlighting.css
@@ -136,6 +136,6 @@ FormatterPreferenceSectionComposite {
      * the background with the lighter color used for the background
      * of toolbars and make the foreground color brighter too.
      */
-    background-color:#515658;
+    background-color:#1E1F22;
     color: white;
 }


### PR DESCRIPTION
As we changed the background color of the editor to a darker shade, the background of the breadcrumbs was still using the older color code. This has been changed to the same color code as the editor's.

Before:
![image](https://github.com/user-attachments/assets/c05ce594-35b0-4d4b-a508-9f1df2d9870a)

After:
![image](https://github.com/user-attachments/assets/d8845efd-5fbb-4519-bc54-16d0da9a3241)
