### PR TITLE
Fix embedded if cleanup to preserve line comments

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -4276,6 +4276,27 @@ public class ASTNodes {
 	}
 
 	/**
+	 * Return a list of trailing line comments for a specified node and an offset from the start
+	 * @param node - ASTNode in a CompilationUnit
+	 * @param offset - offset to add from start of node to start search from
+	 * @return list of Comment nodes
+	 */
+	public static List<Comment> getTrailingLineComments(ASTNode node, int offset) {
+		List<Comment> comments= new ArrayList<>();
+		CompilationUnit cu= (CompilationUnit)node.getRoot();
+		List<Comment> commentList= cu.getCommentList();
+		int nodeLine= cu.getLineNumber(node.getStartPosition() + offset);
+		for (Comment commentFromList : commentList) {
+			if (commentFromList.getStartPosition() >= (node.getStartPosition() + offset) &&
+			    cu.getLineNumber(commentFromList.getStartPosition()) == nodeLine) {
+				comments.add(commentFromList);
+			} else if (cu.getLineNumber(nodeLine) > nodeLine) {
+				break;
+			}
+		}
+		return comments;
+	}
+	/**
 	 * Return a list of trailing comments for a specified node
 	 *
 	 * @param node - ASTNode in a CompilationUnit

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -26156,10 +26156,24 @@ public class CleanUpTest extends CleanUpTestCase {
 			        return 0;
 			    }
 
+			    public int collapseIfStatementsWithLineComment(boolean isActive, boolean isValid) {
+			        // Keep this comment
+			        if (isActive) { // line comment
+			            // Keep this comment too
+			            if (isValid) {
+			                // Keep this comment also
+			                return 1;
+			            }
+			        }
+
+			        return 0;
+			    }
+
 			    public int collapseInnerLoneIf(boolean isActive, boolean isValid) {
 			        // Keep this comment
-			        if (isActive) {
+			        if (isActive) { // line comment
 			            if (isValid)
+				            // Keep this comment also
 			                return 1;
 			        }
 
@@ -26235,10 +26249,23 @@ public class CleanUpTest extends CleanUpTestCase {
 			        return 0;
 			    }
 
+			    public int collapseIfStatementsWithLineComment(boolean isActive, boolean isValid) {
+			        // Keep this comment
+			        // Keep this comment too
+			        if (isActive && isValid) { // line comment
+			            // Keep this comment also
+			            return 1;
+			        }
+
+			        return 0;
+			    }
+
 			    public int collapseInnerLoneIf(boolean isActive, boolean isValid) {
 			        // Keep this comment
-			        if (isActive && isValid)
+			        if (isActive && isValid) { // line comment
+			            // Keep this comment also
 			            return 1;
+			        }
 
 			        return 0;
 			    }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EmbeddedIfCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/EmbeddedIfCleanUp.java
@@ -23,14 +23,25 @@ import org.eclipse.core.runtime.IProgressMonitor;
 
 import org.eclipse.text.edits.TextEditGroup;
 
+import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.BlockComment;
+import org.eclipse.jdt.core.dom.Comment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.LineComment;
+import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
@@ -40,6 +51,7 @@ import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
@@ -79,8 +91,8 @@ public class EmbeddedIfCleanUp extends AbstractMultiFix implements ICleanUpFix {
 				if (isActive && isValid) {
 				  int i = 0;
 				}
-				
-				
+
+
 				"""; //$NON-NLS-1$
 		}
 
@@ -168,8 +180,72 @@ public class EmbeddedIfCleanUp extends AbstractMultiFix implements ICleanUpFix {
 			infixExpression.setLeftOperand(ASTNodeFactory.parenthesizeIfNeeded(ast, ASTNodes.createMoveTarget(rewrite, visited.getExpression())));
 			infixExpression.setOperator(InfixExpression.Operator.CONDITIONAL_AND);
 			infixExpression.setRightOperand(ASTNodeFactory.parenthesizeIfNeeded(ast, ASTNodes.createMoveTarget(rewrite, innerIf.getExpression())));
+			ASTNode visitedNode= visited.getThenStatement() instanceof Block ? visited.getThenStatement() : visited.getExpression();
+			int offset= visited.getThenStatement() instanceof Block ? 1 : visited.getExpression().getLength();
+			List<Comment> visitedLineComments= ASTNodes.getTrailingLineComments(visitedNode, offset);
+			if (!visitedLineComments.isEmpty()) {
+				ASTNode innerNode= innerIf.getThenStatement() instanceof Block ? innerIf.getThenStatement() : innerIf.getExpression();
+				int innerOffset= innerIf.getThenStatement() instanceof Block ? 1 : visited.getExpression().getLength();
+				List<Comment> innerComments= ASTNodes.getTrailingLineComments(innerNode, innerOffset);
+				StringBuilder blockBuilder= new StringBuilder("{"); //$NON-NLS-1$
+				CompilationUnit root= cuRewrite.getRoot();
+				IBuffer buffer= cuRewrite.getCu().getBuffer();
+				appendComments(innerComments, blockBuilder, buffer);
+				appendComments(visitedLineComments, blockBuilder, buffer);
+				blockBuilder.append("\n"); //$NON-NLS-1$
+				String fIndent= "\t"; //$NON-NLS-1$
+				IJavaElement rootElement= root.getJavaElement();
+				if (rootElement != null) {
+					IJavaProject project= rootElement.getJavaProject();
+					if (project != null) {
+						String tab_option= project.getOption(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, true);
+						if (JavaCore.SPACE.equals(tab_option)) {
+							fIndent= ""; //$NON-NLS-1$
+							for (int i= 0; i < CodeFormatterUtil.getTabWidth(project); ++i) {
+								fIndent += " "; //$NON-NLS-1$
+							}
+						}
+					}
+				}
+				if (innerIf.getThenStatement() instanceof Block innerBlock) {
+					ListRewrite innerBlockStmts= rewrite.getListRewrite(innerBlock, Block.STATEMENTS_PROPERTY);
+					List<Statement> originalList= innerBlockStmts.getOriginalList();
+					for (Statement stmt : originalList) {
+						int startOffset= root.getExtendedStartPosition(stmt);
+						int endLength= root.getExtendedLength(stmt);
+						String text= buffer.getText(startOffset,  endLength);
+						String[] textLines= text.split("\n"); //$NON-NLS-1$
+						for (String textLine : textLines) {
+							blockBuilder.append(fIndent + textLine.trim() + "\n"); //$NON-NLS-1$
+						}
+					}
+				} else {
+					int startOffset= root.getExtendedStartPosition(innerIf.getThenStatement());
+					int endLength= root.getExtendedLength(innerIf.getThenStatement());
+					String text= buffer.getText(startOffset,  endLength);
+					String[] textLines= text.split("\n"); //$NON-NLS-1$
+					for (String textLine : textLines) {
+						blockBuilder.append(fIndent + textLine.trim() + "\n"); //$NON-NLS-1$
+					}
+				}
+				blockBuilder.append("}"); //$NON-NLS-1$
+				Block newBlock= (Block) rewrite.createStringPlaceholder(blockBuilder.toString(), ASTNode.BLOCK);
+				rewrite.replace(innerIf.getThenStatement(), newBlock, group);
+			}
 			ASTNodes.replaceButKeepComment(rewrite, innerIf.getExpression(), infixExpression, group);
 			ASTNodes.replaceButKeepComment(rewrite, visited, ASTNodes.createMoveTarget(rewrite, innerIf), group);
+		}
+
+		private void appendComments(List<Comment> commentList, StringBuilder buffer, IBuffer cuBuffer) {
+			for (Comment innerComment : commentList) {
+				if (innerComment instanceof LineComment lineComment) {
+					buffer.append(" "); //$NON-NLS-1$
+					buffer.append(cuBuffer.getText(lineComment.getStartPosition(), lineComment.getLength()));
+				} else if (innerComment instanceof BlockComment blockComment) {
+					buffer.append(" //"); //$NON-NLS-1$
+					buffer.append(cuBuffer.getText(blockComment.getStartPosition(), blockComment.getLength() - 2));
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
- modify EmbeddedIfCleanUp to check for line comments on the top and embedded if statement and preserve them in the merged if statement
- add new method to ASTNodes to get trailing line comment for a node plus an offset
- modify the embedded cleanup test in CleanUpTest to add new line comment scenarios
- fixes #1853

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
