### PR TITLE
Fix pull up scenario referring to outer this type

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PullUpRefactoringProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PullUpRefactoringProcessor.java
@@ -1250,6 +1250,18 @@ public class PullUpRefactoringProcessor extends HierarchyProcessor {
 			return true;
 		}
 
+		@Override
+		public boolean visit(ThisExpression node) {
+			if (node.getLocationInParent() == MethodInvocation.ARGUMENTS_PROPERTY) {
+				ITypeBinding typeBinding= node.resolveTypeBinding();
+				if (isChildTypeMember(typeBinding, fSourceType) && !isChildTypeMember(typeBinding, fTargetType)) {
+					fConflictBinding= typeBinding;
+					throw new AbortSearchException();
+				}
+			}
+			return super.visit(node);
+		}
+
 		private boolean isChildTypeMember(ITypeBinding parentTypeBinding, IType type) {
 			if (parentTypeBinding.getQualifiedName().equals(type.getFullyQualifiedName('.'))) {
 				return true;

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail37/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail37/in/A.java
@@ -1,0 +1,24 @@
+package p;
+
+public class A {
+    public class BaseInner {
+        void innerMethodLambda(Outer outer) {
+            Runnable r = () -> {
+                System.out.println(outer.x);
+                outer.foo();
+            };
+            r.run();
+        }
+    }
+
+    public class Outer {
+        public int x = 0;
+        public void foo(){};
+
+        public class Inner extends BaseInner {
+            void innerMethod() { // Pull this method up to class BaseInner
+				innerMethodLambda(Outer.this);
+            }
+        }
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
@@ -1882,7 +1882,27 @@ public class PullUpTests extends GenericRefactoringTest {
 		testMonitor.assertUsedUp();
 		testMonitor.prepare();
 		assertFalse("precondition was supposed to fail", checkInputResult.isOK());
-//		helper2(new String[] { "method" }, new String[][] { new String[0] }, true, false, 0);
+	}
+	@Test
+	public void testFail37() throws Exception {
+		ICompilationUnit cu= createCUfromTestFile(getPackageP(), "A");
+		IJavaElement element= cu.getElementAt(409);
+		assertTrue("element is method", element instanceof IMethod);
+		IMethod[] methods= new IMethod[] { (IMethod)element };
+
+		PullUpRefactoringProcessor processor= createRefactoringProcessor(methods);
+		Refactoring ref= processor.getRefactoring();
+
+		FussyProgressMonitor testMonitor= new FussyProgressMonitor();
+		assertTrue("activation", ref.checkInitialConditions(testMonitor).isOK());
+		testMonitor.assertUsedUp();
+		testMonitor.prepare();
+		setTargetClass(processor, 0);
+
+		RefactoringStatus checkInputResult= ref.checkFinalConditions(testMonitor);
+		testMonitor.assertUsedUp();
+		testMonitor.prepare();
+		assertFalse("precondition was supposed to fail", checkInputResult.isOK());
 	}
 	//----------------------------------------------------------
 	@Test


### PR DESCRIPTION
- modify PullUpRefactoring.CheckInvalidOuterFieldAccess checker to also look for class.this references that won't be accessible after pulling up the method
- add new test to PullUpTests
- fixes #1823

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
