### PR TITLE
Tests should not explicitly set pre 1.8 compliance

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractForLoopJavaContextTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractForLoopJavaContextTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2020 IBM Corporation and others.
+ * Copyright (c) 2014, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -55,11 +55,11 @@ public abstract class AbstractForLoopJavaContextTest {
 
 	private static final String CU_PREFIX= """
 		package test;
-		
+
 		import java.io.Serializable;
 		import java.util.Collection;
 		import java.util.List;
-		
+
 		public class A<E extends Number> {
 		""";
 
@@ -84,13 +84,13 @@ public abstract class AbstractForLoopJavaContextTest {
 			//			options.put(DefaultCodeFormatterConstants.FORMATTER_INDENTATION_SIZE, "4");
 			JavaCore.setOptions(options);
 		}
-		setUpProject(JavaCore.VERSION_1_5);
+		setUpProject();
 	}
 
-	private void setUpProject(String sourceLevel) throws CoreException, JavaModelException {
+	private void setUpProject() throws CoreException, JavaModelException {
 		fProject= JavaProjectHelper.createJavaProject(PROJECT, "bin");
 		JavaProjectHelper.addRTJar(fProject);
-		fProject.setOption(JavaCore.COMPILER_SOURCE, sourceLevel);
+		fProject.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
 		IPackageFragmentRoot fragmentRoot= JavaProjectHelper.addSourceContainer(fProject, SRC);
 		IPackageFragment fragment= fragmentRoot.createPackageFragment("test", true, new NullProgressMonitor());
 		fCU= fragment.createCompilationUnit(CU_NAME, "", true, new NullProgressMonitor());

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaModelOpCompundUndoTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaModelOpCompundUndoTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -74,9 +74,9 @@ public class JavaModelOpCompundUndoTest {
 	private static final String CU_NAME= "Bug75423.java";
 	private static final String CU_CONTENTS= """
 		package com.example.bugs;
-		
+
 		public class Bug75423 {
-		
+
 		    void foo() {
 		       \s
 		    }
@@ -94,9 +94,9 @@ public class JavaModelOpCompundUndoTest {
 	private ICompilationUnit fCompilationUnit;
 	private IUndoManager fUndoManager;
 
-	private void setUpProject(String sourceLevel) throws CoreException, JavaModelException {
+	private void setUpProject() throws CoreException, JavaModelException {
 		fProject= JavaProjectHelper.createJavaProject(tn.getMethodName(), "bin");
-		fProject.setOption(JavaCore.COMPILER_SOURCE, sourceLevel);
+		fProject.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
 		JavaProjectHelper.addSourceContainer(fProject, SRC);
 		IPackageFragment fragment= fProject.findPackageFragment(new Path(SEP + tn.getMethodName() + SEP + SRC));
 		fCompilationUnit= fragment.createCompilationUnit(CU_NAME, CU_CONTENTS, true, new NullProgressMonitor());
@@ -104,7 +104,7 @@ public class JavaModelOpCompundUndoTest {
 
 	@Before
 	public void setUp() throws Exception {
-		setUpProject(JavaCore.VERSION_1_5);
+		setUpProject();
 		setUpEditor();
 	}
 
@@ -161,9 +161,6 @@ public class JavaModelOpCompundUndoTest {
 
 	@Test
 	public void test2() throws Exception {
-		setUpProject(JavaCore.VERSION_1_5);
-		setUpEditor();
-
 		assertEquals(CU_CONTENTS, fDocument.get());
 		fUndoManager.beginCompoundChange();
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/buildpath/BuildpathProblemQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/buildpath/BuildpathProblemQuickFixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Till Brychcy and others.
+ * Copyright (c) 2020, 2024 Till Brychcy and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -169,7 +169,7 @@ public class BuildpathProblemQuickFixTest {
 
 	@Test
 	public void test3RequiredBinaryLevel() throws CoreException, IOException {
-		IPath container= new Path("org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7");
+		IPath container= new Path("org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8");
 		@SuppressWarnings("restriction")
 		IVMInstall vm= org.eclipse.jdt.internal.launching.JREContainerInitializer.resolveVM(container);
 		if (vm == null) {
@@ -177,8 +177,8 @@ public class BuildpathProblemQuickFixTest {
 		}
 		if (vm instanceof IVMInstall2) {
 			String version= ((IVMInstall2) vm).getJavaVersion();
-			if (version == null || !version.startsWith(JavaCore.VERSION_1_7)) {
-				// higher version instead of JavaSE 1.7 not found:
+			if (version == null || !version.startsWith(JavaCore.VERSION_1_8)) {
+				// higher version instead of JavaSE 1.8 not found:
 				// skip test as error against vm's class files would be reported
 				return;
 			}
@@ -194,7 +194,7 @@ public class BuildpathProblemQuickFixTest {
 		String classpath= """
 			<?xml version="1.0" encoding="UTF-8"?>
 			<classpath>
-				<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+				<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 				<classpathentry kind="src" path="src"/>
 				<classpathentry combineaccessrules="false" kind="src" path="/3_JDKLevelHigh"/>
 				<classpathentry kind="output" path="bin"/>
@@ -202,9 +202,9 @@ public class BuildpathProblemQuickFixTest {
 			""";
 		addFile(fJavaProject1.getPath(), ".classpath", classpath);
 		addFile(src1.getFullPath(), "LowClass.java", "public class LowClass{HighClass x;}");
-		fJavaProject1.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_7);
-		fJavaProject1.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_7);
-		fJavaProject1.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_7);
+		fJavaProject1.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
+		fJavaProject1.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
+		fJavaProject1.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
 		fJavaProject1.setOption(JavaCore.CORE_INCOMPATIBLE_JDK_LEVEL, JavaCore.ERROR);
 
 
@@ -222,15 +222,15 @@ public class BuildpathProblemQuickFixTest {
 			""";
 		addFile(fJavaProject2.getPath(), ".classpath", classpath2);
 		addFile(src2.getFullPath(), "HighClass.java", "public class HighClass{}");
-		fJavaProject2.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_8);
-		fJavaProject2.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
-		fJavaProject2.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_8);
+		fJavaProject2.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_11);
+		fJavaProject2.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_11);
+		fJavaProject2.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_11);
 
 		fJavaProject1.getProject().getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
 
 		IMarker[] markers= fJavaProject1.getResource().findMarkers("org.eclipse.jdt.core.buildpath_problem", true, IResource.DEPTH_INFINITE);
 		assertEquals(
-				"Incompatible .class files version in required binaries. Project '3_JDKLevelLow' is targeting a 1.7 runtime, but is compiled against '3_JDKLevelHigh' which requires a 1.8 runtime",
+				"Incompatible .class files version in required binaries. Project '3_JDKLevelLow' is targeting a 1.8 runtime, but is compiled against '3_JDKLevelHigh' which requires a 11 runtime",
 				markers[0].getAttribute(IMarker.MESSAGE));
 		assertEquals(1, markers.length);
 		IMarkerResolution[] resolutions= sortResolutions(IDE.getMarkerHelpRegistry().getResolutions(markers[0]));


### PR DESCRIPTION
ECJ no longer supports it.
