### PR TITLE
Fix folding of 2 consecutive methods

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.text.tests.codemining.CodeMiningTriggerTest;
 import org.eclipse.jdt.text.tests.codemining.ParameterNamesCodeMiningTest;
 import org.eclipse.jdt.text.tests.contentassist.ContentAssistTestSuite;
 import org.eclipse.jdt.text.tests.folding.FoldingTest;
+import org.eclipse.jdt.text.tests.folding.FoldingTestNew;
 import org.eclipse.jdt.text.tests.semantictokens.SemanticTokensProviderTest;
 import org.eclipse.jdt.text.tests.spelling.SpellCheckEngineTestCase;
 import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
@@ -71,6 +72,7 @@ import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
 	JavaElementPrefixPatternMatcherTest.class,
 	CodeMiningTriggerTest.class,
 	ParameterNamesCodeMiningTest.class,
+	FoldingTestNew.class,
 	FoldingTest.class,
 })
 public class JdtTextTestSuite {

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestNew.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestNew.java
@@ -24,15 +24,20 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.core.runtime.CoreException;
 
+import org.eclipse.jface.preference.IPreferenceStore;
+
 import org.eclipse.jface.text.IRegion;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 
+import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 
-public class FoldingTest {
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+public class FoldingTestNew {
 	@Rule
 	public ProjectTestSetup projectSetup= new ProjectTestSetup();
 
@@ -42,6 +47,8 @@ public class FoldingTest {
 
 	private IPackageFragment packageFragment;
 
+	private IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+
 	@Before
 	public void setUp() throws CoreException {
 		jProject= projectSetup.getProject();
@@ -50,11 +57,14 @@ public class FoldingTest {
 			sourceFolder= JavaProjectHelper.addSourceContainer(jProject, "src");
 		}
 		packageFragment= sourceFolder.createPackageFragment("org.example.test", false, null);
+
+		store.setValue(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED, true);
 	}
 
 	@After
 	public void tearDown() throws CoreException {
 		JavaProjectHelper.delete(jProject);
+		store.setToDefault(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED);
 	}
 
 	@Test
@@ -235,7 +245,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 5);
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 6);
 
 		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // 1. Javadoc
@@ -243,6 +253,7 @@ public class FoldingTest {
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 9); // 3. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 12, 14); // 4. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 15, 19); // Methode b()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 16, 18); // 5. Javadoc
 	}
 
 	@Test
@@ -274,6 +285,221 @@ public class FoldingTest {
 		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 5); // 2. Method
+	}
+
+	@Test
+	public void testIfStatementFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class D {
+				    void x() {			//here should be an annotation
+				        if (true) {		//here should be an annotation
+				        }
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 3); // if
+	}
+
+	@Test
+	public void testTryStatementFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class E {
+				    void x() {						//here should be an annotation
+				        try {						//here should be an annotation
+
+				        } catch (Exception e) {		//here should be an annotation
+
+				        }
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 3);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 7); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // try
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // catch
+	}
+
+	@Test
+	public void testWhileStatementFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class F {
+				    void x() {				//here should be an annotation
+				        while (true) {		//here should be an annotation
+				        }
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 3); // while
+	}
+
+	@Test
+	public void testForStatementFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class G {
+				    void x() {					//here should be an annotation
+				        for(int i=0;i<1;i++){	//here should be an annotation
+				        }
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 3); // for
+	}
+
+	@Test
+	public void testEnhancedForStatementFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class H {
+				    void x() {							//here should be an annotation
+				        for(String s: new String[0]){	//here should be an annotation
+				        }
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 3); // for
+	}
+
+	@Test
+	public void testDoStatementFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class I {
+				    void x() {				//here should be an annotation
+				        do {				//here should be an annotation
+
+				        } while(false);
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // do
+	}
+
+	@Test
+	public void testSynchronizedStatementFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class K {
+				    void x() {					//here should be an annotation
+				        synchronized(this) {	//here should be an annotation
+				        }
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 3); // synchronized
+	}
+
+	@Test
+	public void testLambdaExpressionFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				import java.util.function.Supplier;
+				public class L {
+				    void x() {							//here should be an annotation
+				        Supplier<String> s = () -> {	//here should be an annotation
+				            return "";
+				        };
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 6); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 5); // Supplier
+	}
+
+	@Test
+	public void testAnonymousClassDeclarationFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class M {
+				    Object o = new Object(){		//here should be an annotation
+				        void y() {					//here should be an annotation
+
+				        }
+				    };
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // Object
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // Method
+	}
+
+	@Test
+	public void testEnumDeclarationFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public enum N {					//here should be an annotation
+				    A,
+				    B
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // enum
+	}
+
+	@Test
+	public void testInitializerFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class O {
+				    static {					//here should be an annotation
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 2); // static
+	}
+
+	@Test
+	public void testNestedFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				public class P {
+				    void x() {							//here should be an annotation
+				        if (true) {						//here should be an annotation
+				            for(int i=0;i<1;i++){		//here should be an annotation
+				                while(true) {			//here should be an annotation
+				                    do {				//here should be an annotation
+				                    } while(false);
+				                }
+				            }
+				        }
+				    }
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 5);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 10); // method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 9); // if
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 8); // for
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // while
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 6, 6); // do
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -353,8 +353,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 		@Override
 		public boolean visit(TypeDeclaration node) {
-			boolean isInnerClass= node.isMemberTypeDeclaration();
-			if (isInnerClass) {
+			if (node.isMemberTypeDeclaration() || node.isLocalTypeDeclaration()) {
 				int start= node.getName().getStartPosition();
 				int end= node.getStartPosition() + node.getLength();
 				createFoldingRegion(start, end - start, ctx.collapseMembers());
@@ -1496,7 +1495,6 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				includelastLine= true;
 				IRegion normalized= alignRegion(regions[i], ctx);
 				if (normalized != null) {
-					includelastLine= true;
 					Position position= createCommentPosition(normalized);
 					if (position != null) {
 						boolean commentCollapse;


### PR DESCRIPTION
If the second method starts on the same line where the first one ends, there will still be two foldings. (I accidentally set includeLastLine to true a second time, which caused the issue).

Additionally, I have separated the tests: FoldingTest verifies the old behavior, while FoldingTestNew tests my feature (#1562).

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1992