### PR TITLE
Fix StringBuffer/StringBuilder to text block to handle indexOf(x,y)

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1058,7 +1058,9 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					SimpleName caller= ast.newSimpleName(newVarName);
 					newCall.setExpression(caller);
 					List<Expression> arguments= indexOfCall.arguments();
-					newCall.arguments().add(rewrite.createCopyTarget(arguments.get(0)));
+					for (Expression argument : arguments) {
+						newCall.arguments().add(rewrite.createCopyTarget(argument));
+					}
 					rewrite.replace(indexOfCall, newCall, group);
 				}
 				for (SimpleName arg : fArgList) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -397,6 +397,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			        StringBuilder buf9 = new StringBuilder("abc\\n").append("def\\n").append("ghi");
 			        buf9.append("jkl\\n").append("mno");
 			        System.out.println(buf9.toString());
+			        int index2 = buf9.indexOf("ijk", 3); //$NON-NLS-1$
 			        StringBuilder buf10= new StringBuilder();
 			        buf10.append("    /** bar\\n");
 			        buf10.append("     * foo\\n");
@@ -531,6 +532,7 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			            jkl
 			            mno\""";
 			        System.out.println(str7);
+			        int index2 = str7.indexOf("ijk", 3); //$NON-NLS-1$
 			        String str8 = \"""
 			                /** bar
 			                 * foo


### PR DESCRIPTION
- fix StringConcatToTextBlockFixCore.ChangeStringBufferToTextBlock to not assume indexOf() has just one parameter
- modify CleanUpTest15 to add new scenario
- fixes #1903

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or test modifications.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
