### PR TITLE
Asynchronously decorate quick outline view via DecorationManager #1922

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
@@ -52,7 +52,6 @@ import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 
-import org.eclipse.ui.IDecoratorManager;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
@@ -73,7 +72,6 @@ import org.eclipse.jdt.internal.corext.util.MethodOverrideTester;
 import org.eclipse.jdt.internal.corext.util.SuperTypeHierarchyCache;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.OverrideIndicatorLabelDecorator;
 import org.eclipse.jdt.ui.ProblemsLabelDecorator;
 import org.eclipse.jdt.ui.StandardJavaElementContentProvider;
 
@@ -85,7 +83,7 @@ import org.eclipse.jdt.internal.ui.actions.CategoryFilterActionGroup;
 import org.eclipse.jdt.internal.ui.typehierarchy.AbstractHierarchyViewerSorter;
 import org.eclipse.jdt.internal.ui.viewsupport.AppearanceAwareLabelProvider;
 import org.eclipse.jdt.internal.ui.viewsupport.ColoredViewersManager;
-import org.eclipse.jdt.internal.ui.viewsupport.ColoringLabelProvider;
+import org.eclipse.jdt.internal.ui.viewsupport.DecoratingJavaLabelProvider;
 import org.eclipse.jdt.internal.ui.viewsupport.FocusDescriptor;
 import org.eclipse.jdt.internal.ui.viewsupport.MemberFilter;
 
@@ -584,11 +582,7 @@ public class JavaOutlineInformationControl extends AbstractInformationControl {
 
 		fInnerLabelProvider= new OutlineLabelProvider();
 		fInnerLabelProvider.addLabelDecorator(new ProblemsLabelDecorator(null));
-		IDecoratorManager decoratorMgr= PlatformUI.getWorkbench().getDecoratorManager();
-		if (decoratorMgr.getEnabled("org.eclipse.jdt.ui.override.decorator")) //$NON-NLS-1$
-			fInnerLabelProvider.addLabelDecorator(new OverrideIndicatorLabelDecorator(null));
-
-		treeViewer.setLabelProvider(new ColoringLabelProvider(fInnerLabelProvider));
+		treeViewer.setLabelProvider(new DecoratingJavaLabelProvider(fInnerLabelProvider));
 
 		fLexicalSortingAction= new LexicalSortingAction(treeViewer);
 		fSortByDefiningTypeAction= new SortByDefiningTypeAction(treeViewer);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

The Quick Outline View currently applies (i.e., calculates and draws) decorations for override indicators synchronously. In case the calculation of the indicator takes long, it blocks the UI. The ordinary Outline View defers the responsibility of calculating and applying decorations to the `DecorationManager`. This ensures that (1) that task is performed asynchronously via a dedicated job and (2) that the `DecorationManager` takes care of the current user configuration (i.e., whether those indicators shall be shown or not), which the Quick Outline View currently replicates.

With this change, the Quick Outline View uses the same label decorator as the ordinary Outline View, which makes the `DecorationManager` process the override label decorator asynchronously instead of applying it synchronously.

Contributes to https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1922

This complements https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1926, which improves performance of the business logic used for calculating labels of the view, while this one ensures that the business logic is completely moved outside of the UI thread to be executed asynchronously.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

A reproducer has been kindly provided by @fedejeanne in:
- #1922

To reproduce, do the following:
- Import this Java project: [reproducer.zip](https://github.com/user-attachments/files/18372865/reproducer.zip)
- Make sure the "Java Method Overwrite Indicator" is active
- Go to the class `Broke1` and click `Ctrl + O` twice

Without this patch, the quick outline view will take a high amout of time to open and block the UI while with this patch it will open immediately and stay responsible.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
