### PR TITLE
Stop using deprecated Class.newInstance()

### DIFF
--- a/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RemoteTestRunner.java
+++ b/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RemoteTestRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -369,7 +369,7 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 
 	protected ITestLoader createRawTestLoader(String className) {
 		try {
-			return (ITestLoader) loadTestLoaderClass(className).newInstance();
+			return (ITestLoader) loadTestLoaderClass(className).getDeclaredConstructor().newInstance();
 		} catch (Exception e) {
 			StringWriter trace= new StringWriter();
 			e.printStackTrace(new PrintWriter(trace));


### PR DESCRIPTION
Recommended way is Class.getDeclaredConstructor().newInstance()
