### PR TITLE
Fix extraneous text block conversion from StringBuffer/StringBuilder

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -752,6 +752,9 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			if (!checkValidityVisitor.isValid()) {
 				return failure();
 			} else if (checkValidityVisitor.isPassedAsArgument()) {
+				if (fLiterals.size() < 3) {
+					return failure();
+				}
 				List<Statement> statements= new ArrayList<>(statementList);
 				List<StringLiteral> literals= new ArrayList<>(fLiterals);
 				ModifyStringBufferToUseTextBlock operation= new ModifyStringBufferToUseTextBlock(node, statements,

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -816,6 +816,13 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 			        // comment 1
 			        int index = buf3.indexOf("null");
 			        bufFunc(buf3);
+   			        StringBuilder buf13 = new StringBuilder();
+			        bufFunc(buf13);
+			        StringBuilder buf14 = new StringBuilder("abcd\\n");
+			        bufFunc(buf14);
+			        StringBuilder buf15 = new StringBuilder("abcd\\n");
+			        buf15.append("efg");
+			        bufFunc(buf15);
 			       \s
 			    }
 			    public void bufFunc(StringBuilder x) {
@@ -842,6 +849,13 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 			        // comment 1
 			        int index = buf3.indexOf("null");
 			        bufFunc(buf3);
+   			        StringBuilder buf13 = new StringBuilder();
+			        bufFunc(buf13);
+			        StringBuilder buf14 = new StringBuilder("abcd\\n");
+			        bufFunc(buf14);
+			        StringBuilder buf15 = new StringBuilder("abcd\\n");
+			        buf15.append("efg");
+			        bufFunc(buf15);
 			       \s
 			    }
 			    public void bufFunc(StringBuilder x) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest15.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Red Hat Inc. and others.
+ * Copyright (c) 2021, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -415,6 +415,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			        buf12.append("ijkl\\n");
 			        buf12.append("mnopq\\n");
 			        bufFunc(buf12);
+			        StringBuffer buf13 = new StringBuffer();
+			        bufFunc(buf13);
+			        StringBuffer buf14 = new StringBuffer("abcd\\n");
+			        bufFunc(buf14);
+			        StringBuffer buf15 = new StringBuffer("abcd\\n");
+			        buf15.append("efg");
+			        bufFunc(buf15);
 			    }
 			    private void write(CharSequence c) {
 			        System.out.println(c);
@@ -554,6 +561,13 @@ public class CleanUpTest15 extends CleanUpTestCase {
 			            mnopq
 			            \""");
 			        bufFunc(buf12);
+			        StringBuffer buf13 = new StringBuffer();
+			        bufFunc(buf13);
+			        StringBuffer buf14 = new StringBuffer("abcd\\n");
+			        bufFunc(buf14);
+			        StringBuffer buf15 = new StringBuffer("abcd\\n");
+			        buf15.append("efg");
+			        bufFunc(buf15);
 			    }
 			    private void write(CharSequence c) {
 			        System.out.println(c);


### PR DESCRIPTION
- add check for number of string literals to new logic that converts the initializer of the StringBuilder/StringBuffer
- modify test in CleanUpTest15
- modify test in AssistQuickFixTest15
- fixes #1944

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
