### PR TITLE
Default to JAVA 8

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
@@ -73,7 +73,6 @@ import org.eclipse.ui.texteditor.TextEditorAction;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IBinding;
@@ -609,7 +608,7 @@ public final class ClipboardOperationAction extends TextEditorAction {
 	private void addImports(final ICompilationUnit unit, ClipboardData data) throws CoreException {
 		final ImportRewrite rewrite= StubUtility.createImportRewrite(unit, true);
 		for (String type : data.getTypeImports()) {
-			if (type.indexOf('.') != -1 || JavaModelUtil.isVersionLessThan(unit.getJavaProject().getOption(JavaCore.COMPILER_COMPLIANCE, true), JavaCore.VERSION_1_4)) {
+			if (type.indexOf('.') != -1) {
 				rewrite.addImport(type);
 			}
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
@@ -1239,7 +1239,7 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 	private void setDefaultCompilerComplianceValues() {
 		IVMInstall defaultVMInstall= JavaRuntime.getDefaultVMInstall();
 		if (defaultVMInstall instanceof IVMInstall2) {
-			String complianceLevel= JavaModelUtil.getCompilerCompliance((IVMInstall2)defaultVMInstall, JavaCore.VERSION_1_4);
+			String complianceLevel= JavaModelUtil.getCompilerCompliance((IVMInstall2)defaultVMInstall, JavaCore.VERSION_1_8);
 			if (isOriginalDefaultCompliance(complianceLevel)) {
 				Map<String, String> complianceOptions= new HashMap<>();
 				JavaModelUtil.setComplianceOptions(complianceOptions, complianceLevel);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorColoringConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaEditorColoringConfigurationBlock.java
@@ -782,8 +782,8 @@ class JavaEditorColoringConfigurationBlock extends AbstractConfigurationBlock {
 		fPreviewViewer= new JavaSourceViewer(parent, null, null, false, SWT.H_SCROLL | SWT.BORDER, store);
 		SimpleJavaSourceViewerConfiguration configuration= new SimpleJavaSourceViewerConfiguration(fColorManager, store, null, IJavaPartitions.JAVA_PARTITIONING, false);
 		fPreviewViewer.configure(configuration);
-		// fake 1.5 source to get 1.5 features right.
-		configuration.handlePropertyChangeEvent(new PropertyChangeEvent(this, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_4, JavaCore.VERSION_1_5));
+		// 1.8 source to get 1.8 features right.
+		configuration.handlePropertyChangeEvent(new PropertyChangeEvent(this, JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8, JavaCore.VERSION_1_8));
 		Font font= JFaceResources.getFont(PreferenceConstants.EDITOR_TEXT_FONT);
 		fPreviewViewer.getTextWidget().setFont(font);
 		new JavaSourcePreviewerUpdater(fPreviewViewer, configuration, store);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPageOne.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -544,9 +544,9 @@ public class NewJavaProjectWizardPageOne extends WizardPage {
 					selectionIndex= i;
 				}
 				if (fInstalledJVMs[i] instanceof IVMInstall2) {
-					fJRECompliance[i]= JavaModelUtil.getCompilerCompliance((IVMInstall2) fInstalledJVMs[i], JavaCore.VERSION_1_4);
+					fJRECompliance[i]= JavaModelUtil.getCompilerCompliance((IVMInstall2) fInstalledJVMs[i], JavaCore.VERSION_1_8);
 				} else {
-					fJRECompliance[i]= JavaCore.VERSION_1_4;
+					fJRECompliance[i]= JavaCore.VERSION_1_8;
 				}
 			}
 			comboField.setItems(jreLabels);
@@ -852,7 +852,7 @@ public class NewJavaProjectWizardPageOne extends WizardPage {
 		public String getCompliance() {
 			String compilerCompliance= fJREGroup.getSelectedCompilerCompliance();
 			if (compilerCompliance == null) {
-				compilerCompliance= JavaModelUtil.getCompilerCompliance((IVMInstall2) JavaRuntime.getDefaultVMInstall(), JavaCore.VERSION_1_4);
+				compilerCompliance= JavaModelUtil.getCompilerCompliance((IVMInstall2) JavaRuntime.getDefaultVMInstall(), JavaCore.VERSION_1_8);
 			}
 			return compilerCompliance;
 		}
@@ -1068,9 +1068,9 @@ public class NewJavaProjectWizardPageOne extends WizardPage {
 			if (selectedJVM == null) {
 				selectedJVM= JavaRuntime.getDefaultVMInstall();
 			}
-			String jvmCompliance= JavaCore.VERSION_1_4;
+			String jvmCompliance= JavaCore.VERSION_1_8;
 			if (selectedJVM instanceof IVMInstall2) {
-				jvmCompliance= JavaModelUtil.getCompilerCompliance((IVMInstall2) selectedJVM, JavaCore.VERSION_1_4);
+				jvmCompliance= JavaModelUtil.getCompilerCompliance((IVMInstall2) selectedJVM, JavaCore.VERSION_1_8);
 			}
 			if (!selectedCompliance.equals(jvmCompliance) && (JavaModelUtil.is50OrHigher(selectedCompliance) || JavaModelUtil.is50OrHigher(jvmCompliance))) {
 				fHintText.setText(Messages.format(NewWizardMessages.NewJavaProjectWizardPageOne_DetectGroup_jre_message, new String[] {BasicElementLabels.getVersionName(selectedCompliance), BasicElementLabels.getVersionName(jvmCompliance)}));


### PR DESCRIPTION
Ecj supports min Java 8 so testing/supporting older versions in UI creates the risk of generating/accepting code that compiler may reject.

