### PR TITLE
If no editor is open apply the resolution directly

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/CorrectionMarkerResolutionGenerator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/CorrectionMarkerResolutionGenerator.java
@@ -59,7 +59,6 @@ import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring.MultiFixTarget;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
-import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.cleanup.ICleanUp;
 import org.eclipse.jdt.ui.text.java.CompletionProposalComparator;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
@@ -112,12 +111,17 @@ public class CorrectionMarkerResolutionGenerator implements IMarkerResolutionGen
 			try {
 				IEditorPart part= EditorUtility.isOpenInEditor(fCompilationUnit);
 				if (part == null) {
-					part= JavaUI.openInEditor(fCompilationUnit, true, false);
-					if (part instanceof ITextEditor) {
-						((ITextEditor) part).selectAndReveal(fOffset, fLength);
-					}
-				}
-				if (part != null) {
+						IEditorInput input= EditorUtility.getEditorInput(fCompilationUnit);
+						IDocument doc= JavaPlugin.getDefault().getCompilationUnitDocumentProvider().getDocument(input);
+						fProposal.apply(doc);
+						if (fCompilationUnit.hasUnsavedChanges()) {
+							if (fCompilationUnit.isWorkingCopy()) {
+								fCompilationUnit.commitWorkingCopy(false, new NullProgressMonitor());
+							} else {
+								fCompilationUnit.save(new NullProgressMonitor(), true);
+							}
+						}
+				} else {
 					IEditorInput input= part.getEditorInput();
 					IDocument doc= JavaPlugin.getDefault().getCompilationUnitDocumentProvider().getDocument(input);
 					fProposal.apply(doc);


### PR DESCRIPTION
## What it does

Currently if one applies a QuickFix without the java editor open (e.g. from the Problems view), then JDT opens a new editor, applies the quickfix and then leave the user in a dirty state, so the error/warning is still shown in the problems view unless one manually save the editor.

This now changes the behavior by apply the resolution directly on the document and commit (or save) the compilation unit.
## How to test

I use this simple test class:

```
@SuppressWarnings("restriction")
public class TestWarning {

}
```

it will produce:

```
Description	Resource	Path	Location	Type
Unnecessary @SuppressWarnings("restriction")	TestWarning.java   ...	line 4	Java Problem
```

1. Open the file and apply the quickfix in the editor --> works as before with dirty editor
2. No restore the file and make sure all editors are closed
3. Make sure all editors are closed
4. Got to the problem view and rightclick on the warning choose "QuickFix" to open the Wizard

![grafik](https://github.com/user-attachments/assets/d1d8bdf4-4c46-42d4-a0ae-1c156c0095da)

You will end up with the problem resolved and no dirty editor.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
