### PR TITLE
Avoid unnecessary calls to findOverriddenMethod #1922

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/MethodOverrideTester.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/MethodOverrideTester.java
@@ -136,10 +136,12 @@ public class MethodOverrideTester {
 			return null;
 		}
 
+		Set<String> visited = new HashSet<>();
+
 		IType type= overriding.getDeclaringType();
 		IType superClass= fHierarchy.getSuperclass(type);
 		if (superClass != null) {
-			IMethod res= findOverriddenMethodInHierarchy(superClass, overriding);
+			IMethod res= findOverriddenMethodInHierarchy(superClass, overriding, visited);
 			if (res != null) {
 				if (!testVisibility || JavaModelUtil.isVisibleInHierarchy(res, type.getPackageFragment())) {
 					return res;
@@ -147,7 +149,7 @@ public class MethodOverrideTester {
 			}
 		}
 		for (IType intf : fHierarchy.getSuperInterfaces(type)) {
-			IMethod res= findOverriddenMethodInHierarchy(intf, overriding);
+			IMethod res= findOverriddenMethodInHierarchy(intf, overriding, visited);
 			if (res != null) {
 				return res; // methods from interfaces are always public and therefore visible
 			}
@@ -160,23 +162,29 @@ public class MethodOverrideTester {
 	 * With generics it is possible that 2 methods in the same type are overidden at the same time. In that case, the first overridden method found is returned.
 	 * 	@param type The type to find methods in
 	 * @param overriding The overriding method
+	 * @param visited The types that were visited already
 	 * @return The first overridden method or <code>null</code> if no method is overridden
 	 * @throws JavaModelException if a problem occurs
 	 */
-	public IMethod findOverriddenMethodInHierarchy(IType type, IMethod overriding) throws JavaModelException {
+	public IMethod findOverriddenMethodInHierarchy(IType type, IMethod overriding, Set<String> visited) throws JavaModelException {
+
+		if (!visited.add(type.getElementName())) {
+			return null;
+		}
+
 		IMethod method= findOverriddenMethodInType(type, overriding);
 		if (method != null) {
 			return method;
 		}
 		IType superClass= fHierarchy.getSuperclass(type);
 		if (superClass != null) {
-			IMethod res=  findOverriddenMethodInHierarchy(superClass, overriding);
+			IMethod res=  findOverriddenMethodInHierarchy(superClass, overriding, visited);
 			if (res != null) {
 				return res;
 			}
 		}
 		for (IType superInterface : fHierarchy.getSuperInterfaces(type)) {
-			IMethod res= findOverriddenMethodInHierarchy(superInterface, overriding);
+			IMethod res= findOverriddenMethodInHierarchy(superInterface, overriding, visited);
 			if (res != null) {
 				return res;
 			}

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceIndirectionRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/IntroduceIndirectionRefactoring.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -540,7 +541,7 @@ public class IntroduceIndirectionRefactoring extends Refactoring {
 
 		IType actualTargetType= (IType) fIntermediaryFirstParameterType.getJavaElement();
 		if (!fTargetMethod.getDeclaringType().equals(actualTargetType)) {
-			IMethod actualTargetMethod= new MethodOverrideTester(actualTargetType, actualTargetType.newSupertypeHierarchy(null)).findOverriddenMethodInHierarchy(actualTargetType, fTargetMethod);
+			IMethod actualTargetMethod= new MethodOverrideTester(actualTargetType, actualTargetType.newSupertypeHierarchy(null)).findOverriddenMethodInHierarchy(actualTargetType, fTargetMethod, new HashSet<>());
 			fTargetMethod= actualTargetMethod;
 			fTargetMethodBinding= findMethodBindingInHierarchy(fIntermediaryFirstParameterType, actualTargetMethod);
 			Assert.isNotNull(fTargetMethodBinding);


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1922

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1922#issuecomment-2582766353