### PR TITLE
Do not expand same class twice in (quick) type hierarchy

### DIFF
--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -137,6 +137,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java" type="org.eclipse.jdt.internal.ui.typehierarchy.HierarchyInformationControl">
+        <filter id="571519004">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.internal.ui.typehierarchy.HierarchyInformationControl.createTreeViewer(Composite, int)"/>
+                <message_argument value="TreeViewer"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="ui/org/eclipse/jdt/internal/ui/viewsupport/ProblemTableViewer.java" type="org.eclipse.jdt.internal.ui.viewsupport.ProblemTableViewer">
         <filter id="571473929">
             <message_arguments>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
@@ -14,6 +14,9 @@
 package org.eclipse.jdt.internal.ui.typehierarchy;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
@@ -23,6 +26,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.jface.bindings.TriggerSequence;
 import org.eclipse.jface.bindings.keys.KeySequence;
@@ -130,7 +134,23 @@ public class HierarchyInformationControl extends AbstractInformationControl {
 		gd.heightHint= tree.getItemHeight() * 12;
 		tree.setLayoutData(gd);
 
-		TreeViewer treeViewer= new TreeViewer(tree);
+		TreeViewer treeViewer= new TreeViewer(tree) {
+			@Override
+			protected Predicate<Widget> getShouldWidgetExpand() {
+
+				Set<Object> expanded= new HashSet<>();
+
+				// Expand every class/interface only once
+				return w -> {
+					if (w == null) {
+						return false;
+					}
+
+					Object data= w.getData();
+					return data == null || expanded.add(data);
+				};
+			}
+		};
 		treeViewer.addFilter(new ViewerFilter() {
 			@Override
 			public boolean select(Viewer viewer, Object parentElement, Object element) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewer.java
@@ -13,10 +13,15 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.typehierarchy;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.core.runtime.Assert;
 
@@ -180,6 +185,21 @@ public abstract class TypeHierarchyViewer extends ProblemTreeViewer {
 
 	protected TypeHierarchyContentProvider getHierarchyContentProvider() {
 		return (TypeHierarchyContentProvider)getContentProvider();
+	}
+
+	@Override
+	protected Predicate<Widget> getShouldWidgetExpand() {
+		Set<Object> expanded= new HashSet<>();
+
+		// Expand every class/interface only once
+		return w -> {
+			if (w == null) {
+				return false;
+			}
+
+			Object data= w.getData();
+			return data == null || expanded.add(data);
+		};
 	}
 
 }


### PR DESCRIPTION
## What it does

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1830

## Requires 
- [ ] https://github.com/eclipse-platform/eclipse.platform.ui/pull/2692 


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Expand an interface from here:
```java
class ReproducerRedundantTypeHierarchy {

	interface I0 {}
	interface I1 extends I0 {}
	interface I2 extends I1, I0 {}
	interface I3 extends I2, I1 {}
	interface I4 extends I3, I2 {}
	interface I5 extends I4, I3 {}
	interface I6 extends I5, I4 {}
}
```
The **(Quick) Type Hierarchy** should not expand the same interface twice

![image](https://github.com/user-attachments/assets/e153b4e9-8bef-4134-88d0-772952a5ce77)

---

![image](https://github.com/user-attachments/assets/2ac76cb6-cf82-4019-a3a4-da5ef8e5d344)


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
