### PR TITLE
Fix for Visual Bug in Code Folding

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests.folding;
 
+
 import java.util.List;
 
 import org.junit.After;


### PR DESCRIPTION
Fix folding of 2 consecutive methods

If the second method starts in the same line the first one ends then there will still be 2 foldings.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1539

## How to test

1. Create a class with two or more methods. Ensure that the second method begins immediately after the first method ends. For example:

```java
public class b {
	void a() {
		
	}void b() {
		
	}
}
```

2. Fold the first method. The second method should remain visible.