### PR TITLE
Progress: add missing license header in Progress.java #1920

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/Progress.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/Progress.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2023 SSI and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SSI - initial API and implementation
+ *******************************************************************************/
 package org.eclipse.jdt.internal.ui.util;
 
 import org.eclipse.core.runtime.IProgressMonitor;


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1920

