### PR TITLE
More removals of JavaModelUtil.is1d8OrHigher

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2024 IBM Corporation and others.
+ * Copyright (c) 2018, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -85,7 +85,6 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.refactoring.util.JavaElementUtil;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileManagerCore;
 import org.eclipse.jdt.internal.ui.util.ASTHelper;
@@ -137,7 +136,7 @@ public final class StubUtility2Core {
 		int modifiers= binding.getModifiers();
 		ITypeBinding declaringType= binding.getDeclaringClass();
 		ITypeBinding typeObject= ast.resolveWellKnownType("java.lang.Object"); //$NON-NLS-1$
-		if (!inInterface || (declaringType != typeObject && JavaModelUtil.is1d8OrHigher(javaProject))) {
+		if (!inInterface || (declaringType != typeObject)) {
 			// generate a method body
 
 			Map<String, String> options= FormatterProfileManagerCore.getProjectSettings(javaProject);
@@ -474,7 +473,7 @@ public final class StubUtility2Core {
 		int modifiers= binding.getModifiers();
 		ITypeBinding declaringType= binding.getDeclaringClass();
 		ITypeBinding typeObject= ast.resolveWellKnownType("java.lang.Object"); //$NON-NLS-1$
-		if (!inInterface || (declaringType != typeObject && JavaModelUtil.is1d8OrHigher(javaProject))) {
+		if (!inInterface || (declaringType != typeObject)) {
 			// generate a method body
 
 			Map<String, String> options= unit.getOptions(true);
@@ -685,7 +684,7 @@ public final class StubUtility2Core {
 		int modifiers= method.getModifiers();
 		if (inInterface) {
 			modifiers= modifiers & ~Modifier.PROTECTED & ~Modifier.PUBLIC;
-			if (Modifier.isAbstract(modifiers) && JavaModelUtil.is1d8OrHigher(javaProject)) {
+			if (Modifier.isAbstract(modifiers)) {
 				modifiers= modifiers | Modifier.DEFAULT;
 			}
 		} else {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/TypeAnnotationRewrite.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/TypeAnnotationRewrite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Till Brychcy and others.
+ * Copyright (c) 2017, 2025 Till Brychcy and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,15 +23,12 @@ import org.eclipse.text.edits.TextEditGroup;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.Annotation;
 import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
-import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
-
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 /**
  * Rewrite helper for type annotations.
@@ -55,10 +52,6 @@ public class TypeAnnotationRewrite {
 	 *            ungrouped
 	 */
 	public static void removePureTypeAnnotations(ASTNode node, ChildListPropertyDescriptor childListProperty, ASTRewrite rewrite, TextEditGroup editGroup) {
-		CompilationUnit root= (CompilationUnit) node.getRoot();
-		if (!JavaModelUtil.is1d8OrHigher(root.getJavaElement().getJavaProject())) {
-			return;
-		}
 		ListRewrite listRewrite= rewrite.getListRewrite(node, childListProperty);
 		@SuppressWarnings("unchecked")
 		List<? extends ASTNode> children= (List<? extends ASTNode>) node.getStructuralProperty(childListProperty);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -94,7 +94,6 @@ import org.eclipse.jdt.internal.corext.dom.HierarchicalASTVisitor;
 import org.eclipse.jdt.internal.corext.dom.LinkedNodeFinder;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.JdtFlags;
 
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
@@ -1265,9 +1264,6 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 
 	public static LambdaExpressionsFixCore createConvertToLambdaFix(ClassInstanceCreation cic) {
 		CompilationUnit root= (CompilationUnit) cic.getRoot();
-		if (!JavaModelUtil.is1d8OrHigher(root.getJavaElement().getJavaProject())) {
-			return null;
-		}
 
 		if (!LambdaExpressionsFixCore.isFunctionalAnonymous(cic)) {
 			return null;
@@ -1296,10 +1292,6 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 	}
 
 	public static ICleanUpFix createCleanUp(CompilationUnit compilationUnit, boolean useLambda, boolean useAnonymous, boolean simplifyLambda) {
-		if (!JavaModelUtil.is1d8OrHigher(compilationUnit.getJavaElement().getJavaProject())) {
-			return null;
-		}
-
 		if (useLambda) {
 			ArrayList<ClassInstanceCreation> convertibleNodes= FunctionalAnonymousClassesFinder.perform(compilationUnit);
 			if (convertibleNodes.isEmpty()) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SplitTryResourceFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SplitTryResourceFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Red Hat Inc. and others.
+ * Copyright (c) 2024, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -38,7 +38,6 @@ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
@@ -48,9 +47,7 @@ public final class SplitTryResourceFixCore extends CompilationUnitRewriteOperati
 		super(name, compilationUnit, operations);
 	}
 
-	public static boolean initialConditionsCheck(ICompilationUnit compilationUnit, ASTNode node) {
-		if (!JavaModelUtil.is1d8OrHigher(compilationUnit.getJavaProject()))
-			return false;
+	public static boolean initialConditionsCheck(ASTNode node) {
 		ASTNode foundNode= ASTNodes.getFirstAncestorOrNull(node, VariableDeclarationExpression.class, Statement.class);
 		if (!(foundNode instanceof VariableDeclarationExpression varDeclExp) || varDeclExp.getLocationInParent() != TryStatement.RESOURCES2_PROPERTY) {
 			return false;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringAvailabilityTesterCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringAvailabilityTesterCore.java
@@ -134,8 +134,7 @@ public final class RefactoringAvailabilityTesterCore  {
 		if (!Checks.isAvailable(member))
 			return false;
 		if (type == IJavaElement.METHOD && declaring.isInterface()) {
-			boolean is18OrHigher= JavaModelUtil.is1d8OrHigher(member.getJavaProject());
-			if (!is18OrHigher || !Flags.isStatic(member.getFlags()))
+			if (!Flags.isStatic(member.getFlags()))
 				return false;
 		}
 		if (type == IJavaElement.METHOD && !JdtFlags.isStatic(member))

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1449,8 +1449,6 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String MoveMembersRefactoring_Object;
 
-	public static String MoveMembersRefactoring_only_public_static;
-
 	public static String MoveMembersRefactoring_only_public_static_18;
 
 	public static String MoveMembersRefactoring_override_ref;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/ConvertAnonymousToNestedRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/ConvertAnonymousToNestedRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -113,7 +113,6 @@ import org.eclipse.jdt.internal.corext.refactoring.RefactoringCoreMessages;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
 import org.eclipse.jdt.internal.corext.refactoring.util.ResourceUtil;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 import org.eclipse.jdt.internal.corext.util.JdtFlags;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
@@ -885,8 +884,6 @@ public class ConvertAnonymousToNestedRefactoring extends Refactoring {
 
     private boolean isBindingToTemp(IVariableBinding variable) {
 		if (variable.isField())
-			return false;
-		if (!Modifier.isFinal(variable.getModifiers()) && !JavaModelUtil.is1d8OrHigher(fCu.getJavaProject()))
 			return false;
 		ASTNode declaringNode= fCompilationUnitNode.findDeclaringNode(variable);
 		if (declaringNode == null)

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -698,7 +698,6 @@ MoveMembersRefactoring_referenceUpdate= Update reference to moved member
 MoveMembersRefactoring_static_declaration=Static members can be declared only in top level or static types.
 MoveMembersRefactoring_member_will_be_public=Moved member will be public in the destination interface
 MoveMembersRefactoring_multi_var_fields=Only field declarations with single variable declaration fragments can be moved.
-MoveMembersRefactoring_only_public_static=Only 'public static' types and 'public static final' fields with variable initializers can be moved to an interface.
 MoveMembersRefactoring_only_public_static_18=Only 'public static' types, 'public static' methods and 'public static final' fields with variable initializers can be moved to an interface.
 MoveMembersRefactoring_override_ref=Moving member to ''{0}'' will override references to ''{1}'' from ''{2}''
 MoveMembersRefactoring_Object=Move is not allowed on members declared in 'java.lang.Object'.

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2025,7 +2025,7 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 		if (!binding.isInterface() || binding.isAnnotation())
 			return false;
 		IJavaElement javaElement= binding.getJavaElement();
-		return javaElement != null && JavaModelUtil.is1d8OrHigher(javaElement.getJavaProject());
+		return javaElement != null;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveStaticMembersProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveStaticMembersProcessor.java
@@ -564,16 +564,13 @@ public final class MoveStaticMembersProcessor extends MoveProcessor implements I
 
 	private RefactoringStatus checkMoveToInterface() throws JavaModelException {
 		//could be more clever and make field final if it is only written once...
-		boolean is18OrHigher= JavaModelUtil.is1d8OrHigher(fDestinationType.getJavaProject());
 		RefactoringStatus result= new RefactoringStatus();
 		boolean declaringIsInterface= getDeclaringType().isInterface();
-		if (declaringIsInterface && is18OrHigher)
+		if (declaringIsInterface)
 			return result;
-		String moveMembersMsg= is18OrHigher ? RefactoringCoreMessages.MoveMembersRefactoring_only_public_static_18 : RefactoringCoreMessages.MoveMembersRefactoring_only_public_static;
+		String moveMembersMsg= RefactoringCoreMessages.MoveMembersRefactoring_only_public_static_18;
 		for (IMember memberToMove : fMembersToMove) {
-			if (declaringIsInterface && !(memberToMove instanceof IMethod) && !is18OrHigher) {
-				// moving from interface to interface is OK, unless method is moved to pre-18
-			} else if (!canMoveToInterface(memberToMove, is18OrHigher)) {
+			if (!canMoveToInterface(memberToMove)) {
 				result.addError(moveMembersMsg, JavaStatusContext.create(memberToMove));
 			} else if (!Flags.isPublic(memberToMove.getFlags()) && !declaringIsInterface) {
 				result.addWarning(RefactoringCoreMessages.MoveMembersRefactoring_member_will_be_public, JavaStatusContext.create(memberToMove));
@@ -582,7 +579,7 @@ public final class MoveStaticMembersProcessor extends MoveProcessor implements I
 		return result;
 	}
 
-	private boolean canMoveToInterface(IMember member, boolean is18OrHigher) throws JavaModelException {
+	private boolean canMoveToInterface(IMember member) throws JavaModelException {
 		int flags= member.getFlags();
 		switch (member.getElementType()) {
 			case IJavaElement.FIELD:
@@ -601,7 +598,7 @@ public final class MoveStaticMembersProcessor extends MoveProcessor implements I
 				return Flags.isStatic(flags);
 			}
 			case IJavaElement.METHOD: {
-				return is18OrHigher && Flags.isStatic(flags);
+				return Flags.isStatic(flags);
 			}
 			default:
 				return false;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/ui/fix/UseIteratorToForLoopCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/ui/fix/UseIteratorToForLoopCleanUpCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 Carsten Hammer.
+ * Copyright (c) 2021, 2025 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,6 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
 import org.eclipse.jdt.internal.corext.fix.UseIteratorToForLoopFixCore;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.ui.cleanup.CleanUpContext;
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
@@ -64,9 +63,6 @@ public class UseIteratorToForLoopCleanUpCore extends AbstractCleanUp {
 		}
 		EnumSet<UseIteratorToForLoopFixCore> computeFixSet= computeFixSet();
 		if (!isEnabled(CONTROL_STATEMENTS_CONVERT_FOR_LOOP_TO_ENHANCED) || computeFixSet.isEmpty()) {
-			return null;
-		}
-		if (!JavaModelUtil.is1d8OrHigher(compilationUnit.getJavaElement().getJavaProject())) {
 			return null;
 		}
 		Set<CompilationUnitRewriteOperation> operations= new LinkedHashSet<>();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -3715,7 +3715,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 
 	private static boolean getSplitTryResourceProposal(IInvocationContext context, ASTNode coveringNode, Collection<ICommandAccess> proposals) {
 		if (proposals == null) {
-			return SplitTryResourceFixCore.initialConditionsCheck(context.getCompilationUnit(), coveringNode);
+			return SplitTryResourceFixCore.initialConditionsCheck(coveringNode);
 		}
 		SplitTryResourceFixCore fix= SplitTryResourceFixCore.createSplitVariableFix(context.getASTRoot(), coveringNode);
 		if (fix != null) {


### PR DESCRIPTION
Ecj mandates 1.8 thus such guarded code is not reachable
