### PR TITLE
Support unicode characters in markdown comments

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -53,7 +53,7 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 		fRenderer= HtmlRenderer.builder().extensions(extensions).build();
 	}
 
-	final static Pattern UnicodePattern= Pattern.compile("(\\\\u000[d,D]\\\\u000[a,A]|\\\\u000[a,A]|\\\\u000[d,D])[^\r\n&&\\s]*?///[^\r\n&&\\s]*?"); //$NON-NLS-1$
+	final static Pattern UnicodePattern= Pattern.compile("(\\\\u000[d,D]\\\\u000[a,A]|\\\\u000[a,A]|\\\\u000[d,D])[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
 	final static Pattern Pattern1= Pattern.compile("(\\r\\n?|\\n)[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -53,9 +53,8 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 		fRenderer= HtmlRenderer.builder().extensions(extensions).build();
 	}
 
-	final static String PatternCommon= "[^\r\n&&\\s]*?///[^\r\n&&\\s]*?"; //$NON-NLS-1$
-	final static Pattern UnicodePattern= Pattern.compile("(\\\\u000[d,D]\\\\u000[a,A]|\\\\u000[a,A]|\\\\u000[d,D])" + PatternCommon); //$NON-NLS-1$
-	final static Pattern Pattern1= Pattern.compile("(\\r\\n?|\\n)" + PatternCommon); //$NON-NLS-1$
+	final static Pattern UnicodePattern= Pattern.compile("(\\\\u000[d,D]\\\\u000[a,A]|\\\\u000[a,A]|\\\\u000[d,D])[^\r\n&&\\s]*?///[^\r\n&&\\s]*?"); //$NON-NLS-1$
+	final static Pattern Pattern1= Pattern.compile("(\\r\\n?|\\n)[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
 
 	@Override
 	protected String removeDocLineIntros(String textWithSlashes) {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.core.manipulation.internal.javadoc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.TablesExtension;
@@ -52,12 +53,17 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 		fRenderer= HtmlRenderer.builder().extensions(extensions).build();
 	}
 
+	final static Pattern UnicodePattern= Pattern.compile("\\\\u([0-9A-Fa-f]{4})"); //$NON-NLS-1$
+
 	@Override
 	protected String removeDocLineIntros(String textWithSlashes) {
+		// replace unicode characters
+		String content= UnicodePattern.matcher(textWithSlashes).replaceAll(s -> String.valueOf((char)Integer.parseInt(s.group(1), 16)));
+
 		String lineBreakGroup= "(\\r\\n?|\\n)"; //$NON-NLS-1$
 		String noBreakSpace= "[^\r\n&&\\s]"; //$NON-NLS-1$
 		// in the markdown case relevant leading whitespace is contained in TextElements, no need to preserve blanks *between* elements
-		return textWithSlashes.replaceAll(lineBreakGroup + noBreakSpace + "*///" + noBreakSpace + '*', "$1"); //$NON-NLS-1$ //$NON-NLS-2$
+		return content.replaceAll(lineBreakGroup + noBreakSpace + "*///" + noBreakSpace + '*', "$1"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -60,6 +60,7 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 	protected String removeDocLineIntros(String textWithSlashes) {
 		// in the markdown case relevant leading whitespace is contained in TextElements, no need to preserve blanks *between* elements
 		String content= Pattern1.matcher(textWithSlashes).replaceAll(r -> "$1"); //$NON-NLS-1$
+		String newContent= content;
 		// handle unicode
 		content= UnicodePattern.matcher(content).replaceAll(r -> {
 				return switch(r.group(1)) {
@@ -68,6 +69,12 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 				default -> "\r\n"; //$NON-NLS-1$
 				};
 			});
+		if (!content.equals(newContent)) {
+			System.err.println("comparison failure"); //$NON-NLS-1$
+			System.err.println(content);
+			System.err.println(newContent);
+			throw new NullPointerException();
+		}
 		return content;
 	}
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -59,7 +59,7 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 	@Override
 	protected String removeDocLineIntros(String textWithSlashes) {
 		// in the markdown case relevant leading whitespace is contained in TextElements, no need to preserve blanks *between* elements
-		String content= Pattern1.matcher(textWithSlashes).replaceAll(r -> "$1"); //$NON-NLS-1$
+//		String content= Pattern1.matcher(textWithSlashes).replaceAll(r -> "$1"); //$NON-NLS-1$
 //		String newContent= content;
 //		// handle unicode
 //		content= UnicodePattern.matcher(content).replaceAll(r -> {
@@ -75,7 +75,11 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 //			System.err.println(newContent);
 //			throw new NullPointerException();
 //		}
-		return content;
+		String lineBreakGroup= "(\\r\\n?|\\n)"; //$NON-NLS-1$
+		String noBreakSpace= "[^\r\n&&\\s]"; //$NON-NLS-1$
+		// in the markdown case relevant leading whitespace is contained in TextElements, no need to preserve blanks *between* elements
+		return textWithSlashes.replaceAll(lineBreakGroup + noBreakSpace + "*///" + noBreakSpace + '*', "$1"); //$NON-NLS-1$ //$NON-NLS-2$
+//		return content;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -53,28 +53,28 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 		fRenderer= HtmlRenderer.builder().extensions(extensions).build();
 	}
 
-	final static Pattern UnicodePattern= Pattern.compile("(\\\\u000[d,D]\\\\u000[a,A]|\\\\u000[a,A]|\\\\u000[d,D])[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
+//	final static Pattern UnicodePattern= Pattern.compile("(\\\\u000[d,D]\\\\u000[a,A]|\\\\u000[a,A]|\\\\u000[d,D])[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
 	final static Pattern Pattern1= Pattern.compile("(\\r\\n?|\\n)[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
 
 	@Override
 	protected String removeDocLineIntros(String textWithSlashes) {
 		// in the markdown case relevant leading whitespace is contained in TextElements, no need to preserve blanks *between* elements
 		String content= Pattern1.matcher(textWithSlashes).replaceAll(r -> "$1"); //$NON-NLS-1$
-		String newContent= content;
-		// handle unicode
-		content= UnicodePattern.matcher(content).replaceAll(r -> {
-				return switch(r.group(1)) {
-				case "\\u000a", "\\u000A" -> "\n"; //$NON-NLS-1$  //$NON-NLS-2$ //$NON-NLS-3$
-				case "\\u000d", "\\u000D" -> "\r"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-				default -> "\r\n"; //$NON-NLS-1$
-				};
-			});
-		if (!content.equals(newContent)) {
-			System.err.println("comparison failure"); //$NON-NLS-1$
-			System.err.println(content);
-			System.err.println(newContent);
-			throw new NullPointerException();
-		}
+//		String newContent= content;
+//		// handle unicode
+//		content= UnicodePattern.matcher(content).replaceAll(r -> {
+//				return switch(r.group(1)) {
+//				case "\\u000a", "\\u000A" -> "\n"; //$NON-NLS-1$  //$NON-NLS-2$ //$NON-NLS-3$
+//				case "\\u000d", "\\u000D" -> "\r"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+//				default -> "\r\n"; //$NON-NLS-1$
+//				};
+//			});
+//		if (!content.equals(newContent)) {
+//			System.err.println("comparison failure"); //$NON-NLS-1$
+//			System.err.println(content);
+//			System.err.println(newContent);
+//			throw new NullPointerException();
+//		}
 		return content;
 	}
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.core.manipulation.internal.javadoc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.TablesExtension;
@@ -54,7 +53,7 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 	}
 
 //	final static Pattern UnicodePattern= Pattern.compile("(\\\\u000[d,D]\\\\u000[a,A]|\\\\u000[a,A]|\\\\u000[d,D])[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
-	final static Pattern Pattern1= Pattern.compile("(\\r\\n?|\\n)[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
+//	final static Pattern Pattern1= Pattern.compile("(\\r\\n?|\\n)[^\r\n&&\\s]*///[^\r\n&&\\s]*"); //$NON-NLS-1$
 
 	@Override
 	protected String removeDocLineIntros(String textWithSlashes) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -900,6 +900,30 @@ public class MarkdownCommentTests extends CoreTests {
 		assertHtmlContent(expectedContent, actualHtmlContent);
 	}
 	@Test
+	public void testGH1787() throws CoreException {
+		String source= """
+				package p;
+
+				public class E {
+				    /// Unicode in markdown \u000A///\u000D///\u000D\u000A///here
+				    public void m() {}
+				}
+
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/E.java", source, null);
+		assertNotNull("E.java", cu);
+
+		IType type= cu.getType("E");
+
+		IMethod method= type.getMethods()[0];
+		String actualHtmlContent= getHoverHtmlContent(cu, method);
+		assertHtmlContent("""
+				<p>Unicode in markdown</p>
+				<p>here</p>
+				""",
+				actualHtmlContent);
+	}
+	@Test
 	public void testFenceLenFour_1() throws CoreException {
 		String source= """
 				/// ````


### PR DESCRIPTION
- convert unicode chars in CoreMarkdownAccessImpl.removeDocLineIntros()
- add new test to MarkdownCommentTests
- fixes #1787

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
