### PR TITLE
Bug 285551 - [extract method] "Ambiguous return value" error

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractMethodRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -350,6 +350,14 @@ public class ExtractMethodRefactoring extends Refactoring {
 		fSelectionLength= fAnalyzer.getSelection().getLength();
 
 		result.merge(fAnalyzer.checkInitialConditions(fImportRewriter));
+
+		if (fAnalyzer.isSelectionChanged()) {
+			fRoot.accept(fAnalyzer);
+			fSelectionStart= fAnalyzer.getSelection().getOffset();
+			fSelectionLength= fAnalyzer.getSelection().getLength();
+
+			result.merge(fAnalyzer.checkInitialConditions(fImportRewriter));
+		}
 		if (result.hasFatalError())
 			return result;
 		if (fVisibility == -1) {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1913_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1913_1.java
@@ -1,0 +1,17 @@
+package validSelection_in;
+
+import java.util.ArrayList;
+
+public class A_testIssue1913_1 {
+
+	public void foo() {
+		ArrayList<Integer> list= new ArrayList<Integer>();
+		for (Integer var : list) {}
+		int a= 0;
+		for (int c= 0; c < 10; c++) {
+			/*]*/list.add(a++)/*[*/;
+		}
+		System.out.println(list.toString());
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1913_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_in/A_testIssue1913_2.java
@@ -1,0 +1,17 @@
+package validSelection_in;
+
+import java.util.ArrayList;
+
+public class A_testIssue1913_1 {
+
+	public void foo() {
+		ArrayList<Integer> list= new ArrayList<Integer>();
+		for (Integer var : list) {}
+		int a= 0;
+		for (int c= 0; c < 10; c++) {
+			/*]*/list.add(a++);/*[*/
+		}
+		System.out.println(list.toString());
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1913_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1913_1.java
@@ -1,0 +1,22 @@
+package validSelection_in;
+
+import java.util.ArrayList;
+
+public class A_testIssue1913_1 {
+
+	public void foo() {
+		ArrayList<Integer> list= new ArrayList<Integer>();
+		for (Integer var : list) {}
+		int a= 0;
+		for (int c= 0; c < 10; c++) {
+			/*]*/a = extracted(list, a);
+		}
+		System.out.println(list.toString());
+	}
+
+	protected int extracted(ArrayList<Integer> list, int a) {
+		list.add(a++)/*[*/;
+		return a;
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1913_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/validSelection_out/A_testIssue1913_2.java
@@ -1,0 +1,22 @@
+package validSelection_in;
+
+import java.util.ArrayList;
+
+public class A_testIssue1913_1 {
+
+	public void foo() {
+		ArrayList<Integer> list= new ArrayList<Integer>();
+		for (Integer var : list) {}
+		int a= 0;
+		for (int c= 0; c < 10; c++) {
+			/*]*/a = extracted(list, a);/*[*/
+		}
+		System.out.println(list.toString());
+	}
+
+	protected int extracted(ArrayList<Integer> list, int a) {
+		list.add(a++);
+		return a;
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2739,5 +2739,15 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	@Test
 	public void testIssue1758() throws Exception {
 		invalidSelectionTest();
+	}
+
+	@Test
+	public void testIssue1913_1() throws Exception {
+		validSelectionTestChecked();
+	}
+
+	@Test
+	public void testIssue1913_2() throws Exception {
+		validSelectionTestChecked();
 	}
 }


### PR DESCRIPTION
- fix ExtractMethodAnalyzer.checkInitialConditions() to replace the selection if dealing with an Expression that is part of an ExpressionStatement and the logic has calculated there are multiple return values
- modify ExtractMethodRefactoring to recognize if the analyzer has replaced the selection in which case start again and refresh values
- add new tests to ExtractMethodTests
- fixes #1913

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
