### PR TITLE
Fix duplicate add suppress warnings proposals

### DIFF
--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/SuppressWarningsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/SuppressWarningsBaseSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 IBM Corporation and others.
+ * Copyright (c) 2023, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -91,10 +91,9 @@ public abstract class SuppressWarningsBaseSubProcessor<T> {
 		if (warningToken == null) {
 			return;
 		}
-		for (T element : proposals) {
-			if (element instanceof SuppressWarningsProposalCore && warningToken.equals(((SuppressWarningsProposalCore) element).getWarningToken())) {
-				return; // only one at a time
-			}
+
+		if (alreadyHasProposal(proposals, warningToken)) {
+			return;
 		}
 
 		ASTNode node= problem.getCoveringNode(context.getASTRoot());
@@ -259,4 +258,6 @@ public abstract class SuppressWarningsBaseSubProcessor<T> {
 	protected abstract T createASTRewriteCorrectionProposal(String name, ICompilationUnit cu, ASTRewrite rewrite, int relevance);
 
 	protected abstract T createFixCorrectionProposal(IProposableFix fix, ICleanUp cleanUp, int relevance, IInvocationContext context);
+
+	protected abstract boolean alreadyHasProposal(Collection<T> proposals, String warningToken);
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -698,7 +698,8 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 
 	private static boolean getDeprecatedProposal(IInvocationContext context, ASTNode node, IProblemLocation[] locations, Collection<ICommandAccess> proposals) {
 		// don't add if already added as quick fix
-		if (containsMatchingProblem(locations, IProblem.UsingDeprecatedMethod))
+		if (containsMatchingProblem(locations, IProblem.UsingDeprecatedMethod) ||
+				containsMatchingProblem(locations, IProblem.UsingDeprecatedConstructor))
 			return false;
 
 		if (!(node instanceof MethodInvocation)) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/SuppressWarningsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/SuppressWarningsSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -49,6 +49,9 @@ public class SuppressWarningsSubProcessor extends SuppressWarningsBaseSubProcess
 		public SuppressWarningsProposal(String warningToken, String label, ICompilationUnit cu, ASTNode node, ChildListPropertyDescriptor property, int relevance) {
 			super(label, cu, null, relevance, JavaPluginImages.get(JavaPluginImages.IMG_OBJS_JAVADOCTAG), new SuppressWarningsProposalCore(warningToken, label, cu, node, property, relevance));
 		}
+		public SuppressWarningsProposalCore getCoreDelegate() {
+			return (SuppressWarningsProposalCore) this.getDelegate();
+		}
 	}
 
 	public static void addUnknownSuppressWarningProposals(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
@@ -90,6 +93,17 @@ public class SuppressWarningsSubProcessor extends SuppressWarningsBaseSubProcess
 	}
 
 	SuppressWarningsSubProcessor() {
+	}
+
+
+	@Override
+	protected boolean alreadyHasProposal(Collection<ICommandAccess> proposals, String warningToken) {
+		for (ICommandAccess element : proposals) {
+			if (element instanceof SuppressWarningsProposal swp && warningToken.equals(swp.getCoreDelegate().getWarningToken())) {
+				return true; // only one at a time
+			}
+		}
+		return false;
 	}
 
 }


### PR DESCRIPTION
- add new abstract method alreadyHasProposal() to SuppressWarningsBaseSubProcessor to check if a proposal has already been added
- add implemention of alreadyHasProposal() to SuppressWarningsSubProcessor
- add new test to QuickFixTest1d8
- fixes #1935

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Prevents duplicate proposals to add suppress warnings annotations.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test or issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
