### PR TITLE
Do not expand same class twice in (quick) type hierarchy

### DIFF
--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -137,6 +137,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java" type="org.eclipse.jdt.internal.ui.typehierarchy.HierarchyInformationControl">
+        <filter id="571519004">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.internal.ui.typehierarchy.HierarchyInformationControl.createTreeViewer(Composite, int)"/>
+                <message_argument value="TreeViewer"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="ui/org/eclipse/jdt/internal/ui/viewsupport/ProblemTableViewer.java" type="org.eclipse.jdt.internal.ui.viewsupport.ProblemTableViewer">
         <filter id="571473929">
             <message_arguments>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
@@ -14,6 +14,8 @@
 package org.eclipse.jdt.internal.ui.typehierarchy;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
@@ -23,6 +25,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.jface.bindings.TriggerSequence;
 import org.eclipse.jface.bindings.keys.KeySequence;
@@ -130,7 +133,32 @@ public class HierarchyInformationControl extends AbstractInformationControl {
 		gd.heightHint= tree.getItemHeight() * 12;
 		tree.setLayoutData(gd);
 
-		TreeViewer treeViewer= new TreeViewer(tree);
+		TreeViewer treeViewer= new TreeViewer(tree) {
+			private Set<Object> visited;
+
+			@Override
+			protected void inputChanged(Object input, Object oldInput) {
+				visited= new HashSet<>();
+				super.inputChanged(input, oldInput);
+				visited= null;
+			}
+
+			@Override
+			protected void internalExpandToLevel(Widget node, int level) {
+				if (!shouldExpand(node))
+					return;
+
+				super.internalExpandToLevel(node, level);
+			}
+
+			private boolean shouldExpand(Widget widget) {
+				if (widget == null) {
+					return false;
+				}
+				Object data= widget.getData();
+				return data == null || visited.add(data);
+			}
+		};
 		treeViewer.addFilter(new ViewerFilter() {
 			@Override
 			public boolean select(Viewer viewer, Object parentElement, Object element) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/SubTypeHierarchyViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/SubTypeHierarchyViewer.java
@@ -32,11 +32,8 @@ public class SubTypeHierarchyViewer extends TypeHierarchyViewer {
 		super(parent, new SubTypeHierarchyContentProvider(lifeCycle), lifeCycle);
 	}
 
-	/*
-	 * @see TypeHierarchyViewer#updateContent
-	 */
 	@Override
-	public void updateContent(boolean expand) {
+	protected void hookUpdateContent(boolean expand) {
 		getTree().setRedraw(false);
 		refresh();
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/SuperTypeHierarchyViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/SuperTypeHierarchyViewer.java
@@ -34,11 +34,8 @@ public class SuperTypeHierarchyViewer extends TypeHierarchyViewer {
 		super(parent, new SuperTypeHierarchyContentProvider(lifeCycle), lifeCycle);
 	}
 
-	/*
-	 * @see TypeHierarchyViewer#updateContent
-	 */
 	@Override
-	public void updateContent(boolean expand) {
+	protected void hookUpdateContent(boolean expand) {
 		getTree().setRedraw(false);
 		refresh();
 		if (expand) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TraditionalHierarchyViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TraditionalHierarchyViewer.java
@@ -37,11 +37,8 @@ public class TraditionalHierarchyViewer extends TypeHierarchyViewer {
 		super(parent, new TraditionalHierarchyContentProvider(lifeCycle), lifeCycle);
 	}
 
-	/*
-	 * @see TypeHierarchyViewer#updateContent
-	 */
 	@Override
-	public void updateContent(boolean expand) {
+	protected void hookUpdateContent(boolean expand) {
 		getTree().setRedraw(false);
 		refresh();
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
@@ -1212,12 +1212,7 @@ public class TypeHierarchyViewPart extends ViewPart implements ITypeHierarchyVie
 			fPagebook.showPage(fNoHierarchyShownLabel);
 		} else {
 			if (getCurrentViewer().containsElements() != null) {
-				Runnable runnable= () -> JavaCore.runReadOnly(() -> {
-					TypeHierarchyViewer viewer= getCurrentViewer();
-					viewer.preUpdateContent();
-					viewer.updateContent(doExpand);
-					viewer.postUpdateContent();
-				});
+				Runnable runnable= () -> JavaCore.runReadOnly(() -> getCurrentViewer().updateContent(doExpand));
 				BusyIndicator.showWhile(getDisplay(), runnable);
 				if (!isChildVisible(fViewerbook, getCurrentViewer().getControl())) {
 					setViewerVisibility(true);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
@@ -1212,7 +1212,12 @@ public class TypeHierarchyViewPart extends ViewPart implements ITypeHierarchyVie
 			fPagebook.showPage(fNoHierarchyShownLabel);
 		} else {
 			if (getCurrentViewer().containsElements() != null) {
-				Runnable runnable= () -> JavaCore.runReadOnly(() -> getCurrentViewer().updateContent(doExpand));
+				Runnable runnable= () -> JavaCore.runReadOnly(() -> {
+					TypeHierarchyViewer viewer= getCurrentViewer();
+					viewer.preUpdateContent();
+					viewer.updateContent(doExpand);
+					viewer.postUpdateContent();
+				});
 				BusyIndicator.showWhile(getDisplay(), runnable);
 				if (!isChildVisible(fViewerbook, getCurrentViewer().getControl())) {
 					setViewerVisibility(true);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewer.java
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.typehierarchy;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.core.runtime.Assert;
 
@@ -41,6 +45,8 @@ import org.eclipse.jdt.internal.ui.viewsupport.ProblemTreeViewer;
 public abstract class TypeHierarchyViewer extends ProblemTreeViewer {
 
 	private HierarchyLabelProvider fLabelProvider;
+
+	private Set<Object> visited;
 
 
 	public TypeHierarchyViewer(Composite parent, IContentProvider contentProvider, TypeHierarchyLifeCycle lifeCycle) {
@@ -182,4 +188,34 @@ public abstract class TypeHierarchyViewer extends ProblemTreeViewer {
 		return (TypeHierarchyContentProvider)getContentProvider();
 	}
 
+	@Override
+	protected void inputChanged(Object input, Object oldInput) {
+		preUpdateContent();
+		super.inputChanged(input, oldInput);
+		postUpdateContent();
+	}
+
+	@Override
+	protected void internalExpandToLevel(Widget node, int level) {
+		if (!shouldExpand(node))
+			return;
+
+		super.internalExpandToLevel(node, level);
+	}
+
+	private boolean shouldExpand(Widget widget) {
+		if (widget == null) {
+			return false;
+		}
+		Object data= widget.getData();
+		return data == null || visited.add(data);
+	}
+
+	void preUpdateContent() {
+		visited= new HashSet<>();
+	}
+
+	void postUpdateContent() {
+		visited= null;
+	}
 }


### PR DESCRIPTION
Fixes eclipse-jdt#1830

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Expand an interface from here:
```java
class ReproducerRedundantTypeHierarchy {

	interface I0 {}
	interface I1 extends I0 {}
	interface I2 extends I1, I0 {}
	interface I3 extends I2, I1 {}
	interface I4 extends I3, I2 {}
	interface I5 extends I4, I3 {}
	interface I6 extends I5, I4 {}
}
```
The **(Quick) Type Hierarchy** should not expand the same interface twice

![image](https://github.com/user-attachments/assets/e153b4e9-8bef-4134-88d0-772952a5ce77)

---

![image](https://github.com/user-attachments/assets/2ac76cb6-cf82-4019-a3a4-da5ef8e5d344)


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)