### PR TITLE
Remove code for Java pre 1.5 Java from bytecodeview

### DIFF
--- a/org.eclipse.jdt.bcoview.feature/feature.xml
+++ b/org.eclipse.jdt.bcoview.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.bcoview.feature"
       label="Bytecode Outline View"
-      version="1.2.600.qualifier"
+      version="1.2.700.qualifier"
       provider-name="Eclipse.org"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.bcoview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.bcoview/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.bcoview;singleton:=true
-Bundle-Version: 1.2.600.qualifier
+Bundle-Version: 1.2.700.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.jdt.bcoview.BytecodeOutlinePlugin
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.bcoview/pom.xml
+++ b/org.eclipse.jdt.bcoview/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.bcoview</artifactId>
-  <version>1.2.600-SNAPSHOT</version>
+  <version>1.2.700-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>


### PR DESCRIPTION
Checks were done based on compiler settings for the project and ECJ mandates 1.8 as a minimum now.

