### PR TITLE
Migrate ContentAssistHistory to IEclipsePreferences

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/ContentAssistHistoryTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/ContentAssistHistoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2020 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,7 +25,8 @@ import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
@@ -228,14 +229,14 @@ public class ContentAssistHistoryTest {
 	}
 
 	@Test
-	public void testLoadStore() throws Exception {
+	public void testLoadStoreIEclipsePreferences() throws Exception {
 		ContentAssistHistory history= new ContentAssistHistory();
 
 		history.remember(fgListT, fgArrayListT);
 		history.remember(fgCharSequenceT, fgStringT);
 
 
-		Preferences prefs= new Preferences();
+		IEclipsePreferences prefs= InstanceScope.INSTANCE.getNode("org.eclipse.jdt.text.testsa");
 		String key= "myKey";
 		ContentAssistHistory.store(history, prefs, key);
 		ContentAssistHistory loaded= ContentAssistHistory.load(prefs, key);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
@@ -493,7 +493,7 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 			}
 
 			if (fContentAssistHistory != null) {
-				ContentAssistHistory.store(fContentAssistHistory, getPluginPreferences(), PreferenceConstants.CODEASSIST_LRU_HISTORY);
+				ContentAssistHistory.store(fContentAssistHistory, InstanceScope.INSTANCE.getNode(JavaPlugin.getPluginId()), PreferenceConstants.CODEASSIST_LRU_HISTORY);
 				fContentAssistHistory= null;
 			}
 
@@ -1045,7 +1045,7 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 					return fContentAssistHistory;
 				}
 				try {
-					fContentAssistHistory= ContentAssistHistory.load(getPluginPreferences(), PreferenceConstants.CODEASSIST_LRU_HISTORY);
+					fContentAssistHistory= ContentAssistHistory.load(InstanceScope.INSTANCE.getNode(JavaPlugin.getPluginId()), PreferenceConstants.CODEASSIST_LRU_HISTORY);
 				} catch (CoreException x) {
 					log(x);
 				}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/ContentAssistHistory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/ContentAssistHistory.java
@@ -51,7 +51,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Preferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IType;
@@ -455,12 +455,12 @@ public final class ContentAssistHistory {
 	 * @param preferences the preferences to store the history into
 	 * @param key the key under which to store the history
 	 * @throws CoreException if serialization fails
-	 * @see #load(Preferences, String) on how to restore a history stored by this method
+	 * @see #load(IEclipsePreferences, String) on how to restore a history stored by this method
 	 */
-	public static void store(ContentAssistHistory history, Preferences preferences, String key) throws CoreException {
+	public static void store(ContentAssistHistory history, IEclipsePreferences preferences, String key) throws CoreException {
 		StringWriter writer= new StringWriter();
 		new ReaderWriter().store(history, new StreamResult(writer));
-		preferences.setValue(key, writer.toString());
+		preferences.put(key, writer.toString());
 	}
 
 	/**
@@ -471,11 +471,11 @@ public final class ContentAssistHistory {
 	 * @return the deserialized history, or <code>null</code> if there is nothing stored under the
 	 *         given key
 	 * @throws CoreException if deserialization fails
-	 * @see #store(ContentAssistHistory, Preferences, String) on how to store a history such that it
+	 * @see #store(ContentAssistHistory, IEclipsePreferences, String) on how to store a history such that it
 	 *      can be read by this method
 	 */
-	public static ContentAssistHistory load(Preferences preferences, String key) throws CoreException {
-		String value= preferences.getString(key);
+	public static ContentAssistHistory load(IEclipsePreferences preferences, String key) throws CoreException {
+		String value= preferences.get(key, ""); //$NON-NLS-1$
 		if (value != null && value.length() > 0) {
 			return new ReaderWriter().load(new InputSource(new StringReader(value)));
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26,6 +26,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.RGB;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.jface.action.Action;
@@ -3776,7 +3777,7 @@ public class PreferenceConstants {
 	 * Value is an XML encoded version of the history.
 	 * </p>
 	 *
-	 * @see org.eclipse.jdt.internal.ui.text.java.ContentAssistHistory#load(org.eclipse.core.runtime.Preferences, String)
+	 * @see org.eclipse.jdt.internal.ui.text.java.ContentAssistHistory#load(IEclipsePreferences, String)
 	 * @since 3.2
 	 */
 	public static final String CODEASSIST_LRU_HISTORY= "content_assist_lru_history"; //$NON-NLS-1$


### PR DESCRIPTION
Long deprecated o.e.core.runtime.Preferences class would better not be used anymore.
