### PR TITLE
Deprecate for removal JavaPlugin.getJavaCorePluginPreferences

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AdvancedQuickAssistTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AdvancedQuickAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -77,11 +77,11 @@ public class AdvancedQuickAssistTest extends QuickFixTest {
 
 		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "//TODO\n${body_statement}", null);
 
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 
 		fJProject1= projectSetup.getProject();
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AdvancedQuickAssistTest1d7.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AdvancedQuickAssistTest1d7.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -72,11 +72,11 @@ public class AdvancedQuickAssistTest1d7 extends QuickFixTest {
 
 		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "//TODO\n${body_statement}", null);
 
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 
 		fJProject1= projectSetup.getProject();
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,7 +37,7 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 import org.eclipse.osgi.util.NLS;
 
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -97,11 +97,11 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "//TODO\n${body_statement}", null);
 
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 
 		fJProject1= projectSetup.getProject();
 
@@ -233,9 +233,9 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
 		store.setValue(PreferenceConstants.CODEGEN_KEYWORD_THIS, true);
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
-		corePrefs.setValue(JavaCore.CODEASSIST_LOCAL_PREFIXES, "_");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
+		corePrefs.put(JavaCore.CODEASSIST_LOCAL_PREFIXES, "_");
 
 
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
@@ -358,10 +358,10 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
 		store.setValue(PreferenceConstants.CODEGEN_KEYWORD_THIS, true);
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "fg");
-		corePrefs.setValue(JavaCore.CODEASSIST_LOCAL_PREFIXES, "_");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "fg");
+		corePrefs.put(JavaCore.CODEASSIST_LOCAL_PREFIXES, "_");
 
 
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
@@ -1280,8 +1280,8 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 	@Test
 	public void testAssignParamToField2() throws Exception {
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
 
 
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
@@ -1322,8 +1322,8 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 	@Test
 	public void testAssignParamToField3() throws Exception {
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "fg");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "fg");
 
 		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
 		store.setValue(PreferenceConstants.CODEGEN_KEYWORD_THIS, true);
@@ -1718,8 +1718,8 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 	@Test
 	public void testAssignParamToFieldInGeneric() throws Exception {
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
 
 
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
@@ -7400,10 +7400,10 @@ public class AssistQuickFixTest extends QuickFixTest {
 
 	@Test
 	public void testConvertAnonymousToNested2() throws Exception {
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
-		corePrefs.setValue(JavaCore.CODEASSIST_LOCAL_PREFIXES, "l");
-		corePrefs.setValue(JavaCore.CODEASSIST_ARGUMENT_PREFIXES, "p");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "f");
+		corePrefs.put(JavaCore.CODEASSIST_LOCAL_PREFIXES, "l");
+		corePrefs.put(JavaCore.CODEASSIST_ARGUMENT_PREFIXES, "p");
 
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("pack", false, null);
 		String str= """

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d7.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d7.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2024 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -80,11 +80,11 @@ public class AssistQuickFixTest1d7 extends QuickFixTest {
 
 		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "//TODO\n${body_statement}", null);
 
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 
 		fJProject1= projectSetup.getProject();
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ChangeNonStaticToStaticTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ChangeNonStaticToStaticTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,7 @@ import org.eclipse.jdt.testplugin.TestOptions;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
@@ -78,11 +78,11 @@ public class ChangeNonStaticToStaticTest extends QuickFixTest {
 
 		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "//TODO\n${body_statement}", null);
 
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 
 		fJProject1= projectSetup.getProject();
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTestCase.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,7 +33,7 @@ import org.eclipse.jdt.testplugin.TestOptions;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.core.resources.IWorkspace;
@@ -106,11 +106,11 @@ public abstract class CleanUpTestCase extends QuickFixTest {
 		StubUtility.setCodeTemplate(CodeTemplateContextType.OVERRIDECOMMENT_ID, "/* comment */", null);
 		StubUtility.setCodeTemplate(CodeTemplateContextType.FIELDCOMMENT_ID, FIELD_COMMENT, null);
 
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 
 		fSourceFolder= JavaProjectHelper.addSourceContainer(getProject(), "src");
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/PropertiesFileQuickAssistTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/PropertiesFileQuickAssistTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 IBM Corporation and others.
+ * Copyright (c) 2011, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,7 @@ import org.eclipse.jdt.testplugin.TestOptions;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -95,13 +95,12 @@ public class PropertiesFileQuickAssistTest {
 		JavaProjectHelper.addLibrary(fJProject, JavaProjectHelper.findRtJar(osgiJar)[0]);
 	}
 
-	@Deprecated
 	private void setPreferences() {
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 	}
 
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SurroundWithTemplateTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SurroundWithTemplateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,7 +28,7 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.text.templates.TemplatePersistenceData;
 
@@ -77,11 +77,11 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 
 		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODSTUB_ID, "//TODO\n${body_statement}", null);
 
-		Preferences corePrefs= JavaPlugin.getJavaCorePluginPreferences();
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
-		corePrefs.setValue(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
+		IEclipsePreferences corePrefs= JavaPlugin.getJavaCorePluginPreferencesNew();
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_PREFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_FIELD_SUFFIXES, "");
+		corePrefs.put(JavaCore.CODEASSIST_STATIC_FIELD_SUFFIXES, "");
 
 		fJProject1= projectSetup.getProject();
 
@@ -126,7 +126,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(1);
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -150,7 +150,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        };
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}
@@ -174,7 +174,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(j);
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -210,7 +210,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(j);
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}
@@ -236,7 +236,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        i++;
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -274,7 +274,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        i++;
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}
@@ -338,7 +338,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(i);
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -364,7 +364,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(i);
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}
@@ -382,7 +382,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(i);
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -410,7 +410,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(i);
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}
@@ -427,7 +427,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(i);
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -452,7 +452,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        };
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}
@@ -474,7 +474,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        System.out.println(i);
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -506,7 +506,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        };
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}
@@ -569,7 +569,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        j = 10;
 			    }
 			}
-			
+
 			""";
 		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
 
@@ -598,7 +598,7 @@ public class SurroundWithTemplateTest extends QuickFixTest {
 			        j = 10;
 			    }
 			}
-			
+
 			""";
 		assertExpectedExistInProposals(proposals, new String[] {str2});
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -655,12 +655,18 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 	 *
 	 * @return the Java Core plug-in preferences
 	 * @since 3.7
-	 * deprecated use getJavaCorePluginPreferencesNew
+	 * @deprecated Use {@link #getJavaCorePluginPreferencesNew()} instead.
 	 */
+	@Deprecated(forRemoval= true, since="2025-03")
 	public static org.eclipse.core.runtime.Preferences getJavaCorePluginPreferences() {
 		return JavaCore.getPlugin().getPluginPreferences();
 	}
 
+	/**
+	 * Returns the Java Core plug-in preferences.
+	 *
+	 * @return the Java Core plug-in preferences
+	 */
 	public static IEclipsePreferences getJavaCorePluginPreferencesNew() {
 		return InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
 	}


### PR DESCRIPTION
Class org.eclipse.core.runtime.Preferences has been deprecated for years and method getJavaCorePluginPreferencesNew (returning IEclipsePreferences) is there.
Migrated unit tests to use getJavaCorePluginPreferencesNew.
