### PR TITLE
Make JavaPlugin.getActivePage() aware of not running platform and inline

### DIFF
--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
@@ -71,7 +71,6 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.Region;
 
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
 import org.eclipse.ltk.core.refactoring.Change;
@@ -474,7 +473,7 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
 		if (!status.hasError())
 			return Window.OK;
 
-		Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		Shell shell= JavaPlugin.getActiveWorkbenchShell();
 
 		Dialog dialog= RefactoringUI.createRefactoringStatusDialog(status, shell, "", false); //$NON-NLS-1$
 		return dialog.open();
@@ -674,7 +673,7 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
 
 	private void showSlowCleanUpDialog(final StringBuilder cleanUpNames) {
 		if (OptionalMessageDialog.isDialogEnabled(SlowCleanUpWarningDialog.ID)) {
-			Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+			Shell shell= JavaPlugin.getActiveWorkbenchShell();
 			new SlowCleanUpWarningDialog(shell, FixMessages.CleanUpPostSaveListener_SlowCleanUpDialog_title, cleanUpNames.toString()).open();
 		}
 	}

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/RefactoringExecutionStarter.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/RefactoringExecutionStarter.java
@@ -36,8 +36,6 @@ import org.eclipse.jface.viewers.StructuredSelection;
 
 import org.eclipse.jface.text.ITextSelection;
 
-import org.eclipse.ui.PlatformUI;
-
 import org.eclipse.ltk.core.refactoring.Refactoring;
 import org.eclipse.ltk.core.refactoring.RefactoringCore;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
@@ -109,6 +107,7 @@ import org.eclipse.jdt.ui.refactoring.IRefactoringSaveModes;
 import org.eclipse.jdt.ui.refactoring.RefactoringSaveHelper;
 import org.eclipse.jdt.ui.refactoring.RenameSupport;
 
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.actions.ActionMessages;
 import org.eclipse.jdt.internal.ui.fix.CleanUpRefactoringWizard;
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
@@ -249,7 +248,7 @@ public final class RefactoringExecutionStarter {
 			if (refactoring.getCleanUpTargetsSize() > 1) {
 				context= new ProgressMonitorDialog(shell);
 			} else {
-				context= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+				context= JavaPlugin.getActiveWorkbenchWindow();
 			}
 
 			RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, IStatus.INFO, IRefactoringSaveModes.SAVE_REFACTORING, shell, context);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
@@ -284,11 +284,18 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 	}
 
 	public static IWorkbenchPage getActivePage() {
-		return getDefault().internalGetActivePage();
+		IWorkbenchWindow window= getActiveWorkbenchWindow();
+		if (window != null) {
+			return window.getActivePage();
+		}
+		return null;
 	}
 
 	public static IWorkbenchWindow getActiveWorkbenchWindow() {
-		return PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (PlatformUI.isWorkbenchRunning()) {
+			return PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		}
+		return null;
 	}
 
 	public static Shell getActiveWorkbenchShell() {
@@ -542,13 +549,6 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 		} finally {
 			super.stop(context);
 		}
-	}
-
-	private IWorkbenchPage internalGetActivePage() {
-		IWorkbenchWindow window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-		if (window == null)
-			return null;
-		return window.getActivePage();
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/AddGetterSetterTypeProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/AddGetterSetterTypeProposal.java
@@ -23,7 +23,6 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.text.IDocument;
 
 import org.eclipse.ui.IWorkbenchSite;
-import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.jdt.core.IType;
 
@@ -33,6 +32,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.ui.actions.AddGetterSetterAction;
 import org.eclipse.jdt.ui.text.java.correction.ChangeCorrectionProposal;
 
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
@@ -68,7 +68,7 @@ public class AddGetterSetterTypeProposal extends ChangeCorrectionProposal { // p
 		Display.getDefault().syncExec(() -> {
 			try {
 				IStructuredSelection selection= new StructuredSelection(fType);
-				IWorkbenchSite site= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor().getSite();
+				IWorkbenchSite site= JavaPlugin.getActiveWorkbenchWindow().getActivePage().getActiveEditor().getSite();
 				new AddGetterSetterAction(site).run(selection);
 			} catch (NullPointerException e) {
 				// do nothing

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/EnablePreviewFeaturesAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/EnablePreviewFeaturesAction.java
@@ -34,7 +34,6 @@ import org.eclipse.jface.viewers.IStructuredSelection;
 
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
 import org.eclipse.jdt.core.IJavaProject;
@@ -106,7 +105,7 @@ public class EnablePreviewFeaturesAction implements IObjectActionDelegate {
 				map.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
 				fJavaProject.setOptions(map);
 
-				Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+				Shell shell= JavaPlugin.getActiveWorkbenchShell();
 				Map<String, Object> data= new HashMap<>();
 				data.put(CompliancePreferencePage.DATA_SELECT_OPTION_KEY, JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES);
 				data.put(CompliancePreferencePage.DATA_SELECT_OPTION_QUALIFIER, JavaCore.PLUGIN_ID);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/HashCodeEqualsTypeProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/HashCodeEqualsTypeProposal.java
@@ -23,7 +23,6 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.text.IDocument;
 
 import org.eclipse.ui.IWorkbenchSite;
-import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.jdt.core.IType;
 
@@ -33,6 +32,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.ui.actions.GenerateHashCodeEqualsAction;
 import org.eclipse.jdt.ui.text.java.correction.ChangeCorrectionProposal;
 
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
@@ -68,7 +68,7 @@ public class HashCodeEqualsTypeProposal extends ChangeCorrectionProposal { // pu
 		Display.getDefault().syncExec(() -> {
 			try {
 				IStructuredSelection selection= new StructuredSelection(fType);
-				IWorkbenchSite site= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor().getSite();
+				IWorkbenchSite site= JavaPlugin.getActivePage().getActiveEditor().getSite();
 				new GenerateHashCodeEqualsAction(site).run(selection);
 			} catch (NullPointerException e) {
 				// do nothing

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/SurroundWithTemplateMenuAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/SurroundWithTemplateMenuAction.java
@@ -22,7 +22,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
-import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -95,14 +94,11 @@ public class SurroundWithTemplateMenuAction implements IWorkbenchWindowPulldownD
 
 		@Override
 		public void run() {
-			PreferenceDialog preferenceDialog= PreferencesUtil.createPreferenceDialogOn(getShell(), JAVA_TEMPLATE_PREFERENCE_PAGE_ID, new String[] { JAVA_TEMPLATE_PREFERENCE_PAGE_ID, CODE_TEMPLATE_PREFERENCE_PAGE_ID }, null);
+			PreferenceDialog preferenceDialog= PreferencesUtil.createPreferenceDialogOn(JavaPlugin.getActiveWorkbenchShell(), JAVA_TEMPLATE_PREFERENCE_PAGE_ID, new String[] { JAVA_TEMPLATE_PREFERENCE_PAGE_ID, CODE_TEMPLATE_PREFERENCE_PAGE_ID }, null);
 			preferenceDialog.getTreeViewer().expandAll();
 			preferenceDialog.open();
 		}
 
-		private Shell getShell() {
-			return JavaPlugin.getActiveWorkbenchWindow().getShell();
-		}
 	}
 
 	private static Action NONE_APPLICABLE_ACTION= new Action(ActionMessages.SurroundWithTemplateMenuAction_NoneApplicable) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ToStringTypeProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ToStringTypeProposal.java
@@ -23,7 +23,6 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.text.IDocument;
 
 import org.eclipse.ui.IWorkbenchSite;
-import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.jdt.core.IType;
 
@@ -33,6 +32,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.ui.actions.GenerateToStringAction;
 import org.eclipse.jdt.ui.text.java.correction.ChangeCorrectionProposal;
 
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
@@ -68,7 +68,7 @@ public class ToStringTypeProposal extends ChangeCorrectionProposal { // public f
 		Display.getDefault().syncExec(() -> {
 			try {
 				IStructuredSelection selection= new StructuredSelection(fType);
-				IWorkbenchSite site= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor().getSite();
+				IWorkbenchSite site= JavaPlugin.getActivePage().getActiveEditor().getSite();
 				new GenerateToStringAction(site).run(selection);
 			} catch (NullPointerException e) {
 				// do nothing

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/compare/JavaCompareWithEditionActionImpl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/compare/JavaCompareWithEditionActionImpl.java
@@ -21,14 +21,13 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 
-import org.eclipse.ui.PlatformUI;
-
 import org.eclipse.compare.CompareConfiguration;
 import org.eclipse.compare.CompareUI;
 
 import org.eclipse.jdt.core.IMember;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 
 
 /**
@@ -67,7 +66,7 @@ class JavaCompareWithEditionActionImpl extends JavaHistoryActionImpl {
 			ci.setHelpContextId(IJavaHelpContextIds.COMPARE_ELEMENT_WITH_HISTORY_DIALOG);
 			CompareUI.openCompareDialog(ci);
 		} else {
-			TeamUI.showHistoryFor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), input, pageSource);
+			TeamUI.showHistoryFor(JavaPlugin.getActivePage(), input, pageSource);
 		}
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/infoviews/JavadocView.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/infoviews/JavadocView.java
@@ -792,7 +792,7 @@ public class JavadocView extends AbstractInfoView {
 			return null;
 
 		IWorkbenchPart part= null;
-		IWorkbenchWindow window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow window= JavaPlugin.getActiveWorkbenchWindow();
 		if (window != null) {
 			IWorkbenchPage page= window.getActivePage();
 			if (page != null) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/CreateJarActionDelegate.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/jarpackager/CreateJarActionDelegate.java
@@ -32,8 +32,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.dialogs.ErrorDialog;
 
-import org.eclipse.ui.PlatformUI;
-
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
@@ -97,7 +95,7 @@ public class CreateJarActionDelegate extends JarPackageActionDelegate {
 		Shell shell= getShell();
 		IJarExportRunnable op= jarPackages[0].createJarExportRunnable(jarPackages, shell);
 		try {
-			PlatformUI.getWorkbench().getActiveWorkbenchWindow().run(false, true, op);
+			JavaPlugin.getActiveWorkbenchWindow().run(false, true, op);
 			//PlatformUI.getWorkbench().getProgressService().run(false, true, op); // see bug 118152
 		} catch (InvocationTargetException ex) {
 			if (ex.getTargetException() != null) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementImplementationHyperlink.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementImplementationHyperlink.java
@@ -35,7 +35,6 @@ import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
 
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
@@ -290,7 +289,7 @@ public class JavaElementImplementationHyperlink implements IHyperlink {
 			IStatus status= new Status(IStatus.ERROR, JavaPlugin.getPluginId(), IStatus.OK,
 					Messages.format(JavaEditorMessages.JavaElementImplementationHyperlink_error_status_message, javaElement.getElementName()), e.getCause());
 			JavaPlugin.log(status);
-			ErrorDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+			ErrorDialog.openError(JavaPlugin.getActiveWorkbenchShell(),
 					JavaEditorMessages.JavaElementImplementationHyperlink_hyperlinkText,
 					JavaEditorMessages.JavaElementImplementationHyperlink_error_no_implementations_found_message, status);
 		} catch (InterruptedException e) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/GetterSetterCorrectionSubProcessor.java
@@ -29,7 +29,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.IDocument;
 
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.TextFileChange;
@@ -105,7 +104,7 @@ public class GetterSetterCorrectionSubProcessor extends GetterSetterCorrectionBa
 					refactoring.setConsiderVisibility(false);//private field references are just searched in local file
 				});
 				if (fNoDialog) {
-					IWorkbenchWindow window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+					IWorkbenchWindow window= JavaPlugin.getActiveWorkbenchWindow();
 					final RefactoringExecutionHelper helper= new RefactoringExecutionHelper(compositeRefactoring, RefactoringStatus.ERROR, IRefactoringSaveModes.SAVE_REFACTORING, JavaPlugin.getActiveWorkbenchShell(), window);
 					if (Display.getCurrent() != null) {
 						try {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/PreviewFeaturesSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/PreviewFeaturesSubProcessor.java
@@ -143,7 +143,7 @@ public class PreviewFeaturesSubProcessor {
 			@Override
 			public void apply(IDocument document) {
 
-				Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+				Shell shell= JavaPlugin.getActiveWorkbenchShell();
 				boolean usePropertyPage;
 
 				if (!hasProjectSpecificOptions) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/FixCorrectionProposal.java
@@ -35,8 +35,6 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension2;
 
-import org.eclipse.ui.PlatformUI;
-
 import org.eclipse.ltk.core.refactoring.RefactoringCore;
 
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -108,7 +106,7 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 
 		IRunnableContext context= (fork, cancelable, runnable) -> runnable.run(monitor == null ? new NullProgressMonitor() : monitor);
 
-		Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		Shell shell= JavaPlugin.getActiveWorkbenchShell();
 		RefactoringExecutionHelper helper= new RefactoringExecutionHelper(refactoring, IStatus.INFO, IRefactoringSaveModes.SAVE_REFACTORING, shell, context);
 		try {
 			helper.perform(true, true);
@@ -208,7 +206,7 @@ public class FixCorrectionProposal extends LinkedCorrectionProposal implements I
 
 			int stopSeverity= RefactoringCore.getConditionCheckingFailedSeverity();
 			Shell shell= JavaPlugin.getActiveWorkbenchShell();
-			IRunnableContext context= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+			IRunnableContext context= JavaPlugin.getActiveWorkbenchWindow();
 			RefactoringExecutionHelper executer= new RefactoringExecutionHelper(refactoring, stopSeverity, IRefactoringSaveModes.SAVE_NOTHING, shell, context);
 			try {
 				executer.perform(true, true);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaContentAssistHandler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaContentAssistHandler.java
@@ -20,10 +20,10 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ui.texteditor.ITextEditor;
 
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 import org.eclipse.jdt.internal.ui.javaeditor.SpecificContentAssistExecutor;
 
@@ -56,7 +56,7 @@ public final class JavaContentAssistHandler extends AbstractHandler {
 	}
 
 	private ITextEditor getActiveEditor() {
-		IWorkbenchWindow window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow window= JavaPlugin.getActiveWorkbenchWindow();
 		if (window != null) {
 			IWorkbenchPage page= window.getActivePage();
 			if (page != null) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/AbstractAnnotationHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/AbstractAnnotationHover.java
@@ -81,7 +81,6 @@ import org.eclipse.jface.text.source.ISourceViewer;
 
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IStorageEditorInput;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
 import org.eclipse.ui.texteditor.AnnotationPreference;
@@ -656,7 +655,7 @@ public abstract class AbstractAnnotationHover extends AbstractJavaEditorTextHove
 		 */
 		@Override
 		public void run() {
-			Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+			Shell shell= JavaPlugin.getActiveWorkbenchShell();
 
 			Object data= null;
 			AnnotationPreference preference= getAnnotationPreference(fAnnotation);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/ConfigureProblemSeverityAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/ConfigureProblemSeverityAction.java
@@ -25,7 +25,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 
 import org.eclipse.jface.text.IInformationControl;
 
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
 import org.eclipse.jdt.core.IJavaProject;
@@ -34,6 +33,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
 
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.dialogs.OptionalMessageDialog;
 import org.eclipse.jdt.internal.ui.preferences.ComplianceConfigurationBlock;
@@ -85,7 +85,7 @@ public class ConfigureProblemSeverityAction extends Action {
 	public void run() {
 		boolean showPropertyPage;
 
-		Shell shell= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		Shell shell= JavaPlugin.getActiveWorkbenchShell();
 
 		if (!hasProjectSpecificOptions()) {
 			String message= Messages.format(

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocAutoIndentStrategy.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocAutoIndentStrategy.java
@@ -28,7 +28,6 @@ import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.ui.texteditor.ITextEditorExtension3;
 
@@ -528,7 +527,7 @@ public class JavaDocAutoIndentStrategy extends DefaultIndentLineAutoEditStrategy
 	 */
 	private static ICompilationUnit getCompilationUnit() {
 
-		IWorkbenchWindow window= PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		IWorkbenchWindow window= JavaPlugin.getActiveWorkbenchWindow();
 		if (window == null)
 			return null;
 


### PR DESCRIPTION
Currently JavaPlugin.getActivePage() fails if no workbench is running, while the method itself can return null if there is no active window anyways. Beside that is unnecessary access the default java plugin even though all code called there is static anyways.

This now changes the following parts:

1) guard getActiveWorkbenchWindow against not running workbench 2) used getActiveWorkbenchWindow instead of similar code in getActivePage like in getActiveWorkbenchShell
3) delete no longer needed private method
