### PR TITLE
Remove Java 1.2 and 1.4 checks from JavaModelUtil

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/AbstractPrimitiveRatherThanWrapperFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/AbstractPrimitiveRatherThanWrapperFinder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,6 @@ import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
-import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ConditionalExpression;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
@@ -47,7 +46,6 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.InterruptibleVisitor;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 public abstract class AbstractPrimitiveRatherThanWrapperFinder extends ASTVisitor {
 	protected List<CompilationUnitRewriteOperation> fResult;
@@ -187,7 +185,7 @@ public abstract class AbstractPrimitiveRatherThanWrapperFinder extends ASTVisito
 							varOccurrenceVisitor.getToStringMethods(),
 							varOccurrenceVisitor.getCompareToMethods(),
 							varOccurrenceVisitor.getPrimitiveValueMethods(),
-							getParsingMethodName(getWrapperFullyQualifiedName(), (CompilationUnit) visited.getRoot())));
+							getParsingMethodName(getWrapperFullyQualifiedName())));
 					return false;
 				}
 			}
@@ -259,7 +257,7 @@ public abstract class AbstractPrimitiveRatherThanWrapperFinder extends ASTVisito
 
 		if (methodInvocation != null) {
 			return ASTNodes.usesGivenSignature(methodInvocation, getWrapperFullyQualifiedName(), "valueOf", getPrimitiveTypeName()) //$NON-NLS-1$
-					|| getParsingMethodName(getWrapperFullyQualifiedName(), (CompilationUnit) expression.getRoot()) != null
+					|| getParsingMethodName(getWrapperFullyQualifiedName()) != null
 					&& (
 							ASTNodes.usesGivenSignature(methodInvocation, getWrapperFullyQualifiedName(), "valueOf", String.class.getCanonicalName()) //$NON-NLS-1$
 							|| ASTNodes.usesGivenSignature(methodInvocation, getWrapperFullyQualifiedName(), "valueOf", String.class.getCanonicalName(), int.class.getSimpleName()) //$NON-NLS-1$
@@ -280,8 +278,8 @@ public abstract class AbstractPrimitiveRatherThanWrapperFinder extends ASTVisito
 		return false;
 	}
 
-	private String getParsingMethodName(final String wrapperFullyQualifiedName, final CompilationUnit compilationUnit) {
-		if (Boolean.class.getCanonicalName().equals(wrapperFullyQualifiedName) && JavaModelUtil.is50OrHigher(compilationUnit.getJavaElement().getJavaProject())) {
+	private String getParsingMethodName(final String wrapperFullyQualifiedName) {
+		if (Boolean.class.getCanonicalName().equals(wrapperFullyQualifiedName)) {
 			return "parseBoolean"; //$NON-NLS-1$
 		}
 
@@ -293,11 +291,11 @@ public abstract class AbstractPrimitiveRatherThanWrapperFinder extends ASTVisito
 			return "parseLong"; //$NON-NLS-1$
 		}
 
-		if (Double.class.getCanonicalName().equals(wrapperFullyQualifiedName) && JavaModelUtil.is1d2OrHigher(compilationUnit.getJavaElement().getJavaProject())) {
+		if (Double.class.getCanonicalName().equals(wrapperFullyQualifiedName)) {
 			return "parseDouble"; //$NON-NLS-1$
 		}
 
-		if (Float.class.getCanonicalName().equals(wrapperFullyQualifiedName) && JavaModelUtil.is1d2OrHigher(compilationUnit.getJavaElement().getJavaProject())) {
+		if (Float.class.getCanonicalName().equals(wrapperFullyQualifiedName)) {
 			return "parseFloat"; //$NON-NLS-1$
 		}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StandardComparisonFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StandardComparisonFixCore.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.corext.fix;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
@@ -36,7 +35,6 @@ import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.OrderedInfixExpression;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
@@ -62,11 +60,7 @@ public class StandardComparisonFixCore extends CompilationUnitRewriteOperationsF
 				if (literalValue != null
 						&& literalValue.compareTo(0L) != 0
 						&& comparisonMI.getExpression() != null
-						&& !ASTNodes.is(comparisonMI.getExpression(), ThisExpression.class)
-						&& (ASTNodes.usesGivenSignature(comparisonMI, Comparable.class.getCanonicalName(), "compareTo", Object.class.getCanonicalName()) //$NON-NLS-1$
-						|| ASTNodes.usesGivenSignature(comparisonMI, Comparator.class.getCanonicalName(), "compare", Object.class.getCanonicalName(), Object.class.getCanonicalName()) //$NON-NLS-1$
-						|| JavaModelUtil.is1d2OrHigher(((CompilationUnit) visited.getRoot()).getJavaElement().getJavaProject())
-						&& ASTNodes.usesGivenSignature(comparisonMI, String.class.getCanonicalName(), "compareToIgnoreCase", String.class.getCanonicalName()))) { //$NON-NLS-1$
+						&& !ASTNodes.is(comparisonMI.getExpression(), ThisExpression.class)) {
 					if (literalValue.compareTo(0L) < 0) {
 						if (InfixExpression.Operator.EQUALS.equals(orderedCondition.getOperator())) {
 							fResult.add(new StandardComparisonFixOperation(visited, comparisonMI, InfixExpression.Operator.LESS));

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
@@ -790,14 +790,6 @@ public final class JavaModelUtil {
 	}
 
 
-	public static boolean is1d2OrHigher(String compliance) {
-		return !isVersionLessThan(compliance, JavaCore.VERSION_1_2);
-	}
-
-	public static boolean is40OrHigher(String compliance) {
-		return !isVersionLessThan(compliance, JavaCore.VERSION_1_4);
-	}
-
 	public static boolean is50OrHigher(String compliance) {
 		return !isVersionLessThan(compliance, JavaCore.VERSION_1_5);
 	}
@@ -872,26 +864,6 @@ public final class JavaModelUtil {
 
 	public static boolean is23OrHigher(String compliance) {
 		return !isVersionLessThan(compliance, JavaCore.VERSION_23);
-	}
-
-	/**
-	 * Checks if the given project or workspace has source compliance 1.2 or greater.
-	 *
-	 * @param project the project to test or <code>null</code> to test the workspace settings
-	 * @return <code>true</code> if the given project or workspace has source compliance 1.2 or greater.
-	 */
-	public static boolean is1d2OrHigher(IJavaProject project) {
-		return is1d2OrHigher(getSourceCompliance(project));
-	}
-
-	/**
-	 * Checks if the given project or workspace has source compliance 1.4 or greater.
-	 *
-	 * @param project the project to test or <code>null</code> to test the workspace settings
-	 * @return <code>true</code> if the given project or workspace has source compliance 1.4 or greater.
-	 */
-	public static boolean is1d4OrHigher(IJavaProject project) {
-		return is40OrHigher(getSourceCompliance(project));
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PatternCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PatternCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -65,7 +65,6 @@ import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCo
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
@@ -133,7 +132,7 @@ public class PatternCleanUp extends AbstractMultiFix {
 
 	@Override
 	protected ICleanUpFix createFix(CompilationUnit unit) throws CoreException {
-		if (!isEnabled(CleanUpConstants.PRECOMPILE_REGEX) || !JavaModelUtil.is1d4OrHigher(unit.getJavaElement().getJavaProject())) {
+		if (!isEnabled(CleanUpConstants.PRECOMPILE_REGEX)) {
 			return null;
 		}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveParsingCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/PrimitiveParsingCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.text.edits.TextEditGroup;
 
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
@@ -40,7 +39,6 @@ import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
@@ -124,7 +122,7 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 							return false;
 						}
 
-						String parsingMethodName= getParsingMethodName(canonicalName, wrapperClass.getSimpleName(), visited);
+						String parsingMethodName= getParsingMethodName(canonicalName, wrapperClass.getSimpleName());
 
 						if (parsingMethodName != null
 								&& isValueOfString(visited, canonicalName)) {
@@ -139,7 +137,7 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 				if (typeBinding != null
 						&& visited.arguments().isEmpty()) {
 					String primitiveValueMethodName= getPrimitiveValueMethodName(typeBinding.getQualifiedName());
-					String parsingMethodName= getParsingMethodName(typeBinding.getQualifiedName(), typeBinding.getName(), visited);
+					String parsingMethodName= getParsingMethodName(typeBinding.getQualifiedName(), typeBinding.getName());
 
 					if (primitiveValueMethodName != null
 							&& primitiveValueMethodName.equals(methodName)
@@ -185,17 +183,15 @@ public class PrimitiveParsingCleanUp extends AbstractMultiFix {
 				return null;
 			}
 
-			private String getParsingMethodName(final String wrapperFullyQualifiedName, final String wrapperSimpleName, final MethodInvocation visited) {
+			private String getParsingMethodName(final String wrapperFullyQualifiedName, final String wrapperSimpleName) {
 				if (Integer.class.getCanonicalName().equals(wrapperFullyQualifiedName)) {
 					return "parseInt"; //$NON-NLS-1$
 				}
 
-				IJavaProject javaProject= ((CompilationUnit) visited.getRoot()).getJavaElement().getJavaProject();
-
-				if ((Boolean.class.getCanonicalName().equals(wrapperFullyQualifiedName) && JavaModelUtil.is50OrHigher(javaProject))
+				if (Boolean.class.getCanonicalName().equals(wrapperFullyQualifiedName)
 						|| Long.class.getCanonicalName().equals(wrapperFullyQualifiedName)
-						|| (Double.class.getCanonicalName().equals(wrapperFullyQualifiedName) && JavaModelUtil.is1d2OrHigher(javaProject))
-						|| (Float.class.getCanonicalName().equals(wrapperFullyQualifiedName) && JavaModelUtil.is1d2OrHigher(javaProject))
+						|| Double.class.getCanonicalName().equals(wrapperFullyQualifiedName)
+						|| Float.class.getCanonicalName().equals(wrapperFullyQualifiedName)
 						|| Short.class.getCanonicalName().equals(wrapperFullyQualifiedName)
 						|| Byte.class.getCanonicalName().equals(wrapperFullyQualifiedName)) {
 					return "parse" + wrapperSimpleName; //$NON-NLS-1$


### PR DESCRIPTION
Since ECJ min supported version is 1.8 all other code mandates 1.8+ too.

Part of https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1685

