### PR TITLE
Simplify latest JLS version in astview

### DIFF
--- a/org.eclipse.jdt.astview.feature/feature.xml
+++ b/org.eclipse.jdt.astview.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.astview.feature"
       label="Java AST View"
-      version="1.2.350.qualifier"
+      version="1.2.400.qualifier"
       provider-name="Eclipse.org"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.astview/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.astview
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.astview; singleton:=true
-Bundle-Version: 1.6.250.qualifier
+Bundle-Version: 1.6.300.qualifier
 Bundle-Activator: org.eclipse.jdt.astview.ASTViewPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTView.java
+++ b/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -137,7 +137,6 @@ import org.eclipse.jdt.internal.ui.util.ASTHelper;
 
 public class ASTView extends ViewPart implements IShowInSource, IShowInTargetList {
 
-	static final int JLS_LATEST= AST.getJLSLatest();
 	private static final int JLS23= ASTHelper.JLS23;
 	private static final int JLS22= ASTHelper.JLS22;
 	private static final int JLS21= ASTHelper.JLS21;
@@ -501,7 +500,7 @@ public class ASTView extends ViewPart implements IShowInSource, IShowInTargetLis
 		fStatementsRecovery= !fDialogSettings.getBoolean(SETTINGS_NO_STATEMENTS_RECOVERY); // inverse so that default is use recovery
 		fBindingsRecovery= !fDialogSettings.getBoolean(SETTINGS_NO_BINDINGS_RECOVERY); // inverse so that default is use recovery
 		fIgnoreMethodBodies= fDialogSettings.getBoolean(SETTINGS_IGNORE_METHOD_BODIES);
-		fCurrentASTLevel= JLS_LATEST;
+		fCurrentASTLevel= AST.getJLSLatest();
 		try {
 			int level= fDialogSettings.getInt(SETTINGS_JLS);
 			switch (level) {

--- a/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/Binding.java
+++ b/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/Binding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -525,13 +525,13 @@ public class Binding extends ASTAttribute {
 	}
 
 	public static String getEscapedStringLiteral(String stringValue) {
-		StringLiteral stringLiteral= AST.newAST(ASTView.JLS_LATEST, false).newStringLiteral();
+		StringLiteral stringLiteral= AST.newAST(AST.getJLSLatest(), false).newStringLiteral();
 		stringLiteral.setLiteralValue(stringValue);
 		return stringLiteral.getEscapedValue();
 	}
 
 	public static String getEscapedCharLiteral(char charValue) {
-		CharacterLiteral charLiteral= AST.newAST(ASTView.JLS_LATEST, false).newCharacterLiteral();
+		CharacterLiteral charLiteral= AST.newAST(AST.getJLSLatest(), false).newCharacterLiteral();
 		charLiteral.setCharValue(charValue);
 		return charLiteral.getEscapedValue();
 	}


### PR DESCRIPTION
Instead of inlining (with all drawbacks from that) the JLS_LATEST constant remove the inlined constant and use AST.getJLSLatest()

