### PR TITLE
[dogfooding] Cleanup for text block with latest changes (not to be merged, can be deleted)

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaHeuristicScannerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaHeuristicScannerTest.java
@@ -92,9 +92,10 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testPrevIndentationUnit1() {
-		fDocument.set("\tint a;\n" +
-			"\tif (true)\n" +
-			"");
+		fDocument.set("""
+				int a;
+				if (true)
+			""");
 
 		int pos= fScanner.findReferencePosition(18);
 		assertEquals(9, pos);
@@ -115,10 +116,11 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testPrevIndentationUnit5() {
-		fDocument.set("\tint a;\n" +
-			"\tif (true)\n" +
-			"\t\treturn a;\n" +
-			"");
+		fDocument.set("""
+				int a;
+				if (true)
+					return a;
+			""");
 
 		int pos= fScanner.findReferencePosition(30);
 		assertEquals(9, pos);
@@ -136,10 +138,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testPrevIndentationUnit7() {
 		// for with semis
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tfor (int i= 4; i < 33; i++) \n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					for (int i= 4; i < 33; i++)\s
+			""");
 
 		int pos= fScanner.findReferencePosition(fDocument.getLength());
 		assertEquals(39, pos);
@@ -174,14 +177,15 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testPrevIndentationUnit10() {
 		// if else
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tif (condition()) {\n" +
-			"\t\t\tcode();\n" +
-			"\t\t} else {\n" +
-			"\t\t\totherCode();\n" +
-			"\t\t}\n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					if (condition()) {
+						code();
+					} else {
+						otherCode();
+					}
+			""");
 
 		int pos= fScanner.findReferencePosition(fDocument.getLength());
 		assertEquals(39, pos);
@@ -190,14 +194,15 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testPrevIndentationUnit11() {
 		// inside else block
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tif (condition()) {\n" +
-			"\t\t\tcode();\n" +
-			"\t\t} else {\n" +
-			"\t\t\totherCode();\n" +
-			"\t\t" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					if (condition()) {
+						code();
+					} else {
+						otherCode();
+					\
+			""");
 
 		int pos= fScanner.findReferencePosition(fDocument.getLength());
 		assertEquals(83, pos);
@@ -205,9 +210,10 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testPrevIndentation1() {
-		fDocument.set("\tint a;\n" +
-			"\tif (true)\n" +
-			"");
+		fDocument.set("""
+				int a;
+				if (true)
+			""");
 
 		String indent= fScanner.getReferenceIndentation(18).toString();
 		assertEquals("\t", indent);
@@ -239,10 +245,11 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testPrevIndentation4() {
-		fDocument.set("\tint a;\n" +
-			"\tif (true)\n" +
-			"\t\treturn a\n" +
-			"");
+		fDocument.set("""
+				int a;
+				if (true)
+					return a
+			""");
 
 		String indent= fScanner.getReferenceIndentation(29).toString();
 		assertEquals("\t\t", indent);
@@ -250,10 +257,11 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testPrevIndentation5() {
-		fDocument.set("\tint a;\n" +
-			"\tif (true)\n" +
-			"\t\treturn a;\n" +
-			"");
+		fDocument.set("""
+				int a;
+				if (true)
+					return a;
+			""");
 
 		String indent= fScanner.getReferenceIndentation(30).toString();
 		assertEquals("\t", indent);
@@ -270,10 +278,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testPrevIndentation7() {
 		// for with semis
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tfor (int i= 4; i < 33; i++) \n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					for (int i= 4; i < 33; i++)\s
+			""");
 
 		String indent= fScanner.getReferenceIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t", indent);
@@ -306,14 +315,15 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testPrevIndentation10() {
 		// else
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tif (condition()) {\n" +
-			"\t\t\tcode();\n" +
-			"\t\t} else {\n" +
-			"\t\t\totherCode();\n" +
-			"\t\t}\n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					if (condition()) {
+						code();
+					} else {
+						otherCode();
+					}
+			""");
 
 		String indent= fScanner.getReferenceIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t", indent);
@@ -322,14 +332,15 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testPrevIndentation11() {
 		// else
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tif (condition()) {\n" +
-			"\t\t\tcode();\n" +
-			"\t\t} else {\n" +
-			"\t\t\totherCode();\n" +
-			"\t\t" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					if (condition()) {
+						code();
+					} else {
+						otherCode();
+					\
+			""");
 
 		String indent= fScanner.getReferenceIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t\t", indent);
@@ -337,9 +348,10 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testIndentation1() {
-		fDocument.set("\tint a;\n" +
-			"\tif (true)\n" +
-			"");
+		fDocument.set("""
+				int a;
+				if (true)
+			""");
 
 		String indent= fScanner.computeIndentation(18).toString();
 		assertEquals("\t\t", indent);
@@ -347,10 +359,11 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testIndentation5() {
-		fDocument.set("\tint a;\n" +
-			"\tif (true)\n" +
-			"\t\treturn a;\n" +
-			"");
+		fDocument.set("""
+				int a;
+				if (true)
+					return a;
+			""");
 
 		String indent= fScanner.computeIndentation(30).toString();
 		assertEquals("\t", indent);
@@ -377,10 +390,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation7() {
 		// for with semis
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tfor (int i= 4; i < 33; i++) \n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					for (int i= 4; i < 33; i++)\s
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t\t", indent);
@@ -414,14 +428,15 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation10() {
 		// else
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tif (condition()) {\n" +
-			"\t\t\tcode();\n" +
-			"\t\t} else {\n" +
-			"\t\t\totherCode();\n" +
-			"\t\t}\n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					if (condition()) {
+						code();
+					} else {
+						otherCode();
+					}
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t", indent);
@@ -430,14 +445,15 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation11() {
 		// else
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tif (condition()) {\n" +
-			"\t\t\tcode();\n" +
-			"\t\t} else {\n" +
-			"\t\t\totherCode();\n" +
-			"\t\t" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					if (condition()) {
+						code();
+					} else {
+						otherCode();
+					\
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t\t", indent);
@@ -446,10 +462,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation12() {
 		// multi-line condition
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tif (condition1()\n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					if (condition1()
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t\t", indent);
@@ -458,10 +475,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation13() {
 		// multi-line call
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tthis.doStuff(param1, param2,\n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					this.doStuff(param1, param2,
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t\t", indent);
@@ -470,10 +488,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation14() {
 		// multi-line array initializer
-		fDocument.set("\tvoid proc (int par1, int par2) {\n" +
-			"\t\t\n" +
-			"\t\tString[] arr= new String[] { a1, a2,\n" +
-			"");
+		fDocument.set("""
+				void proc (int par1, int par2) {
+				\t
+					String[] arr= new String[] { a1, a2,
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("		                             ", indent);
@@ -545,9 +564,10 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation21() {
 		// double if w/ brace
-		fDocument.set("\tif (true)\n" +
-			"\t\tif (true) {\n" +
-			"");
+		fDocument.set("""
+				if (true)
+					if (true) {
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t\t\t", indent);
@@ -556,11 +576,12 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation22() {
 		// after double if w/ brace
-		fDocument.set("\tif (true)\n" +
-			"\t\tif (true) {\n" +
-			"\t\t\tstuff();" +
-			"\t\t}\n" +
-			"");
+		fDocument.set("""
+				if (true)
+					if (true) {
+						stuff();\
+					}
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t", indent); // because of possible dangling else
@@ -569,11 +590,12 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation22a() {
 		// after double if w/ brace
-		fDocument.set("\tif (true)\n" +
-			"\t\tif (true) {\n" +
-			"\t\t\tstuff();\n" +
-			"\t\t}\n" +
-			"");
+		fDocument.set("""
+				if (true)
+					if (true) {
+						stuff();
+					}
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength() - 2).toString();
 		assertEquals("\t\t", indent);
@@ -634,10 +656,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation26() {
 		// do while
-		fDocument.set("\tdo\n" +
-			"\t\t\n" +
-			"\twhile (true);" +
-			"");
+		fDocument.set("""
+				do
+				\t
+				while (true);\
+			""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("\t", indent);
@@ -646,10 +669,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation27() {
 		// do while
-		fDocument.set("\tdo\n" +
-			"\t\t;\n" +
-			"\twhile (true);" +
-			"");
+		fDocument.set("""
+				do
+					;
+				while (true);\
+			""");
 
 		int i= fScanner.findReferencePosition(8);
 		assertEquals(1, i);
@@ -660,10 +684,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testIndentation28() {
 		// TODO do while - how to we distinguish from while {} loop?
-		fDocument.set("\tdo\n" +
-			"\t\t;\n" +
-			"\twhile (true);" +
-			"");
+		fDocument.set("""
+				do
+					;
+				while (true);\
+			""");
 
 		int i= fScanner.findReferencePosition(fDocument.getLength());
 		assertEquals(1, i);
@@ -853,10 +878,11 @@ public class JavaHeuristicScannerTest {
 	@Test
 	public void testBlocksInCaseStatements() {
 		fDocument.set(
-				"		switch (i) {\n" +
-				"			case 1:\n" +
-				"				new Runnable() {\n" +
-				"");
+				"""
+							switch (i) {
+								case 1:
+									new Runnable() {
+					""");
 
 		String indent= fScanner.computeIndentation(fDocument.getLength()).toString();
 		assertEquals("					", indent);
@@ -1176,10 +1202,11 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testContinuationIndentation2() {
-		fDocument.set("\tint a;\n" +
-				"\tif (true)\n" +
-				"\t\treturn a\n" +
-				"");
+		fDocument.set("""
+				int a;
+				if (true)
+					return a
+			""");
 
 		int pos= fScanner.findReferencePosition(29);
 		assertEquals(21, pos);
@@ -1211,10 +1238,11 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testContinuationIndentation5() {
-		fDocument.set("\tint a;\n" +
-				"\tif (true)\n" +
-				"\t\treturn a\n" +
-				"");
+		fDocument.set("""
+				int a;
+				if (true)
+					return a
+			""");
 
 		String indent= fScanner.computeIndentation(29).toString();
 		assertEquals("\t\t\t", indent);
@@ -1251,39 +1279,41 @@ public class JavaHeuristicScannerTest {
 
 	@Test
 	public void testDefaultMethod1() {
-		StringBuilder buf= new StringBuilder();
-		buf.append("interface I {\n");
-		buf.append("			default void foo (int a) {\n");
-		buf.append("		switch(a) {\n");
-		buf.append("		case 0: \n");
-		buf.append("			break;\n");
-		buf.append("	default : \n");
-		buf.append("			System.out.println(\"default\");\n");
-		buf.append("		}\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		fDocument.set(buf.toString());
+		String str= """
+			interface I {
+						default void foo (int a) {
+					switch(a) {
+					case 0:\s
+						break;
+				default :\s
+						System.out.println("default");
+					}
+				}
+			}
+			""";
+		fDocument.set(str);
 
-		int offset= buf.indexOf("default void");
+		int offset= str.indexOf("default void");
 		String indent= fScanner.computeIndentation(offset).toString();
 		assertEquals("\t", indent);
 
-		offset= buf.indexOf("default :");
+		offset= str.indexOf("default :");
 		indent= fScanner.computeIndentation(offset).toString();
 		assertEquals("\t\t", indent);
 	}
 
 	@Test
 	public void testDefaultMethod2() {
-		StringBuilder buf= new StringBuilder();
-		buf.append("interface I {\n");
-		buf.append("    default String name() {\n");
-		buf.append("        return \"unnamed\";\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		fDocument.set(buf.toString());
+		String str= """
+			interface I {
+			    default String name() {
+			        return "unnamed";
+			    }
+			}
+			""";
+		fDocument.set(str);
 
-		int offset= buf.indexOf("default String");
+		int offset= str.indexOf("default String");
 		String indent= fScanner.computeIndentation(offset).toString();
 		assertEquals("\t", indent);
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -310,20 +310,21 @@ public class ParameterNamesCodeMiningTest {
 
 	@Test
 	public void testBug547232() throws Exception {
-		String contents= "public class Test {\n" +
-				"    public final Object object;\n" +
-				"    public final String string;\n" +
-				"\n" +
-				"    Test(Object object, String string) {\n" +
-				"        this.object = object;\n" +
-				"        this.string = string;\n" +
-				"    }\n" +
-				"\n" +
-				"    void f() {\n" +
-				"        new Test(null, \"test\");\n" +
-				"    }\n" +
-				"}\n" +
-				"";
+		String contents= """
+			public class Test {
+			    public final Object object;
+			    public final String string;
+			
+			    Test(Object object, String string) {
+			        this.object = object;
+			        this.string = string;
+			    }
+			
+			    void f() {
+			        new Test(null, "test");
+			    }
+			}
+			""";
 		ICompilationUnit compilationUnit= fPackage.createCompilationUnit("Test.java", contents, true, new NullProgressMonitor());
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(compilationUnit);
 		fParameterNameCodeMiningProvider.setContext(editor);
@@ -335,22 +336,23 @@ public class ParameterNamesCodeMiningTest {
 
 	@Test
 	public void testBug549023() throws Exception {
-		String contents= "class Base {\n" +
-				"    public final Object object;\n" +
-				"    public final String string;\n" +
-				"\n" +
-				"    Base(Object object, String string) {\n" +
-				"        this.object = object;\n" +
-				"        this.string = string;\n" +
-				"    }\n" +
-				"}\n" +
-				"\n" +
-				"public class Test extends Base {\n" +
-				"    Test() {\n" +
-				"        super(null, \"\");\n" +
-				"    }\n" +
-				"}\n" +
-				"";
+		String contents= """
+			class Base {
+			    public final Object object;
+			    public final String string;
+			
+			    Base(Object object, String string) {
+			        this.object = object;
+			        this.string = string;
+			    }
+			}
+			
+			public class Test extends Base {
+			    Test() {
+			        super(null, "");
+			    }
+			}
+			""";
 		ICompilationUnit compilationUnit= fPackage.createCompilationUnit("Test.java", contents, true, new NullProgressMonitor());
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(compilationUnit);
 		fParameterNameCodeMiningProvider.setContext(editor);
@@ -362,18 +364,19 @@ public class ParameterNamesCodeMiningTest {
 
 	@Test
 	public void testBug549126() throws Exception {
-		String contents= "public enum TestEnum {\n" +
-				"    A(\"bla\", null);\n" +
-				"\n" +
-				"    public final String string;\n" +
-				"    public final Object object;\n" +
-				"\n" +
-				"    TestEnum(String string, Object object) {\n" +
-				"        this.string = string;\n" +
-				"        this.object = object;\n" +
-				"    }\n" +
-				"}\n" +
-				"";
+		String contents= """
+			public enum TestEnum {
+			    A("bla", null);
+			
+			    public final String string;
+			    public final Object object;
+			
+			    TestEnum(String string, Object object) {
+			        this.string = string;
+			        this.object = object;
+			    }
+			}
+			""";
 		ICompilationUnit compilationUnit= fPackage.createCompilationUnit("TestEnum.java", contents, true, new NullProgressMonitor());
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(compilationUnit);
 		fParameterNameCodeMiningProvider.setContext(editor);
@@ -416,15 +419,16 @@ public class ParameterNamesCodeMiningTest {
 
 	@Test
 	public void testRecordConstructorOK() throws Exception {
-		String contents= "import java.util.Map;\n"
-				+ "public record Edge(int fromNodeId,\n"
-				+ "        int toNodeId,\n"
-				+ "        Map.Entry<Integer, Integer> fromPoint,\n"
-				+ "        Map.Entry<Integer, Integer> toPoint,\n"
-				+ "        double length,\n"
-				+ "        String profile) {\n"
-				+ "}\n"
-				+ "";
+		String contents= """
+			import java.util.Map;
+			public record Edge(int fromNodeId,
+			        int toNodeId,
+			        Map.Entry<Integer, Integer> fromPoint,
+			        Map.Entry<Integer, Integer> toPoint,
+			        double length,
+			        String profile) {
+			}
+			""";
 		fPackage.createCompilationUnit("Edge.java", contents, true, new NullProgressMonitor());
 
 		contents = """

--- a/org.eclipse.jdt.ui.tests/examples/org/eclipse/jdt/ui/examples/ASTRewriteSnippet.java
+++ b/org.eclipse.jdt.ui.tests/examples/org/eclipse/jdt/ui/examples/ASTRewriteSnippet.java
@@ -80,16 +80,17 @@ public class ASTRewriteSnippet {
 			// create a test file
 			IPackageFragmentRoot root= javaProject.getPackageFragmentRoot(project);
 			IPackageFragment pack1= root.createPackageFragment("test1", false, null);
-			StringBuilder buf= new StringBuilder();
-			buf.append("package test1;\n");
-			buf.append("public class E {\n");
-			buf.append("    public void foo(int i) {\n");
-			buf.append("        while (--i > 0) {\n");
-			buf.append("            System.beep();\n");
-			buf.append("        }\n");
-			buf.append("    }\n");
-			buf.append("}\n");
-			ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+			String str= """
+				package test1;
+				public class E {
+				    public void foo(int i) {
+				        while (--i > 0) {
+				            System.beep();
+				        }
+				    }
+				}
+				""";
+			ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
 			// create an AST
 			ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
@@ -132,18 +133,19 @@ public class ASTRewriteSnippet {
 			// test result
 			String preview= cu.getSource();
 
-			buf= new StringBuilder();
-			buf.append("package test1;\n");
-			buf.append("public class E {\n");
-			buf.append("    public void foo(int i) {\n");
-			buf.append("        bar1();\n");
-			buf.append("        while (--i > 0) {\n");
-			buf.append("            System.beep();\n");
-			buf.append("        }\n");
-			buf.append("        bar2();\n");
-			buf.append("    }\n");
-			buf.append("}\n");
-			assertEquals(preview, buf.toString());
+			String str1= """
+				package test1;
+				public class E {
+				    public void foo(int i) {
+				        bar1();
+				        while (--i > 0) {
+				            System.beep();
+				        }
+				        bar2();
+				    }
+				}
+				""";
+			assertEquals(preview, str1);
 		} finally {
 			project.delete(true, null);
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/AddImportTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/AddImportTest.java
@@ -540,19 +540,20 @@ public class AddImportTest extends CoreTests {
 		pack1.createCompilationUnit("TSub.java", str1, false, null);
 
 		IPackageFragment pack2= sourceFolder.createPackageFragment("test2", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test2;\n");
-		buf.append("\n");
-		buf.append("import test1.TSub;\n");
-		buf.append("public class S {\n");
-		buf.append("    public S() {\n");
-		buf.append("        TSub.foo();\n");
-		buf.append("        TSub.foo();\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack2.createCompilationUnit("S.java", buf.toString(), false, null);
+		String str3= """
+			package test2;
+			
+			import test1.TSub;
+			public class S {
+			    public S() {
+			        TSub.foo();
+			        TSub.foo();
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack2.createCompilationUnit("S.java", str3, false, null);
 
-		int selOffset= buf.indexOf("foo");
+		int selOffset= str3.indexOf("foo");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -655,15 +656,16 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class E {\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        getClass();\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class E {
+			    public void foo() {
+			        getClass();
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str1, false, null);
 
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setSource(cu);
@@ -671,7 +673,7 @@ public class AddImportTest extends CoreTests {
 		CompilationUnit astRoot= (CompilationUnit) parser.createAST(null);
 
 		String str= "getClass()";
-		MethodInvocation inv= (MethodInvocation) NodeFinder.perform(astRoot, buf.indexOf(str), str.length());
+		MethodInvocation inv= (MethodInvocation) NodeFinder.perform(astRoot, str1.indexOf(str), str.length());
 		ITypeBinding binding= inv.resolveTypeBinding();
 
 		ImportRewrite rewrite= newImportsRewrite(astRoot, new String[0], 99, 99, true);
@@ -693,16 +695,17 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class E<X> {\n");
-		buf.append("    public static <T> E<T> bar(T t) { return null; }\n");
-		buf.append("    public void foo(E<?> e) {\n");
-		buf.append("        bar(e);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class E<X> {
+			    public static <T> E<T> bar(T t) { return null; }
+			    public void foo(E<?> e) {
+			        bar(e);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str1, false, null);
 
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setSource(cu);
@@ -710,7 +713,7 @@ public class AddImportTest extends CoreTests {
 		CompilationUnit astRoot= (CompilationUnit) parser.createAST(null);
 
 		String str= "bar(e)";
-		MethodInvocation inv= (MethodInvocation) NodeFinder.perform(astRoot, buf.indexOf(str), str.length());
+		MethodInvocation inv= (MethodInvocation) NodeFinder.perform(astRoot, str1.indexOf(str), str.length());
 		ITypeBinding binding= inv.resolveTypeBinding();
 
 		ImportRewrite rewrite= newImportsRewrite(astRoot, new String[0], 99, 99, true);
@@ -732,16 +735,17 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class E<X> {\n");
-		buf.append("    public static <T> E<? extends T> bar(T t) { return null; }\n");
-		buf.append("    public void foo(E<?> e) {\n");
-		buf.append("        bar(e);\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class E<X> {
+			    public static <T> E<? extends T> bar(T t) { return null; }
+			    public void foo(E<?> e) {
+			        bar(e);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str1, false, null);
 
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setSource(cu);
@@ -749,7 +753,7 @@ public class AddImportTest extends CoreTests {
 		CompilationUnit astRoot= (CompilationUnit) parser.createAST(null);
 
 		String str= "bar(e)";
-		MethodInvocation inv= (MethodInvocation) NodeFinder.perform(astRoot, buf.indexOf(str), str.length());
+		MethodInvocation inv= (MethodInvocation) NodeFinder.perform(astRoot, str1.indexOf(str), str.length());
 		ITypeBinding binding= inv.resolveTypeBinding();
 
 		ImportRewrite rewrite= newImportsRewrite(astRoot, new String[0], 99, 99, true);
@@ -906,17 +910,18 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.System;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.util.Vector c= null;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.System;
+			
+			public class C {
+			    java.util.Vector c= null;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Vector");
+		int selOffset= str1.indexOf("Vector");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -939,17 +944,18 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.System;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    Vector c= null;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.System;
+			
+			public class C {
+			    Vector c= null;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Vector");
+		int selOffset= str1.indexOf("Vector");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -972,17 +978,18 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.System;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    Vector c= null\n"); // missing semicolon
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.System;
+			
+			public class C {
+			    Vector c= null
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Vector");
+		int selOffset= str1.indexOf("Vector");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1005,17 +1012,18 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.System;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.util.Vector c= null\n"); // missing semicolon
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.System;
+			
+			public class C {
+			    java.util.Vector c= null
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Vector");
+		int selOffset= str1.indexOf("Vector");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1038,28 +1046,29 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.io.Serializable;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    private static class Serializable { }\n");
-		buf.append("    public void bar() {\n");
-		buf.append("        java.io.Serializable ser= null;\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		buf.append("class Secondary {\n");
-		buf.append("    Serializable s;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str= """
+			package pack1;
+			
+			import java.io.Serializable;
+			
+			public class C {
+			    private static class Serializable { }
+			    public void bar() {
+			        java.io.Serializable ser= null;
+			    }
+			}
+			class Secondary {
+			    Serializable s;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str, false, null);
 
-		int selOffset= buf.indexOf("ser=") - 2;
+		int selOffset= str.indexOf("ser=") - 2;
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
 
-		buf= new StringBuilder();
+		StringBuilder buf= new StringBuilder();
 		buf.append("package pack1;\n");
 		buf.append("\n");
 		buf.append("import java.io.Serializable;\n");
@@ -1200,21 +1209,22 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("p", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package p;\n");
-		buf.append("\n");
-		buf.append("class SnippetY {\n");
-		buf.append("    static class Test {\n");
-		buf.append("        static void bar() {}\n");
-		buf.append("    }\n");
-		buf.append("\n");
-		buf.append("    void foo() {\n");
-		buf.append("        Test.bar();\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+		String str1= """
+			package p;
+			
+			class SnippetY {
+			    static class Test {
+			        static void bar() {}
+			    }
+			
+			    void foo() {
+			        Test.bar();
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", str1, false, null);
 
-		int selOffset= buf.indexOf("bar();");
+		int selOffset= str1.indexOf("bar();");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 3, null, true);
 		op.run(null);
@@ -1242,21 +1252,22 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("p", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package organize.imports.pvtStaticMembers.bug409594;\n");
-		buf.append("\n");
-		buf.append("class SnippetY {    \n");
-		buf.append("    private static class Test {\n");
-		buf.append("        static void bar() {}        \n");
-		buf.append("    }\n");
-		buf.append("    \n");
-		buf.append("    void foo() {\n");
-		buf.append("         Test.bar();\n");
-		buf.append("     }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("A.java", buf.toString(), false, null);
+		String str= """
+			package organize.imports.pvtStaticMembers.bug409594;
+			
+			class SnippetY {   \s
+			    private static class Test {
+			        static void bar() {}       \s
+			    }
+			   \s
+			    void foo() {
+			         Test.bar();
+			     }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", str, false, null);
 
-		int selOffset= buf.indexOf("bar();");
+		int selOffset= str.indexOf("bar();");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 3, null, true);
 		op.run(null);
@@ -1278,16 +1289,17 @@ public class AddImportTest extends CoreTests {
 				}
 			}""";
 		String inputB=
-				"package p;\n" +
-						"\n" +
-						"import q.A;\n" +
-						"\n" +
-						"class B extends A {\n" +
-						"	void foo() {\n" +
-						"		A.bar();\n" +
-						"	}\n" +
-						"}\n" +
-						"";
+				"""
+			package p;
+			
+			import q.A;
+			
+			class B extends A {
+				void foo() {
+					A.bar();
+				}
+			}
+			""";
 		pack1.createCompilationUnit("A.java", inputA, false, null);
 		ICompilationUnit cuB= pack1.createCompilationUnit("B.java", inputB, false, null);
 
@@ -1297,16 +1309,17 @@ public class AddImportTest extends CoreTests {
 		op.run(null);
 
 		String expected=
-				"package p;\n" +
-						"\n" +
-						"import q.A;\n" +
-						"\n" +
-						"class B extends A {\n" +
-						"	void foo() {\n" +
-						"		bar();\n" +
-						"	}\n" +
-						"}\n" +
-						"";
+				"""
+			package p;
+			
+			import q.A;
+			
+			class B extends A {
+				void foo() {
+					bar();
+				}
+			}
+			""";
 		assertEqualString(cuB.getSource(), expected);
 	}
 
@@ -1315,22 +1328,23 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.System;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.util.Vector.class x;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str= """
+			package pack1;
+			
+			import java.lang.System;
+			
+			public class C {
+			    java.util.Vector.class x;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str, false, null);
 
-		int selOffset= buf.indexOf("Vector.class") + "Vector.class".length();
+		int selOffset= str.indexOf("Vector.class") + "Vector.class".length();
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
 
-		buf= new StringBuilder();
+		StringBuilder buf= new StringBuilder();
 		buf.append("package pack1;\n");
 		buf.append("\n");
 		buf.append("import java.lang.System;\n");
@@ -1346,17 +1360,18 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.System;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    String str= java.io.File.separator;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.System;
+			
+			public class C {
+			    String str= java.io.File.separator;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("separator");
+		int selOffset= str1.indexOf("separator");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1382,17 +1397,18 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.System;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    String str= java.io.File.separator;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.System;
+			
+			public class C {
+			    String str= java.io.File.separator;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("separator");
+		int selOffset= str1.indexOf("separator");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1416,15 +1432,16 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.lang.Thread.State s;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class C {
+			    java.lang.Thread.State s;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Thread");
+		int selOffset= str1.indexOf("Thread");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1444,15 +1461,16 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.lang.Thread.State s;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class C {
+			    java.lang.Thread.State s;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("State");
+		int selOffset= str1.indexOf("State");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1474,15 +1492,16 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.util.Map<String, Integer> m;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class C {
+			    java.util.Map<String, Integer> m;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Map");
+		int selOffset= str1.indexOf("Map");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1504,15 +1523,16 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.util.Map.Entry e;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class C {
+			    java.util.Map.Entry e;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Entry");
+		int selOffset= str1.indexOf("Entry");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1534,15 +1554,16 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.util.Map.Entry<String, Object> e;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class C {
+			    java.util.Map.Entry<String, Object> e;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Map");
+		int selOffset= str1.indexOf("Map");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1564,15 +1585,16 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.util.Map.Entry<String, Object> e;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			public class C {
+			    java.util.Map.Entry<String, Object> e;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Entry");
+		int selOffset= str1.indexOf("Entry");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1607,15 +1629,16 @@ public class AddImportTest extends CoreTests {
 		pack2.createCompilationUnit("Outer.java", str, false, null);
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    pack2.Outer.Middle<String>.Inner<Integer> i;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str2= """
+			package pack1;
+			
+			public class C {
+			    pack2.Outer.Middle<String>.Inner<Integer> i;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str2, false, null);
 
-		int selOffset= buf.indexOf("Middle");
+		int selOffset= str2.indexOf("Middle");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1651,15 +1674,16 @@ public class AddImportTest extends CoreTests {
 		pack2.createCompilationUnit("Outer.java", str, false, null);
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    pack2.Outer.Middle<String>.Inner<Integer> i;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str2= """
+			package pack1;
+			
+			public class C {
+			    pack2.Outer.Middle<String>.Inner<Integer> i;
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str2, false, null);
 
-		int selOffset= buf.indexOf("Inner");
+		int selOffset= str2.indexOf("Inner");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1679,19 +1703,20 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.annotation.ElementType;\n");
-		buf.append("import java.lang.annotation.Target;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.text.@A Format.@A Field f;\n");
-		buf.append("}\n");
-		buf.append("@Target(ElementType.TYPE_USE) @interface A {}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.annotation.ElementType;
+			import java.lang.annotation.Target;
+			
+			public class C {
+			    java.text.@A Format.@A Field f;
+			}
+			@Target(ElementType.TYPE_USE) @interface A {}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Format");
+		int selOffset= str1.indexOf("Format");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);
@@ -1717,19 +1742,20 @@ public class AddImportTest extends CoreTests {
 		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
 
 		IPackageFragment pack1= sourceFolder.createPackageFragment("pack1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package pack1;\n");
-		buf.append("\n");
-		buf.append("import java.lang.annotation.ElementType;\n");
-		buf.append("import java.lang.annotation.Target;\n");
-		buf.append("\n");
-		buf.append("public class C {\n");
-		buf.append("    java.text.@A Format.@A Field f;\n");
-		buf.append("}\n");
-		buf.append("@Target(ElementType.TYPE_USE) @interface A {}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
+		String str1= """
+			package pack1;
+			
+			import java.lang.annotation.ElementType;
+			import java.lang.annotation.Target;
+			
+			public class C {
+			    java.text.@A Format.@A Field f;
+			}
+			@Target(ElementType.TYPE_USE) @interface A {}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("C.java", str1, false, null);
 
-		int selOffset= buf.indexOf("Field");
+		int selOffset= str1.indexOf("Field");
 
 		AddImportsOperation op= new AddImportsOperation(cu, selOffset, 0, null, true);
 		op.run(null);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
@@ -3660,68 +3660,66 @@ public class ImportOrganizeTest extends CoreTests {
 
 	@Test
 	public void testPreserveUnresolvableTypeSingleImports() throws Exception {
-		StringBuilder classContents= new StringBuilder();
-		classContents.append("NotFound1 nf1;");
-		classContents.append("Inner1 i1;");
-
-		StringBuilder resultantImports= new StringBuilder();
-		resultantImports.append("import com.notfound.NotFound1;\n");
-		resultantImports.append("import com.notfound.OuterClass.Inner1;\n");
-
-		expectUnresolvableImportsArePreserved(classContents, resultantImports);
+		String str= """
+			NotFound1 nf1;\
+			Inner1 i1;""";
+		String str1= """
+			import com.notfound.NotFound1;
+			import com.notfound.OuterClass.Inner1;
+			""";
+		expectUnresolvableImportsArePreserved(str, str1);
 	}
 
 	@Test
 	public void testPreserveUnresolvableTypeOnDemandImports() throws Exception {
-		StringBuilder classContents= new StringBuilder();
-		classContents.append("NotFound3 nf3;");
-
-		StringBuilder resultantImports= new StringBuilder();
-		resultantImports.append("import com.notfound.*;\n");
-		resultantImports.append("import com.notfound.OuterClass.*;\n");
-
-		expectUnresolvableImportsArePreserved(classContents, resultantImports);
+		String str= """
+			NotFound3 nf3;""";
+		String str1= """
+			import com.notfound.*;
+			import com.notfound.OuterClass.*;
+			""";
+		expectUnresolvableImportsArePreserved(str, str1);
 	}
 
 	@Test
 	public void testPreserveUnresolvableStaticSingleImports() throws Exception {
-		StringBuilder classContents= new StringBuilder();
-		classContents.append("{\n");
-		classContents.append("    int a= FIELD1;\n");
-		classContents.append("    method1();\n");
-		classContents.append("}\n");
-
-		StringBuilder resultantImports= new StringBuilder();
-		resultantImports.append("import static com.notfound.Type.FIELD1;\n");
-		resultantImports.append("import static com.notfound.Type.method1;\n");
-
-		expectUnresolvableImportsArePreserved(classContents, resultantImports);
+		String str= """
+			{
+			    int a= FIELD1;
+			    method1();
+			}
+			""";
+		String str1= """
+			import static com.notfound.Type.FIELD1;
+			import static com.notfound.Type.method1;
+			""";
+		expectUnresolvableImportsArePreserved(str, str1);
 	}
 
 	@Test
 	public void testPreserveUnresolvableStaticOnDemandImportDueToFieldReference() throws Exception {
-		StringBuilder classContents= new StringBuilder();
-		classContents.append("{\n");
-		classContents.append("    int a= FIELD3;\n");
-		classContents.append("}\n");
-
-		StringBuilder resultantImports= new StringBuilder();
-		resultantImports.append("import static com.notfound.Type.*;\n");
-
-		expectUnresolvableImportsArePreserved(classContents, resultantImports);
+		String str= """
+			{
+			    int a= FIELD3;
+			}
+			""";
+		String str1= """
+			import static com.notfound.Type.*;
+			""";
+		expectUnresolvableImportsArePreserved(str, str1);
 	}
 
 	@Test
 	public void testPreserveUnresolvableStaticOnDemandImportDueToMethodReference() throws Exception {
-		StringBuilder classContents= new StringBuilder();
-		classContents.append("{\n");
-		classContents.append("    method3();\n");
-		classContents.append("}\n");
-
-		StringBuilder resultantImports= new StringBuilder();
-		resultantImports.append("import static com.notfound.Type.*;\n");
-
-		expectUnresolvableImportsArePreserved(classContents, resultantImports);
+		String str= """
+			{
+			    method3();
+			}
+			""";
+		String str1= """
+			import static com.notfound.Type.*;
+			""";
+		expectUnresolvableImportsArePreserved(str, str1);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/MethodOverrideTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/MethodOverrideTest1d8.java
@@ -65,24 +65,25 @@ public class MethodOverrideTest1d8 extends MethodOverrideTest {
 	@Test
 	public void overrideLambda1() throws Exception {
 		IPackageFragment pack1= fSrc.createPackageFragment("test1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("public interface MyFunction<T, R> {\n");
-		buf.append("    R apply(T t);\n");
-		buf.append("    default <V> MyFunction<V, R> compose(MyFunction<? super V, ? extends T> before) {\n");
-		buf.append("        return (V v) -> apply(before.apply(v));\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("MyFunction.java", buf.toString(), false, null);
+		String str= """
+			package test1;
+			public interface MyFunction<T, R> {
+			    R apply(T t);
+			    default <V> MyFunction<V, R> compose(MyFunction<? super V, ? extends T> before) {
+			        return (V v) -> apply(before.apply(v));
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("MyFunction.java", str, false, null);
 
 		CompilationUnit root= assertNoCompilationError(cu);
 		IType focusType= cu.getTypes()[0];
 
-		int vStart= buf.indexOf("v))");
+		int vStart= str.indexOf("v))");
 		ILocalVariable v= (ILocalVariable) cu.codeSelect(vStart, 1)[0];
 		IType overridingType= v.getDeclaringMember().getDeclaringType();
 
-		LambdaExpression lambda= (LambdaExpression) NodeFinder.perform(root, buf.indexOf("->"), 2);
+		LambdaExpression lambda= (LambdaExpression) NodeFinder.perform(root, str.indexOf("->"), 2);
 		ITypeBinding overridingTypeBinding= lambda.resolveTypeBinding();
 
 		IType overriddenType= focusType;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateConstructorUsingFieldsTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateConstructorUsingFieldsTest.java
@@ -170,43 +170,46 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 //		"", true, null);
 
 		IPackageFragment packageQ= fRoot.createPackageFragment("q", true, null);
-		packageQ.createCompilationUnit("B.java", "package p;\r\n" +
-		"\r\n" +
-		"public class B {\r\n" +
-		"\r\n" +
-		"}\r\n" +
-		"", true, null);
+		packageQ.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-		"\r\n" +
-		"public class A {\r\n" +
-		"	q.B field1;\r\n" +
-		"	B field2;\r\n" +
-		"}\r\n" +
-		"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				q.B field1;\r
+				B field2;\r
+			}\r
+			""", true, null);
 
 		IField f1= a.getType("A").getField("field1");
 		IField f2= a.getType("A").getField("field2");
 
 		runOperation(a.getType("A"), new IField[] { f1, f2 }, null);
 
-		compareSource("package p;\r\n" +
-		"\r\n" +
-		"public class A {\r\n" +
-		"	q.B field1;\r\n" +
-		"	B field2;\r\n" +
-		"	/**\r\n" +
-		"	 * @param field1\r\n" +
-		"	 * @param field2\r\n" +
-		"	 */\r\n" +
-		"	public A(q.B field1, B field2) {\r\n" +
-		"		super();\r\n" +
-		"		// TODO Auto-generated constructor stub\r\n" +
-		"		this.field1 = field1;\r\n" +
-		"		this.field2 = field2;\r\n" +
-		"	}\r\n" +
-		"}\r\n" +
-		"", a.getSource());
+		compareSource("""
+			package p;\r
+			\r
+			public class A {\r
+				q.B field1;\r
+				B field2;\r
+				/**\r
+				 * @param field1\r
+				 * @param field2\r
+				 */\r
+				public A(q.B field1, B field2) {\r
+					super();\r
+					// TODO Auto-generated constructor stub\r
+					this.field1 = field1;\r
+					this.field2 = field2;\r
+				}\r
+			}\r
+			""", a.getSource());
 	}
 
 	/**
@@ -227,27 +230,28 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 						A beforeHandThirdField;\r
 					}""",
 
-				"package p;\r\n" +
-				"\r\n" +
-				"import java.util.List;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	String firstField;\r\n" +
-				"	List secondField;\r\n" +
-				"	A beforeHandThirdField;\r\n" +
-				"	/**\r\n" +
-				"	 * @param firstField\r\n" +
-				"	 * @param secondField\r\n" +
-				"	 * @param beforeHandThirdField\r\n" +
-				"	 */\r\n" +
-				"	public A(String firstField, List secondField, A beforeHandThirdField) {\r\n" +
-				"		super();\r\n" +
-				"		this.firstField = firstField;\r\n" +
-				"		this.secondField = secondField;\r\n" +
-				"		this.beforeHandThirdField = beforeHandThirdField;\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-		"");
+				"""
+					package p;\r
+					\r
+					import java.util.List;\r
+					\r
+					public class A {\r
+						String firstField;\r
+						List secondField;\r
+						A beforeHandThirdField;\r
+						/**\r
+						 * @param firstField\r
+						 * @param secondField\r
+						 * @param beforeHandThirdField\r
+						 */\r
+						public A(String firstField, List secondField, A beforeHandThirdField) {\r
+							super();\r
+							this.firstField = firstField;\r
+							this.secondField = secondField;\r
+							this.beforeHandThirdField = beforeHandThirdField;\r
+						}\r
+					}\r
+					""");
 	}
 
 	/**
@@ -384,12 +388,13 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 	@Test
 	public void test08() throws Exception {
 
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
 		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
 			package p;\r
@@ -532,27 +537,29 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 	@Test
 	public void test12() throws Exception {
 
-		ICompilationUnit unit= fPackageP.createCompilationUnit("SuperA.java", "package p;\r\n" +
-				"\r\n" +
-				"public class SuperA {\r\n" +
-				"	\r\n" +
-				"	public SuperA() {};\r\n" +
-				"	public SuperA(String a, String b) {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit unit= fPackageP.createCompilationUnit("SuperA.java", """
+			package p;\r
+			\r
+			public class SuperA {\r
+				\r
+				public SuperA() {};\r
+				public SuperA(String a, String b) {}\r
+			\r
+			}\r
+			""", true, null);
 
 		IMethod superConstructor= unit.getType("SuperA").getMethod("SuperA", new String[] { "QString;", "QString;" });
 
 		runIt("A", new String[] { "a", "b" }, superConstructor,
-				"package p;\r\n" +
-				"\r\n" +
-				"public class A extends SuperA {\r\n" +
-				"	\r\n" +
-				"	String a;\r\n" +
-				"	String b;\r\n" +
-				"}\r\n" +
-				"",
+				"""
+					package p;\r
+					\r
+					public class A extends SuperA {\r
+						\r
+						String a;\r
+						String b;\r
+					}\r
+					""",
 
 				"""
 					package p;\r
@@ -581,31 +588,33 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 	@Test
 	public void test13() throws Exception {
 
-		ICompilationUnit unit= fPackageP.createCompilationUnit("SuperA.java", "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Map;\r\n" +
-				"\r\n" +
-				"public class SuperA {\r\n" +
-				"	\r\n" +
-				"	private Map<String, A> someMap;\r\n" +
-				"\r\n" +
-				"	public SuperA() {}\r\n" +
-				"\r\n" +
-				"	public SuperA(Map<String, A> someMap) {\r\n" +
-				"		this.someMap = someMap;\r\n" +
-				"	};\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit unit= fPackageP.createCompilationUnit("SuperA.java", """
+			package p;\r
+			\r
+			import java.util.Map;\r
+			\r
+			public class SuperA {\r
+				\r
+				private Map<String, A> someMap;\r
+			\r
+				public SuperA() {}\r
+			\r
+				public SuperA(Map<String, A> someMap) {\r
+					this.someMap = someMap;\r
+				};\r
+			}\r
+			""", true, null);
 
 		IMethod superConstructor= unit.getType("SuperA").getMethod("SuperA", new String[] { "QMap<QString;QA;>;" });
 
 		runIt("A", new String[] { "field" }, superConstructor,
-				"package p;\r\n" +
-				"\r\n" +
-				"public class A extends SuperA {\r\n" +
-				"	String field;\r\n" +
-				"}\r\n" +
-				"",
+				"""
+					package p;\r
+					\r
+					public class A extends SuperA {\r
+						String field;\r
+					}\r
+					""",
 
 				"""
 					package p;\r
@@ -632,15 +641,16 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 	@Test
 	public void test14() throws Exception {
 
-		ICompilationUnit unit= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A  {\r\n" +
-				"	\r\n" +
-				"	class B {\r\n" +
-				"		A b;\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit unit= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A  {\r
+				\r
+				class B {\r
+					A b;\r
+				}\r
+			}\r
+			""", true, null);
 
 		IType innerType= unit.getType("A").getType("B");
 		IField field= innerType.getField("b");
@@ -684,23 +694,24 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 
 		runOperation(secondary, new IField[] { foo }, null);
 
-		compareSource("package p;\r\n" +
-				"\r\n" +
-				"public class A  {\r\n" +
-				"}\r\n" +
-				"\r\n" +
-				"class B {\r\n" +
-				"	A foo;\r\n" +
-				"\r\n" +
-				"	/**\r\n" +
-				"	 * @param foo\r\n" +
-				"	 */\r\n" +
-				"	public B(A foo) {\r\n" +
-				"		super();\r\n" +
-				"		this.foo = foo;\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", unit.getSource());
+		compareSource("""
+			package p;\r
+			\r
+			public class A  {\r
+			}\r
+			\r
+			class B {\r
+				A foo;\r
+			\r
+				/**\r
+				 * @param foo\r
+				 */\r
+				public B(A foo) {\r
+					super();\r
+					this.foo = foo;\r
+				}\r
+			}\r
+			""", unit.getSource());
 	}
 	@Test
 	public void test16() throws Exception {  // https://bugs.eclipse.org/bugs/show_bug.cgi?id=552556

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateDelegateMethodsTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateDelegateMethodsTest.java
@@ -110,42 +110,45 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test01() throws Exception {
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	\r\n" +
-				"	public void foo_b() {}\r\n" +
-				"	public void bar_b() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				\r
+				public void foo_b() {}\r
+				public void bar_b() {}\r
+			\r
+			}\r
+			""", true, null);
 
 		IMethod foo_b= b.getType("B").getMethod("foo_b", new String[0]);
 		IMethod bar_b= b.getType("B").getMethod("bar_b", new String[0]);
 
-		ICompilationUnit c= fPackageP.createCompilationUnit("C.java", "package p;\r\n" +
-				"\r\n" +
-				"public class C {\r\n" +
-				"	\r\n" +
-				"	public void foo_c() {}\r\n" +
-				"	public void bar_c() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit c= fPackageP.createCompilationUnit("C.java", """
+			package p;\r
+			\r
+			public class C {\r
+				\r
+				public void foo_c() {}\r
+				public void bar_c() {}\r
+			\r
+			}\r
+			""", true, null);
 
 		IMethod foo_c= c.getType("C").getMethod("foo_c", new String[0]);
 		IMethod bar_c= c.getType("C").getMethod("bar_c", new String[0]);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"\r\n" +
-				"	B b1;\r\n" +
-				"	B b2;\r\n" +
-				"	C c1;\r\n" +
-				"	C c2;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				B b1;\r
+				B b2;\r
+				C c1;\r
+				C c2;\r
+			}\r
+			""", true, null);
 
 		IField b1= a.getType("A").getField("b1");
 		IField b2= a.getType("A").getField("b2");
@@ -198,46 +201,49 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test02() throws Exception {
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	\r\n" +
-				"	public void foo_b() {}\r\n" +
-				"	public void bar_b() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				\r
+				public void foo_b() {}\r
+				public void bar_b() {}\r
+			\r
+			}\r
+			""", true, null);
 
 		IMethod foo_b= b.getType("B").getMethod("foo_b", new String[0]);
 		IMethod bar_b= b.getType("B").getMethod("bar_b", new String[0]);
 
-		ICompilationUnit c= fPackageP.createCompilationUnit("C.java", "package p;\r\n" +
-				"\r\n" +
-				"public class C {\r\n" +
-				"	\r\n" +
-				"	public void foo_c() {}\r\n" +
-				"	public void bar_c() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit c= fPackageP.createCompilationUnit("C.java", """
+			package p;\r
+			\r
+			public class C {\r
+				\r
+				public void foo_c() {}\r
+				public void bar_c() {}\r
+			\r
+			}\r
+			""", true, null);
 
 		IMethod foo_c= c.getType("C").getMethod("foo_c", new String[0]);
 		IMethod bar_c= c.getType("C").getMethod("bar_c", new String[0]);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"\r\n" +
-				"	B b1;\r\n" +
-				"	B b2;\r\n" +
-				"	C c1;\r\n" +
-				"	C c2;\r\n" +
-				"	\r\n" +
-				"	public void foo2() {}\r\n" +
-				"	\r\n" +
-				"	public void foo3() {}\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				B b1;\r
+				B b2;\r
+				C c1;\r
+				C c2;\r
+				\r
+				public void foo2() {}\r
+				\r
+				public void foo3() {}\r
+			}\r
+			""", true, null);
 
 		IField b1= a.getType("A").getField("b1");
 		IField b2= a.getType("A").getField("b2");
@@ -248,48 +254,49 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), new IField[] { b1, b2, c1, c2 }, new IMethod[] { foo_b, bar_b, foo_c, bar_c } , insertBefore, true);
 
-		String expected= "package p;\r\n" +
-		"\r\n" +
-		"public class A {\r\n" +
-		"\r\n" +
-		"	B b1;\r\n" +
-		"	B b2;\r\n" +
-		"	C c1;\r\n" +
-		"	C c2;\r\n" +
-		"	\r\n" +
-		"	public void foo2() {}\r\n" +
-		"	\r\n" +
-		"	/* (non-Javadoc)\r\n" +
-		"	 * @see p.B#foo_b()\r\n" +
-		"	 */\r\n" +
-		"	public void foo_b() {\r\n" +
-		"		b1.foo_b();\r\n" +
-		"	}\r\n" +
-		"\r\n" +
-		"	/* (non-Javadoc)\r\n" +
-		"	 * @see p.B#bar_b()\r\n" +
-		"	 */\r\n" +
-		"	public void bar_b() {\r\n" +
-		"		b2.bar_b();\r\n" +
-		"	}\r\n" +
-		"\r\n" +
-		"	/* (non-Javadoc)\r\n" +
-		"	 * @see p.C#foo_c()\r\n" +
-		"	 */\r\n" +
-		"	public void foo_c() {\r\n" +
-		"		c1.foo_c();\r\n" +
-		"	}\r\n" +
-		"\r\n" +
-		"	/* (non-Javadoc)\r\n" +
-		"	 * @see p.C#bar_c()\r\n" +
-		"	 */\r\n" +
-		"	public void bar_c() {\r\n" +
-		"		c2.bar_c();\r\n" +
-		"	}\r\n" +
-		"\r\n" +
-		"	public void foo3() {}\r\n" +
-		"}\r\n" +
-		"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				B b1;\r
+				B b2;\r
+				C c1;\r
+				C c2;\r
+				\r
+				public void foo2() {}\r
+				\r
+				/* (non-Javadoc)\r
+				 * @see p.B#foo_b()\r
+				 */\r
+				public void foo_b() {\r
+					b1.foo_b();\r
+				}\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.B#bar_b()\r
+				 */\r
+				public void bar_b() {\r
+					b2.bar_b();\r
+				}\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.C#foo_c()\r
+				 */\r
+				public void foo_c() {\r
+					c1.foo_c();\r
+				}\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.C#bar_c()\r
+				 */\r
+				public void bar_c() {\r
+					c2.bar_c();\r
+				}\r
+			\r
+				public void foo3() {}\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -301,55 +308,59 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	public void test03() throws Exception {
 
 		IPackageFragment packageSomeOtherPackage= fRoot.createPackageFragment("someOtherPackage", true, null);
-		packageSomeOtherPackage.createCompilationUnit("OtherClass.java", "package someOtherPackage;\r\n" +
-				"\r\n" +
-				"public class OtherClass {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		packageSomeOtherPackage.createCompilationUnit("OtherClass.java", """
+			package someOtherPackage;\r
+			\r
+			public class OtherClass {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"import someOtherPackage.OtherClass;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	\r\n" +
-				"	public OtherClass returnOtherClass() {\r\n" +
-				"		return null;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			import someOtherPackage.OtherClass;\r
+			\r
+			public class B {\r
+				\r
+				public OtherClass returnOtherClass() {\r
+					return null;\r
+				}\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	B b;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				B b;\r
+			}\r
+			""", true, null);
 
 		IField field1= a.getType("A").getField("b");
 		IMethod method1= b.getType("B").getMethod("returnOtherClass", new String[0]);
 
 		runOperation(a.getType("A"), new IField[] { field1 }, new IMethod[] { method1 });
 
-		compareSource("package p;\r\n" +
-				"\r\n" +
-				"import someOtherPackage.OtherClass;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	B b;\r\n" +
-				"\r\n" +
-				"	/* (non-Javadoc)\r\n" +
-				"	 * @see p.B#returnOtherClass()\r\n" +
-				"	 */\r\n" +
-				"	public OtherClass returnOtherClass() {\r\n" +
-				"		return b.returnOtherClass();\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", a.getSource());
+		compareSource("""
+			package p;\r
+			\r
+			import someOtherPackage.OtherClass;\r
+			\r
+			public class A {\r
+				\r
+				B b;\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.B#returnOtherClass()\r
+				 */\r
+				public OtherClass returnOtherClass() {\r
+					return b.returnOtherClass();\r
+				}\r
+			}\r
+			""", a.getSource());
 	}
 
 	/**
@@ -358,19 +369,20 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test04() throws Exception {
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B<E> {\r\n" +
-				"	\r\n" +
-				"	public E get() {\r\n" +
-				"		return null;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	public void set(E e) {\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B<E> {\r
+				\r
+				public E get() {\r
+					return null;\r
+				}\r
+			\r
+				public void set(E e) {\r
+				}\r
+			\r
+			}\r
+			""", true, null);
 
 		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
 			package p;\r
@@ -417,44 +429,47 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test05() throws Exception {
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	\r\n" +
-				"	public <E> E getSome(E e) {\r\n" +
-				"		return e;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				\r
+				public <E> E getSome(E e) {\r
+					return e;\r
+				}\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	B someField;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				B someField;\r
+			}\r
+			""", true, null);
 
 		IField field= a.getType("A").getField("someField");
 		IMethod sMethod= b.getType("B").getMethod("getSome", new String[] { "QE;" });
 
 		runOperation(a.getType("A"), new IField[] { field } , new IMethod[] { sMethod });
 
-		compareSource("package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	B someField;\r\n" +
-				"\r\n" +
-				"	/* (non-Javadoc)\r\n" +
-				"	 * @see p.B#getSome(java.lang.Object)\r\n" +
-				"	 */\r\n" +
-				"	public <E> E getSome(E e) {\r\n" +
-				"		return someField.getSome(e);\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", a.getSource());
+		compareSource("""
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				B someField;\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.B#getSome(java.lang.Object)\r
+				 */\r
+				public <E> E getSome(E e) {\r
+					return someField.getSome(e);\r
+				}\r
+			}\r
+			""", a.getSource());
 	}
 
 	/**
@@ -464,25 +479,27 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test06() throws Exception {
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	\r\n" +
-				"	static enum SomeEnum { X, Y };\r\n" +
-				"	\r\n" +
-				"	public SomeEnum getIt() {\r\n" +
-				"		return SomeEnum.X;\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				\r
+				static enum SomeEnum { X, Y };\r
+				\r
+				public SomeEnum getIt() {\r
+					return SomeEnum.X;\r
+				}\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	B someField;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				B someField;\r
+			}\r
+			""", true, null);
 
 		IField field= a.getType("A").getField("someField");
 		IMethod sMethod= b.getType("B").getMethod("getIt", new String[0]);
@@ -533,26 +550,27 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 
 		runOperation(a.getType("A").getType("C"), new IField[] { fieldSome }, new IMethod[] { method });
 
-		compareSource("package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"\r\n" +
-				"	class C {\r\n" +
-				"		\r\n" +
-				"		A some;\r\n" +
-				"\r\n" +
-				"		/* (non-Javadoc)\r\n" +
-				"		 * @see p.A#foo()\r\n" +
-				"		 */\r\n" +
-				"		public void foo() {\r\n" +
-				"			some.foo();\r\n" +
-				"		}\r\n" +
-				"	}\r\n" +
-				"	\r\n" +
-				"	public void foo() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", a.getSource());
+		compareSource("""
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				class C {\r
+					\r
+					A some;\r
+			\r
+					/* (non-Javadoc)\r
+					 * @see p.A#foo()\r
+					 */\r
+					public void foo() {\r
+						some.foo();\r
+					}\r
+				}\r
+				\r
+				public void foo() {}\r
+			\r
+			}\r
+			""", a.getSource());
 	}
 
 	/**
@@ -605,14 +623,15 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test09() throws Exception {
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	\r\n" +
-				"	public void foo() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				\r
+				public void foo() {}\r
+			\r
+			}\r
+			""", true, null);
 
 		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
 			package p;\r
@@ -652,16 +671,17 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test10() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public void foo() {}\r\n" +
-				"}\r\n" +
-				"\r\n" +
-				"class SecondaryClass {\r\n" +
-				"	A someField;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				public void foo() {}\r
+			}\r
+			\r
+			class SecondaryClass {\r
+				A someField;\r
+			}\r
+			""", true, null);
 
 		IType secondaryType= (IType)a.getElementAt(70);
 		IField someField= secondaryType.getField("someField");
@@ -669,23 +689,24 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 
 		runOperation(secondaryType, new IField[] { someField }, new IMethod[] { theMethod });
 
-		compareSource("package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public void foo() {}\r\n" +
-				"}\r\n" +
-				"\r\n" +
-				"class SecondaryClass {\r\n" +
-				"	A someField;\r\n" +
-				"\r\n" +
-				"	/* (non-Javadoc)\r\n" +
-				"	 * @see p.A#foo()\r\n" +
-				"	 */\r\n" +
-				"	public void foo() {\r\n" +
-				"		someField.foo();\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", a.getSource());
+		compareSource("""
+			package p;\r
+			\r
+			public class A {\r
+				public void foo() {}\r
+			}\r
+			\r
+			class SecondaryClass {\r
+				A someField;\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.A#foo()\r
+				 */\r
+				public void foo() {\r
+					someField.foo();\r
+				}\r
+			}\r
+			""", a.getSource());
 	}
 
 	/**
@@ -694,19 +715,20 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 	@Test
 	public void test11() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public void foo() {\r\n" +
-				"	}\r\n" +
-				"	public final void bar() {\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"\r\n" +
-				"class SecondardClass {\r\n" +
-				"	A someField;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				public void foo() {\r
+				}\r
+				public final void bar() {\r
+				}\r
+			}\r
+			\r
+			class SecondardClass {\r
+				A someField;\r
+			}\r
+			""", true, null);
 
 		IType secondaryType= (IType)a.getElementAt(110);
 		IField someField= secondaryType.getField("someField");
@@ -715,33 +737,34 @@ public class GenerateDelegateMethodsTest extends SourceTestCase {
 
 		runOperation(secondaryType, new IField[] { someField, someField }, new IMethod[] { firstMethod, secondMethod });
 
-		compareSource("package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public void foo() {\r\n" +
-				"	}\r\n" +
-				"	public final void bar() {\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"\r\n" +
-				"class SecondardClass {\r\n" +
-				"	A someField;\r\n" +
-				"\r\n" +
-				"	/* (non-Javadoc)\r\n" +
-				"	 * @see p.A#foo()\r\n" +
-				"	 */\r\n" +
-				"	public void foo() {\r\n" +
-				"		someField.foo();\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	/* (non-Javadoc)\r\n" +
-				"	 * @see p.A#bar()\r\n" +
-				"	 */\r\n" +
-				"	public final void bar() {\r\n" +
-				"		someField.bar();\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", a.getSource());
+		compareSource("""
+			package p;\r
+			\r
+			public class A {\r
+				public void foo() {\r
+				}\r
+				public final void bar() {\r
+				}\r
+			}\r
+			\r
+			class SecondardClass {\r
+				A someField;\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.A#foo()\r
+				 */\r
+				public void foo() {\r
+					someField.foo();\r
+				}\r
+			\r
+				/* (non-Javadoc)\r
+				 * @see p.A#bar()\r
+				 */\r
+				public final void bar() {\r
+					someField.bar();\r
+				}\r
+			}\r
+			""", a.getSource());
 	}
 
 	/**

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateGettersSettersTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateGettersSettersTest.java
@@ -703,13 +703,14 @@ public class GenerateGettersSettersTest extends SourceTestCase {
 	@Test
 	public void test10() throws Exception {
 
-		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"	private float c, d, e = 0;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit b= fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+				private float c, d, e = 0;\r
+			}\r
+			""", true, null);
 
 		IType classB= b.getType("B");
 		IField field1= classB.getField("d");

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateHashCodeEqualsTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateHashCodeEqualsTest.java
@@ -119,64 +119,65 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 		IField[] fields= getFields(a.getType("A"), new String[] {"aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "anEnum" });
 		runOperation(a.getType("A"), fields, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	java.lang.annotation.ElementType anEnum;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + (aBool ? 1231 : 1237);\r\n" +
-				"		result = prime * result + aByte;\r\n" +
-				"		result = prime * result + aChar;\r\n" +
-				"		result = prime * result + anInt;\r\n" +
-				"		long temp;\r\n" +
-				"		temp = Double.doubleToLongBits(aDouble);\r\n" +
-				"		result = prime * result + (int) (temp ^ (temp >>> 32));\r\n" +
-				"		result = prime * result + Float.floatToIntBits(aFloat);\r\n" +
-				"		result = prime * result + (int) (aLong ^ (aLong >>> 32));\r\n" +
-				"		result = prime * result + ((anEnum == null) ? 0 : anEnum.hashCode());\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (aBool != other.aBool)\r\n" +
-				"			return false;\r\n" +
-				"		if (aByte != other.aByte)\r\n" +
-				"			return false;\r\n" +
-				"		if (aChar != other.aChar)\r\n" +
-				"			return false;\r\n" +
-				"		if (anInt != other.anInt)\r\n" +
-				"			return false;\r\n" +
-				"		if (Double.doubleToLongBits(aDouble) != Double.doubleToLongBits(other.aDouble))\r\n" +
-				"			return false;\r\n" +
-				"		if (Float.floatToIntBits(aFloat) != Float.floatToIntBits(other.aFloat))\r\n" +
-				"			return false;\r\n" +
-				"		if (aLong != other.aLong)\r\n" +
-				"			return false;\r\n" +
-				"		if (anEnum != other.anEnum)\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				java.lang.annotation.ElementType anEnum;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + (aBool ? 1231 : 1237);\r
+					result = prime * result + aByte;\r
+					result = prime * result + aChar;\r
+					result = prime * result + anInt;\r
+					long temp;\r
+					temp = Double.doubleToLongBits(aDouble);\r
+					result = prime * result + (int) (temp ^ (temp >>> 32));\r
+					result = prime * result + Float.floatToIntBits(aFloat);\r
+					result = prime * result + (int) (aLong ^ (aLong >>> 32));\r
+					result = prime * result + ((anEnum == null) ? 0 : anEnum.hashCode());\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (aBool != other.aBool)\r
+						return false;\r
+					if (aByte != other.aByte)\r
+						return false;\r
+					if (aChar != other.aChar)\r
+						return false;\r
+					if (anInt != other.anInt)\r
+						return false;\r
+					if (Double.doubleToLongBits(aDouble) != Double.doubleToLongBits(other.aDouble))\r
+						return false;\r
+					if (Float.floatToIntBits(aFloat) != Float.floatToIntBits(other.aFloat))\r
+						return false;\r
+					if (aLong != other.aLong)\r
+						return false;\r
+					if (anEnum != other.anEnum)\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -187,55 +188,58 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test02() throws Exception {
 
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"	\r\n" +
-				"	boolean aBool;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A extends B {\r
+				\r
+				boolean aBool;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"aBool" });
 		runOperation(a.getType("A"), fields, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"	\r\n" +
-				"	boolean aBool;\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + (aBool ? 1231 : 1237);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (aBool != other.aBool)\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A extends B {\r
+				\r
+				boolean aBool;\r
+			\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + (aBool ? 1231 : 1237);\r
+					return result;\r
+				}\r
+			\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (aBool != other.aBool)\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -246,64 +250,67 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test03() throws Exception {
 
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				A anA;\r
+				B aB;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"anA", "aB" });
 		runOperation(a.getType("A"), fields, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r\n" +
-				"		result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (anA == null) {\r\n" +
-				"			if (other.anA != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!anA.equals(other.anA))\r\n" +
-				"			return false;\r\n" +
-				"		if (aB == null) {\r\n" +
-				"			if (other.aB != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!aB.equals(other.aB))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				A anA;\r
+				B aB;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r
+					result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (anA == null) {\r
+						if (other.anA != null)\r
+							return false;\r
+					} else if (!anA.equals(other.anA))\r
+						return false;\r
+					if (aB == null) {\r
+						if (other.aB != null)\r
+							return false;\r
+					} else if (!aB.equals(other.aB))\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -314,64 +321,67 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test04() throws Exception {
 
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A extends B {\r
+				\r
+				A anA;\r
+				B aB;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"anA", "aB" });
 		runOperation(a.getType("A"), fields, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r\n" +
-				"		result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (anA == null) {\r\n" +
-				"			if (other.anA != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!anA.equals(other.anA))\r\n" +
-				"			return false;\r\n" +
-				"		if (aB == null) {\r\n" +
-				"			if (other.aB != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!aB.equals(other.aB))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A extends B {\r
+				\r
+				A anA;\r
+				B aB;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r
+					result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (anA == null) {\r
+						if (other.anA != null)\r
+							return false;\r
+					} else if (!anA.equals(other.anA))\r
+						return false;\r
+					if (aB == null) {\r
+						if (other.aB != null)\r
+							return false;\r
+					} else if (!aB.equals(other.aB))\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -382,53 +392,55 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test05() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A[] someAs;\r\n" +
-				"	int[] someInts;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				A[] someAs;\r
+				int[] someInts;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"someAs", "someInts" });
 		runOperation(a.getType("A"), fields, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A[] someAs;\r\n" +
-				"	int[] someInts;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.hashCode(someAs);\r\n" +
-				"		result = prime * result + Arrays.hashCode(someInts);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (!Arrays.equals(someAs, other.someAs))\r\n" +
-				"			return false;\r\n" +
-				"		if (!Arrays.equals(someInts, other.someInts))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A {\r
+				\r
+				A[] someAs;\r
+				int[] someInts;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.hashCode(someAs);\r
+					result = prime * result + Arrays.hashCode(someInts);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (!Arrays.equals(someAs, other.someAs))\r
+						return false;\r
+					if (!Arrays.equals(someInts, other.someInts))\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -439,52 +451,54 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test06() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	int someInt;\r\n" +
-				"	\r\n" +
-				"	public void foo() {}\r\n" +
-				"	public void bar() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				int someInt;\r
+				\r
+				public void foo() {}\r
+				public void bar() {}\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"someInt" });
 		runOperation(a.getType("A"), fields, a.getType("A").getMethod("bar", new String[0]), true, false, false, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	int someInt;\r\n" +
-				"	\r\n" +
-				"	public void foo() {}\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + someInt;\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (someInt != other.someInt)\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"	public void bar() {}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				int someInt;\r
+				\r
+				public void foo() {}\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + someInt;\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (someInt != other.someInt)\r
+						return false;\r
+					return true;\r
+				}\r
+				public void bar() {}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -709,58 +723,59 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 		IField[] fields= getFields(a.getType("A"), new String[] {"aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong" });
 		runOperation(a.getType("A"), fields, true, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + (aBool ? 1231 : 1237);\r\n" +
-				"		result = prime * result + aByte;\r\n" +
-				"		result = prime * result + aChar;\r\n" +
-				"		result = prime * result + anInt;\r\n" +
-				"		long temp;\r\n" +
-				"		temp = Double.doubleToLongBits(aDouble);\r\n" +
-				"		result = prime * result + (int) (temp ^ (temp >>> 32));\r\n" +
-				"		result = prime * result + Float.floatToIntBits(aFloat);\r\n" +
-				"		result = prime * result + (int) (aLong ^ (aLong >>> 32));\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!(obj instanceof A))\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (aBool != other.aBool)\r\n" +
-				"			return false;\r\n" +
-				"		if (aByte != other.aByte)\r\n" +
-				"			return false;\r\n" +
-				"		if (aChar != other.aChar)\r\n" +
-				"			return false;\r\n" +
-				"		if (anInt != other.anInt)\r\n" +
-				"			return false;\r\n" +
-				"		if (Double.doubleToLongBits(aDouble) != Double.doubleToLongBits(other.aDouble))\r\n" +
-				"			return false;\r\n" +
-				"		if (Float.floatToIntBits(aFloat) != Float.floatToIntBits(other.aFloat))\r\n" +
-				"			return false;\r\n" +
-				"		if (aLong != other.aLong)\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + (aBool ? 1231 : 1237);\r
+					result = prime * result + aByte;\r
+					result = prime * result + aChar;\r
+					result = prime * result + anInt;\r
+					long temp;\r
+					temp = Double.doubleToLongBits(aDouble);\r
+					result = prime * result + (int) (temp ^ (temp >>> 32));\r
+					result = prime * result + Float.floatToIntBits(aFloat);\r
+					result = prime * result + (int) (aLong ^ (aLong >>> 32));\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!(obj instanceof A))\r
+						return false;\r
+					A other = (A) obj;\r
+					if (aBool != other.aBool)\r
+						return false;\r
+					if (aByte != other.aByte)\r
+						return false;\r
+					if (aChar != other.aChar)\r
+						return false;\r
+					if (anInt != other.anInt)\r
+						return false;\r
+					if (Double.doubleToLongBits(aDouble) != Double.doubleToLongBits(other.aDouble))\r
+						return false;\r
+					if (Float.floatToIntBits(aFloat) != Float.floatToIntBits(other.aFloat))\r
+						return false;\r
+					if (aLong != other.aLong)\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -771,53 +786,56 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test11() throws Exception {
 
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"	\r\n" +
-				"	boolean aBool;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A extends B {\r
+				\r
+				boolean aBool;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"aBool" });
 		runOperation(a.getType("A"), fields, true, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"	\r\n" +
-				"	boolean aBool;\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + (aBool ? 1231 : 1237);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!(obj instanceof A))\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (aBool != other.aBool)\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A extends B {\r
+				\r
+				boolean aBool;\r
+			\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + (aBool ? 1231 : 1237);\r
+					return result;\r
+				}\r
+			\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!(obj instanceof A))\r
+						return false;\r
+					A other = (A) obj;\r
+					if (aBool != other.aBool)\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -828,62 +846,65 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test12() throws Exception {
 
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				A anA;\r
+				B aB;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"anA", "aB" });
 		runOperation(a.getType("A"), fields, true, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r\n" +
-				"		result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!(obj instanceof A))\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (anA == null) {\r\n" +
-				"			if (other.anA != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!anA.equals(other.anA))\r\n" +
-				"			return false;\r\n" +
-				"		if (aB == null) {\r\n" +
-				"			if (other.aB != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!aB.equals(other.aB))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				A anA;\r
+				B aB;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r
+					result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!(obj instanceof A))\r
+						return false;\r
+					A other = (A) obj;\r
+					if (anA == null) {\r
+						if (other.anA != null)\r
+							return false;\r
+					} else if (!anA.equals(other.anA))\r
+						return false;\r
+					if (aB == null) {\r
+						if (other.aB != null)\r
+							return false;\r
+					} else if (!aB.equals(other.aB))\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -895,62 +916,65 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void test13() throws Exception {
 
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				A anA;\r
+				B aB;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"anA", "aB" });
 		runOperation(a.getType("A"), fields, true, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	A anA;\r\n" +
-				"	B aB;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r\n" +
-				"		result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!(obj instanceof A))\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (anA == null) {\r\n" +
-				"			if (other.anA != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!anA.equals(other.anA))\r\n" +
-				"			return false;\r\n" +
-				"		if (aB == null) {\r\n" +
-				"			if (other.aB != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!aB.equals(other.aB))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				A anA;\r
+				B aB;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + ((anA == null) ? 0 : anA.hashCode());\r
+					result = prime * result + ((aB == null) ? 0 : aB.hashCode());\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!(obj instanceof A))\r
+						return false;\r
+					A other = (A) obj;\r
+					if (anA == null) {\r
+						if (other.anA != null)\r
+							return false;\r
+					} else if (!anA.equals(other.anA))\r
+						return false;\r
+					if (aB == null) {\r
+						if (other.aB != null)\r
+							return false;\r
+					} else if (!aB.equals(other.aB))\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 
@@ -965,61 +989,62 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.lang.annotation.ElementType;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	ElementType anEnum;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			import java.lang.annotation.ElementType;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				ElementType anEnum;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings", "anEnum" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"import java.lang.annotation.ElementType;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	ElementType anEnum;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings, anEnum);\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && anEnum == other.anEnum;\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			import java.lang.annotation.ElementType;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				ElementType anEnum;\r
+				@Override\r
+				public int hashCode() {\r
+					return Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings, anEnum);\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && anEnum == other.anEnum;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1031,42 +1056,44 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsUniqueFieldIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"public class A {\r\n" +
-				"	String aString;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			public class A {\r
+				String aString;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aString" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Objects;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	String aString;\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return Objects.hash(aString);\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return Objects.equals(aString, other.aString);\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Objects;\r
+			\r
+			public class A {\r
+				String aString;\r
+			\r
+				@Override\r
+				public int hashCode() {\r
+					return Objects.hash(aString);\r
+				}\r
+			\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return Objects.equals(aString, other.aString);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1078,55 +1105,56 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsInstanceOfIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings" });
 		runJ7Operation(a.getType("A"), fields, true);
 
-		String expected= "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!(obj instanceof A))\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				@Override\r
+				public int hashCode() {\r
+					return Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!(obj instanceof A))\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1138,64 +1166,65 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsArrayIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	int[] anArrayOfInts;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				int[] anArrayOfInts;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings", "anArrayOfInts" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	int[] anArrayOfInts;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.hashCode(anArrayOfInts);\r\n" +
-				"		result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.equals(anArrayOfInts, other.anArrayOfInts);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.Arrays;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				int[] anArrayOfInts;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.hashCode(anArrayOfInts);\r
+					result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.equals(anArrayOfInts, other.anArrayOfInts);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1207,64 +1236,65 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsCloneableArrayIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	Cloneable[] anArrayOfCloneables;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				Cloneable[] anArrayOfCloneables;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings", "anArrayOfCloneables" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	Cloneable[] anArrayOfCloneables;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArrayOfCloneables);\r\n" +
-				"		result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfCloneables, other.anArrayOfCloneables);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.Arrays;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				Cloneable[] anArrayOfCloneables;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.deepHashCode(anArrayOfCloneables);\r
+					result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfCloneables, other.anArrayOfCloneables);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1276,66 +1306,67 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsSerializableArrayIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.io.Serializable;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	Serializable[] anArrayOfSerializables;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			import java.io.Serializable;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				Serializable[] anArrayOfSerializables;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings", "anArrayOfSerializables" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"import java.io.Serializable;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	Serializable[] anArrayOfSerializables;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArrayOfSerializables);\r\n" +
-				"		result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfSerializables, other.anArrayOfSerializables);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.Arrays;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			import java.io.Serializable;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				Serializable[] anArrayOfSerializables;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.deepHashCode(anArrayOfSerializables);\r
+					result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfSerializables, other.anArrayOfSerializables);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1347,64 +1378,65 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsObjectArrayIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	Object[] anArrayOfObjects;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				Object[] anArrayOfObjects;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings", "anArrayOfObjects" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	Object[] anArrayOfObjects;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArrayOfObjects);\r\n" +
-				"		result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfObjects, other.anArrayOfObjects);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.Arrays;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				Object[] anArrayOfObjects;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.deepHashCode(anArrayOfObjects);\r
+					result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfObjects, other.anArrayOfObjects);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1416,47 +1448,48 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsTypeVariableArrayIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.io.Serializable;\r\n" +
-				"public class A <S extends Serializable, N extends Number> {\r\n" +
-				"	S[] anArrayOfS;\r\n" +
-				"	N[] anArrayOfN;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.io.Serializable;\r
+			public class A <S extends Serializable, N extends Number> {\r
+				S[] anArrayOfS;\r
+				N[] anArrayOfN;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "anArrayOfS", "anArrayOfN" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.io.Serializable;\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"public class A <S extends Serializable, N extends Number> {\r\n" +
-				"	S[] anArrayOfS;\r\n" +
-				"	N[] anArrayOfN;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArrayOfS);\r\n" +
-				"		result = prime * result + Arrays.hashCode(anArrayOfN);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return Arrays.deepEquals(anArrayOfS, other.anArrayOfS) && Arrays.equals(anArrayOfN, other.anArrayOfN);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.io.Serializable;\r
+			import java.util.Arrays;\r
+			public class A <S extends Serializable, N extends Number> {\r
+				S[] anArrayOfS;\r
+				N[] anArrayOfN;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.deepHashCode(anArrayOfS);\r
+					result = prime * result + Arrays.hashCode(anArrayOfN);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return Arrays.deepEquals(anArrayOfS, other.anArrayOfS) && Arrays.equals(anArrayOfN, other.anArrayOfN);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1468,64 +1501,65 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsMultiArrayIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	int[][] anArrayOfInts;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				int[][] anArrayOfInts;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings", "anArrayOfInts" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	int[][] anArrayOfInts;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArrayOfInts);\r\n" +
-				"		result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfInts, other.anArrayOfInts);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.Arrays;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				int[][] anArrayOfInts;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.deepHashCode(anArrayOfInts);\r
+					result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.deepEquals(anArrayOfInts, other.anArrayOfInts);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1537,67 +1571,68 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsVariousArraysIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"import java.util.List;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	int[] anArrayOfInts;\r\n" +
-				"	String[][] anArrayOfStrings;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			import java.util.List;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				int[] anArrayOfInts;\r
+				String[][] anArrayOfStrings;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aBool", "aByte", "aChar", "anInt", "aDouble", "aFloat", "aLong", "aString", "aListOfStrings", "anArrayOfInts", "anArrayOfStrings" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"import java.util.List;\r\n" +
-				"import java.util.Objects;\r\n" +
-				"public class A {\r\n" +
-				"	boolean aBool;\r\n" +
-				"	byte aByte;\r\n" +
-				"	char aChar;\r\n" +
-				"	int anInt;\r\n" +
-				"	double aDouble;\r\n" +
-				"	float aFloat;\r\n" +
-				"	long aLong;\r\n" +
-				"	String aString;\r\n" +
-				"	List<String> aListOfStrings;\r\n" +
-				"	int[] anArrayOfInts;\r\n" +
-				"	String[][] anArrayOfStrings;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.hashCode(anArrayOfInts);\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArrayOfStrings);\r\n" +
-				"		result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.equals(anArrayOfInts, other.anArrayOfInts) && Arrays.deepEquals(anArrayOfStrings, other.anArrayOfStrings);\r\n"
-				+
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			import java.util.Arrays;\r
+			import java.util.List;\r
+			import java.util.Objects;\r
+			public class A {\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				String aString;\r
+				List<String> aListOfStrings;\r
+				int[] anArrayOfInts;\r
+				String[][] anArrayOfStrings;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.hashCode(anArrayOfInts);\r
+					result = prime * result + Arrays.deepHashCode(anArrayOfStrings);\r
+					result = prime * result + Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return aBool == other.aBool && aByte == other.aByte && aChar == other.aChar && anInt == other.anInt && Double.doubleToLongBits(aDouble) == Double.doubleToLongBits(other.aDouble) && Float.floatToIntBits(aFloat) == Float.floatToIntBits(other.aFloat) && aLong == other.aLong && Objects.equals(aString, other.aString) && Objects.equals(aListOfStrings, other.aListOfStrings) && Arrays.equals(anArrayOfInts, other.anArrayOfInts) && Arrays.deepEquals(anArrayOfStrings, other.anArrayOfStrings);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1609,46 +1644,48 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void hashCodeEqualsOnlyArraysIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"public class A {\r\n" +
-				"	int[] anArrayOfInts;\r\n" +
-				"	String[][] anArrayOfStrings;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			public class A {\r
+				int[] anArrayOfInts;\r
+				String[][] anArrayOfStrings;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "anArrayOfInts", "anArrayOfStrings" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	int[] anArrayOfInts;\r\n" +
-				"	String[][] anArrayOfStrings;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.hashCode(anArrayOfInts);\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(anArrayOfStrings);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return Arrays.equals(anArrayOfInts, other.anArrayOfInts) && Arrays.deepEquals(anArrayOfStrings, other.anArrayOfStrings);\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A {\r
+				int[] anArrayOfInts;\r
+				String[][] anArrayOfStrings;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.hashCode(anArrayOfInts);\r
+					result = prime * result + Arrays.deepHashCode(anArrayOfStrings);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return Arrays.equals(anArrayOfInts, other.anArrayOfInts) && Arrays.deepEquals(anArrayOfStrings, other.anArrayOfStrings);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1659,54 +1696,56 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void enclosingInstance() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public class Inner {\r\n" +
-				"		int x;\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				public class Inner {\r
+					int x;\r
+				}\r
+			}\r
+			""", true, null);
 
 		IType type= a.getType("A").getType("Inner");
 		IField[] fields= getFields(type, new String[] {"x" });
 		runOperation(type, fields, true, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public class Inner {\r\n" +
-				"		int x;\r\n" +
-				"\r\n" +
-				"		@Override\r\n" +
-				"		public int hashCode() {\r\n" +
-				"			final int prime = 31;\r\n" +
-				"			int result = 1;\r\n" +
-				"			result = prime * result + getEnclosingInstance().hashCode();\r\n" +
-				"			result = prime * result + x;\r\n" +
-				"			return result;\r\n" +
-				"		}\r\n" +
-				"\r\n" +
-				"		@Override\r\n" +
-				"		public boolean equals(Object obj) {\r\n" +
-				"			if (this == obj)\r\n" +
-				"				return true;\r\n" +
-				"			if (!(obj instanceof Inner))\r\n" +
-				"				return false;\r\n" +
-				"			Inner other = (Inner) obj;\r\n" +
-				"			if (!getEnclosingInstance().equals(other.getEnclosingInstance()))\r\n" +
-				"				return false;\r\n" +
-				"			if (x != other.x)\r\n" +
-				"				return false;\r\n" +
-				"			return true;\r\n" +
-				"		}\r\n" +
-				"\r\n" +
-				"		private A getEnclosingInstance() {\r\n" +
-				"			return A.this;\r\n" +
-				"		}\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				public class Inner {\r
+					int x;\r
+			\r
+					@Override\r
+					public int hashCode() {\r
+						final int prime = 31;\r
+						int result = 1;\r
+						result = prime * result + getEnclosingInstance().hashCode();\r
+						result = prime * result + x;\r
+						return result;\r
+					}\r
+			\r
+					@Override\r
+					public boolean equals(Object obj) {\r
+						if (this == obj)\r
+							return true;\r
+						if (!(obj instanceof Inner))\r
+							return false;\r
+						Inner other = (Inner) obj;\r
+						if (!getEnclosingInstance().equals(other.getEnclosingInstance()))\r
+							return false;\r
+						if (x != other.x)\r
+							return false;\r
+						return true;\r
+					}\r
+			\r
+					private A getEnclosingInstance() {\r
+						return A.this;\r
+					}\r
+				}\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1717,56 +1756,58 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void enclosingInstanceIn17() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public class Inner {\r\n" +
-				"		int x;\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				public class Inner {\r
+					int x;\r
+				}\r
+			}\r
+			""", true, null);
 
 		IType type= a.getType("A").getType("Inner");
 		IField[] fields= getFields(type, new String[] { "x" });
 		runJ7Operation(type, fields, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Objects;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	public class Inner {\r\n" +
-				"		int x;\r\n" +
-				"\r\n" +
-				"		@Override\r\n" +
-				"		public int hashCode() {\r\n" +
-				"			final int prime = 31;\r\n" +
-				"			int result = 1;\r\n" +
-				"			result = prime * result + getEnclosingInstance().hashCode();\r\n" +
-				"			result = prime * result + Objects.hash(x);\r\n" +
-				"			return result;\r\n" +
-				"		}\r\n" +
-				"\r\n" +
-				"		@Override\r\n" +
-				"		public boolean equals(Object obj) {\r\n" +
-				"			if (this == obj)\r\n" +
-				"				return true;\r\n" +
-				"			if (obj == null)\r\n" +
-				"				return false;\r\n" +
-				"			if (getClass() != obj.getClass())\r\n" +
-				"				return false;\r\n" +
-				"			Inner other = (Inner) obj;\r\n" +
-				"			if (!getEnclosingInstance().equals(other.getEnclosingInstance()))\r\n" +
-				"				return false;\r\n" +
-				"			return x == other.x;\r\n" +
-				"		}\r\n" +
-				"\r\n" +
-				"		private A getEnclosingInstance() {\r\n" +
-				"			return A.this;\r\n" +
-				"		}\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Objects;\r
+			\r
+			public class A {\r
+				public class Inner {\r
+					int x;\r
+			\r
+					@Override\r
+					public int hashCode() {\r
+						final int prime = 31;\r
+						int result = 1;\r
+						result = prime * result + getEnclosingInstance().hashCode();\r
+						result = prime * result + Objects.hash(x);\r
+						return result;\r
+					}\r
+			\r
+					@Override\r
+					public boolean equals(Object obj) {\r
+						if (this == obj)\r
+							return true;\r
+						if (obj == null)\r
+							return false;\r
+						if (getClass() != obj.getClass())\r
+							return false;\r
+						Inner other = (Inner) obj;\r
+						if (!getEnclosingInstance().equals(other.getEnclosingInstance()))\r
+							return false;\r
+						return x == other.x;\r
+					}\r
+			\r
+					private A getEnclosingInstance() {\r
+						return A.this;\r
+					}\r
+				}\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1790,47 +1831,48 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 		IField[] fields= getFields(a.getType("A"), new String[] {"aBool", "obj" });
 		runOperation(a.getType("A"), fields, null, true, false, false, true, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	\r\n" +
-				"	boolean aBool;\r\n" +
-				"	Object obj;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + (aBool ? 1231 : 1237);\r\n" +
-				"		result = prime * result + ((obj == null) ? 0 : obj.hashCode());\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj) {\r\n" +
-				"			return true;\r\n" +
-				"		}\r\n" +
-				"		if (obj == null) {\r\n" +
-				"			return false;\r\n" +
-				"		}\r\n" +
-				"		if (getClass() != obj.getClass()) {\r\n" +
-				"			return false;\r\n" +
-				"		}\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (aBool != other.aBool) {\r\n" +
-				"			return false;\r\n" +
-				"		}\r\n" +
-				"		if (this.obj == null) {\r\n" +
-				"			if (other.obj != null) {\r\n" +
-				"				return false;\r\n" +
-				"			}\r\n" +
-				"		} else if (!this.obj.equals(other.obj)) {\r\n" +
-				"			return false;\r\n" +
-				"		}\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				boolean aBool;\r
+				Object obj;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + (aBool ? 1231 : 1237);\r
+					result = prime * result + ((obj == null) ? 0 : obj.hashCode());\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj) {\r
+						return true;\r
+					}\r
+					if (obj == null) {\r
+						return false;\r
+					}\r
+					if (getClass() != obj.getClass()) {\r
+						return false;\r
+					}\r
+					A other = (A) obj;\r
+					if (aBool != other.aBool) {\r
+						return false;\r
+					}\r
+					if (this.obj == null) {\r
+						if (other.obj != null) {\r
+							return false;\r
+						}\r
+					} else if (!this.obj.equals(other.obj)) {\r
+						return false;\r
+					}\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1840,66 +1882,69 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	 */
 	@Test
 	public void subTypeAndArraysIn14() throws Exception {
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return 1;\r\n" +
-				"	}\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		return obj instanceof B;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				public int hashCode() {\r
+					return 1;\r
+				}\r
+				public boolean equals(Object obj) {\r
+					return obj instanceof B;\r
+				}\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"\r\n" +
-				"	A[] anArray;\r\n" +
-				"	double[] anDArray;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A extends B {\r
+			\r
+				A[] anArray;\r
+				double[] anDArray;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"anArray", "anDArray"});
 		runOperation(a.getType("A"), fields, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"\r\n" +
-				"	A[] anArray;\r\n" +
-				"	double[] anDArray;\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = super.hashCode();\r\n" +
-				"		result = prime * result + Arrays.hashCode(anArray);\r\n" +
-				"		result = prime * result + Arrays.hashCode(anDArray);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!super.equals(obj))\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (!Arrays.equals(anArray, other.anArray))\r\n" +
-				"			return false;\r\n" +
-				"		if (!Arrays.equals(anDArray, other.anDArray))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A extends B {\r
+			\r
+				A[] anArray;\r
+				double[] anDArray;\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = super.hashCode();\r
+					result = prime * result + Arrays.hashCode(anArray);\r
+					result = prime * result + Arrays.hashCode(anDArray);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!super.equals(obj))\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (!Arrays.equals(anArray, other.anArray))\r
+						return false;\r
+					if (!Arrays.equals(anDArray, other.anDArray))\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1909,61 +1954,64 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	 */
 	@Test
 	public void subTypeIn17() throws Exception {
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return 1;\r\n" +
-				"	}\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		return obj instanceof B;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				public int hashCode() {\r
+					return 1;\r
+				}\r
+				public boolean equals(Object obj) {\r
+					return obj instanceof B;\r
+				}\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"\r\n" +
-				"	String aString;\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A extends B {\r
+			\r
+				String aString;\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "aString" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Objects;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"\r\n" +
-				"	String aString;\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = super.hashCode();\r\n" +
-				"		result = prime * result + Objects.hash(aString);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!super.equals(obj))\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return Objects.equals(aString, other.aString);\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Objects;\r
+			\r
+			public class A extends B {\r
+			\r
+				String aString;\r
+			\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = super.hashCode();\r
+					result = prime * result + Objects.hash(aString);\r
+					return result;\r
+				}\r
+			\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!super.equals(obj))\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return Objects.equals(aString, other.aString);\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -1973,41 +2021,43 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	 * (https://bugs.eclipse.org/bugs/show_bug.cgi?id=561517)
 	 */
 	public void otherFieldIn17() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	private String other;\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+				private String other;\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] { "other" });
 		runJ7Operation(a.getType("A"), fields, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Objects;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"	private String other;\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return Objects.hash(other);\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		return Objects.equals(this.other, other.other);\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Objects;\r
+			\r
+			public class A {\r
+				private String other;\r
+			\r
+				@Override\r
+				public int hashCode() {\r
+					return Objects.hash(other);\r
+				}\r
+			\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					return Objects.equals(this.other, other.other);\r
+				}\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -2017,48 +2067,51 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	 */
 	@Test
 	public void subTypeNoFields() throws Exception {
-		fPackageP.createCompilationUnit("B.java", "package p;\r\n" +
-				"\r\n" +
-				"public class B {\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return 1;\r\n" +
-				"	}\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		return obj instanceof B;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		fPackageP.createCompilationUnit("B.java", """
+			package p;\r
+			\r
+			public class B {\r
+				public int hashCode() {\r
+					return 1;\r
+				}\r
+				public boolean equals(Object obj) {\r
+					return obj instanceof B;\r
+				}\r
+			\r
+			}\r
+			""", true, null);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A extends B {\r
+			}\r
+			""", true, null);
 
 		runOperation(a.getType("A"), new IField[0], false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"public class A extends B {\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		return super.hashCode();\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (!super.equals(obj))\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"}\r\n" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			public class A extends B {\r
+			\r
+				@Override\r
+				public int hashCode() {\r
+					return super.hashCode();\r
+				}\r
+			\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (!super.equals(obj))\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					return true;\r
+				}\r
+			}\r
+			""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -2126,57 +2179,57 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	@Test
 	public void abstractSuperMethods() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"abstract class Super {\r\n" +
-				"	public abstract int hashCode();\r\n" +
-				"	public abstract boolean equals(Object other);\r\n" +
-				"}\r\n" +
-				"\r\n" +
-				"class Sub extends Super {\r\n" +
-				"	String name;\r\n" +
-				"}" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			abstract class Super {\r
+				public abstract int hashCode();\r
+				public abstract boolean equals(Object other);\r
+			}\r
+			\r
+			class Sub extends Super {\r
+				String name;\r
+			}""", true, null);
 
 		IField[] fields= getFields(a.getType("Sub"), new String[] {"name" });
 		runOperation(a.getType("Sub"), fields, null, false, false, false, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"abstract class Super {\r\n" +
-				"	public abstract int hashCode();\r\n" +
-				"	public abstract boolean equals(Object other);\r\n" +
-				"}\r\n" +
-				"\r\n" +
-				"class Sub extends Super {\r\n" +
-				"	String name;\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + ((name == null) ? 0 : name.hashCode());\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		Sub other = (Sub) obj;\r\n" +
-				"		if (name == null) {\r\n" +
-				"			if (other.name != null)\r\n" +
-				"				return false;\r\n" +
-				"		} else if (!name.equals(other.name))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"}" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			abstract class Super {\r
+				public abstract int hashCode();\r
+				public abstract boolean equals(Object other);\r
+			}\r
+			\r
+			class Sub extends Super {\r
+				String name;\r
+			\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + ((name == null) ? 0 : name.hashCode());\r
+					return result;\r
+				}\r
+			\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					Sub other = (Sub) obj;\r
+					if (name == null) {\r
+						if (other.name != null)\r
+							return false;\r
+					} else if (!name.equals(other.name))\r
+						return false;\r
+					return true;\r
+				}\r
+			}""";
 
 		compareSource(expected, a.getSource());
 	}
@@ -2189,53 +2242,54 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 	 */
 	@Test
 	public void arraysDeepEqualsIn15() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"\r\n" +
-				"	 int[][][] a = new int[][][] {{null}};\r\n" +
-				"	 int[][][] b = new int[][][] {{null}};\r\n" +
-				"\r\n" +
-				"}\r\n" +
-				"", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				 int[][][] a = new int[][][] {{null}};\r
+				 int[][][] b = new int[][][] {{null}};\r
+			\r
+			}\r
+			""", true, null);
 
 		IField[] fields= getFields(a.getType("A"), new String[] {"a", "b"});
 		runOperation(a.getType("A"), fields, false, false);
 
-		String expected= "package p;\r\n" +
-				"\r\n" +
-				"import java.util.Arrays;\r\n" +
-				"\r\n" +
-				"public class A {\r\n" +
-				"\r\n" +
-				"	 int[][][] a = new int[][][] {{null}};\r\n" +
-				"	 int[][][] b = new int[][][] {{null}};\r\n" +
-				"	@Override\r\n" +
-				"	public int hashCode() {\r\n" +
-				"		final int prime = 31;\r\n" +
-				"		int result = 1;\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(a);\r\n" +
-				"		result = prime * result + Arrays.deepHashCode(b);\r\n" +
-				"		return result;\r\n" +
-				"	}\r\n" +
-				"	@Override\r\n" +
-				"	public boolean equals(Object obj) {\r\n" +
-				"		if (this == obj)\r\n" +
-				"			return true;\r\n" +
-				"		if (obj == null)\r\n" +
-				"			return false;\r\n" +
-				"		if (getClass() != obj.getClass())\r\n" +
-				"			return false;\r\n" +
-				"		A other = (A) obj;\r\n" +
-				"		if (!Arrays.deepEquals(a, other.a))\r\n" +
-				"			return false;\r\n" +
-				"		if (!Arrays.deepEquals(b, other.b))\r\n" +
-				"			return false;\r\n" +
-				"		return true;\r\n" +
-				"	}\r\n" +
-				"\r\n" +
-				"}" +
-				"";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A {\r
+			\r
+				 int[][][] a = new int[][][] {{null}};\r
+				 int[][][] b = new int[][][] {{null}};\r
+				@Override\r
+				public int hashCode() {\r
+					final int prime = 31;\r
+					int result = 1;\r
+					result = prime * result + Arrays.deepHashCode(a);\r
+					result = prime * result + Arrays.deepHashCode(b);\r
+					return result;\r
+				}\r
+				@Override\r
+				public boolean equals(Object obj) {\r
+					if (this == obj)\r
+						return true;\r
+					if (obj == null)\r
+						return false;\r
+					if (getClass() != obj.getClass())\r
+						return false;\r
+					A other = (A) obj;\r
+					if (!Arrays.deepEquals(a, other.a))\r
+						return false;\r
+					if (!Arrays.deepEquals(b, other.b))\r
+						return false;\r
+					return true;\r
+				}\r
+			\r
+			}""";
 		compareSource(expected, a.getSource());
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateToStringTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateToStringTest.java
@@ -221,27 +221,31 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.createComments= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "	\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	byte aByte;\r\n"
-				+ "	char aChar;\r\n"
-				+ "	int anInt;\r\n"
-				+ "	double aDouble;\r\n"
-				+ "	float aFloat;\r\n"
-				+ "	long aLong;\r\n"
-				+ "	int aFloatMethod() {\r\n"
-				+ "		return 3.3;\r\n"
-				+ "	}\r\n"
-				+ "	int aStringMethod() {\r\n"
-				+ "		return \"\";\r\n"
-				+ "	}\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		return \"A [aBool=\" + aBool + \", aByte=\" + aByte + \", aChar=\" + aChar + \", anInt=\" + anInt + \", aDouble=\" + aDouble + \", aFloat=\" + aFloat + \", aLong=\" + aLong + \", aFloatMethod()=\" + aFloatMethod() + \", aStringMethod()=\" + aStringMethod() + \"]\";\r\n"
-				+ "	}\r\n" + "\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			public class A {\r
+				\r
+				boolean aBool;\r
+				byte aByte;\r
+				char aChar;\r
+				int anInt;\r
+				double aDouble;\r
+				float aFloat;\r
+				long aLong;\r
+				int aFloatMethod() {\r
+					return 3.3;\r
+				}\r
+				int aStringMethod() {\r
+					return "";\r
+				}\r
+				@Override\r
+				public String toString() {\r
+					return "A [aBool=" + aBool + ", aByte=" + aByte + ", aChar=" + aChar + ", anInt=" + anInt + ", aDouble=" + aDouble + ", aFloat=" + aFloat + ", aLong=" + aLong + ", aFloatMethod()=" + aFloatMethod() + ", aStringMethod()=" + aStringMethod() + "]";\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -315,36 +319,56 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatArray() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] anArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n" + "\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+			\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "intArray", "list", "object", "stringArray", "anArrayMethod" });
 		fSettings2.customArrayToString= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] anArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		return \"A [AArray=\" + Arrays.toString(AArray) + \", aBool=\" + aBool + \", anA=\" + anA + \", floatArray=\" + Arrays.toString(floatArray) + \", intArray=\" + Arrays.toString(intArray) + \", list=\" + list + \", object=\" + object + \", stringArray=\" + Arrays.toString(stringArray) + \", anArrayMethod()=\" + Arrays.toString(anArrayMethod()) + \"]\";\r\n"
-				+ "	}\r\n" + "\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+				@Override\r
+				public String toString() {\r
+					return "A [AArray=" + Arrays.toString(AArray) + ", aBool=" + aBool + ", anA=" + anA + ", floatArray=" + Arrays.toString(floatArray) + ", intArray=" + Arrays.toString(intArray) + ", list=" + list + ", object=" + object + ", stringArray=" + Arrays.toString(stringArray) + ", anArrayMethod()=" + Arrays.toString(anArrayMethod()) + "]";\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -356,11 +380,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -368,39 +416,54 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitElements= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [AArray=\" + AArray + \", aBool=\" + aBool + \", anA=\" + anA + \", floatArray=\" + floatArray + \", hashMap=\" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + \", intArray=\" + intArray + \", integerCollection=\" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + \", list=\" + (list != null ? toString(list, maxLen) : null) + \", object=\" + object + \", stringArray=\" + stringArray + \", wildCollection=\" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + \", charArrayMethod()=\" + charArrayMethod() + \", floatArrayMethod()=\" + floatArrayMethod() + \"]\";\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n"
-				+ "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [AArray=" + AArray + ", aBool=" + aBool + ", anA=" + anA + ", floatArray=" + floatArray + ", hashMap=" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + ", intArray=" + intArray + ", integerCollection=" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + ", list=" + (list != null ? toString(list, maxLen) : null) + ", object=" + object + ", stringArray=" + stringArray + ", wildCollection=" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + ", charArrayMethod()=" + charArrayMethod() + ", floatArrayMethod()=" + floatArrayMethod() + "]";\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -412,11 +475,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatArrayLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -425,41 +512,56 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitElements= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [AArray=\" + (AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null) + \", aBool=\" + aBool + \", anA=\" + anA + \", floatArray=\" + (floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null) + \", hashMap=\" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + \", intArray=\" + (intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null) + \", integerCollection=\" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + \", list=\" + (list != null ? toString(list, maxLen) : null) + \", object=\" + object + \", stringArray=\" + (stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null) + \", wildCollection=\" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + \", charArrayMethod()=\"\r\n"
-				+ "				+ (charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null) + \", floatArrayMethod()=\" + (floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null) + \"]\";\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n"
-				+ "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [AArray=" + (AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null) + ", aBool=" + aBool + ", anA=" + anA + ", floatArray=" + (floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null) + ", hashMap=" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + ", intArray=" + (intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null) + ", integerCollection=" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + ", list=" + (list != null ? toString(list, maxLen) : null) + ", object=" + object + ", stringArray=" + (stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null) + ", wildCollection=" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + ", charArrayMethod()="\r
+							+ (charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null) + ", floatArrayMethod()=" + (floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null) + "]";\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -472,10 +574,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void concatArrayLimit1_4() throws Exception {
 		setCompilerLevels(false, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	\r\n" + "}\r\n" + "",
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				\r
+			}\r
+			""",
 				true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
@@ -485,45 +612,79 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitElements= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [AArray=\" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null) + \", aBool=\" + aBool + \", anA=\" + anA + \", floatArray=\" + (floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null) + \", hashMap=\" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + \", intArray=\" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null) + \", integerCollection=\" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + \", list=\" + (list != null ? toString(list, maxLen) : null) + \", object=\" + object + \", stringArray=\" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null) + \", wildCollection=\" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + \", charArrayMethod()=\" + (charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null) + \", floatArrayMethod()=\"\r\n"
-				+ "				+ (floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null) + \"]\";\r\n" + "	}\r\n" + "	private String toString(Collection collection, int maxLen) {\r\n" + "		StringBuffer buffer = new StringBuffer();\r\n" + "		buffer.append(\"[\");\r\n" + "		int i = 0;\r\n"
-				+ "		for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer.append(\", \");\r\n" + "			}\r\n"
-				+ "			buffer.append(iterator.next());\r\n" + "		}\r\n" + "		buffer.append(\"]\");\r\n" + "		return buffer.toString();\r\n" + "	}\r\n"
-				+ "	private String arrayToString(Object array, int len, int maxLen) {\r\n" + "		StringBuffer buffer = new StringBuffer();\r\n" + "		len = Math.min(len, maxLen);\r\n"
-				+ "		buffer.append(\"[\");\r\n" + "		for (int i = 0; i < len; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer.append(\", \");\r\n" + "			}\r\n"
-				+ "			if (array instanceof float[]) {\r\n" + "				buffer.append(((float[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof int[]) {\r\n"
-				+ "				buffer.append(((int[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof char[]) {\r\n" + "				buffer.append(((char[]) array)[i]);\r\n" + "			}\r\n"
-				+ "			if (array instanceof Object[]) {\r\n" + "				buffer.append(((Object[]) array)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		buffer.append(\"]\");\r\n"
-				+ "		return buffer.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [AArray=" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null) + ", aBool=" + aBool + ", anA=" + anA + ", floatArray=" + (floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null) + ", hashMap=" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + ", intArray=" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null) + ", integerCollection=" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + ", list=" + (list != null ? toString(list, maxLen) : null) + ", object=" + object + ", stringArray=" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null) + ", wildCollection=" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + ", charArrayMethod()=" + (charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null) + ", floatArrayMethod()="\r
+							+ (floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null) + "]";\r
+				}\r
+				private String toString(Collection collection, int maxLen) {\r
+					StringBuffer buffer = new StringBuffer();\r
+					buffer.append("[");\r
+					int i = 0;\r
+					for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							buffer.append(", ");\r
+						}\r
+						buffer.append(iterator.next());\r
+					}\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				private String arrayToString(Object array, int len, int maxLen) {\r
+					StringBuffer buffer = new StringBuffer();\r
+					len = Math.min(len, maxLen);\r
+					buffer.append("[");\r
+					for (int i = 0; i < len; i++) {\r
+						if (i > 0) {\r
+							buffer.append(", ");\r
+						}\r
+						if (array instanceof float[]) {\r
+							buffer.append(((float[]) array)[i]);\r
+						}\r
+						if (array instanceof int[]) {\r
+							buffer.append(((int[]) array)[i]);\r
+						}\r
+						if (array instanceof char[]) {\r
+							buffer.append(((char[]) array)[i]);\r
+						}\r
+						if (array instanceof Object[]) {\r
+							buffer.append(((Object[]) array)[i]);\r
+						}\r
+					}\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -537,10 +698,31 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void concatArrayLimit1_4Unique() throws Exception {
 		setCompilerLevels(false, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n"
-				+ "	Object len;\r\n" + "	Object collection;\r\n" + "	Object array;\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "aBool", "intArray", "stringArray", "AArray", "list", "hashMap", "wildCollection", "integerCollection", "builder", "buffer",
@@ -549,40 +731,68 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitElements= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	Object builder;\r\n"
-				+ "	Object buffer;\r\n"
-				+ "	Object maxLen;\r\n"
-				+ "	Object len;\r\n"
-				+ "	Object collection;\r\n"
-				+ "	Object array;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen2 = 10;\r\n"
-				+ "		return \"A [aBool=\" + aBool + \", intArray=\" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen2) : null) + \", stringArray=\" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen2) : null) + \", AArray=\" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen2) : null) + \", list=\" + (list != null ? toString(list, maxLen2) : null) + \", hashMap=\" + (hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null) + \", wildCollection=\" + (wildCollection != null ? toString(wildCollection, maxLen2) : null) + \", integerCollection=\" + (integerCollection != null ? toString(integerCollection, maxLen2) : null) + \", builder=\" + builder + \", buffer=\" + buffer + \", maxLen=\" + maxLen + \", len=\" + len + \", collection=\" + collection + \", array=\" + array + \"]\";\r\n"
-				+ "	}\r\n" + "	private String toString(Collection collection2, int maxLen2) {\r\n" + "		StringBuffer buffer2 = new StringBuffer();\r\n" + "		buffer2.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer2.append(\", \");\r\n"
-				+ "			}\r\n" + "			buffer2.append(iterator.next());\r\n" + "		}\r\n" + "		buffer2.append(\"]\");\r\n" + "		return buffer2.toString();\r\n" + "	}\r\n"
-				+ "	private String arrayToString(Object array2, int len2, int maxLen2) {\r\n" + "		StringBuffer buffer2 = new StringBuffer();\r\n" + "		len2 = Math.min(len2, maxLen2);\r\n"
-				+ "		buffer2.append(\"[\");\r\n" + "		for (int i = 0; i < len2; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer2.append(\", \");\r\n" + "			}\r\n"
-				+ "			if (array2 instanceof int[]) {\r\n" + "				buffer2.append(((int[]) array2)[i]);\r\n" + "			}\r\n" + "			if (array2 instanceof Object[]) {\r\n"
-				+ "				buffer2.append(((Object[]) array2)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		buffer2.append(\"]\");\r\n" + "		return buffer2.toString();\r\n" + "	}\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen2 = 10;\r
+					return "A [aBool=" + aBool + ", intArray=" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen2) : null) + ", stringArray=" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen2) : null) + ", AArray=" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen2) : null) + ", list=" + (list != null ? toString(list, maxLen2) : null) + ", hashMap=" + (hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null) + ", wildCollection=" + (wildCollection != null ? toString(wildCollection, maxLen2) : null) + ", integerCollection=" + (integerCollection != null ? toString(integerCollection, maxLen2) : null) + ", builder=" + builder + ", buffer=" + buffer + ", maxLen=" + maxLen + ", len=" + len + ", collection=" + collection + ", array=" + array + "]";\r
+				}\r
+				private String toString(Collection collection2, int maxLen2) {\r
+					StringBuffer buffer2 = new StringBuffer();\r
+					buffer2.append("[");\r
+					int i = 0;\r
+					for (Iterator iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r
+						if (i > 0) {\r
+							buffer2.append(", ");\r
+						}\r
+						buffer2.append(iterator.next());\r
+					}\r
+					buffer2.append("]");\r
+					return buffer2.toString();\r
+				}\r
+				private String arrayToString(Object array2, int len2, int maxLen2) {\r
+					StringBuffer buffer2 = new StringBuffer();\r
+					len2 = Math.min(len2, maxLen2);\r
+					buffer2.append("[");\r
+					for (int i = 0; i < len2; i++) {\r
+						if (i > 0) {\r
+							buffer2.append(", ");\r
+						}\r
+						if (array2 instanceof int[]) {\r
+							buffer2.append(((int[]) array2)[i]);\r
+						}\r
+						if (array2 instanceof Object[]) {\r
+							buffer2.append(((Object[]) array2)[i]);\r
+						}\r
+					}\r
+					buffer2.append("]");\r
+					return buffer2.toString();\r
+				}\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -595,10 +805,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void concatArrayLimit1_5() throws Exception {
 		setCompilerLevels(true, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	\r\n" + "}\r\n" + "",
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				\r
+			}\r
+			""",
 				true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
@@ -608,46 +843,79 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitElements= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [AArray=\" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null) + \", aBool=\" + aBool + \", anA=\" + anA + \", floatArray=\" + (floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null) + \", hashMap=\" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + \", intArray=\" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null) + \", integerCollection=\" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + \", list=\" + (list != null ? toString(list, maxLen) : null) + \", object=\" + object + \", stringArray=\" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null) + \", wildCollection=\" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + \", charArrayMethod()=\" + (charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null) + \", floatArrayMethod()=\"\r\n"
-				+ "				+ (floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null) + \"]\";\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n"
-				+ "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n" + "			}\r\n"
-				+ "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n"
-				+ "	private String arrayToString(Object array, int len, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		len = Math.min(len, maxLen);\r\n"
-				+ "		builder.append(\"[\");\r\n" + "		for (int i = 0; i < len; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n" + "			}\r\n"
-				+ "			if (array instanceof float[]) {\r\n" + "				builder.append(((float[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof int[]) {\r\n"
-				+ "				builder.append(((int[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof char[]) {\r\n" + "				builder.append(((char[]) array)[i]);\r\n" + "			}\r\n"
-				+ "			if (array instanceof Object[]) {\r\n" + "				builder.append(((Object[]) array)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [AArray=" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null) + ", aBool=" + aBool + ", anA=" + anA + ", floatArray=" + (floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null) + ", hashMap=" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + ", intArray=" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null) + ", integerCollection=" + (integerCollection != null ? toString(integerCollection, maxLen) : null) + ", list=" + (list != null ? toString(list, maxLen) : null) + ", object=" + object + ", stringArray=" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null) + ", wildCollection=" + (wildCollection != null ? toString(wildCollection, maxLen) : null) + ", charArrayMethod()=" + (charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null) + ", floatArrayMethod()="\r
+							+ (floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null) + "]";\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				private String arrayToString(Object array, int len, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					len = Math.min(len, maxLen);\r
+					builder.append("[");\r
+					for (int i = 0; i < len; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						if (array instanceof float[]) {\r
+							builder.append(((float[]) array)[i]);\r
+						}\r
+						if (array instanceof int[]) {\r
+							builder.append(((int[]) array)[i]);\r
+						}\r
+						if (array instanceof char[]) {\r
+							builder.append(((char[]) array)[i]);\r
+						}\r
+						if (array instanceof Object[]) {\r
+							builder.append(((Object[]) array)[i]);\r
+						}\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -661,10 +929,31 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void concatArrayLimit1_5Unique() throws Exception {
 		setCompilerLevels(true, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n"
-				+ "	Object len;\r\n" + "	Object collection;\r\n" + "	Object array;\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "aBool", "intArray", "stringArray", "AArray", "list", "hashMap", "wildCollection", "integerCollection", "builder", "buffer",
@@ -673,40 +962,68 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitElements= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	Object builder;\r\n"
-				+ "	Object buffer;\r\n"
-				+ "	Object maxLen;\r\n"
-				+ "	Object len;\r\n"
-				+ "	Object collection;\r\n"
-				+ "	Object array;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen2 = 10;\r\n"
-				+ "		return \"A [aBool=\" + aBool + \", intArray=\" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen2) : null) + \", stringArray=\" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen2) : null) + \", AArray=\" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen2) : null) + \", list=\" + (list != null ? toString(list, maxLen2) : null) + \", hashMap=\" + (hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null) + \", wildCollection=\" + (wildCollection != null ? toString(wildCollection, maxLen2) : null) + \", integerCollection=\" + (integerCollection != null ? toString(integerCollection, maxLen2) : null) + \", builder=\" + builder + \", buffer=\" + buffer + \", maxLen=\" + maxLen + \", len=\" + len + \", collection=\" + collection + \", array=\" + array + \"]\";\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection2, int maxLen2) {\r\n" + "		StringBuilder builder2 = new StringBuilder();\r\n" + "		builder2.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r\n" + "			if (i > 0) {\r\n"
-				+ "				builder2.append(\", \");\r\n" + "			}\r\n" + "			builder2.append(iterator.next());\r\n" + "		}\r\n" + "		builder2.append(\"]\");\r\n" + "		return builder2.toString();\r\n"
-				+ "	}\r\n" + "	private String arrayToString(Object array2, int len2, int maxLen2) {\r\n" + "		StringBuilder builder2 = new StringBuilder();\r\n"
-				+ "		len2 = Math.min(len2, maxLen2);\r\n" + "		builder2.append(\"[\");\r\n" + "		for (int i = 0; i < len2; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder2.append(\", \");\r\n"
-				+ "			}\r\n" + "			if (array2 instanceof int[]) {\r\n" + "				builder2.append(((int[]) array2)[i]);\r\n" + "			}\r\n" + "			if (array2 instanceof Object[]) {\r\n"
-				+ "				builder2.append(((Object[]) array2)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		builder2.append(\"]\");\r\n" + "		return builder2.toString();\r\n" + "	}\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen2 = 10;\r
+					return "A [aBool=" + aBool + ", intArray=" + (intArray != null ? arrayToString(intArray, intArray.length, maxLen2) : null) + ", stringArray=" + (stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen2) : null) + ", AArray=" + (AArray != null ? arrayToString(AArray, AArray.length, maxLen2) : null) + ", list=" + (list != null ? toString(list, maxLen2) : null) + ", hashMap=" + (hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null) + ", wildCollection=" + (wildCollection != null ? toString(wildCollection, maxLen2) : null) + ", integerCollection=" + (integerCollection != null ? toString(integerCollection, maxLen2) : null) + ", builder=" + builder + ", buffer=" + buffer + ", maxLen=" + maxLen + ", len=" + len + ", collection=" + collection + ", array=" + array + "]";\r
+				}\r
+				private String toString(Collection<?> collection2, int maxLen2) {\r
+					StringBuilder builder2 = new StringBuilder();\r
+					builder2.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r
+						if (i > 0) {\r
+							builder2.append(", ");\r
+						}\r
+						builder2.append(iterator.next());\r
+					}\r
+					builder2.append("]");\r
+					return builder2.toString();\r
+				}\r
+				private String arrayToString(Object array2, int len2, int maxLen2) {\r
+					StringBuilder builder2 = new StringBuilder();\r
+					len2 = Math.min(len2, maxLen2);\r
+					builder2.append("[");\r
+					for (int i = 0; i < len2; i++) {\r
+						if (i > 0) {\r
+							builder2.append(", ");\r
+						}\r
+						if (array2 instanceof int[]) {\r
+							builder2.append(((int[]) array2)[i]);\r
+						}\r
+						if (array2 instanceof Object[]) {\r
+							builder2.append(((Object[]) array2)[i]);\r
+						}\r
+					}\r
+					builder2.append("]");\r
+					return builder2.toString();\r
+				}\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -718,10 +1035,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatArrayLimitZero() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	\r\n" + "}\r\n" + "",
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				\r
+			}\r
+			""",
 				true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
@@ -732,35 +1074,39 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitValue= 0;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		return \"A [AArray=\" + (AArray != null ? \"[]\" : null) + \", aBool=\" + aBool + \", anA=\" + anA + \", floatArray=\" + (floatArray != null ? \"[]\" : null) + \", hashMap=\" + (hashMap != null ? \"[]\" : null) + \", intArray=\" + (intArray != null ? \"[]\" : null) + \", integerCollection=\" + (integerCollection != null ? \"[]\" : null) + \", list=\" + (list != null ? \"[]\" : null) + \", object=\" + object + \", stringArray=\" + (stringArray != null ? \"[]\" : null) + \", wildCollection=\" + (wildCollection != null ? \"[]\" : null) + \", charArrayMethod()=\" + (charArrayMethod() != null ? \"[]\" : null) + \", floatArrayMethod()=\" + (floatArrayMethod() != null ? \"[]\" : null) + \"]\";\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					return "A [AArray=" + (AArray != null ? "[]" : null) + ", aBool=" + aBool + ", anA=" + anA + ", floatArray=" + (floatArray != null ? "[]" : null) + ", hashMap=" + (hashMap != null ? "[]" : null) + ", intArray=" + (intArray != null ? "[]" : null) + ", integerCollection=" + (integerCollection != null ? "[]" : null) + ", list=" + (list != null ? "[]" : null) + ", object=" + object + ", stringArray=" + (stringArray != null ? "[]" : null) + ", wildCollection=" + (wildCollection != null ? "[]" : null) + ", charArrayMethod()=" + (charArrayMethod() != null ? "[]" : null) + ", floatArrayMethod()=" + (floatArrayMethod() != null ? "[]" : null) + "]";\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -772,10 +1118,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatArrayLimitZeroNulls() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	\r\n" + "}\r\n" + "",
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				\r
+			}\r
+			""",
 				true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
@@ -787,35 +1158,39 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.skipNulls= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		return \"A [\" + (AArray != null ? \"AArray=[], \" : \"\") + \"aBool=\" + aBool + \", \" + (anA != null ? \"anA=\" + anA + \", \" : \"\") + (floatArray != null ? \"floatArray=[], \" : \"\") + (hashMap != null ? \"hashMap=[], \" : \"\") + (intArray != null ? \"intArray=[], \" : \"\") + (integerCollection != null ? \"integerCollection=[], \" : \"\") + (list != null ? \"list=[], \" : \"\") + (object != null ? \"object=\" + object + \", \" : \"\") + (stringArray != null ? \"stringArray=[], \" : \"\") + (wildCollection != null ? \"wildCollection=[], \" : \"\") + (charArrayMethod() != null ? \"charArrayMethod()=[], \" : \"\") + (floatArrayMethod() != null ? \"floatArrayMethod()=[]\" : \"\") + \"]\";\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					return "A [" + (AArray != null ? "AArray=[], " : "") + "aBool=" + aBool + ", " + (anA != null ? "anA=" + anA + ", " : "") + (floatArray != null ? "floatArray=[], " : "") + (hashMap != null ? "hashMap=[], " : "") + (intArray != null ? "intArray=[], " : "") + (integerCollection != null ? "integerCollection=[], " : "") + (list != null ? "list=[], " : "") + (object != null ? "object=" + object + ", " : "") + (stringArray != null ? "stringArray=[], " : "") + (wildCollection != null ? "wildCollection=[], " : "") + (charArrayMethod() != null ? "charArrayMethod()=[], " : "") + (floatArrayMethod() != null ? "floatArrayMethod()=[]" : "") + "]";\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -827,11 +1202,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatArrayLimitThisNoBlock() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -843,41 +1242,55 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [AArray=\" + (this.AArray != null ? Arrays.asList(this.AArray).subList(0, Math.min(this.AArray.length, maxLen)) : null) + \", aBool=\" + this.aBool + \", anA=\" + this.anA + \", floatArray=\" + (this.floatArray != null ? Arrays.toString(Arrays.copyOf(this.floatArray, Math.min(this.floatArray.length, maxLen))) : null) + \", hashMap=\" + (this.hashMap != null ? this.toString(this.hashMap.entrySet(), maxLen) : null) + \", intArray=\" + (this.intArray != null ? Arrays.toString(Arrays.copyOf(this.intArray, Math.min(this.intArray.length, maxLen))) : null) + \", integerCollection=\" + (this.integerCollection != null ? this.toString(this.integerCollection, maxLen) : null) + \", list=\" + (this.list != null ? this.toString(this.list, maxLen) : null) + \", object=\" + this.object + \", stringArray=\" + (this.stringArray != null ? Arrays.asList(this.stringArray).subList(0, Math.min(this.stringArray.length, maxLen)) : null) + \", wildCollection=\"\r\n"
-				+ "				+ (this.wildCollection != null ? this.toString(this.wildCollection, maxLen) : null) + \", charArrayMethod()=\" + (this.charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(this.charArrayMethod(), Math.min(this.charArrayMethod().length, maxLen))) : null) + \", floatArrayMethod()=\" + (this.floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(this.floatArrayMethod(), Math.min(this.floatArrayMethod().length, maxLen))) : null) + \"]\";\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0)\r\n" + "				builder.append(\", \");\r\n"
-				+ "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [AArray=" + (this.AArray != null ? Arrays.asList(this.AArray).subList(0, Math.min(this.AArray.length, maxLen)) : null) + ", aBool=" + this.aBool + ", anA=" + this.anA + ", floatArray=" + (this.floatArray != null ? Arrays.toString(Arrays.copyOf(this.floatArray, Math.min(this.floatArray.length, maxLen))) : null) + ", hashMap=" + (this.hashMap != null ? this.toString(this.hashMap.entrySet(), maxLen) : null) + ", intArray=" + (this.intArray != null ? Arrays.toString(Arrays.copyOf(this.intArray, Math.min(this.intArray.length, maxLen))) : null) + ", integerCollection=" + (this.integerCollection != null ? this.toString(this.integerCollection, maxLen) : null) + ", list=" + (this.list != null ? this.toString(this.list, maxLen) : null) + ", object=" + this.object + ", stringArray=" + (this.stringArray != null ? Arrays.asList(this.stringArray).subList(0, Math.min(this.stringArray.length, maxLen)) : null) + ", wildCollection="\r
+							+ (this.wildCollection != null ? this.toString(this.wildCollection, maxLen) : null) + ", charArrayMethod()=" + (this.charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(this.charArrayMethod(), Math.min(this.charArrayMethod().length, maxLen))) : null) + ", floatArrayMethod()=" + (this.floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(this.floatArrayMethod(), Math.min(this.floatArrayMethod().length, maxLen))) : null) + "]";\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0)\r
+							builder.append(", ");\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -889,11 +1302,36 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatArrayLimitNulls() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anInt", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -904,42 +1342,57 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ " int anInt;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [\" + (AArray != null ? \"AArray=\" + Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) + \", \" : \"\") + \"aBool=\" + aBool + \", anInt=\" + anInt + \", \" + (anA != null ? \"anA=\" + anA + \", \" : \"\") + (floatArray != null ? \"floatArray=\" + Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) + \", \" : \"\") + (hashMap != null ? \"hashMap=\" + toString(hashMap.entrySet(), maxLen) + \", \" : \"\") + (intArray != null ? \"intArray=\" + Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) + \", \" : \"\") + (integerCollection != null ? \"integerCollection=\" + toString(integerCollection, maxLen) + \", \" : \"\") + (list != null ? \"list=\" + toString(list, maxLen) + \", \" : \"\") + (object != null ? \"object=\" + object + \", \" : \"\") + (stringArray != null ? \"stringArray=\" + Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) + \", \" : \"\")\r\n"
-				+ "				+ (wildCollection != null ? \"wildCollection=\" + toString(wildCollection, maxLen) + \", \" : \"\") + (charArrayMethod() != null ? \"charArrayMethod()=\" + Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) + \", \" : \"\") + (floatArrayMethod() != null ? \"floatArrayMethod()=\" + Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : \"\") + \"]\";\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n"
-				+ "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [" + (AArray != null ? "AArray=" + Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) + ", " : "") + "aBool=" + aBool + ", anInt=" + anInt + ", " + (anA != null ? "anA=" + anA + ", " : "") + (floatArray != null ? "floatArray=" + Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) + ", " : "") + (hashMap != null ? "hashMap=" + toString(hashMap.entrySet(), maxLen) + ", " : "") + (intArray != null ? "intArray=" + Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) + ", " : "") + (integerCollection != null ? "integerCollection=" + toString(integerCollection, maxLen) + ", " : "") + (list != null ? "list=" + toString(list, maxLen) + ", " : "") + (object != null ? "object=" + object + ", " : "") + (stringArray != null ? "stringArray=" + Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) + ", " : "")\r
+							+ (wildCollection != null ? "wildCollection=" + toString(wildCollection, maxLen) + ", " : "") + (charArrayMethod() != null ? "charArrayMethod()=" + Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) + ", " : "") + (floatArrayMethod() != null ? "floatArrayMethod()=" + Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : "") + "]";\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -951,11 +1404,36 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void concatArrayLimitNoHelpers() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anInt", "anA", "floatArray", "intArray", "list", "object", "stringArray", "charArrayMethod",
@@ -966,39 +1444,43 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ " int anInt;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [\" + (AArray != null ? \"AArray=\" + Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) + \", \" : \"\") + \"aBool=\" + aBool + \", anInt=\" + anInt + \", \" + (anA != null ? \"anA=\" + anA + \", \" : \"\") + (floatArray != null ? \"floatArray=\" + Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) + \", \" : \"\") + (intArray != null ? \"intArray=\" + Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) + \", \" : \"\") + (list != null ? \"list=\" + list.subList(0, Math.min(list.size(), maxLen)) + \", \" : \"\") + (object != null ? \"object=\" + object + \", \" : \"\") + (stringArray != null ? \"stringArray=\" + Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) + \", \" : \"\") + (charArrayMethod() != null ? \"charArrayMethod()=\" + Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) + \", \" : \"\")\r\n"
-				+ "				+ (floatArrayMethod() != null ? \"floatArrayMethod()=\" + Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : \"\") + \"]\";\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [" + (AArray != null ? "AArray=" + Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) + ", " : "") + "aBool=" + aBool + ", anInt=" + anInt + ", " + (anA != null ? "anA=" + anA + ", " : "") + (floatArray != null ? "floatArray=" + Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) + ", " : "") + (intArray != null ? "intArray=" + Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) + ", " : "") + (list != null ? "list=" + list.subList(0, Math.min(list.size(), maxLen)) + ", " : "") + (object != null ? "object=" + object + ", " : "") + (stringArray != null ? "stringArray=" + Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) + ", " : "") + (charArrayMethod() != null ? "charArrayMethod()=" + Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) + ", " : "")\r
+							+ (floatArrayMethod() != null ? "floatArrayMethod()=" + Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : "") + "]";\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1075,12 +1557,38 @@ public class GenerateToStringTest extends SourceTestCase {
 	public void concatReplace() throws Exception {
 		setCompilerLevels(true, false);
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	A anA;\r\n" + "	float[] floatArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	@Override\r\n"
-				+ "	public String toString() {\r\n" + "		return \"A []\";\r\n" + "	}\r\n" + "	private String arrayToString(Object array, int len, int maxLen) {\r\n"
-				+ "		return array[0].toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		return collection.toString();\r\n" + "	}\r\n" + "	\r\n"
-				+ "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				A anA;\r
+				float[] floatArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				@Override\r
+				public String toString() {\r
+					return "A []";\r
+				}\r
+				private String arrayToString(Object array, int len, int maxLen) {\r
+					return array[0].toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					return collection.toString();\r
+				}\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "anA", "floatArray", "hashMap", "list", "charArrayMethod", "floatArrayMethod" });
@@ -1088,34 +1596,55 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.limitElements= true;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	A anA;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return \"A [anA=\" + anA + \", floatArray=\" + (floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null) + \", hashMap=\" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + \", list=\" + (list != null ? toString(list, maxLen) : null) + \", charArrayMethod()=\" + (charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null) + \", floatArrayMethod()=\" + (floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null) + \"]\";\r\n"
-				+ "	}\r\n" + "	private String arrayToString(Object array, int len, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		len = Math.min(len, maxLen);\r\n"
-				+ "		builder.append(\"[\");\r\n" + "		for (int i = 0; i < len; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n" + "			}\r\n"
-				+ "			if (array instanceof float[]) {\r\n" + "				builder.append(((float[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof char[]) {\r\n"
-				+ "				builder.append(((char[]) array)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n"
-				+ "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		return collection.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				A anA;\r
+				float[] floatArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return "A [anA=" + anA + ", floatArray=" + (floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null) + ", hashMap=" + (hashMap != null ? toString(hashMap.entrySet(), maxLen) : null) + ", list=" + (list != null ? toString(list, maxLen) : null) + ", charArrayMethod()=" + (charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null) + ", floatArrayMethod()=" + (floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null) + "]";\r
+				}\r
+				private String arrayToString(Object array, int len, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					len = Math.min(len, maxLen);\r
+					builder.append("[");\r
+					for (int i = 0; i < len; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						if (array instanceof float[]) {\r
+							builder.append(((float[]) array)[i]);\r
+						}\r
+						if (array instanceof char[]) {\r
+							builder.append(((char[]) array)[i]);\r
+						}\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					return collection.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1216,9 +1745,25 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderArray() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] anArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n" + "\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+			\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "intArray", "list", "object", "stringArray", "anArrayMethod" });
@@ -1226,15 +1771,51 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 1;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] anArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"A [AArray=\");\r\n" + "		builder.append(Arrays.toString(AArray));\r\n" + "		builder.append(\", aBool=\");\r\n" + "		builder.append(aBool);\r\n"
-				+ "		builder.append(\", anA=\");\r\n" + "		builder.append(anA);\r\n" + "		builder.append(\", floatArray=\");\r\n" + "		builder.append(Arrays.toString(floatArray));\r\n"
-				+ "		builder.append(\", intArray=\");\r\n" + "		builder.append(Arrays.toString(intArray));\r\n" + "		builder.append(\", list=\");\r\n" + "		builder.append(list);\r\n"
-				+ "		builder.append(\", object=\");\r\n" + "		builder.append(object);\r\n" + "		builder.append(\", stringArray=\");\r\n" + "		builder.append(Arrays.toString(stringArray));\r\n"
-				+ "		builder.append(\", anArrayMethod()=\");\r\n" + "		builder.append(Arrays.toString(anArrayMethod()));\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n"
-				+ "	}\r\n" + "\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+				@Override\r
+				public String toString() {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [AArray=");\r
+					builder.append(Arrays.toString(AArray));\r
+					builder.append(", aBool=");\r
+					builder.append(aBool);\r
+					builder.append(", anA=");\r
+					builder.append(anA);\r
+					builder.append(", floatArray=");\r
+					builder.append(Arrays.toString(floatArray));\r
+					builder.append(", intArray=");\r
+					builder.append(Arrays.toString(intArray));\r
+					builder.append(", list=");\r
+					builder.append(list);\r
+					builder.append(", object=");\r
+					builder.append(object);\r
+					builder.append(", stringArray=");\r
+					builder.append(Arrays.toString(stringArray));\r
+					builder.append(", anArrayMethod()=");\r
+					builder.append(Arrays.toString(anArrayMethod()));\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1246,11 +1827,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1259,23 +1864,82 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 1;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n" + "import java.util.List;\r\n" + "\r\n"
-				+ "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n"
-				+ "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n" + "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n"
-				+ "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A [AArray=\");\r\n"
-				+ "		builder.append(AArray);\r\n" + "		builder.append(\", aBool=\");\r\n" + "		builder.append(aBool);\r\n" + "		builder.append(\", anA=\");\r\n" + "		builder.append(anA);\r\n"
-				+ "		builder.append(\", floatArray=\");\r\n" + "		builder.append(floatArray);\r\n" + "		builder.append(\", hashMap=\");\r\n"
-				+ "		builder.append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r\n" + "		builder.append(\", intArray=\");\r\n" + "		builder.append(intArray);\r\n"
-				+ "		builder.append(\", integerCollection=\");\r\n" + "		builder.append(integerCollection != null ? toString(integerCollection, maxLen) : null);\r\n"
-				+ "		builder.append(\", list=\");\r\n" + "		builder.append(list != null ? toString(list, maxLen) : null);\r\n" + "		builder.append(\", object=\");\r\n"
-				+ "		builder.append(object);\r\n" + "		builder.append(\", stringArray=\");\r\n" + "		builder.append(stringArray);\r\n" + "		builder.append(\", wildCollection=\");\r\n"
-				+ "		builder.append(wildCollection != null ? toString(wildCollection, maxLen) : null);\r\n" + "		builder.append(\", charArrayMethod()=\");\r\n"
-				+ "		builder.append(charArrayMethod());\r\n" + "		builder.append(\", floatArrayMethod()=\");\r\n" + "		builder.append(floatArrayMethod());\r\n" + "		builder.append(\"]\");\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n"
-				+ "				builder.append(\", \");\r\n" + "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [AArray=");\r
+					builder.append(AArray);\r
+					builder.append(", aBool=");\r
+					builder.append(aBool);\r
+					builder.append(", anA=");\r
+					builder.append(anA);\r
+					builder.append(", floatArray=");\r
+					builder.append(floatArray);\r
+					builder.append(", hashMap=");\r
+					builder.append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r
+					builder.append(", intArray=");\r
+					builder.append(intArray);\r
+					builder.append(", integerCollection=");\r
+					builder.append(integerCollection != null ? toString(integerCollection, maxLen) : null);\r
+					builder.append(", list=");\r
+					builder.append(list != null ? toString(list, maxLen) : null);\r
+					builder.append(", object=");\r
+					builder.append(object);\r
+					builder.append(", stringArray=");\r
+					builder.append(stringArray);\r
+					builder.append(", wildCollection=");\r
+					builder.append(wildCollection != null ? toString(wildCollection, maxLen) : null);\r
+					builder.append(", charArrayMethod()=");\r
+					builder.append(charArrayMethod());\r
+					builder.append(", floatArrayMethod()=");\r
+					builder.append(floatArrayMethod());\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1287,11 +1951,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderArrayLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1301,29 +1989,83 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 1;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A [AArray=\");\r\n"
-				+ "		builder.append(AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null);\r\n" + "		builder.append(\", aBool=\");\r\n"
-				+ "		builder.append(aBool);\r\n" + "		builder.append(\", anA=\");\r\n" + "		builder.append(anA);\r\n" + "		builder.append(\", floatArray=\");\r\n"
-				+ "		builder.append(floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null);\r\n" + "		builder.append(\", hashMap=\");\r\n"
-				+ "		builder.append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r\n" + "		builder.append(\", intArray=\");\r\n"
-				+ "		builder.append(intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null);\r\n" + "		builder.append(\", integerCollection=\");\r\n"
-				+ "		builder.append(integerCollection != null ? toString(integerCollection, maxLen) : null);\r\n" + "		builder.append(\", list=\");\r\n"
-				+ "		builder.append(list != null ? toString(list, maxLen) : null);\r\n" + "		builder.append(\", object=\");\r\n" + "		builder.append(object);\r\n"
-				+ "		builder.append(\", stringArray=\");\r\n" + "		builder.append(stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r\n"
-				+ "		builder.append(\", wildCollection=\");\r\n" + "		builder.append(wildCollection != null ? toString(wildCollection, maxLen) : null);\r\n"
-				+ "		builder.append(\", charArrayMethod()=\");\r\n"
-				+ "		builder.append(charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null);\r\n"
-				+ "		builder.append(\", floatArrayMethod()=\");\r\n"
-				+ "		builder.append(floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r\n"
-				+ "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n"
-				+ "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n" + "			}\r\n"
-				+ "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [AArray=");\r
+					builder.append(AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null);\r
+					builder.append(", aBool=");\r
+					builder.append(aBool);\r
+					builder.append(", anA=");\r
+					builder.append(anA);\r
+					builder.append(", floatArray=");\r
+					builder.append(floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null);\r
+					builder.append(", hashMap=");\r
+					builder.append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r
+					builder.append(", intArray=");\r
+					builder.append(intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null);\r
+					builder.append(", integerCollection=");\r
+					builder.append(integerCollection != null ? toString(integerCollection, maxLen) : null);\r
+					builder.append(", list=");\r
+					builder.append(list != null ? toString(list, maxLen) : null);\r
+					builder.append(", object=");\r
+					builder.append(object);\r
+					builder.append(", stringArray=");\r
+					builder.append(stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r
+					builder.append(", wildCollection=");\r
+					builder.append(wildCollection != null ? toString(wildCollection, maxLen) : null);\r
+					builder.append(", charArrayMethod()=");\r
+					builder.append(charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null);\r
+					builder.append(", floatArrayMethod()=");\r
+					builder.append(floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1336,10 +2078,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void builderArrayLimit1_4() throws Exception {
 		setCompilerLevels(false, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	\r\n" + "}\r\n" + "",
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				\r
+			}\r
+			""",
 				true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
@@ -1350,34 +2117,106 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 1;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n" + "import java.util.List;\r\n" + "\r\n"
-				+ "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n"
-				+ "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n" + "		StringBuffer buffer = new StringBuffer();\r\n" + "		buffer.append(\"A [AArray=\");\r\n"
-				+ "		buffer.append(AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null);\r\n" + "		buffer.append(\", aBool=\");\r\n" + "		buffer.append(aBool);\r\n"
-				+ "		buffer.append(\", anA=\");\r\n" + "		buffer.append(anA);\r\n" + "		buffer.append(\", floatArray=\");\r\n"
-				+ "		buffer.append(floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null);\r\n" + "		buffer.append(\", hashMap=\");\r\n"
-				+ "		buffer.append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r\n" + "		buffer.append(\", intArray=\");\r\n"
-				+ "		buffer.append(intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null);\r\n" + "		buffer.append(\", integerCollection=\");\r\n"
-				+ "		buffer.append(integerCollection != null ? toString(integerCollection, maxLen) : null);\r\n" + "		buffer.append(\", list=\");\r\n"
-				+ "		buffer.append(list != null ? toString(list, maxLen) : null);\r\n" + "		buffer.append(\", object=\");\r\n" + "		buffer.append(object);\r\n"
-				+ "		buffer.append(\", stringArray=\");\r\n" + "		buffer.append(stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null);\r\n"
-				+ "		buffer.append(\", wildCollection=\");\r\n" + "		buffer.append(wildCollection != null ? toString(wildCollection, maxLen) : null);\r\n"
-				+ "		buffer.append(\", charArrayMethod()=\");\r\n" + "		buffer.append(charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null);\r\n"
-				+ "		buffer.append(\", floatArrayMethod()=\");\r\n" + "		buffer.append(floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null);\r\n"
-				+ "		buffer.append(\"]\");\r\n" + "		return buffer.toString();\r\n" + "	}\r\n" + "	private String toString(Collection collection, int maxLen) {\r\n"
-				+ "		StringBuffer buffer = new StringBuffer();\r\n" + "		buffer.append(\"[\");\r\n" + "		int i = 0;\r\n"
-				+ "		for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer.append(\", \");\r\n" + "			}\r\n"
-				+ "			buffer.append(iterator.next());\r\n" + "		}\r\n" + "		buffer.append(\"]\");\r\n" + "		return buffer.toString();\r\n" + "	}\r\n"
-				+ "	private String arrayToString(Object array, int len, int maxLen) {\r\n" + "		StringBuffer buffer = new StringBuffer();\r\n" + "		len = Math.min(len, maxLen);\r\n"
-				+ "		buffer.append(\"[\");\r\n" + "		for (int i = 0; i < len; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer.append(\", \");\r\n" + "			}\r\n"
-				+ "			if (array instanceof float[]) {\r\n" + "				buffer.append(((float[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof int[]) {\r\n"
-				+ "				buffer.append(((int[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof char[]) {\r\n" + "				buffer.append(((char[]) array)[i]);\r\n" + "			}\r\n"
-				+ "			if (array instanceof Object[]) {\r\n" + "				buffer.append(((Object[]) array)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		buffer.append(\"]\");\r\n"
-				+ "		return buffer.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuffer buffer = new StringBuffer();\r
+					buffer.append("A [AArray=");\r
+					buffer.append(AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null);\r
+					buffer.append(", aBool=");\r
+					buffer.append(aBool);\r
+					buffer.append(", anA=");\r
+					buffer.append(anA);\r
+					buffer.append(", floatArray=");\r
+					buffer.append(floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null);\r
+					buffer.append(", hashMap=");\r
+					buffer.append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r
+					buffer.append(", intArray=");\r
+					buffer.append(intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null);\r
+					buffer.append(", integerCollection=");\r
+					buffer.append(integerCollection != null ? toString(integerCollection, maxLen) : null);\r
+					buffer.append(", list=");\r
+					buffer.append(list != null ? toString(list, maxLen) : null);\r
+					buffer.append(", object=");\r
+					buffer.append(object);\r
+					buffer.append(", stringArray=");\r
+					buffer.append(stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null);\r
+					buffer.append(", wildCollection=");\r
+					buffer.append(wildCollection != null ? toString(wildCollection, maxLen) : null);\r
+					buffer.append(", charArrayMethod()=");\r
+					buffer.append(charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null);\r
+					buffer.append(", floatArrayMethod()=");\r
+					buffer.append(floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null);\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				private String toString(Collection collection, int maxLen) {\r
+					StringBuffer buffer = new StringBuffer();\r
+					buffer.append("[");\r
+					int i = 0;\r
+					for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							buffer.append(", ");\r
+						}\r
+						buffer.append(iterator.next());\r
+					}\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				private String arrayToString(Object array, int len, int maxLen) {\r
+					StringBuffer buffer = new StringBuffer();\r
+					len = Math.min(len, maxLen);\r
+					buffer.append("[");\r
+					for (int i = 0; i < len; i++) {\r
+						if (i > 0) {\r
+							buffer.append(", ");\r
+						}\r
+						if (array instanceof float[]) {\r
+							buffer.append(((float[]) array)[i]);\r
+						}\r
+						if (array instanceof int[]) {\r
+							buffer.append(((int[]) array)[i]);\r
+						}\r
+						if (array instanceof char[]) {\r
+							buffer.append(((char[]) array)[i]);\r
+						}\r
+						if (array instanceof Object[]) {\r
+							buffer.append(((Object[]) array)[i]);\r
+						}\r
+					}\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1391,10 +2230,31 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void builderArrayLimit1_4Unique() throws Exception {
 		setCompilerLevels(false, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n"
-				+ "	Object len;\r\n" + "	Object collection;\r\n" + "	Object array;\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "aBool", "intArray", "stringArray", "AArray", "list", "hashMap", "wildCollection", "integerCollection", "builder", "buffer",
@@ -1404,30 +2264,98 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 1;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n" + "import java.util.List;\r\n" + "\r\n"
-				+ "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n" + "	Object len;\r\n"
-				+ "	Object collection;\r\n" + "	Object array;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n" + "		final int maxLen2 = 10;\r\n" + "		StringBuffer buffer2 = new StringBuffer();\r\n"
-				+ "		buffer2.append(\"A [aBool=\");\r\n" + "		buffer2.append(aBool);\r\n" + "		buffer2.append(\", intArray=\");\r\n"
-				+ "		buffer2.append(intArray != null ? arrayToString(intArray, intArray.length, maxLen2) : null);\r\n" + "		buffer2.append(\", stringArray=\");\r\n"
-				+ "		buffer2.append(stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen2) : null);\r\n" + "		buffer2.append(\", AArray=\");\r\n"
-				+ "		buffer2.append(AArray != null ? arrayToString(AArray, AArray.length, maxLen2) : null);\r\n" + "		buffer2.append(\", list=\");\r\n"
-				+ "		buffer2.append(list != null ? toString(list, maxLen2) : null);\r\n" + "		buffer2.append(\", hashMap=\");\r\n"
-				+ "		buffer2.append(hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null);\r\n" + "		buffer2.append(\", wildCollection=\");\r\n"
-				+ "		buffer2.append(wildCollection != null ? toString(wildCollection, maxLen2) : null);\r\n" + "		buffer2.append(\", integerCollection=\");\r\n"
-				+ "		buffer2.append(integerCollection != null ? toString(integerCollection, maxLen2) : null);\r\n" + "		buffer2.append(\", builder=\");\r\n" + "		buffer2.append(builder);\r\n"
-				+ "		buffer2.append(\", buffer=\");\r\n" + "		buffer2.append(buffer);\r\n" + "		buffer2.append(\", maxLen=\");\r\n" + "		buffer2.append(maxLen);\r\n"
-				+ "		buffer2.append(\", len=\");\r\n" + "		buffer2.append(len);\r\n" + "		buffer2.append(\", collection=\");\r\n" + "		buffer2.append(collection);\r\n"
-				+ "		buffer2.append(\", array=\");\r\n" + "		buffer2.append(array);\r\n" + "		buffer2.append(\"]\");\r\n" + "		return buffer2.toString();\r\n" + "	}\r\n"
-				+ "	private String toString(Collection collection2, int maxLen2) {\r\n" + "		StringBuffer buffer2 = new StringBuffer();\r\n" + "		buffer2.append(\"[\");\r\n" + "		int i = 0;\r\n"
-				+ "		for (Iterator iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer2.append(\", \");\r\n" + "			}\r\n"
-				+ "			buffer2.append(iterator.next());\r\n" + "		}\r\n" + "		buffer2.append(\"]\");\r\n" + "		return buffer2.toString();\r\n" + "	}\r\n"
-				+ "	private String arrayToString(Object array2, int len2, int maxLen2) {\r\n" + "		StringBuffer buffer2 = new StringBuffer();\r\n" + "		len2 = Math.min(len2, maxLen2);\r\n"
-				+ "		buffer2.append(\"[\");\r\n" + "		for (int i = 0; i < len2; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer2.append(\", \");\r\n" + "			}\r\n"
-				+ "			if (array2 instanceof int[]) {\r\n" + "				buffer2.append(((int[]) array2)[i]);\r\n" + "			}\r\n" + "			if (array2 instanceof Object[]) {\r\n"
-				+ "				buffer2.append(((Object[]) array2)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		buffer2.append(\"]\");\r\n" + "		return buffer2.toString();\r\n" + "	}\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen2 = 10;\r
+					StringBuffer buffer2 = new StringBuffer();\r
+					buffer2.append("A [aBool=");\r
+					buffer2.append(aBool);\r
+					buffer2.append(", intArray=");\r
+					buffer2.append(intArray != null ? arrayToString(intArray, intArray.length, maxLen2) : null);\r
+					buffer2.append(", stringArray=");\r
+					buffer2.append(stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen2) : null);\r
+					buffer2.append(", AArray=");\r
+					buffer2.append(AArray != null ? arrayToString(AArray, AArray.length, maxLen2) : null);\r
+					buffer2.append(", list=");\r
+					buffer2.append(list != null ? toString(list, maxLen2) : null);\r
+					buffer2.append(", hashMap=");\r
+					buffer2.append(hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null);\r
+					buffer2.append(", wildCollection=");\r
+					buffer2.append(wildCollection != null ? toString(wildCollection, maxLen2) : null);\r
+					buffer2.append(", integerCollection=");\r
+					buffer2.append(integerCollection != null ? toString(integerCollection, maxLen2) : null);\r
+					buffer2.append(", builder=");\r
+					buffer2.append(builder);\r
+					buffer2.append(", buffer=");\r
+					buffer2.append(buffer);\r
+					buffer2.append(", maxLen=");\r
+					buffer2.append(maxLen);\r
+					buffer2.append(", len=");\r
+					buffer2.append(len);\r
+					buffer2.append(", collection=");\r
+					buffer2.append(collection);\r
+					buffer2.append(", array=");\r
+					buffer2.append(array);\r
+					buffer2.append("]");\r
+					return buffer2.toString();\r
+				}\r
+				private String toString(Collection collection2, int maxLen2) {\r
+					StringBuffer buffer2 = new StringBuffer();\r
+					buffer2.append("[");\r
+					int i = 0;\r
+					for (Iterator iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r
+						if (i > 0) {\r
+							buffer2.append(", ");\r
+						}\r
+						buffer2.append(iterator.next());\r
+					}\r
+					buffer2.append("]");\r
+					return buffer2.toString();\r
+				}\r
+				private String arrayToString(Object array2, int len2, int maxLen2) {\r
+					StringBuffer buffer2 = new StringBuffer();\r
+					len2 = Math.min(len2, maxLen2);\r
+					buffer2.append("[");\r
+					for (int i = 0; i < len2; i++) {\r
+						if (i > 0) {\r
+							buffer2.append(", ");\r
+						}\r
+						if (array2 instanceof int[]) {\r
+							buffer2.append(((int[]) array2)[i]);\r
+						}\r
+						if (array2 instanceof Object[]) {\r
+							buffer2.append(((Object[]) array2)[i]);\r
+						}\r
+					}\r
+					buffer2.append("]");\r
+					return buffer2.toString();\r
+				}\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1440,11 +2368,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderArrayLimitNullsThisNoBlocks() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1459,30 +2411,105 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A[ \");\r\n" + "		if (this.AArray != null) {\r\n"
-				+ "			builder.append(Arrays.asList(this.AArray).subList(0, Math.min(this.AArray.length, maxLen)));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		builder.append(this.aBool);\r\n" + "		builder.append(\", \");\r\n" + "		if (this.anA != null) {\r\n" + "			builder.append(this.anA);\r\n" + "			builder.append(\", \");\r\n"
-				+ "		}\r\n" + "		if (this.floatArray != null) {\r\n" + "			builder.append(Arrays.toString(Arrays.copyOf(this.floatArray, Math.min(this.floatArray.length, maxLen))));\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (this.hashMap != null) {\r\n" + "			builder.append(this.toString(this.hashMap.entrySet(), maxLen));\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (this.intArray != null) {\r\n"
-				+ "			builder.append(Arrays.toString(Arrays.copyOf(this.intArray, Math.min(this.intArray.length, maxLen))));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		if (this.integerCollection != null) {\r\n" + "			builder.append(this.toString(this.integerCollection, maxLen));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		if (this.list != null) {\r\n" + "			builder.append(this.toString(this.list, maxLen));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (this.object != null) {\r\n"
-				+ "			builder.append(this.object);\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (this.stringArray != null) {\r\n"
-				+ "			builder.append(Arrays.asList(this.stringArray).subList(0, Math.min(this.stringArray.length, maxLen)));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		if (this.wildCollection != null) {\r\n" + "			builder.append(this.toString(this.wildCollection, maxLen));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		if (this.charArrayMethod() != null) {\r\n" + "			builder.append(Arrays.toString(Arrays.copyOf(this.charArrayMethod(), Math.min(this.charArrayMethod().length, maxLen))));\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (this.floatArrayMethod() != null)\r\n"
-				+ "			builder.append(Arrays.toString(Arrays.copyOf(this.floatArrayMethod(), Math.min(this.floatArrayMethod().length, maxLen))));\r\n" + "		builder.append(\"]\");\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0)\r\n"
-				+ "				builder.append(\", \");\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n"
-				+ "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A[ ");\r
+					if (this.AArray != null) {\r
+						builder.append(Arrays.asList(this.AArray).subList(0, Math.min(this.AArray.length, maxLen)));\r
+						builder.append(", ");\r
+					}\r
+					builder.append(this.aBool);\r
+					builder.append(", ");\r
+					if (this.anA != null) {\r
+						builder.append(this.anA);\r
+						builder.append(", ");\r
+					}\r
+					if (this.floatArray != null) {\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.floatArray, Math.min(this.floatArray.length, maxLen))));\r
+						builder.append(", ");\r
+					}\r
+					if (this.hashMap != null) {\r
+						builder.append(this.toString(this.hashMap.entrySet(), maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (this.intArray != null) {\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.intArray, Math.min(this.intArray.length, maxLen))));\r
+						builder.append(", ");\r
+					}\r
+					if (this.integerCollection != null) {\r
+						builder.append(this.toString(this.integerCollection, maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (this.list != null) {\r
+						builder.append(this.toString(this.list, maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (this.object != null) {\r
+						builder.append(this.object);\r
+						builder.append(", ");\r
+					}\r
+					if (this.stringArray != null) {\r
+						builder.append(Arrays.asList(this.stringArray).subList(0, Math.min(this.stringArray.length, maxLen)));\r
+						builder.append(", ");\r
+					}\r
+					if (this.wildCollection != null) {\r
+						builder.append(this.toString(this.wildCollection, maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (this.charArrayMethod() != null) {\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.charArrayMethod(), Math.min(this.charArrayMethod().length, maxLen))));\r
+						builder.append(", ");\r
+					}\r
+					if (this.floatArrayMethod() != null)\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.floatArrayMethod(), Math.min(this.floatArrayMethod().length, maxLen))));\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0)\r
+							builder.append(", ");\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1494,11 +2521,36 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderArrayLimitNulls() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anInt", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1510,33 +2562,123 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A [\");\r\n" + "		if (AArray != null) {\r\n" + "			builder.append(\"AArray=\");\r\n"
-				+ "			builder.append(Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n" + "		builder.append(\"aBool=\");\r\n"
-				+ "		builder.append(aBool);\r\n" + "		builder.append(\", anInt=\");\r\n" + "		builder.append(anInt);\r\n" + "		builder.append(\", \");\r\n" + "		if (anA != null) {\r\n"
-				+ "			builder.append(\"anA=\");\r\n" + "			builder.append(anA);\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (floatArray != null) {\r\n"
-				+ "			builder.append(\"floatArray=\");\r\n" + "			builder.append(Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))));\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (hashMap != null) {\r\n" + "			builder.append(\"hashMap=\");\r\n"
-				+ "			builder.append(toString(hashMap.entrySet(), maxLen));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (intArray != null) {\r\n"
-				+ "			builder.append(\"intArray=\");\r\n" + "			builder.append(Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))));\r\n" + "			builder.append(\", \");\r\n"
-				+ "		}\r\n" + "		if (integerCollection != null) {\r\n" + "			builder.append(\"integerCollection=\");\r\n" + "			builder.append(toString(integerCollection, maxLen));\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (list != null) {\r\n" + "			builder.append(\"list=\");\r\n" + "			builder.append(toString(list, maxLen));\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (object != null) {\r\n" + "			builder.append(\"object=\");\r\n" + "			builder.append(object);\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (stringArray != null) {\r\n" + "			builder.append(\"stringArray=\");\r\n"
-				+ "			builder.append(Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		if (wildCollection != null) {\r\n" + "			builder.append(\"wildCollection=\");\r\n" + "			builder.append(toString(wildCollection, maxLen));\r\n" + "			builder.append(\", \");\r\n"
-				+ "		}\r\n" + "		if (charArrayMethod() != null) {\r\n" + "			builder.append(\"charArrayMethod()=\");\r\n"
-				+ "			builder.append(Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))));\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		if (floatArrayMethod() != null) {\r\n" + "			builder.append(\"floatArrayMethod()=\");\r\n"
-				+ "			builder.append(Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))));\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n"
-				+ "				builder.append(\", \");\r\n" + "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [");\r
+					if (AArray != null) {\r
+						builder.append("AArray=");\r
+						builder.append(Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)));\r
+						builder.append(", ");\r
+					}\r
+					builder.append("aBool=");\r
+					builder.append(aBool);\r
+					builder.append(", anInt=");\r
+					builder.append(anInt);\r
+					builder.append(", ");\r
+					if (anA != null) {\r
+						builder.append("anA=");\r
+						builder.append(anA);\r
+						builder.append(", ");\r
+					}\r
+					if (floatArray != null) {\r
+						builder.append("floatArray=");\r
+						builder.append(Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))));\r
+						builder.append(", ");\r
+					}\r
+					if (hashMap != null) {\r
+						builder.append("hashMap=");\r
+						builder.append(toString(hashMap.entrySet(), maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (intArray != null) {\r
+						builder.append("intArray=");\r
+						builder.append(Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))));\r
+						builder.append(", ");\r
+					}\r
+					if (integerCollection != null) {\r
+						builder.append("integerCollection=");\r
+						builder.append(toString(integerCollection, maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (list != null) {\r
+						builder.append("list=");\r
+						builder.append(toString(list, maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (object != null) {\r
+						builder.append("object=");\r
+						builder.append(object);\r
+						builder.append(", ");\r
+					}\r
+					if (stringArray != null) {\r
+						builder.append("stringArray=");\r
+						builder.append(Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)));\r
+						builder.append(", ");\r
+					}\r
+					if (wildCollection != null) {\r
+						builder.append("wildCollection=");\r
+						builder.append(toString(wildCollection, maxLen));\r
+						builder.append(", ");\r
+					}\r
+					if (charArrayMethod() != null) {\r
+						builder.append("charArrayMethod()=");\r
+						builder.append(Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))));\r
+						builder.append(", ");\r
+					}\r
+					if (floatArrayMethod() != null) {\r
+						builder.append("floatArrayMethod()=");\r
+						builder.append(Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))));\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1548,11 +2690,36 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderArrayLimitNoHelpers() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anInt", "anA", "floatArray", "intArray", "list", "object", "stringArray", "charArrayMethod",
@@ -1563,23 +2730,66 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n" + "\r\n"
-				+ "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A [AArray=\");\r\n"
-				+ "		builder.append(AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null);\r\n" + "		builder.append(\", aBool=\");\r\n"
-				+ "		builder.append(aBool);\r\n" + "		builder.append(\", anInt=\");\r\n" + "		builder.append(anInt);\r\n" + "		builder.append(\", anA=\");\r\n" + "		builder.append(anA);\r\n"
-				+ "		builder.append(\", floatArray=\");\r\n" + "		builder.append(floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null);\r\n"
-				+ "		builder.append(\", intArray=\");\r\n" + "		builder.append(intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null);\r\n"
-				+ "		builder.append(\", list=\");\r\n" + "		builder.append(list != null ? list.subList(0, Math.min(list.size(), maxLen)) : null);\r\n" + "		builder.append(\", object=\");\r\n"
-				+ "		builder.append(object);\r\n" + "		builder.append(\", stringArray=\");\r\n"
-				+ "		builder.append(stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r\n" + "		builder.append(\", charArrayMethod()=\");\r\n"
-				+ "		builder.append(charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null);\r\n"
-				+ "		builder.append(\", floatArrayMethod()=\");\r\n"
-				+ "		builder.append(floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r\n"
-				+ "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [AArray=");\r
+					builder.append(AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null);\r
+					builder.append(", aBool=");\r
+					builder.append(aBool);\r
+					builder.append(", anInt=");\r
+					builder.append(anInt);\r
+					builder.append(", anA=");\r
+					builder.append(anA);\r
+					builder.append(", floatArray=");\r
+					builder.append(floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null);\r
+					builder.append(", intArray=");\r
+					builder.append(intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null);\r
+					builder.append(", list=");\r
+					builder.append(list != null ? list.subList(0, Math.min(list.size(), maxLen)) : null);\r
+					builder.append(", object=");\r
+					builder.append(object);\r
+					builder.append(", stringArray=");\r
+					builder.append(stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r
+					builder.append(", charArrayMethod()=");\r
+					builder.append(charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null);\r
+					builder.append(", floatArrayMethod()=");\r
+					builder.append(floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1591,11 +2801,36 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderArrayLimitZero() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anInt", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1607,20 +2842,70 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n"
-				+ "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n"
-				+ "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n" + "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n"
-				+ "	public String toString() {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A [AArray=\");\r\n"
-				+ "		builder.append(AArray != null ? \"[]\" : null);\r\n" + "		builder.append(\", aBool=\");\r\n" + "		builder.append(aBool);\r\n" + "		builder.append(\", anInt=\");\r\n"
-				+ "		builder.append(anInt);\r\n" + "		builder.append(\", anA=\");\r\n" + "		builder.append(anA);\r\n" + "		builder.append(\", floatArray=\");\r\n"
-				+ "		builder.append(floatArray != null ? \"[]\" : null);\r\n" + "		builder.append(\", hashMap=\");\r\n" + "		builder.append(hashMap != null ? \"[]\" : null);\r\n"
-				+ "		builder.append(\", intArray=\");\r\n" + "		builder.append(intArray != null ? \"[]\" : null);\r\n" + "		builder.append(\", integerCollection=\");\r\n"
-				+ "		builder.append(integerCollection != null ? \"[]\" : null);\r\n" + "		builder.append(\", list=\");\r\n" + "		builder.append(list != null ? \"[]\" : null);\r\n"
-				+ "		builder.append(\", object=\");\r\n" + "		builder.append(object);\r\n" + "		builder.append(\", stringArray=\");\r\n" + "		builder.append(stringArray != null ? \"[]\" : null);\r\n"
-				+ "		builder.append(\", wildCollection=\");\r\n" + "		builder.append(wildCollection != null ? \"[]\" : null);\r\n" + "		builder.append(\", charArrayMethod()=\");\r\n"
-				+ "		builder.append(charArrayMethod() != null ? \"[]\" : null);\r\n" + "		builder.append(\", floatArrayMethod()=\");\r\n"
-				+ "		builder.append(floatArrayMethod() != null ? \"[]\" : null);\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [AArray=");\r
+					builder.append(AArray != null ? "[]" : null);\r
+					builder.append(", aBool=");\r
+					builder.append(aBool);\r
+					builder.append(", anInt=");\r
+					builder.append(anInt);\r
+					builder.append(", anA=");\r
+					builder.append(anA);\r
+					builder.append(", floatArray=");\r
+					builder.append(floatArray != null ? "[]" : null);\r
+					builder.append(", hashMap=");\r
+					builder.append(hashMap != null ? "[]" : null);\r
+					builder.append(", intArray=");\r
+					builder.append(intArray != null ? "[]" : null);\r
+					builder.append(", integerCollection=");\r
+					builder.append(integerCollection != null ? "[]" : null);\r
+					builder.append(", list=");\r
+					builder.append(list != null ? "[]" : null);\r
+					builder.append(", object=");\r
+					builder.append(object);\r
+					builder.append(", stringArray=");\r
+					builder.append(stringArray != null ? "[]" : null);\r
+					builder.append(", wildCollection=");\r
+					builder.append(wildCollection != null ? "[]" : null);\r
+					builder.append(", charArrayMethod()=");\r
+					builder.append(charArrayMethod() != null ? "[]" : null);\r
+					builder.append(", floatArrayMethod()=");\r
+					builder.append(floatArrayMethod() != null ? "[]" : null);\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1632,11 +2917,36 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void builderArrayLimitZeroNulls() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anInt", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1649,21 +2959,88 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n"
-				+ "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n"
-				+ "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n" + "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n"
-				+ "	public String toString() {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A [\");\r\n" + "		if (AArray != null) {\r\n"
-				+ "			builder.append(\"AArray=[], \");\r\n" + "		}\r\n" + "		builder.append(\"aBool=\");\r\n" + "		builder.append(aBool);\r\n" + "		builder.append(\", anInt=\");\r\n"
-				+ "		builder.append(anInt);\r\n" + "		builder.append(\", \");\r\n" + "		if (anA != null) {\r\n" + "			builder.append(\"anA=\");\r\n" + "			builder.append(anA);\r\n"
-				+ "			builder.append(\", \");\r\n" + "		}\r\n" + "		if (floatArray != null) {\r\n" + "			builder.append(\"floatArray=[], \");\r\n" + "		}\r\n" + "		if (hashMap != null) {\r\n"
-				+ "			builder.append(\"hashMap=[], \");\r\n" + "		}\r\n" + "		if (intArray != null) {\r\n" + "			builder.append(\"intArray=[], \");\r\n" + "		}\r\n"
-				+ "		if (integerCollection != null) {\r\n" + "			builder.append(\"integerCollection=[], \");\r\n" + "		}\r\n" + "		if (list != null) {\r\n" + "			builder.append(\"list=[], \");\r\n"
-				+ "		}\r\n" + "		if (object != null) {\r\n" + "			builder.append(\"object=\");\r\n" + "			builder.append(object);\r\n" + "			builder.append(\", \");\r\n" + "		}\r\n"
-				+ "		if (stringArray != null) {\r\n" + "			builder.append(\"stringArray=[], \");\r\n" + "		}\r\n" + "		if (wildCollection != null) {\r\n"
-				+ "			builder.append(\"wildCollection=[], \");\r\n" + "		}\r\n" + "		if (charArrayMethod() != null) {\r\n" + "			builder.append(\"charArrayMethod()=[], \");\r\n" + "		}\r\n"
-				+ "		if (floatArrayMethod() != null) {\r\n" + "			builder.append(\"floatArrayMethod()=[]\");\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [");\r
+					if (AArray != null) {\r
+						builder.append("AArray=[], ");\r
+					}\r
+					builder.append("aBool=");\r
+					builder.append(aBool);\r
+					builder.append(", anInt=");\r
+					builder.append(anInt);\r
+					builder.append(", ");\r
+					if (anA != null) {\r
+						builder.append("anA=");\r
+						builder.append(anA);\r
+						builder.append(", ");\r
+					}\r
+					if (floatArray != null) {\r
+						builder.append("floatArray=[], ");\r
+					}\r
+					if (hashMap != null) {\r
+						builder.append("hashMap=[], ");\r
+					}\r
+					if (intArray != null) {\r
+						builder.append("intArray=[], ");\r
+					}\r
+					if (integerCollection != null) {\r
+						builder.append("integerCollection=[], ");\r
+					}\r
+					if (list != null) {\r
+						builder.append("list=[], ");\r
+					}\r
+					if (object != null) {\r
+						builder.append("object=");\r
+						builder.append(object);\r
+						builder.append(", ");\r
+					}\r
+					if (stringArray != null) {\r
+						builder.append("stringArray=[], ");\r
+					}\r
+					if (wildCollection != null) {\r
+						builder.append("wildCollection=[], ");\r
+					}\r
+					if (charArrayMethod() != null) {\r
+						builder.append("charArrayMethod()=[], ");\r
+					}\r
+					if (floatArrayMethod() != null) {\r
+						builder.append("floatArrayMethod()=[]");\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1752,9 +3129,25 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void chainedBuilderArray() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] anArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n" + "\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+			\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "intArray", "list", "object", "stringArray", "anArrayMethod" });
@@ -1762,28 +3155,33 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 2;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] anArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"A [AArray=\").append(Arrays.toString(AArray)).append(\", aBool=\").append(aBool).append(\", anA=\").append(anA).append(\", floatArray=\").append(Arrays.toString(floatArray)).append(\", intArray=\").append(Arrays.toString(intArray)).append(\", list=\").append(list).append(\", object=\").append(object).append(\", stringArray=\").append(Arrays.toString(stringArray)).append(\", anArrayMethod()=\").append(Arrays.toString(anArrayMethod())).append(\"]\");\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+				@Override\r
+				public String toString() {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A [AArray=").append(Arrays.toString(AArray)).append(", aBool=").append(aBool).append(", anA=").append(anA).append(", floatArray=").append(Arrays.toString(floatArray)).append(", intArray=").append(Arrays.toString(intArray)).append(", list=").append(list).append(", object=").append(object).append(", stringArray=").append(Arrays.toString(stringArray)).append(", anArrayMethod()=").append(Arrays.toString(anArrayMethod())).append("]");\r
+					return builder.toString();\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1796,10 +3194,31 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void chainedBuilderArrayUnique() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n"
-				+ "	Object len;\r\n" + "	Object collection;\r\n" + "	Object array;\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "aBool", "intArray", "stringArray", "AArray", "list", "hashMap", "wildCollection", "integerCollection", "builder", "buffer",
@@ -1808,34 +3227,38 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 2;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	Object builder;\r\n"
-				+ "	Object buffer;\r\n"
-				+ "	Object maxLen;\r\n"
-				+ "	Object len;\r\n"
-				+ "	Object collection;\r\n"
-				+ "	Object array;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		StringBuilder builder2 = new StringBuilder();\r\n"
-				+ "		builder2.append(\"A [aBool=\").append(aBool).append(\", intArray=\").append(Arrays.toString(intArray)).append(\", stringArray=\").append(Arrays.toString(stringArray)).append(\", AArray=\").append(Arrays.toString(AArray)).append(\", list=\").append(list).append(\", hashMap=\").append(hashMap).append(\", wildCollection=\").append(wildCollection).append(\", integerCollection=\").append(integerCollection).append(\", builder=\").append(builder).append(\", buffer=\").append(buffer).append(\", maxLen=\").append(maxLen).append(\", len=\").append(len).append(\", collection=\").append(collection).append(\", array=\").append(array).append(\"]\");\r\n"
-				+ "		return builder2.toString();\r\n" + "	}\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+				@Override\r
+				public String toString() {\r
+					StringBuilder builder2 = new StringBuilder();\r
+					builder2.append("A [aBool=").append(aBool).append(", intArray=").append(Arrays.toString(intArray)).append(", stringArray=").append(Arrays.toString(stringArray)).append(", AArray=").append(Arrays.toString(AArray)).append(", list=").append(list).append(", hashMap=").append(hashMap).append(", wildCollection=").append(wildCollection).append(", integerCollection=").append(integerCollection).append(", builder=").append(builder).append(", buffer=").append(buffer).append(", maxLen=").append(maxLen).append(", len=").append(len).append(", collection=").append(collection).append(", array=").append(array).append("]");\r
+					return builder2.toString();\r
+				}\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1849,10 +3272,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void chainedBuilderArrayLimit1_4() throws Exception {
 		setCompilerLevels(false, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	\r\n" + "}\r\n" + "",
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				\r
+			}\r
+			""",
 				true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
@@ -1863,47 +3311,81 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 2;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		StringBuffer buffer = new StringBuffer();\r\n"
-				+ "		buffer.append(\"A [AArray=\").append(AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null).append(\", aBool=\").append(aBool).append(\", anA=\").append(anA).append(\", floatArray=\").append(floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null).append(\", hashMap=\").append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null).append(\", intArray=\").append(intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null).append(\", integerCollection=\").append(integerCollection != null ? toString(integerCollection, maxLen) : null).append(\", list=\").append(list != null ? toString(list, maxLen) : null).append(\", object=\").append(object).append(\", stringArray=\").append(stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null).append(\", wildCollection=\").append(wildCollection != null ? toString(wildCollection, maxLen) : null).append(\", charArrayMethod()=\")\r\n"
-				+ "				.append(charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null).append(\", floatArrayMethod()=\").append(floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null).append(\"]\");\r\n"
-				+ "		return buffer.toString();\r\n" + "	}\r\n" + "	private String toString(Collection collection, int maxLen) {\r\n" + "		StringBuffer buffer = new StringBuffer();\r\n"
-				+ "		buffer.append(\"[\");\r\n" + "		int i = 0;\r\n" + "		for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n"
-				+ "				buffer.append(\", \");\r\n" + "			}\r\n" + "			buffer.append(iterator.next());\r\n" + "		}\r\n" + "		buffer.append(\"]\");\r\n" + "		return buffer.toString();\r\n" + "	}\r\n"
-				+ "	private String arrayToString(Object array, int len, int maxLen) {\r\n" + "		StringBuffer buffer = new StringBuffer();\r\n" + "		len = Math.min(len, maxLen);\r\n"
-				+ "		buffer.append(\"[\");\r\n" + "		for (int i = 0; i < len; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer.append(\", \");\r\n" + "			}\r\n"
-				+ "			if (array instanceof float[]) {\r\n" + "				buffer.append(((float[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof int[]) {\r\n"
-				+ "				buffer.append(((int[]) array)[i]);\r\n" + "			}\r\n" + "			if (array instanceof char[]) {\r\n" + "				buffer.append(((char[]) array)[i]);\r\n" + "			}\r\n"
-				+ "			if (array instanceof Object[]) {\r\n" + "				buffer.append(((Object[]) array)[i]);\r\n" + "			}\r\n" + "		}\r\n" + "		buffer.append(\"]\");\r\n"
-				+ "		return buffer.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuffer buffer = new StringBuffer();\r
+					buffer.append("A [AArray=").append(AArray != null ? arrayToString(AArray, AArray.length, maxLen) : null).append(", aBool=").append(aBool).append(", anA=").append(anA).append(", floatArray=").append(floatArray != null ? arrayToString(floatArray, floatArray.length, maxLen) : null).append(", hashMap=").append(hashMap != null ? toString(hashMap.entrySet(), maxLen) : null).append(", intArray=").append(intArray != null ? arrayToString(intArray, intArray.length, maxLen) : null).append(", integerCollection=").append(integerCollection != null ? toString(integerCollection, maxLen) : null).append(", list=").append(list != null ? toString(list, maxLen) : null).append(", object=").append(object).append(", stringArray=").append(stringArray != null ? arrayToString(stringArray, stringArray.length, maxLen) : null).append(", wildCollection=").append(wildCollection != null ? toString(wildCollection, maxLen) : null).append(", charArrayMethod()=")\r
+							.append(charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, maxLen) : null).append(", floatArrayMethod()=").append(floatArrayMethod() != null ? arrayToString(floatArrayMethod(), floatArrayMethod().length, maxLen) : null).append("]");\r
+					return buffer.toString();\r
+				}\r
+				private String toString(Collection collection, int maxLen) {\r
+					StringBuffer buffer = new StringBuffer();\r
+					buffer.append("[");\r
+					int i = 0;\r
+					for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							buffer.append(", ");\r
+						}\r
+						buffer.append(iterator.next());\r
+					}\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				private String arrayToString(Object array, int len, int maxLen) {\r
+					StringBuffer buffer = new StringBuffer();\r
+					len = Math.min(len, maxLen);\r
+					buffer.append("[");\r
+					for (int i = 0; i < len; i++) {\r
+						if (i > 0) {\r
+							buffer.append(", ");\r
+						}\r
+						if (array instanceof float[]) {\r
+							buffer.append(((float[]) array)[i]);\r
+						}\r
+						if (array instanceof int[]) {\r
+							buffer.append(((int[]) array)[i]);\r
+						}\r
+						if (array instanceof char[]) {\r
+							buffer.append(((char[]) array)[i]);\r
+						}\r
+						if (array instanceof Object[]) {\r
+							buffer.append(((Object[]) array)[i]);\r
+						}\r
+					}\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1917,11 +3399,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void chainedBuilderArray1_5() throws Exception {
 		setCompilerLevels(true, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1932,37 +3438,42 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"A[ \").append(Arrays.toString(AArray)).append(\", \").append(aBool).append(\", \").append(anA).append(\", \").append(Arrays.toString(floatArray)).append(\", \").append(hashMap).append(\", \").append(Arrays.toString(intArray)).append(\", \").append(integerCollection).append(\", \").append(list).append(\", \").append(object).append(\", \").append(Arrays.toString(stringArray)).append(\", \").append(wildCollection).append(\", \").append(Arrays.toString(charArrayMethod())).append(\", \").append(Arrays.toString(floatArrayMethod())).append(\"]\");\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A[ ").append(Arrays.toString(AArray)).append(", ").append(aBool).append(", ").append(anA).append(", ").append(Arrays.toString(floatArray)).append(", ").append(hashMap).append(", ").append(Arrays.toString(intArray)).append(", ").append(integerCollection).append(", ").append(list).append(", ").append(object).append(", ").append(Arrays.toString(stringArray)).append(", ").append(wildCollection).append(", ").append(Arrays.toString(charArrayMethod())).append(", ").append(Arrays.toString(floatArrayMethod())).append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -1975,11 +3486,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void chainedBuilderArrayLimitNullsThisNoBlocks() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -1994,27 +3529,82 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"A[ \");\r\n" + "		if (this.AArray != null)\r\n"
-				+ "			builder.append(Arrays.asList(this.AArray).subList(0, Math.min(this.AArray.length, maxLen))).append(\", \");\r\n" + "		builder.append(this.aBool).append(\", \");\r\n"
-				+ "		if (this.anA != null)\r\n" + "			builder.append(this.anA).append(\", \");\r\n" + "		if (this.floatArray != null)\r\n"
-				+ "			builder.append(Arrays.toString(Arrays.copyOf(this.floatArray, Math.min(this.floatArray.length, maxLen)))).append(\", \");\r\n" + "		if (this.hashMap != null)\r\n"
-				+ "			builder.append(this.toString(this.hashMap.entrySet(), maxLen)).append(\", \");\r\n" + "		if (this.intArray != null)\r\n"
-				+ "			builder.append(Arrays.toString(Arrays.copyOf(this.intArray, Math.min(this.intArray.length, maxLen)))).append(\", \");\r\n" + "		if (this.integerCollection != null)\r\n"
-				+ "			builder.append(this.toString(this.integerCollection, maxLen)).append(\", \");\r\n" + "		if (this.list != null)\r\n"
-				+ "			builder.append(this.toString(this.list, maxLen)).append(\", \");\r\n" + "		if (this.object != null)\r\n" + "			builder.append(this.object).append(\", \");\r\n"
-				+ "		if (this.stringArray != null)\r\n" + "			builder.append(Arrays.asList(this.stringArray).subList(0, Math.min(this.stringArray.length, maxLen))).append(\", \");\r\n"
-				+ "		if (this.wildCollection != null)\r\n" + "			builder.append(this.toString(this.wildCollection, maxLen)).append(\", \");\r\n" + "		if (this.charArrayMethod() != null)\r\n"
-				+ "			builder.append(Arrays.toString(Arrays.copyOf(this.charArrayMethod(), Math.min(this.charArrayMethod().length, maxLen)))).append(\", \");\r\n"
-				+ "		if (this.floatArrayMethod() != null)\r\n" + "			builder.append(Arrays.toString(Arrays.copyOf(this.floatArrayMethod(), Math.min(this.floatArrayMethod().length, maxLen))));\r\n"
-				+ "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n"
-				+ "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n"
-				+ "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0)\r\n" + "				builder.append(\", \");\r\n"
-				+ "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("A[ ");\r
+					if (this.AArray != null)\r
+						builder.append(Arrays.asList(this.AArray).subList(0, Math.min(this.AArray.length, maxLen))).append(", ");\r
+					builder.append(this.aBool).append(", ");\r
+					if (this.anA != null)\r
+						builder.append(this.anA).append(", ");\r
+					if (this.floatArray != null)\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.floatArray, Math.min(this.floatArray.length, maxLen)))).append(", ");\r
+					if (this.hashMap != null)\r
+						builder.append(this.toString(this.hashMap.entrySet(), maxLen)).append(", ");\r
+					if (this.intArray != null)\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.intArray, Math.min(this.intArray.length, maxLen)))).append(", ");\r
+					if (this.integerCollection != null)\r
+						builder.append(this.toString(this.integerCollection, maxLen)).append(", ");\r
+					if (this.list != null)\r
+						builder.append(this.toString(this.list, maxLen)).append(", ");\r
+					if (this.object != null)\r
+						builder.append(this.object).append(", ");\r
+					if (this.stringArray != null)\r
+						builder.append(Arrays.asList(this.stringArray).subList(0, Math.min(this.stringArray.length, maxLen))).append(", ");\r
+					if (this.wildCollection != null)\r
+						builder.append(this.toString(this.wildCollection, maxLen)).append(", ");\r
+					if (this.charArrayMethod() != null)\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.charArrayMethod(), Math.min(this.charArrayMethod().length, maxLen)))).append(", ");\r
+					if (this.floatArrayMethod() != null)\r
+						builder.append(Arrays.toString(Arrays.copyOf(this.floatArrayMethod(), Math.min(this.floatArrayMethod().length, maxLen))));\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0)\r
+							builder.append(", ");\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2088,9 +3678,25 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void formatArray() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] anArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n" + "\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+			\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "intArray", "list", "object", "stringArray", "anArrayMethod" });
@@ -2098,27 +3704,31 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 3;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] anArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		return String.format(\"A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, intArray=%s, list=%s, object=%s, stringArray=%s, anArrayMethod()=%s]\", Arrays.toString(AArray), aBool, anA, Arrays.toString(floatArray), Arrays.toString(intArray), list, object, Arrays.toString(stringArray), Arrays.toString(anArrayMethod()));\r\n"
-				+ "	}\r\n" + "\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+				@Override\r
+				public String toString() {\r
+					return String.format("A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, intArray=%s, list=%s, object=%s, stringArray=%s, anArrayMethod()=%s]", Arrays.toString(AArray), aBool, anA, Arrays.toString(floatArray), Arrays.toString(intArray), list, object, Arrays.toString(stringArray), Arrays.toString(anArrayMethod()));\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2130,11 +3740,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void formatLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2143,39 +3777,54 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 3;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return String.format(\"A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]\", AArray, aBool, anA, floatArray, hashMap != null ? toString(hashMap.entrySet(), maxLen) : null, intArray, integerCollection != null ? toString(integerCollection, maxLen) : null, list != null ? toString(list, maxLen) : null, object, stringArray, wildCollection != null ? toString(wildCollection, maxLen) : null, charArrayMethod(), floatArrayMethod());\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n"
-				+ "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return String.format("A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]", AArray, aBool, anA, floatArray, hashMap != null ? toString(hashMap.entrySet(), maxLen) : null, intArray, integerCollection != null ? toString(integerCollection, maxLen) : null, list != null ? toString(list, maxLen) : null, object, stringArray, wildCollection != null ? toString(wildCollection, maxLen) : null, charArrayMethod(), floatArrayMethod());\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2187,11 +3836,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void formatArrayLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2201,41 +3874,56 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 3;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return String.format(\"A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]\", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null, aBool, anA, floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null, hashMap != null ? toString(hashMap.entrySet(), maxLen) : null, intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null, integerCollection != null ? toString(integerCollection, maxLen) : null, list != null ? toString(list, maxLen) : null, object, stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null, wildCollection != null ? toString(wildCollection, maxLen) : null,\r\n"
-				+ "				charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null, floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n"
-				+ "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return String.format("A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null, aBool, anA, floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null, hashMap != null ? toString(hashMap.entrySet(), maxLen) : null, intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null, integerCollection != null ? toString(integerCollection, maxLen) : null, list != null ? toString(list, maxLen) : null, object, stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null, wildCollection != null ? toString(wildCollection, maxLen) : null,\r
+							charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null, floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2248,11 +3936,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void formatArrayLimit1_5NoHelpers() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "list", "object", "stringArray" });
@@ -2261,37 +3973,41 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 3;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Arrays;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return String.format(\"A [AArray=%s, aBool=%s, anA=%s, list=%s, object=%s, stringArray=%s]\", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null, aBool, anA, list != null ? list.subList(0, Math.min(list.size(), maxLen)) : null, object, stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return String.format("A [AArray=%s, aBool=%s, anA=%s, list=%s, object=%s, stringArray=%s]", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null, aBool, anA, list != null ? list.subList(0, Math.min(list.size(), maxLen)) : null, object, stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2303,11 +4019,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void formatArrayLimitZero() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2318,35 +4058,39 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 3;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		return String.format(\"A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]\", AArray != null ? \"[]\" : null, aBool, anA, floatArray != null ? \"[]\" : null, hashMap != null ? \"[]\" : null, intArray != null ? \"[]\" : null, integerCollection != null ? \"[]\" : null, list != null ? \"[]\" : null, object, stringArray != null ? \"[]\" : null, wildCollection != null ? \"[]\" : null, charArrayMethod() != null ? \"[]\" : null, floatArrayMethod() != null ? \"[]\" : null);\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					return String.format("A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]", AArray != null ? "[]" : null, aBool, anA, floatArray != null ? "[]" : null, hashMap != null ? "[]" : null, intArray != null ? "[]" : null, integerCollection != null ? "[]" : null, list != null ? "[]" : null, object, stringArray != null ? "[]" : null, wildCollection != null ? "[]" : null, charArrayMethod() != null ? "[]" : null, floatArrayMethod() != null ? "[]" : null);\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2358,11 +4102,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void formatLimitThis() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2373,39 +4141,54 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return String.format(\"A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]\", this.AArray, this.aBool, this.anA, this.floatArray, this.hashMap != null ? this.toString(this.hashMap.entrySet(), maxLen) : null, this.intArray, this.integerCollection != null ? this.toString(this.integerCollection, maxLen) : null, this.list != null ? this.toString(this.list, maxLen) : null, this.object, this.stringArray, this.wildCollection != null ? this.toString(this.wildCollection, maxLen) : null, this.charArrayMethod(), this.floatArrayMethod());\r\n"
-				+ "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n"
-				+ "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return String.format("A [AArray=%s, aBool=%s, anA=%s, floatArray=%s, hashMap=%s, intArray=%s, integerCollection=%s, list=%s, object=%s, stringArray=%s, wildCollection=%s, charArrayMethod()=%s, floatArrayMethod()=%s]", this.AArray, this.aBool, this.anA, this.floatArray, this.hashMap != null ? this.toString(this.hashMap.entrySet(), maxLen) : null, this.intArray, this.integerCollection != null ? this.toString(this.integerCollection, maxLen) : null, this.list != null ? this.toString(this.list, maxLen) : null, this.object, this.stringArray, this.wildCollection != null ? this.toString(this.wildCollection, maxLen) : null, this.charArrayMethod(), this.floatArrayMethod());\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2418,11 +4201,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void formatLimit1_4() throws Exception {
 		setCompilerLevels(false, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2432,40 +4239,55 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.text.MessageFormat;\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	Object object;\r\n"
-				+ "	A anA;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int maxLen = 10;\r\n"
-				+ "		return MessageFormat.format(\"A [AArray={0}, aBool={1}, anA={2}, floatArray={3}, hashMap={4}, intArray={5}, integerCollection={6}, list={7}, object={8}, stringArray={9}, wildCollection={10}, charArrayMethod()={11}, floatArrayMethod()={12}]\", new Object[]{AArray, new Boolean(aBool), anA, floatArray, hashMap != null ? toString(hashMap.entrySet(), maxLen) : null, intArray, integerCollection != null ? toString(integerCollection, maxLen) : null, list != null ? toString(list, maxLen) : null, object, stringArray, wildCollection != null ? toString(wildCollection, maxLen) : null, charArrayMethod(), floatArrayMethod()});\r\n"
-				+ "	}\r\n" + "	private String toString(Collection collection, int maxLen) {\r\n" + "		StringBuffer buffer = new StringBuffer();\r\n" + "		buffer.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				buffer.append(\", \");\r\n"
-				+ "			}\r\n" + "			buffer.append(iterator.next());\r\n" + "		}\r\n" + "		buffer.append(\"]\");\r\n" + "		return buffer.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.text.MessageFormat;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					return MessageFormat.format("A [AArray={0}, aBool={1}, anA={2}, floatArray={3}, hashMap={4}, intArray={5}, integerCollection={6}, list={7}, object={8}, stringArray={9}, wildCollection={10}, charArrayMethod()={11}, floatArrayMethod()={12}]", new Object[]{AArray, new Boolean(aBool), anA, floatArray, hashMap != null ? toString(hashMap.entrySet(), maxLen) : null, intArray, integerCollection != null ? toString(integerCollection, maxLen) : null, list != null ? toString(list, maxLen) : null, object, stringArray, wildCollection != null ? toString(wildCollection, maxLen) : null, charArrayMethod(), floatArrayMethod()});\r
+				}\r
+				private String toString(Collection collection, int maxLen) {\r
+					StringBuffer buffer = new StringBuffer();\r
+					buffer.append("[");\r
+					int i = 0;\r
+					for (Iterator iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							buffer.append(", ");\r
+						}\r
+						buffer.append(iterator.next());\r
+					}\r
+					buffer.append("]");\r
+					return buffer.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2626,9 +4448,25 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void customBuilderArray() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] anArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	java.util.List<Boolean> list;\r\n" + "\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+			\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "intArray", "list", "object", "stringArray", "anArrayMethod" });
@@ -2636,13 +4474,43 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 4;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "\r\n" + "import com.pack.ToStringBuilder;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n"
-				+ "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n"
-				+ "	char[] anArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	java.util.List<Boolean> list;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n"
-				+ "		ToStringBuilder builder = new ToStringBuilder(this);\r\n" + "		builder.append(\"AArray\", Arrays.toString(AArray));\r\n" + "		builder.append(\"aBool\", aBool);\r\n"
-				+ "		builder.append(\"anA\", anA);\r\n" + "		builder.append(\"floatArray\", Arrays.toString(floatArray));\r\n" + "		builder.append(\"intArray\", Arrays.toString(intArray));\r\n"
-				+ "		builder.append(\"list\", list);\r\n" + "		builder.append(\"object\", object);\r\n" + "		builder.append(\"stringArray\", Arrays.toString(stringArray));\r\n"
-				+ "		builder.append(\"anArrayMethod()\", Arrays.toString(anArrayMethod()));\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			\r
+			import com.pack.ToStringBuilder;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] anArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				java.util.List<Boolean> list;\r
+				@Override\r
+				public String toString() {\r
+					ToStringBuilder builder = new ToStringBuilder(this);\r
+					builder.append("AArray", Arrays.toString(AArray));\r
+					builder.append("aBool", aBool);\r
+					builder.append("anA", anA);\r
+					builder.append("floatArray", Arrays.toString(floatArray));\r
+					builder.append("intArray", Arrays.toString(intArray));\r
+					builder.append("list", list);\r
+					builder.append("object", object);\r
+					builder.append("stringArray", Arrays.toString(stringArray));\r
+					builder.append("anArrayMethod()", Arrays.toString(anArrayMethod()));\r
+					return builder.toString();\r
+				}\r
+			\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2654,11 +4522,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void customBuilderLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2667,21 +4559,70 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 4;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n" + "import java.util.List;\r\n" + "\r\n"
-				+ "import com.pack.ToStringBuilder;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n"
-				+ "		ToStringBuilder builder = new ToStringBuilder(this);\r\n" + "		builder.append(\"AArray\", AArray);\r\n" + "		builder.append(\"aBool\", aBool);\r\n"
-				+ "		builder.append(\"anA\", anA);\r\n" + "		builder.append(\"floatArray\", floatArray);\r\n"
-				+ "		builder.append(\"hashMap\", hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r\n" + "		builder.append(\"intArray\", intArray);\r\n"
-				+ "		builder.append(\"integerCollection\", integerCollection != null ? toString(integerCollection, maxLen) : null);\r\n"
-				+ "		builder.append(\"list\", list != null ? toString(list, maxLen) : null);\r\n" + "		builder.append(\"object\", object);\r\n" + "		builder.append(\"stringArray\", stringArray);\r\n"
-				+ "		builder.append(\"wildCollection\", wildCollection != null ? toString(wildCollection, maxLen) : null);\r\n" + "		builder.append(\"charArrayMethod()\", charArrayMethod());\r\n"
-				+ "		builder.append(\"floatArrayMethod()\", floatArrayMethod());\r\n" + "		return builder.toString();\r\n" + "	}\r\n"
-				+ "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n" + "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n"
-				+ "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n" + "				builder.append(\", \");\r\n" + "			}\r\n"
-				+ "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			import com.pack.ToStringBuilder;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					ToStringBuilder builder = new ToStringBuilder(this);\r
+					builder.append("AArray", AArray);\r
+					builder.append("aBool", aBool);\r
+					builder.append("anA", anA);\r
+					builder.append("floatArray", floatArray);\r
+					builder.append("hashMap", hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r
+					builder.append("intArray", intArray);\r
+					builder.append("integerCollection", integerCollection != null ? toString(integerCollection, maxLen) : null);\r
+					builder.append("list", list != null ? toString(list, maxLen) : null);\r
+					builder.append("object", object);\r
+					builder.append("stringArray", stringArray);\r
+					builder.append("wildCollection", wildCollection != null ? toString(wildCollection, maxLen) : null);\r
+					builder.append("charArrayMethod()", charArrayMethod());\r
+					builder.append("floatArrayMethod()", floatArrayMethod());\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2694,11 +4635,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void customBuilderArrayLimit() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2708,27 +4673,71 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 4;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n" + "\r\n" + "import com.pack.ToStringBuilder;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n"
-				+ "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n" + "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n"
-				+ "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n" + "		ToStringBuilder builder = new ToStringBuilder(this);\r\n"
-				+ "		builder.append(\"AArray\", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null);\r\n" + "		builder.append(\"aBool\", aBool);\r\n"
-				+ "		builder.append(\"anA\", anA);\r\n"
-				+ "		builder.append(\"floatArray\", floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null);\r\n"
-				+ "		builder.append(\"hashMap\", hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r\n"
-				+ "		builder.append(\"intArray\", intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null);\r\n"
-				+ "		builder.append(\"integerCollection\", integerCollection != null ? toString(integerCollection, maxLen) : null);\r\n"
-				+ "		builder.append(\"list\", list != null ? toString(list, maxLen) : null);\r\n" + "		builder.append(\"object\", object);\r\n"
-				+ "		builder.append(\"stringArray\", stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r\n"
-				+ "		builder.append(\"wildCollection\", wildCollection != null ? toString(wildCollection, maxLen) : null);\r\n"
-				+ "		builder.append(\"charArrayMethod()\", charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null);\r\n"
-				+ "		builder.append(\"floatArrayMethod()\", floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n"
-				+ "				builder.append(\", \");\r\n" + "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			import com.pack.ToStringBuilder;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					ToStringBuilder builder = new ToStringBuilder(this);\r
+					builder.append("AArray", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)) : null);\r
+					builder.append("aBool", aBool);\r
+					builder.append("anA", anA);\r
+					builder.append("floatArray", floatArray != null ? Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))) : null);\r
+					builder.append("hashMap", hashMap != null ? toString(hashMap.entrySet(), maxLen) : null);\r
+					builder.append("intArray", intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))) : null);\r
+					builder.append("integerCollection", integerCollection != null ? toString(integerCollection, maxLen) : null);\r
+					builder.append("list", list != null ? toString(list, maxLen) : null);\r
+					builder.append("object", object);\r
+					builder.append("stringArray", stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)) : null);\r
+					builder.append("wildCollection", wildCollection != null ? toString(wildCollection, maxLen) : null);\r
+					builder.append("charArrayMethod()", charArrayMethod() != null ? Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))) : null);\r
+					builder.append("floatArrayMethod()", floatArrayMethod() != null ? Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))) : null);\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2740,10 +4749,31 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void customBuilderArrayLimitUnique() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n"
-				+ "	Object len;\r\n" + "	Object collection;\r\n" + "	Object array;\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "aBool", "intArray", "stringArray", "AArray", "list", "hashMap", "wildCollection", "integerCollection", "builder", "buffer",
@@ -2753,25 +4783,68 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.toStringStyle= 4;
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n" + "\r\n" + "import com.pack.ToStringBuilder;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n"
-				+ "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n" + "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n" + "	Object len;\r\n" + "	Object collection;\r\n" + "	Object array;\r\n"
-				+ "	@Override\r\n" + "	public String toString() {\r\n" + "		final int maxLen2 = 10;\r\n" + "		ToStringBuilder builder2 = new ToStringBuilder(this);\r\n"
-				+ "		builder2.append(\"aBool\", aBool);\r\n"
-				+ "		builder2.append(\"intArray\", intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen2))) : null);\r\n"
-				+ "		builder2.append(\"stringArray\", stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen2)) : null);\r\n"
-				+ "		builder2.append(\"AArray\", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen2)) : null);\r\n"
-				+ "		builder2.append(\"list\", list != null ? toString(list, maxLen2) : null);\r\n"
-				+ "		builder2.append(\"hashMap\", hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null);\r\n"
-				+ "		builder2.append(\"wildCollection\", wildCollection != null ? toString(wildCollection, maxLen2) : null);\r\n"
-				+ "		builder2.append(\"integerCollection\", integerCollection != null ? toString(integerCollection, maxLen2) : null);\r\n" + "		builder2.append(\"builder\", builder);\r\n"
-				+ "		builder2.append(\"buffer\", buffer);\r\n" + "		builder2.append(\"maxLen\", maxLen);\r\n" + "		builder2.append(\"len\", len);\r\n"
-				+ "		builder2.append(\"collection\", collection);\r\n" + "		builder2.append(\"array\", array);\r\n" + "		return builder2.toString();\r\n" + "	}\r\n"
-				+ "	private String toString(Collection<?> collection2, int maxLen2) {\r\n" + "		StringBuilder builder2 = new StringBuilder();\r\n" + "		builder2.append(\"[\");\r\n"
-				+ "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r\n" + "			if (i > 0) {\r\n"
-				+ "				builder2.append(\", \");\r\n" + "			}\r\n" + "			builder2.append(iterator.next());\r\n" + "		}\r\n" + "		builder2.append(\"]\");\r\n" + "		return builder2.toString();\r\n"
-				+ "	}\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			import com.pack.ToStringBuilder;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen2 = 10;\r
+					ToStringBuilder builder2 = new ToStringBuilder(this);\r
+					builder2.append("aBool", aBool);\r
+					builder2.append("intArray", intArray != null ? Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen2))) : null);\r
+					builder2.append("stringArray", stringArray != null ? Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen2)) : null);\r
+					builder2.append("AArray", AArray != null ? Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen2)) : null);\r
+					builder2.append("list", list != null ? toString(list, maxLen2) : null);\r
+					builder2.append("hashMap", hashMap != null ? toString(hashMap.entrySet(), maxLen2) : null);\r
+					builder2.append("wildCollection", wildCollection != null ? toString(wildCollection, maxLen2) : null);\r
+					builder2.append("integerCollection", integerCollection != null ? toString(integerCollection, maxLen2) : null);\r
+					builder2.append("builder", builder);\r
+					builder2.append("buffer", buffer);\r
+					builder2.append("maxLen", maxLen);\r
+					builder2.append("len", len);\r
+					builder2.append("collection", collection);\r
+					builder2.append("array", array);\r
+					return builder2.toString();\r
+				}\r
+				private String toString(Collection<?> collection2, int maxLen2) {\r
+					StringBuilder builder2 = new StringBuilder();\r
+					builder2.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection2.iterator(); iterator.hasNext() && i < maxLen2; i++) {\r
+						if (i > 0) {\r
+							builder2.append(", ");\r
+						}\r
+						builder2.append(iterator.next());\r
+					}\r
+					builder2.append("]");\r
+					return builder2.toString();\r
+				}\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2783,11 +4856,35 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void customBuilderNullsThisNoBlocks() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2799,19 +4896,67 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n" + "\r\n"
-				+ "import com.pack.ToStringBuilder;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	Object object;\r\n" + "	A anA;\r\n"
-				+ "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n"
-				+ "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n" + "	public String toString() {\r\n" + "		ToStringBuilder builder = new ToStringBuilder(this);\r\n"
-				+ "		if (this.AArray != null)\r\n" + "			builder.append(\"AArray\", this.AArray);\r\n" + "		builder.append(\"aBool\", this.aBool);\r\n" + "		if (this.anA != null)\r\n"
-				+ "			builder.append(\"anA\", this.anA);\r\n" + "		if (this.floatArray != null)\r\n" + "			builder.append(\"floatArray\", this.floatArray);\r\n" + "		if (this.hashMap != null)\r\n"
-				+ "			builder.append(\"hashMap\", this.hashMap);\r\n" + "		if (this.intArray != null)\r\n" + "			builder.append(\"intArray\", this.intArray);\r\n"
-				+ "		if (this.integerCollection != null)\r\n" + "			builder.append(\"integerCollection\", this.integerCollection);\r\n" + "		if (this.list != null)\r\n"
-				+ "			builder.append(\"list\", this.list);\r\n" + "		if (this.object != null)\r\n" + "			builder.append(\"object\", this.object);\r\n" + "		if (this.stringArray != null)\r\n"
-				+ "			builder.append(\"stringArray\", this.stringArray);\r\n" + "		if (this.wildCollection != null)\r\n" + "			builder.append(\"wildCollection\", this.wildCollection);\r\n"
-				+ "		if (this.charArrayMethod() != null)\r\n" + "			builder.append(\"charArrayMethod()\", this.charArrayMethod());\r\n" + "		if (this.floatArrayMethod() != null)\r\n"
-				+ "			builder.append(\"floatArrayMethod()\", this.floatArrayMethod());\r\n" + "		return builder.toString();\r\n" + "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			import com.pack.ToStringBuilder;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					ToStringBuilder builder = new ToStringBuilder(this);\r
+					if (this.AArray != null)\r
+						builder.append("AArray", this.AArray);\r
+					builder.append("aBool", this.aBool);\r
+					if (this.anA != null)\r
+						builder.append("anA", this.anA);\r
+					if (this.floatArray != null)\r
+						builder.append("floatArray", this.floatArray);\r
+					if (this.hashMap != null)\r
+						builder.append("hashMap", this.hashMap);\r
+					if (this.intArray != null)\r
+						builder.append("intArray", this.intArray);\r
+					if (this.integerCollection != null)\r
+						builder.append("integerCollection", this.integerCollection);\r
+					if (this.list != null)\r
+						builder.append("list", this.list);\r
+					if (this.object != null)\r
+						builder.append("object", this.object);\r
+					if (this.stringArray != null)\r
+						builder.append("stringArray", this.stringArray);\r
+					if (this.wildCollection != null)\r
+						builder.append("wildCollection", this.wildCollection);\r
+					if (this.charArrayMethod() != null)\r
+						builder.append("charArrayMethod()", this.charArrayMethod());\r
+					if (this.floatArrayMethod() != null)\r
+						builder.append("floatArrayMethod()", this.floatArrayMethod());\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -2823,11 +4968,36 @@ public class GenerateToStringTest extends SourceTestCase {
 	 */
 	@Test
 	public void customBuilderArrayLimitNulls() throws Exception {
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n"
-				+ "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n"
-				+ "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n" + "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "aBool", "anInt", "anA", "floatArray", "hashMap", "intArray", "integerCollection", "list", "object", "stringArray",
@@ -2839,28 +5009,97 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n" + "\r\n" + "import java.util.Arrays;\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n" + "\r\n" + "import com.pack.ToStringBuilder;\r\n" + "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n"
-				+ " int anInt;\r\n" + "	Object object;\r\n" + "	A anA;\r\n" + "	int[] intArray;\r\n" + "	float[] floatArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	float[] floatArrayMethod() {\r\n" + "		return null;\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n" + "	Collection<Integer> integerCollection;\r\n" + "	@Override\r\n"
-				+ "	public String toString() {\r\n" + "		final int maxLen = 10;\r\n" + "		ToStringBuilder builder = new ToStringBuilder(this);\r\n" + "		if (AArray != null) {\r\n"
-				+ "			builder.append(\"AArray\", Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)));\r\n" + "		}\r\n" + "		builder.append(\"aBool\", aBool);\r\n"
-				+ "		builder.append(\"anInt\", anInt);\r\n" + "		if (anA != null) {\r\n" + "			builder.append(\"anA\", anA);\r\n" + "		}\r\n" + "		if (floatArray != null) {\r\n"
-				+ "			builder.append(\"floatArray\", Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))));\r\n" + "		}\r\n" + "		if (hashMap != null) {\r\n"
-				+ "			builder.append(\"hashMap\", toString(hashMap.entrySet(), maxLen));\r\n" + "		}\r\n" + "		if (intArray != null) {\r\n"
-				+ "			builder.append(\"intArray\", Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))));\r\n" + "		}\r\n" + "		if (integerCollection != null) {\r\n"
-				+ "			builder.append(\"integerCollection\", toString(integerCollection, maxLen));\r\n" + "		}\r\n" + "		if (list != null) {\r\n"
-				+ "			builder.append(\"list\", toString(list, maxLen));\r\n" + "		}\r\n" + "		if (object != null) {\r\n" + "			builder.append(\"object\", object);\r\n" + "		}\r\n"
-				+ "		if (stringArray != null) {\r\n" + "			builder.append(\"stringArray\", Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)));\r\n" + "		}\r\n"
-				+ "		if (wildCollection != null) {\r\n" + "			builder.append(\"wildCollection\", toString(wildCollection, maxLen));\r\n" + "		}\r\n" + "		if (charArrayMethod() != null) {\r\n"
-				+ "			builder.append(\"charArrayMethod()\", Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))));\r\n" + "		}\r\n"
-				+ "		if (floatArrayMethod() != null) {\r\n"
-				+ "			builder.append(\"floatArrayMethod()\", Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))));\r\n" + "		}\r\n"
-				+ "		return builder.toString();\r\n" + "	}\r\n" + "	private String toString(Collection<?> collection, int maxLen) {\r\n" + "		StringBuilder builder = new StringBuilder();\r\n"
-				+ "		builder.append(\"[\");\r\n" + "		int i = 0;\r\n" + "		for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r\n" + "			if (i > 0) {\r\n"
-				+ "				builder.append(\", \");\r\n" + "			}\r\n" + "			builder.append(iterator.next());\r\n" + "		}\r\n" + "		builder.append(\"]\");\r\n" + "		return builder.toString();\r\n"
-				+ "	}\r\n" + "	\r\n" + "}\r\n" + "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Arrays;\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			import com.pack.ToStringBuilder;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+			 int anInt;\r
+				Object object;\r
+				A anA;\r
+				int[] intArray;\r
+				float[] floatArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				float[] floatArrayMethod() {\r
+					return null;\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int maxLen = 10;\r
+					ToStringBuilder builder = new ToStringBuilder(this);\r
+					if (AArray != null) {\r
+						builder.append("AArray", Arrays.asList(AArray).subList(0, Math.min(AArray.length, maxLen)));\r
+					}\r
+					builder.append("aBool", aBool);\r
+					builder.append("anInt", anInt);\r
+					if (anA != null) {\r
+						builder.append("anA", anA);\r
+					}\r
+					if (floatArray != null) {\r
+						builder.append("floatArray", Arrays.toString(Arrays.copyOf(floatArray, Math.min(floatArray.length, maxLen))));\r
+					}\r
+					if (hashMap != null) {\r
+						builder.append("hashMap", toString(hashMap.entrySet(), maxLen));\r
+					}\r
+					if (intArray != null) {\r
+						builder.append("intArray", Arrays.toString(Arrays.copyOf(intArray, Math.min(intArray.length, maxLen))));\r
+					}\r
+					if (integerCollection != null) {\r
+						builder.append("integerCollection", toString(integerCollection, maxLen));\r
+					}\r
+					if (list != null) {\r
+						builder.append("list", toString(list, maxLen));\r
+					}\r
+					if (object != null) {\r
+						builder.append("object", object);\r
+					}\r
+					if (stringArray != null) {\r
+						builder.append("stringArray", Arrays.asList(stringArray).subList(0, Math.min(stringArray.length, maxLen)));\r
+					}\r
+					if (wildCollection != null) {\r
+						builder.append("wildCollection", toString(wildCollection, maxLen));\r
+					}\r
+					if (charArrayMethod() != null) {\r
+						builder.append("charArrayMethod()", Arrays.toString(Arrays.copyOf(charArrayMethod(), Math.min(charArrayMethod().length, maxLen))));\r
+					}\r
+					if (floatArrayMethod() != null) {\r
+						builder.append("floatArrayMethod()", Arrays.toString(Arrays.copyOf(floatArrayMethod(), Math.min(floatArrayMethod().length, maxLen))));\r
+					}\r
+					return builder.toString();\r
+				}\r
+				private String toString(Collection<?> collection, int maxLen) {\r
+					StringBuilder builder = new StringBuilder();\r
+					builder.append("[");\r
+					int i = 0;\r
+					for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {\r
+						if (i > 0) {\r
+							builder.append(", ");\r
+						}\r
+						builder.append(iterator.next());\r
+					}\r
+					builder.append("]");\r
+					return builder.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -3161,10 +5400,32 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void alternativeCustomBuilderUnique() throws Exception {
 
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	boolean aBool;\r\n" + "	int[] intArray;\r\n" + "	String[] stringArray;\r\n" + "	A[] AArray;\r\n" + "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n" + "	Collection wildCollection;\r\n" + "	Collection integerCollection;\r\n" + "	Object builder;\r\n" + "	Object buffer;\r\n" + "	Object maxLen;\r\n"
-				+ "	Object len;\r\n" + "	Object collection;\r\n" + "	Object array;\r\n" + "	Object creator;\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+				Object creator;\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "aBool", "intArray", "stringArray", "AArray", "list", "hashMap", "wildCollection", "integerCollection", "builder", "buffer",
@@ -3176,53 +5437,54 @@ public class GenerateToStringTest extends SourceTestCase {
 		fSettings2.customBuilderSettings.resultMethod= "getResult";
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "import org.another.pack.AnotherToStringCreator;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	boolean aBool;\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	String[] stringArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	List list;\r\n"
-				+ "	HashMap hashMap;\r\n"
-				+ "	Collection wildCollection;\r\n"
-				+ "	Collection integerCollection;\r\n"
-				+ "	Object builder;\r\n"
-				+ "	Object buffer;\r\n"
-				+ "	Object maxLen;\r\n"
-				+ "	Object len;\r\n"
-				+ "	Object collection;\r\n"
-				+ "	Object array;\r\n"
-				+ "	Object creator;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		AnotherToStringCreator creator2 = new AnotherToStringCreator(this);\r\n"
-				+ "		creator2.addSth(aBool, \"aBool\");\r\n"
-				+ "		creator2.addSth(intArray, \"intArray\");\r\n"
-				+ "		creator2.addSth(stringArray, \"stringArray\");\r\n"
-				+ "		creator2.addSth(AArray, \"AArray\");\r\n"
-				+ "		creator2.addSth(list, \"list\");\r\n"
-				+ "		creator2.addSth(hashMap, \"hashMap\");\r\n"
-				+ "		creator2.addSth(wildCollection, \"wildCollection\");\r\n"
-				+ "		creator2.addSth(integerCollection, \"integerCollection\");\r\n"
-				+ "		creator2.addSth(builder, \"builder\");\r\n"
-				+ "		creator2.addSth(buffer, \"buffer\");\r\n"
-				+ "		creator2.addSth(maxLen, \"maxLen\");\r\n"
-				+ "		creator2.addSth(len, \"len\");\r\n"
-				+ "		creator2.addSth(collection, \"collection\");\r\n"
-				+ "		creator2.addSth(array, \"array\");\r\n"
-				+ "		creator2.addSth(creator, \"creator\");\r\n"
-				+ "		return creator2.getResult();\r\n"
-				+ "	}\r\n"
-				+ "}\r\n"
-				+ "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			import org.another.pack.AnotherToStringCreator;\r
+			\r
+			public class A {\r
+			\r
+				boolean aBool;\r
+				int[] intArray;\r
+				String[] stringArray;\r
+				A[] AArray;\r
+				List list;\r
+				HashMap hashMap;\r
+				Collection wildCollection;\r
+				Collection integerCollection;\r
+				Object builder;\r
+				Object buffer;\r
+				Object maxLen;\r
+				Object len;\r
+				Object collection;\r
+				Object array;\r
+				Object creator;\r
+				@Override\r
+				public String toString() {\r
+					AnotherToStringCreator creator2 = new AnotherToStringCreator(this);\r
+					creator2.addSth(aBool, "aBool");\r
+					creator2.addSth(intArray, "intArray");\r
+					creator2.addSth(stringArray, "stringArray");\r
+					creator2.addSth(AArray, "AArray");\r
+					creator2.addSth(list, "list");\r
+					creator2.addSth(hashMap, "hashMap");\r
+					creator2.addSth(wildCollection, "wildCollection");\r
+					creator2.addSth(integerCollection, "integerCollection");\r
+					creator2.addSth(builder, "builder");\r
+					creator2.addSth(buffer, "buffer");\r
+					creator2.addSth(maxLen, "maxLen");\r
+					creator2.addSth(len, "len");\r
+					creator2.addSth(collection, "collection");\r
+					creator2.addSth(array, "array");\r
+					creator2.addSth(creator, "creator");\r
+					return creator2.getResult();\r
+				}\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}
@@ -3389,10 +5651,27 @@ public class GenerateToStringTest extends SourceTestCase {
 	@Test
 	public void builderArrayLimit1_4Prefixes() throws Exception {
 		setCompilerLevels(false, false);
-		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" + "\r\n" + "import java.util.Collection;\r\n" + "import java.util.HashMap;\r\n" + "import java.util.List;\r\n"
-				+ "\r\n" + "public class A {\r\n" + "\r\n" + "	int[] intArray;\r\n"
-				+ "	A[] AArray;\r\n" + "	char[] charArrayMethod() {\r\n" + "		return new char[0];\r\n" + "	}\r\n" + "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n" + "	Collection<?> wildCollection;\r\n" + "	Collection<Integer> integerCollection;\r\n" + "	\r\n" + "}\r\n" + "", true, null);
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				int[] intArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				\r
+			}\r
+			""", true, null);
 		CompilationUnit oldCUNode= getCUNode(a);
 
 		IMember[] members= getMembers(a.getType("A"), new String[] { "AArray", "hashMap", "intArray", "integerCollection", "list", "wildCollection", "charArrayMethod"});
@@ -3408,82 +5687,83 @@ public class GenerateToStringTest extends SourceTestCase {
 
 		runOperation(a.getType("A"), members, null);
 
-		String expected= "package p;\r\n"
-				+ "\r\n"
-				+ "import java.util.Collection;\r\n"
-				+ "import java.util.HashMap;\r\n"
-				+ "import java.util.Iterator;\r\n"
-				+ "import java.util.List;\r\n"
-				+ "\r\n"
-				+ "public class A {\r\n"
-				+ "\r\n"
-				+ "	int[] intArray;\r\n"
-				+ "	A[] AArray;\r\n"
-				+ "	char[] charArrayMethod() {\r\n"
-				+ "		return new char[0];\r\n"
-				+ "	}\r\n"
-				+ "	List<Boolean> list;\r\n"
-				+ "	HashMap<Integer, String> hashMap;\r\n"
-				+ "	Collection<?> wildCollection;\r\n"
-				+ "	Collection<Integer> integerCollection;\r\n"
-				+ "	@Override\r\n"
-				+ "	public String toString() {\r\n"
-				+ "		final int l_maxLen_l = 10;\r\n"
-				+ "		StringBuffer l_buffer_l = new StringBuffer();\r\n"
-				+ "		l_buffer_l.append(\"A [AArray=\");\r\n"
-				+ "		l_buffer_l.append(AArray != null ? arrayToString(AArray, AArray.length, l_maxLen_l) : null);\r\n"
-				+ "		l_buffer_l.append(\", hashMap=\");\r\n"
-				+ "		l_buffer_l.append(hashMap != null ? toString(hashMap.entrySet(), l_maxLen_l) : null);\r\n"
-				+ "		l_buffer_l.append(\", intArray=\");\r\n"
-				+ "		l_buffer_l.append(intArray != null ? arrayToString(intArray, intArray.length, l_maxLen_l) : null);\r\n"
-				+ "		l_buffer_l.append(\", integerCollection=\");\r\n"
-				+ "		l_buffer_l.append(integerCollection != null ? toString(integerCollection, l_maxLen_l) : null);\r\n"
-				+ "		l_buffer_l.append(\", list=\");\r\n"
-				+ "		l_buffer_l.append(list != null ? toString(list, l_maxLen_l) : null);\r\n"
-				+ "		l_buffer_l.append(\", wildCollection=\");\r\n"
-				+ "		l_buffer_l.append(wildCollection != null ? toString(wildCollection, l_maxLen_l) : null);\r\n"
-				+ "		l_buffer_l.append(\", charArrayMethod()=\");\r\n"
-				+ "		l_buffer_l.append(charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, l_maxLen_l) : null);\r\n"
-				+ "		l_buffer_l.append(\"]\");\r\n"
-				+ "		return l_buffer_l.toString();\r\n"
-				+ "	}\r\n"
-				+ "	private String toString(Collection a_collection_a, int a_maxLen_a) {\r\n"
-				+ "		StringBuffer l_buffer_l = new StringBuffer();\r\n"
-				+ "		l_buffer_l.append(\"[\");\r\n"
-				+ "		int l_i_l = 0;\r\n"
-				+ "		for (Iterator l_iterator_l = a_collection_a.iterator(); l_iterator_l.hasNext() && l_i_l < a_maxLen_a; l_i_l++) {\r\n"
-				+ "			if (l_i_l > 0) {\r\n"
-				+ "				l_buffer_l.append(\", \");\r\n"
-				+ "			}\r\n"
-				+ "			l_buffer_l.append(l_iterator_l.next());\r\n"
-				+ "		}\r\n"
-				+ "		l_buffer_l.append(\"]\");\r\n"
-				+ "		return l_buffer_l.toString();\r\n"
-				+ "	}\r\n"
-				+ "	private String arrayToString(Object a_array_a, int a_len_a, int a_maxLen_a) {\r\n"
-				+ "		StringBuffer l_buffer_l = new StringBuffer();\r\n"
-				+ "		a_len_a = Math.min(a_len_a, a_maxLen_a);\r\n"
-				+ "		l_buffer_l.append(\"[\");\r\n"
-				+ "		for (int l_i_l = 0; l_i_l < a_len_a; l_i_l++) {\r\n"
-				+ "			if (l_i_l > 0) {\r\n"
-				+ "				l_buffer_l.append(\", \");\r\n"
-				+ "			}\r\n"
-				+ "			if (a_array_a instanceof int[]) {\r\n"
-				+ "				l_buffer_l.append(((int[]) a_array_a)[l_i_l]);\r\n"
-				+ "			}\r\n"
-				+ "			if (a_array_a instanceof char[]) {\r\n"
-				+ "				l_buffer_l.append(((char[]) a_array_a)[l_i_l]);\r\n"
-				+ "			}\r\n"
-				+ "			if (a_array_a instanceof Object[]) {\r\n"
-				+ "				l_buffer_l.append(((Object[]) a_array_a)[l_i_l]);\r\n"
-				+ "			}\r\n"
-				+ "		}\r\n"
-				+ "		l_buffer_l.append(\"]\");\r\n"
-				+ "		return l_buffer_l.toString();\r\n"
-				+ "	}\r\n"
-				+ "	\r\n"
-				+ "}\r\n"
-				+ "";
+		String expected= """
+			package p;\r
+			\r
+			import java.util.Collection;\r
+			import java.util.HashMap;\r
+			import java.util.Iterator;\r
+			import java.util.List;\r
+			\r
+			public class A {\r
+			\r
+				int[] intArray;\r
+				A[] AArray;\r
+				char[] charArrayMethod() {\r
+					return new char[0];\r
+				}\r
+				List<Boolean> list;\r
+				HashMap<Integer, String> hashMap;\r
+				Collection<?> wildCollection;\r
+				Collection<Integer> integerCollection;\r
+				@Override\r
+				public String toString() {\r
+					final int l_maxLen_l = 10;\r
+					StringBuffer l_buffer_l = new StringBuffer();\r
+					l_buffer_l.append("A [AArray=");\r
+					l_buffer_l.append(AArray != null ? arrayToString(AArray, AArray.length, l_maxLen_l) : null);\r
+					l_buffer_l.append(", hashMap=");\r
+					l_buffer_l.append(hashMap != null ? toString(hashMap.entrySet(), l_maxLen_l) : null);\r
+					l_buffer_l.append(", intArray=");\r
+					l_buffer_l.append(intArray != null ? arrayToString(intArray, intArray.length, l_maxLen_l) : null);\r
+					l_buffer_l.append(", integerCollection=");\r
+					l_buffer_l.append(integerCollection != null ? toString(integerCollection, l_maxLen_l) : null);\r
+					l_buffer_l.append(", list=");\r
+					l_buffer_l.append(list != null ? toString(list, l_maxLen_l) : null);\r
+					l_buffer_l.append(", wildCollection=");\r
+					l_buffer_l.append(wildCollection != null ? toString(wildCollection, l_maxLen_l) : null);\r
+					l_buffer_l.append(", charArrayMethod()=");\r
+					l_buffer_l.append(charArrayMethod() != null ? arrayToString(charArrayMethod(), charArrayMethod().length, l_maxLen_l) : null);\r
+					l_buffer_l.append("]");\r
+					return l_buffer_l.toString();\r
+				}\r
+				private String toString(Collection a_collection_a, int a_maxLen_a) {\r
+					StringBuffer l_buffer_l = new StringBuffer();\r
+					l_buffer_l.append("[");\r
+					int l_i_l = 0;\r
+					for (Iterator l_iterator_l = a_collection_a.iterator(); l_iterator_l.hasNext() && l_i_l < a_maxLen_a; l_i_l++) {\r
+						if (l_i_l > 0) {\r
+							l_buffer_l.append(", ");\r
+						}\r
+						l_buffer_l.append(l_iterator_l.next());\r
+					}\r
+					l_buffer_l.append("]");\r
+					return l_buffer_l.toString();\r
+				}\r
+				private String arrayToString(Object a_array_a, int a_len_a, int a_maxLen_a) {\r
+					StringBuffer l_buffer_l = new StringBuffer();\r
+					a_len_a = Math.min(a_len_a, a_maxLen_a);\r
+					l_buffer_l.append("[");\r
+					for (int l_i_l = 0; l_i_l < a_len_a; l_i_l++) {\r
+						if (l_i_l > 0) {\r
+							l_buffer_l.append(", ");\r
+						}\r
+						if (a_array_a instanceof int[]) {\r
+							l_buffer_l.append(((int[]) a_array_a)[l_i_l]);\r
+						}\r
+						if (a_array_a instanceof char[]) {\r
+							l_buffer_l.append(((char[]) a_array_a)[l_i_l]);\r
+						}\r
+						if (a_array_a instanceof Object[]) {\r
+							l_buffer_l.append(((Object[]) a_array_a)[l_i_l]);\r
+						}\r
+					}\r
+					l_buffer_l.append("]");\r
+					return l_buffer_l.toString();\r
+				}\r
+				\r
+			}\r
+			""";
 
 		compareSourceAssertCompilation(expected, a, oldCUNode);
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -124,17 +124,18 @@ public class JavadocHoverTests extends CoreTests {
 
 	@Test
 	public void testEnumWithAnonymousClass() throws Exception {
-		String myEnumSource = "package test;\n"
-				+ "public enum MyEnum {\n"
-				+ "	ENUM1 {\n"
-				+ "		@Override\n"
-				+ "		public String get() {\n"
-				+ "			return \"ENUM1\";\n"
-				+ "		}\n"
-				+ "	};\n"
-				+ "	public abstract String get();\n"
-				+ "}\n"
-				+ "";
+		String myEnumSource = """
+			package test;
+			public enum MyEnum {
+				ENUM1 {
+					@Override
+					public String get() {
+						return "ENUM1";
+					}
+				};
+				public abstract String get();
+			}
+			""";
 		ICompilationUnit myEnumCu= getWorkingCopy("/TestSetupProject/src/test/MyEnum.java", myEnumSource, null);
 		assertNotNull("MyEnum.java", myEnumCu);
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
@@ -72,33 +72,34 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	public int foo(Day day) {\n");
-		buf.append("		// return variable\n");
-		buf.append("		int i;\n");
-		buf.append("		switch (day) {\n");
-		buf.append("			case SATURDAY:\n");
-		buf.append("			case SUNDAY: i = 5; break;\n");
-		buf.append("			case MONDAY:\n");
-		buf.append("			case TUESDAY, WEDNESDAY: i = 7; break;\n");
-		buf.append("			case THURSDAY:\n");
-		buf.append("			case FRIDAY: i = 14; break;\n");
-		buf.append("			default :\n");
-		buf.append("				i = 22;\n");
-		buf.append("				break;\n");
-		buf.append("		}\n");
-		buf.append("		return i;\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		buf.append("\n");
-		buf.append("enum Day {\n");
-		buf.append("    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(Day day) {
+					// return variable
+					int i;
+					switch (day) {
+						case SATURDAY:
+						case SUNDAY: i = 5; break;
+						case MONDAY:
+						case TUESDAY, WEDNESDAY: i = 7; break;
+						case THURSDAY:
+						case FRIDAY: i = 14; break;
+						default :
+							i = 22;
+							break;
+					}
+					return i;
+				}
+			}
+			
+			enum Day {
+			    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("\t\tswitch (day) {");
+		int index= str1.indexOf("\t\tswitch (day) {");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 16);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -144,34 +145,35 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	public int foo(Day day) {\n");
-		buf.append("		// return variable\n");
-		buf.append("		int i;\n");
-		buf.append("		int j = 4;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (day) {\n");
-		buf.append("			case SATURDAY:\n");
-		buf.append("			case SUNDAY: i = 5; break;\n");
-		buf.append("			case MONDAY:\n");
-		buf.append("			case TUESDAY:\n");
-		buf.append("			case WEDNESDAY: System.out.println(\"here\"); i = 7; break;\n");
-		buf.append("			case THURSDAY:\n");
-		buf.append("			case FRIDAY: i = 14; break;\n");
-		buf.append("			default: i = 22; break;\n");
-		buf.append("		}\n");
-		buf.append("		return i;\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		buf.append("\n");
-		buf.append("enum Day {\n");
-		buf.append("    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(Day day) {
+					// return variable
+					int i;
+					int j = 4;
+					// logic comment
+					switch (day) {
+						case SATURDAY:
+						case SUNDAY: i = 5; break;
+						case MONDAY:
+						case TUESDAY:
+						case WEDNESDAY: System.out.println("here"); i = 7; break;
+						case THURSDAY:
+						case FRIDAY: i = 14; break;
+						default: i = 22; break;
+					}
+					return i;
+				}
+			}
+			
+			enum Day {
+			    MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY;
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -223,33 +225,34 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	static int i;\n");
-		buf.append("	static {\n");
-		buf.append("		// var comment\n");
-		buf.append("		int j = 4;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (j) {\n");
-		buf.append("			case 0:\n");
-		buf.append("			case 1: i = 5; break;\n");
-		buf.append("			case 2:\n");
-		buf.append("			case 3:\n");
-		buf.append("			case 4:\n");
-		buf.append("                System.out.println(\"here\"); // comment 1\n");
-		buf.append("                // comment 2\n");
-		buf.append("                i = 7; // comment 3\n");
-		buf.append("                break;\n");
-		buf.append("			case 5:\n");
-		buf.append("			case 6: i = 14; break;\n");
-		buf.append("			default: i = 22; break;\n");
-		buf.append("		}\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				static int i;
+				static {
+					// var comment
+					int j = 4;
+					// logic comment
+					switch (j) {
+						case 0:
+						case 1: i = 5; break;
+						case 2:
+						case 3:
+						case 4:
+			                System.out.println("here"); // comment 1
+			                // comment 2
+			                i = 7; // comment 3
+			                break;
+						case 5:
+						case 6: i = 14; break;
+						default: i = 22; break;
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -297,29 +300,30 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	public int foo(int j, int k) {\n");
-		buf.append("		// var comment\n");
-		buf.append("		int i;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (j) {\n");
-		buf.append("			case 0:\n");
-		buf.append("			case 1: i = k > 7 ? 5 : 6; break;\n");
-		buf.append("			case 2:\n");
-		buf.append("			case 3:\n");
-		buf.append("			case 4: System.out.println(\"here\"); i = 7; break;\n");
-		buf.append("			case 5:\n");
-		buf.append("			case 6: i = 14; break;\n");
-		buf.append("			default: i = 22; break;\n");
-		buf.append("		}\n");
-		buf.append("		return i;\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int j, int k) {
+					// var comment
+					int i;
+					// logic comment
+					switch (j) {
+						case 0:
+						case 1: i = k > 7 ? 5 : 6; break;
+						case 2:
+						case 3:
+						case 4: System.out.println("here"); i = 7; break;
+						case 5:
+						case 6: i = 14; break;
+						default: i = 22; break;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -364,21 +368,22 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("    public int foo(int i) {\n");
-		buf.append("        switch (i) {\n");
-		buf.append("        case 0: // comment\n");
-		buf.append("            return 0;\n");
-		buf.append("        default:\n");
-		buf.append("            return 1;\n");
-		buf.append("        }\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public int foo(int i) {
+			        switch (i) {
+			        case 0: // comment
+			            return 0;
+			        default:
+			            return 1;
+			        }
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -418,29 +423,30 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	static int i;\n");
-		buf.append("	static {\n");
-		buf.append("		// var comment\n");
-		buf.append("		int j = 4;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (j) {\n");
-		buf.append("			case 0: break; // no statements\n");
-		buf.append("			case 1: i = 5; break;\n");
-		buf.append("			case 2:\n");
-		buf.append("			case 3:\n");
-		buf.append("			case 4: System.out.println(\"here\"); i = 7; break;\n");
-		buf.append("			case 5:\n");
-		buf.append("			case 6: i = 14; break;\n");
-		buf.append("			default: i = 22; break;\n");
-		buf.append("		}\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				static int i;
+				static {
+					// var comment
+					int j = 4;
+					// logic comment
+					switch (j) {
+						case 0: break; // no statements
+						case 1: i = 5; break;
+						case 2:
+						case 3:
+						case 4: System.out.println("here"); i = 7; break;
+						case 5:
+						case 6: i = 14; break;
+						default: i = 22; break;
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -463,30 +469,31 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	public int foo(int k) {\n");
-		buf.append("		int i;\n");
-		buf.append("		// var comment\n");
-		buf.append("		int j = 4;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (j) {\n");
-		buf.append("			case 0: System.out.println(\"here\"); // fall-through with statements\n");
-		buf.append("			case 1: i = 5; break;\n");
-		buf.append("			case 2:\n");
-		buf.append("			case 3:\n");
-		buf.append("			case 4: System.out.println(\"here\"); i = 7; break;\n");
-		buf.append("			case 5:\n");
-		buf.append("			case 6: i = 14; break;\n");
-		buf.append("			default: i = 22; break;\n");
-		buf.append("		}\n");
-		buf.append("		return i;\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// var comment
+					int j = 4;
+					// logic comment
+					switch (j) {
+						case 0: System.out.println("here"); // fall-through with statements
+						case 1: i = 5; break;
+						case 2:
+						case 3:
+						case 4: System.out.println("here"); i = 7; break;
+						case 5:
+						case 6: i = 14; break;
+						default: i = 22; break;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -509,30 +516,31 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	public int foo(int k) {\n");
-		buf.append("		int i;\n");
-		buf.append("		// var comment\n");
-		buf.append("		int j = 4;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (j) {\n");
-		buf.append("			case 0:\n");
-		buf.append("			case 1: i = 5; return i; // return statement\n");
-		buf.append("			case 2:\n");
-		buf.append("			case 3:\n");
-		buf.append("			case 4: System.out.println(\"here\"); i = 7; break;\n");
-		buf.append("			case 5:\n");
-		buf.append("			case 6: i = 14; break;\n");
-		buf.append("			default: i = 22; break;\n");
-		buf.append("		}\n");
-		buf.append("		return i;\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// var comment
+					int j = 4;
+					// logic comment
+					switch (j) {
+						case 0:
+						case 1: i = 5; return i; // return statement
+						case 2:
+						case 3:
+						case 4: System.out.println("here"); i = 7; break;
+						case 5:
+						case 6: i = 14; break;
+						default: i = 22; break;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -555,30 +563,31 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	public int foo(int k) {\n");
-		buf.append("		int i;\n");
-		buf.append("		// var comment\n");
-		buf.append("		int j = 4;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (j) {\n");
-		buf.append("			case 0:\n");
-		buf.append("			case 1: i = 5; j = 5; break; // last statement not common assignment\n");
-		buf.append("			case 2:\n");
-		buf.append("			case 3:\n");
-		buf.append("			case 4: System.out.println(\"here\"); i = 7; break;\n");
-		buf.append("			case 5:\n");
-		buf.append("			case 6: i = 14; break;\n");
-		buf.append("			default: i = 22; break;\n");
-		buf.append("		}\n");
-		buf.append("		return i;\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// var comment
+					int j = 4;
+					// logic comment
+					switch (j) {
+						case 0:
+						case 1: i = 5; j = 5; break; // last statement not common assignment
+						case 2:
+						case 3:
+						case 4: System.out.println("here"); i = 7; break;
+						case 5:
+						case 6: i = 14; break;
+						default: i = 22; break;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
@@ -601,30 +610,31 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		def.createCompilationUnit("module-info.java", str, false, null);
 
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test;\n");
-		buf.append("public class Cls {\n");
-		buf.append("	public int foo(int k) {\n");
-		buf.append("		int i;\n");
-		buf.append("		// var comment\n");
-		buf.append("		int j = 4;\n");
-		buf.append("		// logic comment\n");
-		buf.append("		switch (j) {\n");
-		buf.append("			case 0:\n");
-		buf.append("			case 1: i = 5; break;\n");
-		buf.append("			case 2:\n");
-		buf.append("			case 3:\n");
-		buf.append("			case 4: System.out.println(\"here\"); i = 7; break;\n");
-		buf.append("			case 5:\n");
-		buf.append("			case 6: i = 14; break;\n");
-		buf.append("			// no default\n");
-		buf.append("		}\n");
-		buf.append("		return i;\n");
-		buf.append("	}\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", buf.toString(), false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// var comment
+					int j = 4;
+					// logic comment
+					switch (j) {
+						case 0:
+						case 1: i = 5; break;
+						case 2:
+						case 3:
+						case 4: System.out.println("here"); i = 7; break;
+						case 5:
+						case 6: i = 14; break;
+						// no default
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= buf.indexOf("switch");
+		int index= str1.indexOf("switch");
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
 		assertProposalDoesNotExist(proposals, FixMessages.SwitchExpressionsFix_convert_to_switch_expression);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/LocalCorrectionsQuickFixTest.java
@@ -1355,25 +1355,26 @@ public class LocalCorrectionsQuickFixTest extends QuickFixTest {
 	public void testUncaughtExceptionExtendedSelection() throws Exception {
 
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("import java.io.IOException;\n");
-		buf.append("public class E {\n");
-		buf.append("    public String goo(int i) throws IOException {\n");
-		buf.append("        return null;\n");
-		buf.append("    }\n");
-		buf.append("    public void foo() {\n");
-		buf.append("        System.out.println(goo(1));\n");
-		buf.append("        System.out.println(goo(2));\n");
-		buf.append("    }\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		String str= """
+			package test1;
+			import java.io.IOException;
+			public class E {
+			    public String goo(int i) throws IOException {
+			        return null;
+			    }
+			    public void foo() {
+			        System.out.println(goo(1));
+			        System.out.println(goo(2));
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
 		CompilationUnit astRoot= getASTRoot(cu);
 		String begin= "goo(1)", end= "goo(2));";
 
-		int offset= buf.indexOf(begin);
-		int length= buf.indexOf(end) + end.length() - offset;
+		int offset= str.indexOf(begin);
+		int length= str.indexOf(end) + end.length() - offset;
 		AssistContext context= getCorrectionContext(cu, offset, length);
 		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 2, context);
 		assertNumberOfProposals(proposals, 2);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
@@ -1794,17 +1794,18 @@ public class QuickFixTest1d8 extends QuickFixTest {
 
 		JavaProjectHelper.addLibrary(fJProject1, new Path(Java1d8ProjectTestSetup.getJdtAnnotations20Path()));
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
-		StringBuilder buf= new StringBuilder();
-		buf.append("package test1;\n");
-		buf.append("import org.eclipse.jdt.annotation.*;\n");
-		buf.append("@NonNullByDefault\n");
-		buf.append("public class E {\n");
-		buf.append("    @NonNull Object f=new Object();\n");
-		buf.append("}\n");
-		ICompilationUnit cu= pack1.createCompilationUnit("E.java", buf.toString(), false, null);
+		String str1= """
+			package test1;
+			import org.eclipse.jdt.annotation.*;
+			@NonNullByDefault
+			public class E {
+			    @NonNull Object f=new Object();
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str1, false, null);
 
 		CompilationUnit astRoot= getASTRoot(cu);
-		int offset= buf.indexOf("Object f");
+		int offset= str1.indexOf("Object f");
 		AssistContext context= new AssistContext(cu, offset, 0);
 		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1, context);
 		assertNumberOfProposals(proposals, 3);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UtilitiesTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/UtilitiesTest.java
@@ -87,19 +87,19 @@ public class UtilitiesTest extends QuickFixTest {
 			import java.util.ArrayList;
 			import java.util.HashMap;
 			public class E<T> {
-			
+
 			    public class F<U> {}
 			    X[] x1= new String[0];
 			    X[][] x2= new String[][0];
 			    X[][] x3= new String[][][0];
-			
+
 			    ArrayList<X> x4= new ArrayList<String>();
 			    X<String> x5= new ArrayList<String>();
 			    HashMap<ArrayList<String>, X> x6= new HashMap<ArrayList<String>, Number>();
 			    HashMap<ArrayList<X>, Number> x7= new HashMap<ArrayList<String>, Number>();
-			
+
 			    HashMap<? extends X, Number> x8= new HashMap<? extends Number, Number>();
-			
+
 			    E<String>.F<X> x9 = new E<String>().new F<Number>();
 			    E<String>.X<Number> x10 = new E<String>().new F<Number>();
 			    X<String>.F<Number> x11 = new E<String>().new F<Number>();
@@ -117,7 +117,7 @@ public class UtilitiesTest extends QuickFixTest {
 		CompilationUnit astRoot= getASTRoot(cu);
 		FieldDeclaration[] fields= ((TypeDeclaration) astRoot.types().get(0)).getFields();
 		for (int i= 0; i < fields.length; i++) {
-			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X"), 1);
+			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X", fields[i].getStartPosition()), 1);
 			ITypeBinding actualBinding= ASTResolving.guessBindingForTypeReference(node);
 			String actual= actualBinding != null ? actualBinding.getQualifiedName() : "null";
 			if (!actual.equals(expected[i])) {
@@ -155,7 +155,7 @@ public class UtilitiesTest extends QuickFixTest {
 		CompilationUnit astRoot= getASTRoot(cu);
 		MethodDeclaration[] methods= ((TypeDeclaration) astRoot.types().get(0)).getMethods();
 		for (int i= 0; i < methods.length; i++) {
-			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X"), 1);
+			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X", methods[i].getStartPosition()), 1);
 			ITypeBinding actualBinding= ASTResolving.guessBindingForTypeReference(node);
 			String actual= actualBinding != null ? actualBinding.getQualifiedName() : "null";
 			if (!actual.equals(expected[i])) {
@@ -178,13 +178,13 @@ public class UtilitiesTest extends QuickFixTest {
 			    X<String> x3;
 			    ArrayList<X> x4;
 			    ArrayList<? extends X> x5;
-			
+
 			    E<String>.X x6;
 			    X<String>.A x7;
 			    Object x8= new X();
 			    Object x9= new X() { };
 			    Object x10= (X) x1;
-			
+
 			    X.A x11;
 			    Object x12= X.class;
 			}
@@ -211,7 +211,7 @@ public class UtilitiesTest extends QuickFixTest {
 		CompilationUnit astRoot= getASTRoot(cu);
 		FieldDeclaration[] fields= ((TypeDeclaration) astRoot.types().get(0)).getFields();
 		for (int i= 0; i < fields.length; i++) {
-			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X"), 1);
+			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X",fields[i].getStartPosition()), 1);
 			int kinds= ASTResolving.getPossibleTypeKinds(node);
 			if (kinds != expected[i]) {
 				assertEquals("Guessing failed for " + fields[i].toString(), expected[i], kinds);
@@ -240,7 +240,7 @@ public class UtilitiesTest extends QuickFixTest {
 		CompilationUnit astRoot= getASTRoot(cu);
 		for (int i = 0; i < astRoot.types().size(); i++) {
 			TypeDeclaration typeDecl = (TypeDeclaration) astRoot.types().get(i);
-			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X"), 1);
+			ASTNode node= NodeFinder.perform(astRoot, str.indexOf("X", typeDecl.getStartPosition()), 1);
 			int kinds= ASTResolving.getPossibleTypeKinds(node);
 			assertEquals("Guessing failed for " + node.toString(), expected[i], kinds);
 		}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
This PR contains the result of applying the latest incarnation of the text block cleanup to the junit test code base of jdt ui. After some fixes to support more cases from @jjohnstn a lot of prior unsupported cases show up.

## How to test
Basically all should be fine when the tests are still running through as there are no changes to the jdt ui code base. Only tests are affected.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
