### PR TITLE
Remove last Java 5 checks from UI

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -2471,8 +2471,6 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String TypeContextChecker_invalid_type_syntax;
 
-	public static String TypeContextChecker_no_vararg_below_50;
-
 	public static String TypeContextChecker_not_unique;
 
 	public static String TypeContextChecker_parameter_type;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/TypeContextChecker.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/TypeContextChecker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -490,11 +490,6 @@ public class TypeContextChecker {
 
 		if ("".equals(newTypeName.trim())){ //$NON-NLS-1$
 			String msg= Messages.format(RefactoringCoreMessages.TypeContextChecker_parameter_type, typeLabel);
-			return RefactoringStatus.createFatalErrorStatus(msg);
-		}
-
-		if (ParameterInfo.isVarargs(type) && ! JavaModelUtil.is50OrHigher(project)) {
-			String msg= Messages.format(RefactoringCoreMessages.TypeContextChecker_no_vararg_below_50, typeLabel);
 			return RefactoringStatus.createFatalErrorStatus(msg);
 		}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -850,7 +850,6 @@ TypeContextChecker_couldNotResolveType=Could not resolve type ''{0}''.
 TypeContextChecker_ambiguous=Parameter type name ''{0}'' is ambiguous. There are {1} types with that name.
 TypeContextChecker_not_unique=Parameter type name ''{0}'' cannot be uniquely resolved or is not a valid type name.
 TypeContextChecker_parameter_type=Enter the type for parameter ''{0}''.
-TypeContextChecker_no_vararg_below_50=''{0}'' is not a valid parameter type; variable arity parameters are only supported if the source level is 1.5.
 TypeContextChecker_invalid_type_name=''{0}'' is not a valid parameter type.
 TypeContextChecker_invalid_type_syntax=''{0}'' is not a valid parameter type: {1}.
 TypeContextChecker_return_type_not_empty=The return type cannot be empty.

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
@@ -787,11 +787,6 @@ public final class JavaModelUtil {
 		return JavaCore.compareJavaVersions(version1, version2) < 0;
 	}
 
-
-	public static boolean is50OrHigher(String compliance) {
-		return !isVersionLessThan(compliance, JavaCore.VERSION_1_5);
-	}
-
 	public static boolean is1d7OrHigher(String compliance) {
 		return !isVersionLessThan(compliance, JavaCore.VERSION_1_7);
 	}
@@ -858,16 +853,6 @@ public final class JavaModelUtil {
 
 	public static boolean is23OrHigher(String compliance) {
 		return !isVersionLessThan(compliance, JavaCore.VERSION_23);
-	}
-
-	/**
-	 * Checks if the given project or workspace has source compliance 1.5 or greater.
-	 *
-	 * @param project the project to test or <code>null</code> to test the workspace settings
-	 * @return <code>true</code> if the given project or workspace has source compliance 1.5 or greater.
-	 */
-	public static boolean is50OrHigher(IJavaProject project) {
-		return is50OrHigher(getSourceCompliance(project));
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
@@ -115,7 +115,6 @@ public final class NewWizardMessages extends NLS {
 	public static String NewTypeWizardPage_error_PackageNameEmptyForModule;
 	public static String NewTypeWizardPage_warning_DiscouragedPackageName;
 	public static String NewTypeWizardPage_warning_DefaultPackageDiscouraged;
-	public static String NewTypeWizardPage_warning_NotJDKCompliant;
 	public static String NewTypeWizardPage_warning_NotJDKCompliant2;
 	public static String NewTypeWizardPage_warning_EnumClassNotFound;
 	public static String NewTypeWizardPage_warning_RecordClassNotFound;
@@ -158,13 +157,10 @@ public final class NewWizardMessages extends NLS {
 	public static String NewTypeWizardPage_error_QualifiedName;
 	public static String NewTypeWizardPage_info_FileExtensionNotRequired;
 	public static String NewTypeWizardPage_warning_TypeNameDiscouraged;
-	public static String NewTypeWizardPage_error_TypeParameters;
 	public static String NewTypeWizardPage_error_InvalidSuperClassName;
 	public static String NewTypeWizardPage_error_InvalidSuperClassRecord;
 	public static String NewTypeWizardPage_error_InvalidFinalSuperClass;
-	public static String NewTypeWizardPage_error_SuperClassNotParameterized;
 	public static String NewTypeWizardPage_error_InvalidSuperInterfaceName;
-	public static String NewTypeWizardPage_error_SuperInterfaceNotParameterized;
 	public static String NewTypeWizardPage_error_ModifiersFinalAndAbstract;
 	public static String NewTypeWizardPage_error_TypeNameFiltered;
 	public static String NewTypeWizardPage_error_PackageNameFiltered;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
@@ -90,7 +90,6 @@ NewTypeWizardPage_error_PackageNameEmptyForModule=A package name must be specifi
 NewTypeWizardPage_error_uri_location_unkown=Cannot locate resource {0}
 NewTypeWizardPage_warning_DiscouragedPackageName=This package name is discouraged. {0}
 NewTypeWizardPage_warning_DefaultPackageDiscouraged=The use of the default package is discouraged.
-NewTypeWizardPage_warning_NotJDKCompliant=Project ''{0}'' is not a J2SE 5.0 compliant project.
 NewTypeWizardPage_warning_NotJDKCompliant2=Project ''{0}'' is not a Java {1} compliant project.
 NewTypeWizardPage_warning_EnumClassNotFound=Type 'java.lang.Enum' is not on the project's build path. Make sure you use a 1.5 JDK.
 NewTypeWizardPage_warning_RecordClassNotFound=Type 'java.lang.Record' is not on the project's build path. Make sure you use a 14 JDK.
@@ -140,12 +139,9 @@ NewTypeWizardPage_error_InvalidTypeName=Type name is not valid. {0}
 NewTypeWizardPage_error_QualifiedName=Type name must not be qualified.
 NewTypeWizardPage_info_FileExtensionNotRequired=The file extension '.java' will not be part of the type name.
 NewTypeWizardPage_warning_TypeNameDiscouraged=Type name is discouraged. {0}
-NewTypeWizardPage_error_TypeParameters=Type name is not valid. Type parameters are only available if source level is 1.5.
 
 NewTypeWizardPage_error_InvalidSuperClassName=Superclass type is not valid.
-NewTypeWizardPage_error_SuperClassNotParameterized=Superclass cannot be parameterized unless source level is 1.5.
 NewTypeWizardPage_error_InvalidSuperInterfaceName=Extended interface ''{0}'' is not valid.
-NewTypeWizardPage_error_SuperInterfaceNotParameterized=Extended interface ''{0}'' cannot be parameterized unless source level is 1.5.
 NewTypeWizardPage_error_InvalidSuperClassRecord=Record ''{0}'' cannot be superclass. A record is final.
 NewTypeWizardPage_error_InvalidFinalSuperClass=Class ''{0}'' cannot be superclass as it is final.  
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
@@ -108,7 +108,6 @@ import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.ImportDeclaration;
-import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -1834,10 +1833,6 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 		IStatus status= super.containerChanged();
 	    IPackageFragmentRoot root= getPackageFragmentRoot();
 		if ((fTypeKind == ANNOTATION_TYPE || fTypeKind == ENUM_TYPE) && !status.matches(IStatus.ERROR)) {
-	    	if (root != null && !JavaModelUtil.is50OrHigher(root.getJavaProject())) {
-	    		// error as createType will fail otherwise (bug 96928)
-	    		return new StatusInfo(IStatus.ERROR, Messages.format(NewWizardMessages.NewTypeWizardPage_warning_NotJDKCompliant, BasicElementLabels.getJavaElementName(root.getJavaProject().getElementName())));
-	    	}
 	    	if (root != null && fTypeKind == ENUM_TYPE) {
 		    	try {
 		    	    // if findType(...) == null then Enum is unavailable
@@ -2150,10 +2145,6 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 		}
 
 		if (!typeNameWithParameters.equals(typeName) && project != null) {
-			if (!JavaModelUtil.is50OrHigher(project)) {
-				status.setError(NewWizardMessages.NewTypeWizardPage_error_TypeParameters);
-				return status;
-			}
 			String typeDeclaration= "class " + typeNameWithParameters + " {}"; //$NON-NLS-1$//$NON-NLS-2$
 			ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 			parser.setSource(typeDeclaration.toCharArray());
@@ -2210,10 +2201,6 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 			Type type= TypeContextChecker.parseSuperClass(sclassName);
 			if (type == null) {
 				status.setError(NewWizardMessages.NewTypeWizardPage_error_InvalidSuperClassName);
-				return status;
-			}
-			if (type instanceof ParameterizedType && ! JavaModelUtil.is50OrHigher(root.getJavaProject())) {
-				status.setError(NewWizardMessages.NewTypeWizardPage_error_SuperClassNotParameterized);
 				return status;
 			}
 		} else {
@@ -2478,10 +2465,6 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 				Type type= TypeContextChecker.parseSuperInterface(intfname);
 				if (type == null) {
 					status.setError(Messages.format(NewWizardMessages.NewTypeWizardPage_error_InvalidSuperInterfaceName, BasicElementLabels.getJavaElementName(intfname)));
-					return status;
-				}
-				if (type instanceof ParameterizedType && ! JavaModelUtil.is50OrHigher(root.getJavaProject())) {
-					status.setError(Messages.format(NewWizardMessages.NewTypeWizardPage_error_SuperInterfaceNotParameterized, BasicElementLabels.getJavaElementName(intfname)));
 					return status;
 				}
 			}


### PR DESCRIPTION
Having code to show errors if Java 5 JVM when Java UI migrates projects to Java 8 is pointless.

