### PR TITLE
Null check annotations for Semantic Tokens API

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -120,5 +120,6 @@ Require-Bundle:
  org.eclipse.ui.navigator;bundle-version="[3.3.200,4.0.0)",
  org.eclipse.ui.navigator.resources;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.jdt.core.manipulation;bundle-version="[1.15.200,2.0.0)",
- org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)"
+ org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)",
+ org.eclipse.jdt.annotation
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/ISemanticTokensProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/ISemanticTokensProvider.java
@@ -13,6 +13,8 @@ package org.eclipse.jdt.ui.text.java;
 
 import java.util.Collection;
 
+import org.eclipse.jdt.annotation.NonNull;
+
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
 /**
@@ -58,7 +60,7 @@ public interface ISemanticTokensProvider {
 		KEYWORD,
 	}
 
-	Collection<SemanticToken> computeSemanticTokens(CompilationUnit ast);
+	@NonNull Collection<SemanticToken> computeSemanticTokens(@NonNull CompilationUnit ast);
 
 }
 


### PR DESCRIPTION
The downstream plugins using the new `ISemanticTokensProvider` API and having JDT `null` analysis turned on having issues compiling classes deriving from the `ISemanticTokensProvider`. Whether I add `@Nullable` or `@NonNull` the class still fails to compile with 

```
Error: 2,352 [ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:4.0.10:compile (default-compile) on project org.eclipse.lsp4e.jdt: Compilation failure: Compilation failure: 
Error: 2,352 [ERROR] /Users/runner/work/lsp4e/lsp4e/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaSemanticTokensProvider.java:[42] 
Error: 2,352 [ERROR] 	public Collection<ISemanticTokensProvider.SemanticToken> computeSemanticTokens(CompilationUnit ast) {
Error: 2,352 [ERROR] 	       ^^^^^^^^^^
Error: 2,352 [ERROR] The return type is incompatible with 'Collection<ISemanticTokensProvider.SemanticToken>' returned from ISemanticTokensProvider.computeSemanticTokens(CompilationUnit) (mismatching null constraints)
Error: 2,352 [ERROR] 1 problem (1 error)
```

Adding the `@NonNull` for the return type and the parameter sets the proper API expectations as well as hopefully would help sorting the downstream compiler errors out.