### PR TITLE
WorkingSetModel.setActiveWorkingSets: fix IllegalArgumentException #1863

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/packageview/WorkingSetDropAdapterTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/packageview/WorkingSetDropAdapterTest.java
@@ -28,6 +28,8 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.swt.dnd.DND;
 
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.ILogListener;
+import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.core.resources.IFolder;
 
@@ -60,10 +62,11 @@ public class WorkingSetDropAdapterTest {
 	private PackageExplorerPart fPackageExplorer;
 	private Accessor fPackageExplorerPartAccessor;
 	private WorkingSetDropAdapter fAdapter;
-
+	private ILogListener expectNoLogging= (status, plugin) -> {throw new AssertionError(status.getMessage(), status.getException());};
 
 	@BeforeEach
 	public void setUp() throws Exception {
+		Platform.addLogListener(expectNoLogging);
 		fProject= JavaProjectHelper.createJavaProject("Test", "bin");
 		IWorkbenchPage activePage= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		fPackageExplorer= (PackageExplorerPart)activePage.showView(JavaUI.ID_PACKAGES);
@@ -77,6 +80,7 @@ public class WorkingSetDropAdapterTest {
 		IWorkbenchPage activePage= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
 		activePage.hideView(fPackageExplorer);
 		assertTrue(fPackageExplorer.getTreeViewer().getTree().isDisposed());
+		Platform.removeLogListener(expectNoLogging);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/WorkingSetModel.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/WorkingSetModel.java
@@ -449,7 +449,9 @@ public class WorkingSetModel {
 	 * @param workingSets the active working sets to be set
 	 */
 	public void setActiveWorkingSets(IWorkingSet[] workingSets) {
+		List<IWorkingSet> backup= fAllWorkingSets;  // modified by getAllWorkingSets, see gh#1863:
 		Assert.isLegal(Arrays.asList(getAllWorkingSets()).containsAll(Arrays.asList(workingSets)));
+		fAllWorkingSets= backup;
 		if (fIsSortingEnabled) {
 			Arrays.sort(workingSets, new WorkingSetComparator(true));
 		}


### PR DESCRIPTION
The getter getAllWorkingSets() illegally caches - i.e. modified its state while that is unexpected during setWorkingSets()

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1863

tested by WorkingSetDropAdapterTest
