### PR TITLE
[Help Needed] Implement provider for sticky scrolling in JAVA/JDT

### DIFF
--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7830,4 +7830,18 @@
            file-extensions="class without source">
      </file-association>
   </extension>
+  <extension
+         point="org.eclipse.ui.editors.stickyLinesProviders">
+      <stickyLinesProvider
+            class="org.eclipse.jdt.internal.ui.javaeditor.StickyLinesProviderJava"
+            id="org.eclipse.jdt.internal.ui.StickyLinesProviderJava">
+         <enabledWhen>
+            <and>
+               <with variable="editor">
+                  <instanceof value="org.eclipse.jdt.internal.ui.javaeditor.JavaEditor"/>
+               </with>
+            </and>
+         </enabledWhen>
+      </stickyLinesProvider>
+   </extension>
 </plugin>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/StickyLinesProviderJava.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/StickyLinesProviderJava.java
@@ -1,0 +1,51 @@
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.source.ISourceViewer;
+
+import org.eclipse.ui.texteditor.stickyscroll.IStickyLine;
+import org.eclipse.ui.texteditor.stickyscroll.IStickyLinesProvider;
+import org.eclipse.ui.texteditor.stickyscroll.StickyLine;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.ISourceReference;
+import org.eclipse.jdt.core.JavaModelException;
+
+public class StickyLinesProviderJava implements IStickyLinesProvider {
+
+	@Override
+	public List<IStickyLine> getStickyLines(ISourceViewer sourceViewer, int lineNumber, StickyLinesProperties properties) {
+		LinkedList<IStickyLine> stickyLines= new LinkedList<>();
+		JavaEditor javaEditor= (JavaEditor) properties.editor();
+
+		IJavaElement element= null;
+		try {
+			element= javaEditor.getElementAt(sourceViewer.getDocument().getLineOffset(lineNumber));
+		} catch (BadLocationException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+
+		while (element != null) {
+			if (element.getElementType() == IJavaElement.METHOD || element.getElementType() == IJavaElement.TYPE) {
+				try {
+					ISourceRange sourceRange= ((ISourceReference) element).getNameRange();
+					int offset= sourceRange.getOffset();
+					int stickyLineNumber= sourceViewer.getDocument().getLineOfOffset(offset);
+					stickyLines.addFirst(new StickyLine(stickyLineNumber, sourceViewer));
+				} catch (JavaModelException | BadLocationException e) {
+					// TODO Auto-generated catch block
+					e.printStackTrace();
+				}
+			}
+			element= element.getParent();
+		}
+
+		return stickyLines;
+	}
+
+}


### PR DESCRIPTION
## What it does
The current sticky scrolling functionality is based solely on indentation. This can cause issues when the source code is formatted in unexpected ways. To address this, an extension point for providing language-specific sticky lines has been introduced in the following pull request: https://github.com/eclipse-platform/eclipse.platform.ui/pull/2398.

This change represents the first proof-of-concept implementation for sticky lines in Java/JDT. As I lack experience in JDT development, the proposed approach for calculating sticky lines in Java may not be optimal.
I would greatly appreciate assistance from the community in identifying a more effective method for calculating sticky lines.

Fixes:
https://github.com/eclipse-platform/eclipse.platform.ui/issues/1950
https://github.com/eclipse-platform/eclipse.platform.ui/issues/2128
https://github.com/eclipse-platform/eclipse.platform.ui/issues/2338

## How to test
1. Check out the PR from https://github.com/eclipse-platform/eclipse.platform.ui/pull/2398. and open plugin org.eclipse.ui.editors 
2. Enable the Sticky Scrolling Feature via Preferences > General >  Editors > Text Editors > Enable Sticky Scrolling
3. Open the class EnumMap, scroll to line 775 (method writeObject)

With proper Sticky Lines calculation: 
![image](https://github.com/user-attachments/assets/76defe51-d33d-40ae-95cf-a24718154395)

With the Default Sticky Lines calculation based on indentation:
![image](https://github.com/user-attachments/assets/7818bc9a-c9cc-4817-b9a5-c2ea57b77b7e)


