### PR TITLE
Stop using deprecated URL constructors in o.e.jdt.ui.tests

### DIFF
--- a/org.eclipse.jdt.ui.tests/test plugin/org/eclipse/jdt/testplugin/JavaTestPlugin.java
+++ b/org.eclipse.jdt.ui.tests/test plugin/org/eclipse/jdt/testplugin/JavaTestPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -48,7 +48,7 @@ public class JavaTestPlugin extends AbstractUIPlugin {
 
 	public File getFileInPlugin(IPath path) throws CoreException {
 		try {
-			URL installURL= new URL(getBundle().getEntry("/"), path.toString());
+			URL installURL= getBundle().getEntry("/"+ path.toString());
 			URL localURL= FileLocator.toFileURL(installURL);
 			return new File(localURL.getFile());
 		} catch (IOException e) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/PackageJavadocTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/PackageJavadocTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2020 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.net.URL;
+import java.net.URI;
 
 import org.junit.After;
 import org.junit.Before;
@@ -239,7 +239,7 @@ public class PackageJavadocTests extends CoreTests {
 		String connectionTestUrl= "https://docs.oracle.com/";
 		try {
 			// Trying to connect to the internet. Exception will be thrown if there is no net connection.
-			new URL(connectionTestUrl).openConnection().connect();
+			URI.create(connectionTestUrl).toURL().openConnection().connect();
 			assertTrue(actualHtmlContent, actualHtmlContent.contains("Provides classes for performing arbitrary-precision integer"));
 		} catch (Exception e) {
 			System.out.println("PackageJavadocTests.testGetPackageAttacheddoc(): no internet connection to access docs at " + connectionTestUrl);


### PR DESCRIPTION
* Let Bundle.getEntry do full resolving
* If it's actually used to openConnection go through URI creation.
