### PR TITLE
Handle < > brackets unconditionally

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/BracketInserterTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/BracketInserterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -81,14 +81,14 @@ public class BracketInserterTest {
 	private static final String CU_NAME= "PR75423.java";
 	private static final String CU_CONTENTS= """
 		package com.example.bugs;
-		
+
 		import java.lang.String;
 		import java.lang.Integer;
-		
+
 		public class PR75423 {
 		    String string;
 		    Integer integer;
-		
+
 		    public static void main(String[] args) {
 		       \s
 		    }
@@ -119,6 +119,8 @@ public class BracketInserterTest {
 	public void setUp() throws Exception {
 		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
 		store.setValue(PreferenceConstants.EDITOR_CLOSE_BRACKETS, true);
+		setUpProject(JavaCore.VERSION_1_8);
+		setUpEditor();
 	}
 
 	private void setUpProject(String sourceLevel) throws CoreException, JavaModelException {
@@ -147,7 +149,7 @@ public class BracketInserterTest {
 		try {
 			return (JavaEditor)EditorTestHelper.openInEditor(file, true);
 		} catch (PartInitException e) {
-			fail();
+			fail(e.getMessage());
 			return null;
 		}
 	}
@@ -167,8 +169,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testInsertClosingParenthesis() throws BadLocationException, JavaModelException, CoreException, JavaModelException, CoreException {
-		use14();
+	public void testInsertClosingParenthesis() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type('(');
 
@@ -177,8 +178,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testDeletingParenthesis() throws JavaModelException, CoreException {
-		use14();
+	public void testDeletingParenthesis() {
 		setCaret(BODY_OFFSET);
 		type('(');
 		type(SWT.BS);
@@ -188,8 +188,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testMultipleParenthesisInsertion() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testMultipleParenthesisInsertion() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type("((((");
 
@@ -200,8 +199,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testDeletingMultipleParenthesisInertion() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testDeletingMultipleParenthesisInertion() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type("((((");
 
@@ -227,8 +225,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testNoInsertInsideText() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testNoInsertInsideText() throws BadLocationException {
 		setCaret(ARGS_OFFSET);
 		type('(');
 
@@ -238,8 +235,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testInsertInsideBrackets() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testInsertInsideBrackets() throws BadLocationException {
 		setCaret(BRACKETS_OFFSET);
 		type('(');
 
@@ -248,8 +244,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testPeerEntry() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testPeerEntry() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type("()");
 
@@ -259,17 +254,8 @@ public class BracketInserterTest {
 		assertFalse(LinkedModeModel.hasInstalledModel(fDocument));
 	}
 
-//	public void testLoop() throws Exception {
-//		for (int i= 0; i < 50; i++) {
-//			setUp();
-//			testExitOnTab();
-//			tearDown();
-//		}
-//	}
-//
 	@Test
-	public void testMultiplePeerEntry() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testMultiplePeerEntry() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type("((((");
 
@@ -293,8 +279,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testExitOnTab() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testExitOnTab() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type("((((");
 		linkedType('\t', true, ILinkedModeListener.NONE);
@@ -317,8 +302,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testExitOnReturn() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testExitOnReturn() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type("((((");
 		linkedType(SWT.CR, true, ILinkedModeListener.UPDATE_CARET | ILinkedModeListener.EXIT_ALL);
@@ -330,8 +314,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testExitOnEsc() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testExitOnEsc() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type("((((");
 		linkedType(SWT.ESC, true, ILinkedModeListener.EXIT_ALL);
@@ -343,8 +326,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testInsertClosingQuote() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testInsertClosingQuote() throws BadLocationException {
 		setCaret(BODY_OFFSET);
 		type('"');
 
@@ -354,8 +336,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testPreferences() throws BadLocationException, JavaModelException, CoreException {
-		use14();
+	public void testPreferences() throws BadLocationException {
 		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
 		store.setValue(PreferenceConstants.EDITOR_CLOSE_BRACKETS, false);
 
@@ -370,7 +351,6 @@ public class BracketInserterTest {
 
 	@Test
 	public void testAngleBracketsAsOperator() throws Exception {
-		use15();
 		setCaret(BODY_OFFSET);
 		type("test<");
 
@@ -382,22 +362,7 @@ public class BracketInserterTest {
 	}
 
 	@Test
-	public void testAngleBracketsIn14Project() throws BadLocationException, JavaModelException, CoreException {
-		use14();
-		setCaret(BODY_OFFSET);
-		type("Test<");
-
-		assertEquals("Test<", fDocument.get(BODY_OFFSET, 5));
-		assertNotEquals(">", fDocument.get(BODY_OFFSET + 5, 1));
-		assertEquals(BODY_OFFSET + 5, getCaret());
-
-		assertFalse(LinkedModeModel.hasInstalledModel(fDocument));
-	}
-
-	@Test
 	public void testAngleBracketsIn15Project() throws Exception {
-		use15();
-
 		setCaret(BODY_OFFSET);
 		type("Test<");
 
@@ -407,8 +372,6 @@ public class BracketInserterTest {
 
 	@Test
 	public void testAngleBracketsInFieldDecl15() throws Exception {
-		use15();
-
 		setCaret(FIELD_OFFSET);
 		type('<');
 
@@ -418,8 +381,6 @@ public class BracketInserterTest {
 
 	@Test
 	public void testAngleBracketsInsideMethodDecl15() throws Exception {
-		use15();
-
 		setCaret(MAIN_VOID_OFFSET);
 		type('<');
 
@@ -429,8 +390,6 @@ public class BracketInserterTest {
 
 	@Test
 	public void testAngleBracketsBeforeMethodDecl15() throws Exception {
-		use15();
-
 		setCaret(FOO_VOID_OFFSET);
 
 		type('<');
@@ -441,8 +400,6 @@ public class BracketInserterTest {
 
 	@Test
 	public void testAngleBracketsBeforeTypeArgument15() throws Exception {
-		use15();
-
 		String PRE= "new ArrayList";
 		String POST= "String>();";
 
@@ -457,8 +414,6 @@ public class BracketInserterTest {
 
 	@Test
 	public void testAngleBracketsBeforeWildcard15() throws Exception {
-		use15();
-
 		String PRE= "new ArrayList";
 		String POST= "? extends Number>();";
 
@@ -474,8 +429,6 @@ public class BracketInserterTest {
 	@Test
 	public void testAngleBracketsAfterIdentifierOnFirstColumn1_15() throws Exception {
 		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=347734
-		use15();
-
 		String PRE= "x";
 
 		fDocument.replace(FIRST_COLUMN_OFFSET, 0, PRE);
@@ -490,8 +443,6 @@ public class BracketInserterTest {
 	@Test
 	public void testAngleBracketsAfterIdentifierOnFirstColumn2_15() throws Exception {
 		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=347734
-		use15();
-
 		String PRE= "List";
 
 		fDocument.replace(FIRST_COLUMN_OFFSET, 0, PRE);
@@ -512,16 +463,6 @@ public class BracketInserterTest {
 		assertNotNull(position);
 		assertEquals(offset, position.getOffset());
 		assertEquals(0, position.getLength());
-	}
-
-	private void use15() throws CoreException, JavaModelException {
-		setUpProject(JavaCore.VERSION_1_5);
-		setUpEditor();
-	}
-
-	private void use14() throws CoreException, JavaModelException {
-		setUpProject(JavaCore.VERSION_1_4);
-		setUpEditor();
 	}
 
 	/**

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPairMatcherTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPairMatcherTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,9 +14,12 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.After;
 import org.junit.Before;
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -81,6 +84,7 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 		fPairMatcher= null;
 	}
 
+	@Test
 	public void testBeforeOpeningMatch() {
 		IRegion match= fPairMatcher.match(fDocument, 2);
 		assertNotNull(match);
@@ -91,6 +95,7 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 		assertTrue(match.getOffset() == 5 && match.getLength() == 4);
 	}
 
+	@Test
 	public void testAfterOpeningMatch() {
 		IRegion match= fPairMatcher.match(fDocument, 3);
 		assertNotNull(match);
@@ -100,7 +105,7 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 		assertNotNull(match);
 		assertTrue(match.getOffset() == 5 && match.getLength() == 4);
 	}
-
+	@Test
 	public void testBeforeClosingMatch() {
 		IRegion match= fPairMatcher.match(fDocument, 11);
 		assertNotNull(match);
@@ -111,7 +116,7 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 		assertTrue(match.getOffset() == 5 && match.getLength() == 4);
 
 	}
-
+	@Test
 	public void testAfterClosingMatch() {
 		IRegion match= fPairMatcher.match(fDocument, 12);
 		assertNotNull(match);
@@ -121,35 +126,35 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 		assertNotNull(match);
 		assertTrue(match.getOffset() == 5 && match.getLength() == 4);
 	}
-
+	@Test
 	public void testBeforeClosingMatchWithNL() {
 		fDocument.set("x(y\ny)x");
 		IRegion match= fPairMatcher.match(fDocument, 5);
 		assertNotNull(match);
 		assertTrue(match.getOffset() == 1 && match.getLength() == 5);
 	}
-
+	@Test
 	public void testAfterClosingMatchWithNL() {
 		fDocument.set("x(y\ny)x");
 		IRegion match= fPairMatcher.match(fDocument, 6);
 		assertNotNull(match);
 		assertTrue(match.getOffset() == 1 && match.getLength() == 5);
 	}
-
+	@Test
 	public void testBeforeClosingMatchWithNLAndSingleLineComment() {
 		fDocument.set("x\nx(y\nx //(x\ny)x");
 		IRegion match= fPairMatcher.match(fDocument, 14);
 		assertNotNull(match);
 		assertTrue(match.getOffset() == 3 && match.getLength() == 12);
 	}
-
+	@Test
 	public void testAfterClosingMatchWithNLAndSingleLineComment() {
 		fDocument.set("x\nx(y\nx //(x\ny)x");
 		IRegion match= fPairMatcher.match(fDocument, 15);
 		assertNotNull(match);
 		assertTrue(match.getOffset() == 3 && match.getLength() == 12);
 	}
-
+	@Test
 	public void testEnclosingMatch() {
 		IRegion match= fPairMatcher.findEnclosingPeerCharacters(fDocument, 4, 0);
 		assertNotNull(match);
@@ -159,22 +164,7 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 		assertNotNull(match);
 		assertTrue(match.getOffset() == 5 && match.getLength() == 4);
 	}
-
-	public void testAngleBrackets1_4() {
-		final JavaPairMatcher matcher= (JavaPairMatcher) createMatcher("(){}[]<>");
-		matcher.setSourceVersion(JavaCore.VERSION_1_4);
-		performMatch(matcher, " <>% ");
-		performMatch(matcher, " <%> ");
-		performMatch(matcher, " 2 < 3 || 4 >% 5 ");
-		performMatch(matcher, " 2 <% 3 || 4 > 5 ");
-		performMatch(matcher, " List<String>% ");
-		performMatch(matcher, " foo < T >% ");
-		performMatch(matcher, " foo <% T > ");
-		performMatch(matcher, " foo < T >% ");
-		performMatch(matcher, " final <% T > ");
-		matcher.dispose();
-	}
-
+	@Test
 	public void testAngleBrackets1_5() {
 		final JavaPairMatcher matcher= (JavaPairMatcher) createMatcher("(){}[]<>");
 		matcher.setSourceVersion(JavaCore.VERSION_1_5);
@@ -189,7 +179,7 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 		performMatch(matcher, " final <% T ># ");
 		matcher.dispose();
 	}
-
+	@Test
 	public void testBug209505() {
 		fDocument.set("(xny)/*  */");
 		IRegion match= fPairMatcher.match(fDocument, 4);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
@@ -403,7 +403,6 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 
 		private boolean fCloseBrackets= true;
 		private boolean fCloseStrings= true;
-		private boolean fCloseAngularBrackets= true;
 		private final String CATEGORY= toString();
 		private final IPositionUpdater fUpdater= new ExclusivePositionUpdater(CATEGORY);
 		private final Stack<BracketLevel> fBracketLevelStack= new Stack<>();
@@ -414,10 +413,6 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 
 		public void setCloseStringsEnabled(boolean enabled) {
 			fCloseStrings= enabled;
-		}
-
-		public void setCloseAngularBracketsEnabled(boolean enabled) {
-			fCloseAngularBrackets= enabled;
 		}
 
 		private boolean isTypeArgumentStart(String identifier) {
@@ -495,7 +490,7 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 						break;
 
 					case '<':
-						if (!fCloseAngularBrackets || !fCloseBrackets
+						if (!fCloseBrackets
 								|| nextToken == Symbols.TokenLESSTHAN
 								|| nextToken == Symbols.TokenQUESTIONMARK
 								|| nextToken == Symbols.TokenIDENT && isTypeArgumentStart(next)
@@ -1528,11 +1523,9 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 		IPreferenceStore preferenceStore= getPreferenceStore();
 		boolean closeBrackets= preferenceStore.getBoolean(CLOSE_BRACKETS);
 		boolean closeStrings= preferenceStore.getBoolean(CLOSE_STRINGS);
-		boolean closeAngularBrackets= JavaCore.compareJavaVersions(JavaCore.VERSION_1_5, preferenceStore.getString(JavaCore.COMPILER_SOURCE)) <= 0;
 
 		fBracketInserter.setCloseBracketsEnabled(closeBrackets);
 		fBracketInserter.setCloseStringsEnabled(closeStrings);
-		fBracketInserter.setCloseAngularBracketsEnabled(closeAngularBrackets);
 
 		ISourceViewer sourceViewer= getSourceViewer();
 		if (sourceViewer instanceof ITextViewerExtension)
@@ -1608,10 +1601,6 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 							else
 								uninstallTabsToSpacesConverter();
 							return;
-						case JavaCore.COMPILER_SOURCE:
-							boolean closeAngularBrackets= JavaCore.compareJavaVersions(JavaCore.VERSION_1_5, getPreferenceStore().getString(p)) <= 0;
-							fBracketInserter.setCloseAngularBracketsEnabled(closeAngularBrackets);
-							break;
 						case PreferenceConstants.EDITOR_SMART_TAB:
 							if (getPreferenceStore().getBoolean(PreferenceConstants.EDITOR_SMART_TAB)) {
 								setActionActivationCode("IndentOnTab", '\t', -1, SWT.NONE); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaPairMatcher.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaPairMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,21 +20,12 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.jface.text.source.DefaultCharacterPairMatcher;
 
-import org.eclipse.jdt.core.JavaCore;
-
 import org.eclipse.jdt.ui.text.IJavaPartitions;
 
 /**
  * Helper class for match pairs of characters.
  */
 public final class JavaPairMatcher extends DefaultCharacterPairMatcher implements ISourceVersionDependent {
-
-	/**
-	 * Stores the source version state.
-	 * @since 3.1
-	 */
-	private boolean fHighlightAngularBrackets= false;
-
 
 	public JavaPairMatcher(char[] pairs) {
 		super(pairs, IJavaPartitions.JAVA_PARTITIONING, true);
@@ -68,8 +59,6 @@ public final class JavaPairMatcher extends DefaultCharacterPairMatcher implement
 			currChar= document.getChar(offset);
 		}
 
-		if ((prevChar == '<' || currChar == '>') && !fHighlightAngularBrackets)
-			return null;
 		if (prevChar == '<' && isLessThanOperator(document, offset - 1))
 			return null;
 		final IRegion region= super.match(document, offset);
@@ -221,10 +210,7 @@ public final class JavaPairMatcher extends DefaultCharacterPairMatcher implement
 	 */
 	@Override
 	public void setSourceVersion(String version) {
-		if (JavaCore.compareJavaVersions(JavaCore.VERSION_1_5, version) <= 0)
-			fHighlightAngularBrackets= true;
-		else
-			fHighlightAngularBrackets= false;
+		// nothing to do
 	}
 
 	/*


### PR DESCRIPTION
Remove checks whether running on Java 1.5+ to handle them as ECJ mandates 1.8 thus this is always true.
Removed tests for pre 1.5 behavior and enable tests in JavaPairMatcherTest that were not executed at all.

