### PR TITLE
Adjust to JavaCore.defaultRootModules deprecation

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ModuleDependenciesPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ModuleDependenciesPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 GK Software SE, and others.
+ * Copyright (c) 2019, 2025 GK Software SE, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.wizards.buildpaths;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -25,8 +26,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import java.text.MessageFormat;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
@@ -347,7 +346,14 @@ public class ModuleDependenciesPage extends BuildPathBasePage {
 						}
 						try {
 							if (fCurrJProject.getModuleDescription() == null) { // cache default roots when compiling the unnamed module:
-								fAllDefaultSystemModules= closure(JavaCore.defaultRootModules(Arrays.asList(fAllSystemRoots)));
+								String release = fCurrJProject.getOption(JavaCore.COMPILER_RELEASE, true);
+								if (release == null) {
+									release = fCurrJProject.getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, true);
+								}
+								if (release == null) {
+									release = JavaCore.latestSupportedJavaVersion();
+								}
+								fAllDefaultSystemModules= closure(JavaCore.defaultRootModules(Arrays.asList(fAllSystemRoots), release));
 							}
 						} catch (JavaModelException e) {
 							JavaPlugin.log(e);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ModuleDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/ModuleDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 GK Software SE, and others.
+ * Copyright (c) 2017, 2025 GK Software SE, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -799,11 +799,18 @@ public class ModuleDialog extends StatusDialog {
 		if (fJavaElements != null) {
 			List<IPackageFragmentRoot> roots= new ArrayList<>();
 			for (IJavaElement element : fJavaElements) {
-				if (element instanceof IPackageFragmentRoot) {
-					roots.add((IPackageFragmentRoot) element);
+				if (element instanceof IPackageFragmentRoot el) {
+					roots.add(el);
 				}
 			}
-			return JavaCore.defaultRootModules(roots);
+			String release = fJavaElements[0].getJavaProject().getOption(JavaCore.COMPILER_RELEASE, true);
+			if (release == null) {
+				release = fJavaElements[0].getJavaProject().getOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, true);
+			}
+			if (release == null) {
+				release = JavaCore.latestSupportedJavaVersion();
+			}
+			return JavaCore.defaultRootModules(roots, release);
 		}
 		return Collections.emptyList();
 	}


### PR DESCRIPTION
Use the new method that filters based on the release. If release option is not set, use target and if it's not there too use the latest version.

