### PR TITLE
Fix inline method to attempt to copy over NLS comments when appropriate

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1856_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_1856_1.java
@@ -1,0 +1,11 @@
+package bugs_in;
+
+public class Test_issue_1856_1 {
+	String foo() {
+		return "abc"; //$NON-NLS-1$
+	}
+	String bar() {
+		String result = /*]*/foo()/*[*/;
+		return result;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1856_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_1856_1.java
@@ -1,0 +1,11 @@
+package bugs_in;
+
+public class Test_issue_1856_1 {
+	String foo() {
+		return "abc"; //$NON-NLS-1$
+	}
+	String bar() {
+		String result = /*]*/"abc"; //$NON-NLS-1$
+		return result;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -495,6 +495,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	@Test
 	public void test_issue_1529_2() throws Exception {
 		performInvalidTest();
+	}
+
+	@Test
+	public void test_issue_1856_1() throws Exception {
+		performBugTest();
 	}
 
 	/* *********************** Argument Tests ******************************* */


### PR DESCRIPTION
- change SourceProvider.getExpressionRanges() to add in comments of return statement when NLS comments are present
- change CallInliner.replaceCall() to try and split the last block at a semi-colon in case it was created by a return statement that had NLS comments
- if the split results in 2 segments, try and form a new statement that adds the new expression and NLS comments
- add new test to InlineMethodTests
- does not handle modifying existing NLS markers at target
- fixes #1856

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
