### PR TITLE
Handles the TypePattern DOM API modifications in the JDT.UI

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/OneIfRatherThanDuplicateBlocksThatFallThroughFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/OneIfRatherThanDuplicateBlocksThatFallThroughFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2025 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -35,6 +35,7 @@ import org.eclipse.jdt.core.dom.Pattern;
 import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.TypePattern;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 
@@ -102,12 +103,23 @@ public class OneIfRatherThanDuplicateBlocksThatFallThroughFixCore extends Compil
 			private class PatternNameVisitor extends ASTVisitor {
 				private Set<String> patternNames= new HashSet<>();
 
+				@SuppressWarnings({ "null"})
 				@Override
 				public boolean visit(PatternInstanceofExpression node) {
 					Pattern p= node.getPattern();
 					if (p instanceof TypePattern typePattern) {
-						SingleVariableDeclaration patternVariable= typePattern.getPatternVariable();
-						patternNames.add(patternVariable.getName().getFullyQualifiedName());
+						final boolean isBeforeJLS22 = node.getAST().apiLevel() < AST.JLS22;
+
+					    final SingleVariableDeclaration patternVariable = isBeforeJLS22
+					        ? typePattern.getPatternVariable()
+					        : null;
+					    final VariableDeclaration patternVariable2 = isBeforeJLS22
+					        ? null
+					        : typePattern.getPatternVariable2();
+
+					    patternNames.add(isBeforeJLS22
+					        ? patternVariable.getName().getFullyQualifiedName()
+					        : patternVariable2.getName().getFullyQualifiedName());
 					}
 					return true;
 				}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2025 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypePattern;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
@@ -193,6 +194,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			this.expressionToMove= expressionToMove;
 		}
 
+		@SuppressWarnings("removal")
 		@Override
 		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
@@ -220,7 +222,9 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			}
 			if ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled()) || ast.apiLevel() > AST.JLS20) {
 				TypePattern newTypePattern= ast.newTypePattern();
-				newTypePattern.setPatternVariable(newSVDecl);
+
+				newTypePattern.setPatternVariable(ast.apiLevel() > AST.JLS22 ? (VariableDeclaration) newSVDecl : newSVDecl);
+
 				newInstanceof.setPattern(newTypePattern);
 			} else {
 				newInstanceof.setRightOperand(newSVDecl);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -194,7 +194,6 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			this.expressionToMove= expressionToMove;
 		}
 
-		@SuppressWarnings("removal")
 		@Override
 		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -194,6 +194,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 			this.expressionToMove= expressionToMove;
 		}
 
+		@SuppressWarnings("deprecation")
 		@Override
 		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/surround/SurroundWithTryCatchAnalyzer.java
@@ -101,7 +101,7 @@ public class SurroundWithTryCatchAnalyzer extends SurroundWithAnalyzer {
 				if (ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled() || ast.apiLevel() > AST.JLS20) {
 					Pattern p= node.getPattern();
 					if (p instanceof TypePattern typePattern) {
-						svd= typePattern.getPatternVariable();
+						svd=  (ast.apiLevel() < AST.JLS22) ? typePattern.getPatternVariable() : (SingleVariableDeclaration)typePattern.getPatternVariable2();
 					} else {
 						return false;
 					}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MergeConditionalBlocksCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/MergeConditionalBlocksCleanUp.java
@@ -38,6 +38,7 @@ import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.TypePattern;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
@@ -157,12 +158,23 @@ public class MergeConditionalBlocksCleanUp extends AbstractMultiFix {
 		private class PatternNameVisitor extends ASTVisitor {
 			private Set<String> patternNames= new HashSet<>();
 
+			@SuppressWarnings("null")
 			@Override
 			public boolean visit(PatternInstanceofExpression node) {
 				Pattern p= node.getPattern();
 				if (p instanceof TypePattern typePattern) {
-					SingleVariableDeclaration patternVariable= typePattern.getPatternVariable();
-					patternNames.add(patternVariable.getName().getFullyQualifiedName());
+					final boolean isBeforeJLS22 = node.getAST().apiLevel() < AST.JLS22;
+
+					final SingleVariableDeclaration patternVariable = isBeforeJLS22
+					        ? typePattern.getPatternVariable()
+					        : null;
+				    final VariableDeclaration patternVariable2 = isBeforeJLS22
+				        ? null
+				        : typePattern.getPatternVariable2();
+
+				    patternNames.add(isBeforeJLS22
+				        ? patternVariable.getName().getFullyQualifiedName()
+				        : patternVariable2.getName().getFullyQualifiedName());
 				}
 				return true;
 			}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
In the JDT Core DOM, the TypePattern APIs have been modified to handle [unnamed variables and patterns](https://openjdk.org/jeps/456), as expected to be implemented through https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3635. Therefore, appropriate changes need to be made in JDT UI as well.

This PR closes #1994 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
