### PR TITLE
Simplify "string" generation/cleanups by dropping pre 1.5

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/CustomBuilderGenerator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/CustomBuilderGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Mateusz Matela and others.
+ * Copyright (c) 2008, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -273,19 +273,11 @@ public class CustomBuilderGenerator extends AbstractToStringGenerator {
 		ITypeBinding memberType= getMemberType(member);
 		String memberTypeName= memberType.getQualifiedName();
 
-		Expression memberAccessExpression= null;
-
 		AppendMethodInformation ami= appendMethodSpecificTypes.get(memberTypeName);
 		if (ami == null && memberType.isPrimitive()) {
 			memberTypeName= wrapperTypes[primitiveTypes.indexOf(memberTypeName)];
 			memberType= fAst.resolveWellKnownType(memberTypeName);
 			ami= appendMethodSpecificTypes.get(memberTypeName);
-			if (!getContext().is50orHigher()) {
-				ClassInstanceCreation classInstance= fAst.newClassInstanceCreation();
-				classInstance.setType(fAst.newSimpleType(addImport(memberTypeName)));
-				classInstance.arguments().add(createMemberAccessExpression(member, true, true));
-				memberAccessExpression= classInstance;
-			}
 		}
 		while (ami == null) {
 			ITypeBinding oldMemberType= memberType;
@@ -297,9 +289,7 @@ public class CustomBuilderGenerator extends AbstractToStringGenerator {
 			ami= appendMethodSpecificTypes.get(memberTypeName);
 		}
 
-		if (memberAccessExpression == null) {
-			memberAccessExpression= createMemberAccessExpression(member, false, getContext().isSkipNulls());
-		}
+		Expression memberAccessExpression= createMemberAccessExpression(member, false, getContext().isSkipNulls());
 
 		MethodInvocation appendInvocation= fAst.newMethodInvocation();
 		appendInvocation.setName(fAst.newSimpleName(getContext().getCustomBuilderAppendMethod()));

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/StringBuilderGenerator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/StringBuilderGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Mateusz Matela and others.
+ * Copyright (c) 2008, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -74,12 +74,12 @@ public class StringBuilderGenerator extends AbstractToStringGenerator {
 	@Override
 	protected void initialize() {
 		super.initialize();
-		fBuilderVariableName= createNameSuggestion(getContext().is50orHigher() ? "builder" : "buffer", NamingConventions.VK_LOCAL); //$NON-NLS-1$ //$NON-NLS-2$
+		fBuilderVariableName= createNameSuggestion("builder", NamingConventions.VK_LOCAL); //$NON-NLS-1$
 		fBuffer= new StringBuffer();
 		VariableDeclarationFragment fragment= fAst.newVariableDeclarationFragment();
 		fragment.setName(fAst.newSimpleName(fBuilderVariableName));
 		ClassInstanceCreation classInstance= fAst.newClassInstanceCreation();
-		Name typeName= addImport(getContext().is50orHigher() ? "java.lang.StringBuilder" : "java.lang.StringBuffer"); //$NON-NLS-1$ //$NON-NLS-2$
+		Name typeName= addImport("java.lang.StringBuilder"); //$NON-NLS-1$
 		classInstance.setType(fAst.newSimpleType(typeName));
 		fragment.setInitializer(classInstance);
 		VariableDeclarationStatement vStatement= fAst.newVariableDeclarationStatement(fragment);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/StringFormatGenerator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/StringFormatGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Mateusz Matela and others.
+ * Copyright (c) 2008, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,11 +20,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 
-import org.eclipse.jdt.core.dom.ArrayCreation;
-import org.eclipse.jdt.core.dom.ArrayInitializer;
-import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.Expression;
-import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.StringLiteral;
@@ -61,25 +57,12 @@ public class StringFormatGenerator extends AbstractToStringGenerator {
 	protected void complete() throws CoreException {
 		super.complete();
 		ReturnStatement rStatement= fAst.newReturnStatement();
-		String formatClass;
-		if (getContext().is50orHigher())
-			formatClass= "java.lang.String"; //$NON-NLS-1$
-		else
-			formatClass= "java.text.MessageFormat"; //$NON-NLS-1$
+		String formatClass= "java.lang.String"; //$NON-NLS-1$
 		MethodInvocation formatInvocation= createMethodInvocation(addImport(formatClass), "format", null); //$NON-NLS-1$
 		StringLiteral literal= fAst.newStringLiteral();
 		literal.setLiteralValue(buffer.toString());
 		formatInvocation.arguments().add(literal);
-		if (getContext().is50orHigher()) {
-			formatInvocation.arguments().addAll(arguments);
-		} else {
-			ArrayCreation arrayCreation= fAst.newArrayCreation();
-			arrayCreation.setType(fAst.newArrayType(fAst.newSimpleType(addImport("java.lang.Object")))); //$NON-NLS-1$
-			ArrayInitializer initializer= fAst.newArrayInitializer();
-			arrayCreation.setInitializer(initializer);
-			initializer.expressions().addAll(arguments);
-			formatInvocation.arguments().add(arrayCreation);
-		}
+		formatInvocation.arguments().addAll(arguments);
 		rStatement.setExpression(formatInvocation);
 		toStringMethod.getBody().statements().add(rStatement);
 	}
@@ -99,34 +82,8 @@ public class StringFormatGenerator extends AbstractToStringGenerator {
 		}
 		if (element instanceof Expression) {
 			arguments.add((Expression) element);
-			if (getContext().is50orHigher()) {
-				buffer.append("%s"); //$NON-NLS-1$
-			} else {
-				buffer.append("{" + (arguments.size() - 1) + "}"); //$NON-NLS-1$ //$NON-NLS-2$
-			}
+			buffer.append("%s"); //$NON-NLS-1$
 		}
-	}
-
-	@Override
-	protected Expression createMemberAccessExpression(Object member, boolean ignoreArraysCollections, boolean ignoreNulls) {
-		ITypeBinding type= getMemberType(member);
-		if (!getContext().is50orHigher() && type.isPrimitive()) {
-			String nonPrimitiveType= null;
-			String typeName= type.getName();
-			if ("byte".equals(typeName))nonPrimitiveType= "java.lang.Byte"; //$NON-NLS-1$ //$NON-NLS-2$
-			if ("short".equals(typeName))nonPrimitiveType= "java.lang.Short"; //$NON-NLS-1$ //$NON-NLS-2$
-			if ("char".equals(typeName))nonPrimitiveType= "java.lang.Character"; //$NON-NLS-1$ //$NON-NLS-2$
-			if ("int".equals(typeName))nonPrimitiveType= "java.lang.Integer"; //$NON-NLS-1$ //$NON-NLS-2$
-			if ("long".equals(typeName))nonPrimitiveType= "java.lang.Long"; //$NON-NLS-1$ //$NON-NLS-2$
-			if ("float".equals(typeName))nonPrimitiveType= "java.lang.Float"; //$NON-NLS-1$ //$NON-NLS-2$
-			if ("double".equals(typeName))nonPrimitiveType= "java.lang.Double"; //$NON-NLS-1$ //$NON-NLS-2$
-			if ("boolean".equals(typeName))nonPrimitiveType= "java.lang.Boolean"; //$NON-NLS-1$ //$NON-NLS-2$
-			ClassInstanceCreation classInstance= fAst.newClassInstanceCreation();
-			classInstance.setType(fAst.newSimpleType(addImport(nonPrimitiveType)));
-			classInstance.arguments().add(super.createMemberAccessExpression(member, true, true));
-			return classInstance;
-		}
-		return super.createMemberAccessExpression(member, ignoreArraysCollections, ignoreNulls);
 	}
 
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/ToStringGenerationContext.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/ToStringGenerationContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Mateusz Matela and others.
+ * Copyright (c) 2008, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -79,10 +79,6 @@ class ToStringGenerationContext {
 
 	public ITypeBinding getTypeBinding() {
 		return fType;
-	}
-
-	public boolean is50orHigher() {
-		return fSettings.is50orHigher;
 	}
 
 	public boolean is60orHigher() {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/ToStringGenerationSettingsCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/ToStringGenerationSettingsCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Mateusz Matela and others.
+ * Copyright (c) 2019, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -98,9 +98,6 @@ public class ToStringGenerationSettingsCore extends CodeGenerationSettings {
 
 	/** should blocks be forced in if/for/while statements? */
 	public boolean useBlocks;
-
-	/** can generated code use jdk 1.5 API? **/
-	public boolean is50orHigher;
 
 	/** can generated code use jdk 1.6 API? **/
 	public boolean is60orHigher;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringBufferFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringBufferFixCore.java
@@ -58,7 +58,6 @@ import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSScanner;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
@@ -99,14 +98,9 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 			return null;
 		}
 
-		String bufferOrBuilderName;
 		SimpleName existingBuffer= getEnclosingAppendBuffer(oldInfixExpression);
-		if (JavaModelUtil.is50OrHigher(compilationUnit.getTypeRoot().getJavaProject())) {
-			bufferOrBuilderName= "StringBuilder"; //$NON-NLS-1$
-		} else {
-			bufferOrBuilderName= "StringBuffer"; //$NON-NLS-1$
-		}
-		var mechanismName= BasicElementLabels.getJavaElementName(existingBuffer == null ? bufferOrBuilderName : existingBuffer.getIdentifier());
+		String builderName= "StringBuilder"; //$NON-NLS-1$
+		var mechanismName= BasicElementLabels.getJavaElementName(existingBuffer == null ? builderName : existingBuffer.getIdentifier());
 		var label= Messages.format(CorrectionMessages.QuickAssistProcessor_convert_to_string_buffer_description, mechanismName);
 		return new ConvertToStringBufferFixCore(label, compilationUnit, new ConvertToStringBufferProposalOperation(oldInfixExpression));
 
@@ -178,14 +172,9 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 
 		@Override
 		public void rewriteAST(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel) throws CoreException {
-			String bufferOrBuilderName;
 			ICompilationUnit cu= cuRewrite.getCu();
 			AST ast= cuRewrite.getAST();
-			if (JavaModelUtil.is50OrHigher(cu.getJavaProject())) {
-				bufferOrBuilderName= "StringBuilder"; //$NON-NLS-1$
-			} else {
-				bufferOrBuilderName= "StringBuffer"; //$NON-NLS-1$
-			}
+			String builderName= "StringBuilder"; //$NON-NLS-1$
 
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
 
@@ -218,10 +207,10 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 				// check if name is already in use and provide alternative
 				List<String> fExcludedVariableNames= Arrays.asList(ASTResolving.getUsedVariableNames(oldInfixExpression));
 
-				SimpleType bufferType= ast.newSimpleType(ast.newName(bufferOrBuilderName));
+				SimpleType bufferType= ast.newSimpleType(ast.newName(builderName));
 				ClassInstanceCreation newBufferExpression= ast.newClassInstanceCreation();
 
-				String[] newBufferNames= StubUtility.getVariableNameSuggestions(NamingConventions.VK_LOCAL, cu.getJavaProject(), bufferOrBuilderName, 0, fExcludedVariableNames, true);
+				String[] newBufferNames= StubUtility.getVariableNameSuggestions(NamingConventions.VK_LOCAL, cu.getJavaProject(), builderName, 0, fExcludedVariableNames, true);
 				bufferName= newBufferNames[0];
 
 				SimpleName bufferNameDeclaration= ast.newSimpleName(bufferName);
@@ -239,7 +228,7 @@ public class ConvertToStringBufferFixCore extends CompilationUnitRewriteOperatio
 
 
 				VariableDeclarationStatement bufferDeclaration= ast.newVariableDeclarationStatement(frag);
-				bufferDeclaration.setType(ast.newSimpleType(ast.newName(bufferOrBuilderName)));
+				bufferDeclaration.setType(ast.newSimpleType(ast.newName(builderName)));
 				insertAfter= bufferDeclaration;
 
 				Statement statement= ASTResolving.findParentStatement(oldInfixExpression);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ConvertToStringFormatFixCore.java
@@ -94,11 +94,6 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 			return null;
 		}
 
-		boolean is50OrHigher= JavaModelUtil.is50OrHigher(compilationUnit.getTypeRoot().getJavaProject());
-		if (!is50OrHigher) {
-			return null;
-		}
-
 		// collect operands
 		List<Expression> operands= new ArrayList<>();
 		collectInfixPlusOperands(oldInfixExpression, operands);
@@ -109,12 +104,6 @@ public class ConvertToStringFormatFixCore extends CompilationUnitRewriteOperatio
 		// we need to loop through all to exclude any null binding scenarios.
 		for (Expression operand : operands) {
 			if (!(operand instanceof StringLiteral)) {
-				if (!is50OrHigher) {
-					ITypeBinding binding= operand.resolveTypeBinding();
-					if (binding == null) {
-						return null;
-					}
-				}
 				foundNoneLiteralOperand= true;
 			} else {
 				// ensure either all string literals are nls-tagged or none are

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringBufferToStringBuilderFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2024 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -65,7 +65,6 @@ import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
@@ -866,9 +865,6 @@ public class StringBufferToStringBuilderFixCore extends CompilationUnitRewriteOp
 	}
 
 	public static ICleanUpFix createCleanUp(final CompilationUnit compilationUnit, boolean forLocalsOnly) {
-		if (!JavaModelUtil.is50OrHigher(compilationUnit.getJavaElement().getJavaProject()))
-			return null;
-
 		List<CompilationUnitRewriteOperation> operations= new ArrayList<>();
 
 		if (forLocalsOnly) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringBuilderCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/StringBuilderCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -70,7 +70,6 @@ import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
@@ -604,12 +603,7 @@ public class StringBuilderCleanUp extends AbstractMultiFix implements ICleanUpFi
 			// StringBuilder builder = new StringBuilder().append(i).append("bar");
 			// StringBuilder builder = new StringBuilder("foo").append(i);
 
-			Class<?> builder;
-			if (JavaModelUtil.is50OrHigher(((CompilationUnit) type.getRoot()).getJavaElement().getJavaProject())) {
-				builder= StringBuilder.class;
-			} else {
-				builder= StringBuffer.class;
-			}
+			Class<?> builder= StringBuilder.class;
 
 			ASTNodes.replaceButKeepComment(rewrite, type, ast.newSimpleType(ASTNodeFactory.newName(ast, builder.getSimpleName())), group);
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/GenerateToStringAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/GenerateToStringAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2019 Mateusz Matela and others.
+ * Copyright (c) 2008, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -188,7 +188,6 @@ public class GenerateToStringAction extends GenerateMethodAbstractAction {
 		settings.createComments= dialog.getGenerateComment();
 		settings.useBlocks= useBlocks(type.getJavaProject());
 		String version= fUnit.getJavaElement().getJavaProject().getOption(JavaCore.COMPILER_SOURCE, true);
-		settings.is50orHigher= !JavaModelUtil.isVersionLessThan(version, JavaCore.VERSION_1_5);
 		settings.is60orHigher= !JavaModelUtil.isVersionLessThan(version, JavaCore.VERSION_1_6);
 		return settings;
 	}


### PR DESCRIPTION
ECJ mandates 1.8+ and JDT UI converts compiler settings to that unconditionally so this code is simply non-reachable.
