### PR TITLE
Improve the instanceof pattern matching refactoring

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -186,13 +186,13 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 					return variableName != null && !statementsToRemove.isEmpty();
 				}
 
-				void addMatching(final VariableDeclarationStatement statementToRemove, final SimpleName expressionToMove, boolean toConvert) {
-					if (this.variableName == null || this.variableName.getIdentifier().equals(expressionToMove.getIdentifier())) {
-						this.variableName = expressionToMove;
+				void addMatching(final VariableDeclarationStatement statement, final SimpleName name, boolean toConvert) {
+					if (this.variableName == null || this.variableName.getIdentifier().equals(name.getIdentifier())) {
+						this.variableName = name;
 						if (toConvert) {
-							this.statementsToConvert.add(statementToRemove);
+							this.statementsToConvert.add(statement);
 						} else {
-							this.statementsToRemove.add(statementToRemove);
+							this.statementsToRemove.add(statement);
 						}
 					}
 				}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -24,9 +24,12 @@ import org.eclipse.text.edits.TextEditGroup;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InfixExpression.Operator;
@@ -142,55 +145,102 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 
 				IfStatement ifStatement= (IfStatement) currentNode.getParent();
 
+				ResultCollector collector = new ResultCollector(visited);
 				if (isPositiveCaseToAnalyze) {
-					return maybeMatchPattern(visited, ifStatement.getThenStatement());
+					collector.collect(ifStatement.getThenStatement());
+				} else if (ifStatement.getElseStatement() != null) {
+					collector.collect(ifStatement.getElseStatement());
+				} else if (ASTNodes.fallsThrough(ifStatement.getThenStatement())) {
+					collector.collect(ASTNodes.getNextSibling(ifStatement));
 				}
 
-				if (ifStatement.getElseStatement() != null) {
-					return maybeMatchPattern(visited, ifStatement.getElseStatement());
+				if (collector.hasResult()) {
+					fResult.add(collector.build());
+					return false;
 				}
-
-				if (ASTNodes.fallsThrough(ifStatement.getThenStatement())) {
-					return maybeMatchPattern(visited, ASTNodes.getNextSibling(ifStatement));
-				}
-
 				return true;
 			}
 
-			private boolean maybeMatchPattern(final InstanceofExpression visited, final Statement conditionalStatements) {
-				List<Statement> statements= ASTNodes.asList(conditionalStatements);
+			static class ResultCollector {
+				final InstanceofExpression visited;
+				SimpleName variableName;
+				final List<VariableDeclarationStatement> statementsToRemove = new ArrayList<>();
 
-				if (!statements.isEmpty()) {
-					VariableDeclarationStatement variableDeclarationExpression= ASTNodes.as(statements.get(0), VariableDeclarationStatement.class);
-					VariableDeclarationFragment variableDeclarationFragment= ASTNodes.getUniqueFragment(variableDeclarationExpression);
+				ResultCollector(InstanceofExpression visited) {
+					this.visited = visited;
+				}
 
-					if (variableDeclarationFragment != null
-							&& Objects.equals(visited.getRightOperand().resolveBinding(), variableDeclarationExpression.getType().resolveBinding())) {
-						CastExpression castExpression= ASTNodes.as(variableDeclarationFragment.getInitializer(), CastExpression.class);
+				public PatternMatchingForInstanceofFixOperation build() {
+					return new PatternMatchingForInstanceofFixOperation(visited, statementsToRemove, variableName);
+				}
 
-						if (castExpression != null
-								&& Objects.equals(visited.getRightOperand().resolveBinding(), castExpression.getType().resolveBinding())
-								&& ASTNodes.match(visited.getLeftOperand(), castExpression.getExpression())
-								&& ASTNodes.isPassive(visited.getLeftOperand())) {
-							fResult.add(new PatternMatchingForInstanceofFixOperation(visited, variableDeclarationExpression, variableDeclarationFragment.getName()));
-							return false;
+				private String getIdentifierName(Expression expression) {
+					if (expression instanceof SimpleName simpleName) {
+						return simpleName.getIdentifier();
+					}
+					return null;
+				}
+
+				boolean hasResult() {
+					return variableName != null && !statementsToRemove.isEmpty();
+				}
+
+				void addMatching(final VariableDeclarationStatement statementToRemove, final SimpleName expressionToMove) {
+					if (this.variableName == null || this.variableName.getIdentifier().equals(expressionToMove.getIdentifier())) {
+						this.variableName = expressionToMove;
+						this.statementsToRemove.add(statementToRemove);
+					}
+				}
+
+				void collect(final Statement conditionalStatements) {
+					List<Statement> statements= ASTNodes.asList(conditionalStatements);
+
+					if (!statements.isEmpty()) {
+						for (Statement statement : statements) {
+							if (statement instanceof ExpressionStatement expressionStatement) {
+								Assignment assignment = ASTNodes.as(expressionStatement.getExpression(), Assignment.class);
+								if (assignment != null && Objects.equals(getIdentifierName(visited.getLeftOperand()), getIdentifierName(assignment.getLeftHandSide()))) {
+									// The same variable is assigned, this can't be handled further.
+									return;
+								}
+							}
+							if (statement instanceof VariableDeclarationStatement variableDeclarationExpression) {
+								VariableDeclarationFragment variableDeclarationFragment= ASTNodes.getUniqueFragment(variableDeclarationExpression);
+								if (variableDeclarationFragment != null
+										&& Objects.equals(visited.getRightOperand().resolveBinding(), variableDeclarationExpression.getType().resolveBinding())) {
+									CastExpression castExpression= ASTNodes.as(variableDeclarationFragment.getInitializer(), CastExpression.class);
+
+									if (castExpression != null
+											&& Objects.equals(visited.getRightOperand().resolveBinding(), castExpression.getType().resolveBinding())
+											&& ASTNodes.match(visited.getLeftOperand(), castExpression.getExpression())
+											&& ASTNodes.isPassive(visited.getLeftOperand())) {
+										addMatching(variableDeclarationExpression, variableDeclarationFragment.getName());
+									}
+								}
+							}
+							if (statement instanceof IfStatement innerIf) {
+								collect(innerIf.getThenStatement());
+								if (innerIf.getElseStatement() != null) {
+									collect(innerIf.getElseStatement());
+								}
+							}
 						}
 					}
 				}
 
-				return true;
 			}
+
 		}
 	}
 
 	public static class PatternMatchingForInstanceofFixOperation extends CompilationUnitRewriteOperation {
 		private final InstanceofExpression nodeToComplete;
-		private final VariableDeclarationStatement statementToRemove;
+		private final List<VariableDeclarationStatement> statementsToRemove;
 		private final SimpleName expressionToMove;
 
-		public PatternMatchingForInstanceofFixOperation(final InstanceofExpression nodeToComplete, final VariableDeclarationStatement statementToRemove, final SimpleName expressionToMove) {
+		public PatternMatchingForInstanceofFixOperation(final InstanceofExpression nodeToComplete, final List<VariableDeclarationStatement> statementsToRemove, final SimpleName expressionToMove) {
 			this.nodeToComplete= nodeToComplete;
-			this.statementToRemove= statementToRemove;
+			this.statementsToRemove= statementsToRemove;
 			this.expressionToMove= expressionToMove;
 		}
 
@@ -216,7 +266,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			SingleVariableDeclaration newSVDecl= ast.newSingleVariableDeclaration();
 			newSVDecl.setName(ASTNodes.createMoveTarget(rewrite, expressionToMove));
 			newSVDecl.setType(ASTNodes.createMoveTarget(rewrite, nodeToComplete.getRightOperand()));
-			if (Modifier.isFinal(statementToRemove.getModifiers())) {
+			if (statementsToRemove.stream().allMatch(varDec -> Modifier.isFinal(varDec.getModifiers()))) {
 				newSVDecl.modifiers().add(ast.newModifier(ModifierKeyword.fromFlagValue(Modifier.FINAL)));
 			}
 			if ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled()) || ast.apiLevel() > AST.JLS20) {
@@ -229,12 +279,14 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 
 			ASTNodes.replaceButKeepComment(rewrite, nodeToComplete, newInstanceof, group);
 
-			if (ASTNodes.canHaveSiblings(statementToRemove) || statementToRemove.getLocationInParent() == IfStatement.ELSE_STATEMENT_PROPERTY) {
-				ASTNodes.removeButKeepComment(rewrite, statementToRemove, group);
-			} else {
-				ASTNodes.replaceButKeepComment(rewrite, statementToRemove, ast.newBlock(), group);
+			for (var statementToRemove : statementsToRemove) {
+				if (ASTNodes.canHaveSiblings(statementToRemove) || statementToRemove.getLocationInParent() == IfStatement.ELSE_STATEMENT_PROPERTY) {
+					ASTNodes.removeButKeepComment(rewrite, statementToRemove, group);
+				} else {
+					ASTNodes.replaceButKeepComment(rewrite, statementToRemove, ast.newBlock(), group);
+				}
+				importRemover.registerRemovedNode(statementToRemove);
 			}
-			importRemover.registerRemovedNode(statementToRemove);
 		}
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -591,6 +591,18 @@ public class CleanUpTest16 extends CleanUpTestCase {
 						System.out.println(s);
 					}
 				}
+				public void foo4(Object o, Object p) {
+					if (o instanceof String && p instanceof Integer) {
+						if (o != p) {
+							String s = (String) o;
+							Integer i = (Integer) p;
+							System.out.println(s.trim() + i.toString());
+							i = 3;
+						}
+						Integer i = (Integer) p;
+						i = 7;
+					}
+				}
 			}
 			""";
 		ICompilationUnit cu= pack.createCompilationUnit("E.java", given, false, null);
@@ -636,6 +648,16 @@ public class CleanUpTest16 extends CleanUpTestCase {
 								System.out.println(s.length() + k);
 							}
 							System.out.println(s);
+						}
+					}
+					public void foo4(Object o, Object p) {
+						if (o instanceof String s && p instanceof Integer i) {
+							if (o != p) {
+								System.out.println(s.trim() + i.toString());
+								i = 3;
+							}
+							i = (Integer) p;
+							i = 7;
 						}
 					}
 				}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -541,6 +541,116 @@ public class CleanUpTest16 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testDeeperMatches() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
+		String given= """
+			package test1;
+
+			public class E {
+			    public int matchPatternInDeeperLevels(Object object, boolean valid) {
+			        // Keep this comment
+			        if (object instanceof String) {
+			            if (valid) {
+			                // Keep this comment too
+			                String s = (String) object;
+			                return s.length();
+			            }
+			        }
+			        return 0;
+			    }
+			    public int matchPatternInDeeperLevels2(Object object, boolean valid) {
+			        // Keep this comment
+			        if (object instanceof String && valid) {
+			            System.out.println(valid);
+			            // Keep this comment too
+			            String s = (String) object;
+			            return s.length();
+			        }
+			        return 0;
+			    }
+			    public double calculateLucky(Object target, String operation) {
+			         if (target instanceof Double) {
+			              if (name.equals("double")) {
+			                  Double number= (Double) target;
+			                  return number * 2.0;
+			              } else if (name.equals("sqr")) {
+			                  Double number= (Double) target;
+			                  return number * number;
+			              }
+			        }
+			        return 0;
+			    }
+			    public double calculateUnLucky(Object target, String operation) {
+			         if (target instanceof Double) {
+			              if (name.equals("double")) {
+			                  Double number= (Double) target;
+			                  return number * 2.0;
+			              } else if (name.equals("sqr")) {
+			                  Double number2= (Double) target;
+			                  return number2 * number2;
+			              }
+			        }
+			        return 0;
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("E.java", given, false, null);
+
+		enable(CleanUpConstants.USE_PATTERN_MATCHING_FOR_INSTANCEOF);
+		String expected= """
+			package test1;
+
+			public class E {
+			    public int matchPatternInDeeperLevels(Object object, boolean valid) {
+			        // Keep this comment
+			        if (object instanceof String s) {
+			            if (valid) {
+			                // Keep this comment too
+			                return s.length();
+			            }
+			        }
+			        return 0;
+			    }
+			    public int matchPatternInDeeperLevels2(Object object, boolean valid) {
+			        // Keep this comment
+			        if (object instanceof String s && valid) {
+			            System.out.println(valid);
+			            // Keep this comment too
+			            return s.length();
+			        }
+			        return 0;
+			    }
+			    public double calculateLucky(Object target, String operation) {
+			         if (target instanceof Double number) {
+			              if (name.equals("double")) {
+			                  return number * 2.0;
+			              } else if (name.equals("sqr")) {
+			                  return number * number;
+			              }
+			        }
+			        return 0;
+			    }
+			    public double calculateUnLucky(Object target, String operation) {
+			         if (target instanceof Double number) {
+			              if (name.equals("double")) {
+			                  return number * 2.0;
+			              } else if (name.equals("sqr")) {
+			                  Double number2= (Double) target;
+			                  return number2 * number2;
+			              }
+			        }
+			        return 0;
+			    }
+			}
+			""";
+
+		assertNotEquals("The class must be changed", expected, given);
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu }, new String[] { expected },
+				new HashSet<>(Arrays.asList(MultiFixMessages.PatternMatchingForInstanceofCleanup_description)));
+
+	}
+
+	@Test
 	public void testDoNotAddFinalForRecordComponent() throws Exception {
 		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """


### PR DESCRIPTION
Check if the smart casting can be used in deeper parts of the AST, not just directly as the first expression, which is surprisingly common.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Improve the logic which tries to locate casts that can be eliminated with pattern matching

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run the refactoring on a bigger codebase

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
