### PR TITLE
Stop support for pre 1.8 source in some editor features

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaDoubleClickSelectorTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaDoubleClickSelectorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,8 +22,6 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 
-import org.eclipse.jdt.core.JavaCore;
-
 import org.eclipse.jdt.internal.ui.text.java.JavaDoubleClickSelector;
 
 /**
@@ -37,150 +35,110 @@ public class JavaDoubleClickSelectorTest {
 		}
 	}
 
-	private void assert14Selection(String content, int offset, int selOffset, int selLength) {
+	private void assertSelection(String content, int offset, int selOffset, int selLength) {
 		IDocument document= new Document(content);
 		PublicSelector selector= new PublicSelector();
-		selector.setSourceVersion(JavaCore.VERSION_1_4);
-		IRegion selection= selector.findWord(document, offset);
-		assertEquals(new Region(selOffset, selLength), selection);
-	}
-
-	private void assert15Selection(String content, int offset, int selOffset, int selLength) {
-		IDocument document= new Document(content);
-		PublicSelector selector= new PublicSelector();
-		selector.setSourceVersion(JavaCore.VERSION_1_5);
 		IRegion selection= selector.findWord(document, offset);
 		assertEquals(new Region(selOffset, selLength), selection);
 	}
 
 	@Test
 	public void testIdentifierBefore() throws Exception {
-		assert14Selection("  foobar  ", 2, 2, 6);
+		assertSelection("  foobar  ", 2, 2, 6);
 	}
 
 	@Test
 	public void testIdentifierInside() throws Exception {
-		assert14Selection("  foobar  ", 3, 2, 6);
+		assertSelection("  foobar  ", 3, 2, 6);
 	}
 
 	@Test
 	public void testIdentifierBehind() throws Exception {
-		assert14Selection("  foobar  ", 8, 8, 0);
+		assertSelection("  foobar  ", 8, 8, 0);
 	}
 
 	@Test
 	public void testWhitespaceBefore() throws Exception {
-		assert14Selection("  foobar  ", 1, 1, 0);
+		assertSelection("  foobar  ", 1, 1, 7);
 	}
 
 	@Test
 	public void testWhitespaceBehind() throws Exception {
-		assert14Selection("  foobar  ", 9, 9, 0);
-	}
-
-	@Test
-	public void test14AnnotationBefore() throws Exception {
-		assert14Selection("  @  Deprecated  ", 2, 2, 0);
-	}
-
-	@Test
-	public void test14AnnotationInside1() throws Exception {
-		assert14Selection("  @  Deprecated  ", 3, 3, 0);
-	}
-
-	@Test
-	public void test14AnnotationInside2() throws Exception {
-		assert14Selection("  @  Deprecated  ", 4, 4, 0);
-	}
-
-	@Test
-	public void test14AnnotationInside3() throws Exception {
-		assert14Selection("  @  Deprecated  ", 5, 5, 10);
-	}
-
-	@Test
-	public void test14AnnotationInside4() throws Exception {
-		assert14Selection("  @  Deprecated  ", 6, 5, 10);
-	}
-
-	@Test
-	public void test14AnnotationBehind() throws Exception {
-		assert14Selection("  @  Deprecated  ", 15, 15, 0);
+		assertSelection("  foobar  ", 9, 9, 0);
 	}
 
 	@Test
 	public void test15AnnotationBefore() throws Exception {
-		assert15Selection("  @  Deprecated  ", 2, 2, 13);
+		assertSelection("  @  Deprecated  ", 2, 2, 13);
 	}
 
 	@Test
 	public void test15AnnotationInside1() throws Exception {
-		assert15Selection("  @  Deprecated  ", 3, 2, 13);
+		assertSelection("  @  Deprecated  ", 3, 2, 13);
 	}
 
 	@Test
 	public void test15AnnotationInside2() throws Exception {
-		assert15Selection("  @  Deprecated  ", 4, 2, 13);
+		assertSelection("  @  Deprecated  ", 4, 2, 13);
 	}
 
 	@Test
 	public void test15AnnotationInside3() throws Exception {
-		assert15Selection("  @  Deprecated  ", 5, 2, 13);
+		assertSelection("  @  Deprecated  ", 5, 2, 13);
 	}
 
 	@Test
 	public void test15AnnotationInside4() throws Exception {
-		assert15Selection("  @  Deprecated  ", 6, 2, 13);
+		assertSelection("  @  Deprecated  ", 6, 2, 13);
 	}
 
 	@Test
 	public void test15AnnotationBehind() throws Exception {
-		assert15Selection("  @  Deprecated  ", 15, 15, 0);
+		assertSelection("  @  Deprecated  ", 15, 15, 0);
 	}
 
 	@Test
 	public void test15AnnotationNoSpaceBefore() throws Exception {
-		assert15Selection("  @Deprecated  ", 2, 2, 11);
+		assertSelection("  @Deprecated  ", 2, 2, 11);
 	}
 
 	@Test
 	public void test15AnnotationNoSpaceInside1() throws Exception {
-		assert15Selection("  @Deprecated  ", 3, 2, 11);
+		assertSelection("  @Deprecated  ", 3, 2, 11);
 	}
 
 	@Test
 	public void test15AnnotationNoSpaceInside2() throws Exception {
-		assert15Selection("  @Deprecated  ", 4, 2, 11);
+		assertSelection("  @Deprecated  ", 4, 2, 11);
 	}
 
 	@Test
 	public void test15AnnotationNoSpaceBehind() throws Exception {
-		assert15Selection("  @Deprecated  ", 13, 13, 0);
+		assertSelection("  @Deprecated  ", 13, 13, 0);
 	}
 
 	@Test
 	public void testAnnotationNoIdStartBefore() {
-		assert15Selection("  @2foobar  ", 2, 2, 0);
+		assertSelection("  @2foobar  ", 2, 2, 0);
 	}
 
 	@Test
 	public void testAnnotationNoIdStartInside1() {
-		assert15Selection("  @2foobar  ", 3, 3, 7);
+		assertSelection("  @2foobar  ", 3, 3, 7);
 	}
 
 	@Test
 	public void testAnnotationNoIdStartInside2() {
-		assert15Selection("  @2foobar  ", 4, 3, 7);
+		assertSelection("  @2foobar  ", 4, 3, 7);
 	}
 
 	@Test
 	public void testAnnotationNoIdStartBehind() {
-		assert15Selection("  @2foobar  ", 10, 10, 0);
+		assertSelection("  @2foobar  ", 10, 10, 0);
 	}
 
 	@Test
 	public void testBackwardsOnDot() {
-		assert14Selection("Systen.out", 6, 0, 6);
-		assert15Selection("Systen.out", 6, 0, 6);
+		assertSelection("Systen.out", 6, 0, 6);
 	}
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPairMatcherTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPairMatcherTest.java
@@ -28,8 +28,6 @@ import org.eclipse.jface.text.rules.FastPartitioner;
 import org.eclipse.jface.text.source.ICharacterPairMatcher;
 import org.eclipse.jface.text.tests.AbstractPairMatcherTest;
 
-import org.eclipse.jdt.core.JavaCore;
-
 import org.eclipse.jdt.ui.text.IJavaPartitions;
 
 import org.eclipse.jdt.internal.ui.text.FastJavaPartitionScanner;
@@ -167,7 +165,6 @@ public class JavaPairMatcherTest extends AbstractPairMatcherTest {
 	@Test
 	public void testAngleBrackets1_5() {
 		final JavaPairMatcher matcher= (JavaPairMatcher) createMatcher("(){}[]<>");
-		matcher.setSourceVersion(JavaCore.VERSION_1_5);
 		performMatch(matcher, " #< %> ");
 		performMatch(matcher, " <%># ");
 		performMatch(matcher, " 2 < 3 || 4 >% 5 ");

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
@@ -2947,12 +2947,6 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 				return;
 			}
 
-			if (JavaCore.COMPILER_SOURCE.equals(property)) {
-				if (event.getNewValue() instanceof String)
-					fBracketMatcher.setSourceVersion((String) event.getNewValue());
-				// fall through as others are interested in source change as well.
-			}
-
 			((JavaSourceViewerConfiguration)getSourceViewerConfiguration()).handlePropertyChangeEvent(event);
 
 			if (affectsOverrideIndicatorAnnotations(event)) {
@@ -3128,7 +3122,6 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 	@Override
 	protected void configureSourceViewerDecorationSupport(SourceViewerDecorationSupport support) {
 
-		fBracketMatcher.setSourceVersion(getPreferenceStore().getString(JavaCore.COMPILER_SOURCE));
 		support.setCharacterPairMatcher(fBracketMatcher);
 		support.setMatchingCharacterPainterPreferenceKeys(MATCHING_BRACKETS, MATCHING_BRACKETS_COLOR, HIGHLIGHT_BRACKET_AT_CARET_LOCATION, ENCLOSING_BRACKETS);
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaPairMatcher.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaPairMatcher.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.ui.text.IJavaPartitions;
 /**
  * Helper class for match pairs of characters.
  */
-public final class JavaPairMatcher extends DefaultCharacterPairMatcher implements ISourceVersionDependent {
+public final class JavaPairMatcher extends DefaultCharacterPairMatcher {
 
 	public JavaPairMatcher(char[] pairs) {
 		super(pairs, IJavaPartitions.JAVA_PARTITIONING, true);
@@ -203,14 +203,6 @@ public final class JavaPairMatcher extends DefaultCharacterPairMatcher implement
 						|| identifier.startsWith("public") //$NON-NLS-1$
 						|| identifier.startsWith("protected") //$NON-NLS-1$
 						|| identifier.startsWith("private")); //$NON-NLS-1$
-	}
-
-	/*
-	 * @see org.eclipse.jdt.internal.ui.text.ISourceVersionDependent#setSourceVersion(java.lang.String)
-	 */
-	@Override
-	public void setSourceVersion(String version) {
-		// nothing to do
 	}
 
 	/*

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaDoubleClickSelector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaDoubleClickSelector.java
@@ -13,6 +13,10 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.text.java;
 
+import static java.lang.Character.isJavaIdentifierPart;
+import static java.lang.Character.isJavaIdentifierStart;
+import static java.lang.Character.isWhitespace;
+
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DefaultTextDoubleClickStrategy;
 import org.eclipse.jface.text.IDocument;
@@ -28,7 +32,7 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy {
 
 	/**
 	 * Detects java words depending on the source level. In 1.4 mode, detects
-	 * <code>[[:ID:]]*</code>. In 1.5 mode, it also detects
+	 * <code>[[:ID:]]*</code> and
 	 * <code>@\s*[[:IDS:]][[:ID:]]*</code>.
 	 *
 	 * Character class definitions:
@@ -87,18 +91,6 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy {
 			return c == '@';
 		}
 
-		private boolean isIdentifierStart(char c) {
-			return Character.isJavaIdentifierStart(c);
-		}
-
-		private boolean isIdentifierPart(char c) {
-			return Character.isJavaIdentifierPart(c);
-		}
-
-		private boolean isWhitespace(char c) {
-			return Character.isWhitespace(c);
-		}
-
 		/**
 		 * Try to add a character to the word going backward. Only call after
 		 * forward calls!
@@ -121,24 +113,24 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy {
 						fState= WS;
 						return true;
 					}
-					if (isIdentifierStart(c)) {
+					if (isJavaIdentifierStart(c)) {
 						fStart= offset;
 						fState= IDS;
 						return true;
 					}
-					if (isIdentifierPart(c)) {
+					if (isJavaIdentifierPart(c)) {
 						fStart= offset;
 						fState= ID;
 						return true;
 					}
 					return false;
 				case ID:
-					if (isIdentifierStart(c)) {
+					if (isJavaIdentifierStart(c)) {
 						fStart= offset;
 						fState= IDS;
 						return true;
 					}
-					if (isIdentifierPart(c)) {
+					if (isJavaIdentifierPart(c)) {
 						fStart= offset;
 						fState= ID;
 						return true;
@@ -185,7 +177,7 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy {
 						fState= WS;
 						return true;
 					}
-					if (isIdentifierStart(c)) {
+					if (isJavaIdentifierStart(c)) {
 						fEnd= offset;
 						fState= IDS;
 						return true;
@@ -193,25 +185,25 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy {
 					return false;
 				case IDS:
 				case ID:
-					if (isIdentifierStart(c)) {
+					if (isJavaIdentifierStart(c)) {
 						fEnd= offset;
 						fState= IDS;
 						return true;
 					}
-					if (isIdentifierPart(c)) {
+					if (isJavaIdentifierPart(c)) {
 						fEnd= offset;
 						fState= ID;
 						return true;
 					}
 					return false;
 				case UNKNOWN:
-					if (isIdentifierStart(c)) {
+					if (isJavaIdentifierStart(c)) {
 						fEnd= offset;
 						fState= IDS;
 						fAnchorState= fState;
 						return true;
 					}
-					if (isIdentifierPart(c)) {
+					if (isJavaIdentifierPart(c)) {
 						fEnd= offset;
 						fState= ID;
 						fAnchorState= fState;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaDoubleClickSelector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaDoubleClickSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,17 +19,12 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 
-import org.eclipse.jdt.core.JavaCore;
-
-import org.eclipse.jdt.internal.ui.text.ISourceVersionDependent;
 import org.eclipse.jdt.internal.ui.text.JavaPairMatcher;
-
-
 
 /**
  * Double click strategy aware of Java identifier syntax rules.
  */
-public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy implements ISourceVersionDependent {
+public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy {
 
 	/**
 	 * Detects java words depending on the source level. In 1.4 mode, detects
@@ -46,9 +41,7 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy impl
 	 *
 	 * @since 3.1
 	 */
-	private static final class AtJavaIdentifierDetector implements ISourceVersionDependent {
-
-		private boolean fSelectAnnotations;
+	private static final class AtJavaIdentifierDetector {
 
 		private static final int UNKNOWN= -1;
 
@@ -91,7 +84,7 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy impl
 		}
 
 		private boolean isAt(char c) {
-			return fSelectAnnotations && c == '@';
+			return c == '@';
 		}
 
 		private boolean isIdentifierStart(char c) {
@@ -103,18 +96,7 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy impl
 		}
 
 		private boolean isWhitespace(char c) {
-			return fSelectAnnotations && Character.isWhitespace(c);
-		}
-
-		/*
-		 * @see org.eclipse.jdt.internal.ui.text.ISourceVersionDependent#setSourceVersion(java.lang.String)
-		 */
-		@Override
-		public void setSourceVersion(String version) {
-			if (JavaCore.compareJavaVersions(JavaCore.VERSION_1_5, version) <= 0)
-				fSelectAnnotations= true;
-			else
-				fSelectAnnotations= false;
+			return Character.isWhitespace(c);
 		}
 
 		/**
@@ -324,15 +306,6 @@ public class JavaDoubleClickSelector extends DefaultTextDoubleClickStrategy impl
 	@Override
 	protected IRegion findWord(IDocument document, int anchor) {
 		return fWordDetector.getWordSelection(document, anchor);
-	}
-
-	/*
-	 * @see org.eclipse.jdt.internal.ui.text.ISourceVersionDependent#setSourceVersion(java.lang.String)
-	 */
-	@Override
-	public void setSourceVersion(String version) {
-		fPairMatcher.setSourceVersion(version);
-		fWordDetector.setSourceVersion(version);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaSourceViewerConfiguration.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaSourceViewerConfiguration.java
@@ -571,7 +571,6 @@ public class JavaSourceViewerConfiguration extends TextSourceViewerConfiguration
 		}
 		if (fJavaDoubleClickSelector == null) {
 			fJavaDoubleClickSelector= new JavaDoubleClickSelector();
-			fJavaDoubleClickSelector.setSourceVersion(fPreferenceStore.getString(JavaCore.COMPILER_SOURCE));
 		}
 		return fJavaDoubleClickSelector;
 	}
@@ -967,9 +966,6 @@ public class JavaSourceViewerConfiguration extends TextSourceViewerConfiguration
 		if (fJavaDocScanner.affectsBehavior(event))
 			fJavaDocScanner.adaptToPreferenceChange(event);
 		if (JavaCore.COMPILER_SOURCE.equals(event.getProperty()) && event.getNewValue() instanceof String) {
-			if (fJavaDoubleClickSelector != null) {
-				fJavaDoubleClickSelector.setSourceVersion((String) event.getNewValue());
-			}
 			if (fJavaStringDoubleClickStrategy != null) {
 				fJavaStringDoubleClickStrategy.setSourceVersion((String) event.getNewValue());
 			}


### PR DESCRIPTION
This is only code level cleanup as it is impossible for anyone to use as this was consulting project which can't not be pre 1.8 already.

