### PR TITLE
Fix extraneous this expression being added during inline

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
@@ -644,7 +644,7 @@ public class InlineTempRefactoring extends Refactoring {
 				if (isStatic) {
 					ans.add(createFullyQualifiedName(simpleNameInitializer, resolvedVariableBinding.getDeclaringClass(), false));
 					ans.add(createFullyQualifiedName(simpleNameInitializer, resolvedVariableBinding.getDeclaringClass(), true));
-				} else {
+				} else if (resolvedVariableBinding.isField()) {
 					AST ast= fASTRoot.getAST();
 					FieldAccess newFieldAccess= ast.newFieldAccess();
 					newFieldAccess.setExpression(ast.newThisExpression());

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test66_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test66_in.java
@@ -1,0 +1,23 @@
+package p;
+
+import java.util.Set;
+
+public class A {
+	public class B {
+		public int id;
+	}
+
+	private class C {
+		public B original() {
+			return new B();
+		}
+	}
+
+	public void foo(B enumConstant, Set<B> unenumerated) {
+		C field = new C();
+		int intValue = field.original().id;
+		if (enumConstant.id == intValue) {
+			unenumerated.remove(enumConstant);
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test66_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineTemp/canInline/A_test66_out.java
@@ -1,0 +1,22 @@
+package p;
+
+import java.util.Set;
+
+public class A {
+	public class B {
+		public int id;
+	}
+
+	private class C {
+		public B original() {
+			return new B();
+		}
+	}
+
+	public void foo(B enumConstant, Set<B> unenumerated) {
+		C field = new C();
+		if (enumConstant.id == field.original().id) {
+			unenumerated.remove(enumConstant);
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineTempTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -495,6 +495,12 @@ public class InlineTempTests extends GenericRefactoringTest {
 	public void test65() throws Exception {
 		//https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1705
 		helper1(6, 13, 6, 19);
+	}
+
+	@Test
+	public void test66() throws Exception {
+		//https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1859
+		helper1(18, 13, 18, 21);
 	}
 
 	//------


### PR DESCRIPTION
- fix InlineTempRefactoring.getAlternativeQualification() method to not add this qualifier to a local variable
- add new test to InlineTempTests
- fixes #1859

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
