### PR TITLE
Fix add permitted types quickfix

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest22.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest22.java
@@ -411,6 +411,86 @@ public class QuickFixTest22 extends QuickFixTest {
 	}
 
 	@Test
+	public void testAddPermittedTypesToSwitchStatement2() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectsetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set22CompilerOptions(fJProject1);
+
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
+
+		String shape= """
+			package test;
+			public sealed class Shape permits Circle, Square {
+			}
+			""";
+		pack1.createCompilationUnit("Shape.java", shape, false, null);
+
+		String circle= """
+				package test;
+				public final class Circle extends Shape {
+				}
+				""";
+		pack1.createCompilationUnit("Circle.java", circle, false, null);
+
+		String square= """
+				package test;
+				public final class Square extends Shape {
+				}
+				""";
+		pack1.createCompilationUnit("Square.java", square, false, null);
+
+		String test= """
+			package test;
+
+			public class TestSwitch {
+
+				public static void main(String[] args) {
+					Shape shape = getShape();
+					switch (shape) {
+					}
+				}
+
+				private static Shape getShape() {
+					return new Circle();
+				}
+			}
+			""";
+
+			ICompilationUnit cu= pack1.createCompilationUnit("TestSwitch.java", test, false, null);
+
+			CompilationUnit astRoot= getASTRoot(cu);
+			ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1);
+			assertCorrectLabels(proposals);
+
+			CUCorrectionProposal proposal1= (CUCorrectionProposal) proposals.get(0);
+			String preview1= getPreviewContent(proposal1);
+
+			String expected1= """
+			package test;
+
+			public class TestSwitch {
+
+				public static void main(String[] args) {
+					Shape shape = getShape();
+					switch (shape) {
+						case Circle c -> {}
+						case Square s -> {}
+						case null -> {}
+						default -> {}
+					}
+				}
+
+				private static Shape getShape() {
+					return new Circle();
+				}
+			}
+			""";
+
+			assertEqualString(preview1, expected1);
+	}
+
+	@Test
 	public void testAddPermittedTypesToSwitchExpression() throws Exception {
 		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
 		fJProject1.setRawClasspath(projectsetup.getDefaultClasspath(), null);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -2461,9 +2461,13 @@ public class LocalCorrectionsSubProcessor {
 				String[][] resolvedName= sealedType.resolveType(permittedTypeName);
 				for (int i= 0; i < resolvedName.length; ++i) {
 					String[] inner= resolvedName[i];
-					if (!inner[0].isEmpty() && !inner[0].equals(pkgName)) {
-						needImport= true;
+					if (!inner[0].isEmpty()) {
 						importName= inner[0] + "." + inner[1]; //$NON-NLS-1$
+						if (!inner[0].equals(pkgName)) {
+							needImport= true;
+						}
+					} else {
+						importName= inner[1];
 					}
 					if (permittedTypeName.startsWith(sealedType.getTypeQualifiedName('.'))) {
 						needImport= false;


### PR DESCRIPTION
- fix LocalCorrectionsSubProcessor.addPermittedTypes() method to not pass empty importName to the search pattern
- add new test to QuickFixTest22
- fixes #1845

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
