### PR TITLE
Fix convert to lambda for one statement that has non-NLS marker

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionsFixCore.java
@@ -717,12 +717,19 @@ public class LambdaExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 				if (statements.size() == 1) {
 					// use short form with just an expression body if possible
 					Statement statement= statements.get(0);
-					if (statement instanceof ExpressionStatement) {
-						lambdaBody= ((ExpressionStatement) statement).getExpression();
-					} else if (statement instanceof ReturnStatement) {
-						Expression returnExpression= ((ReturnStatement) statement).getExpression();
-						if (returnExpression != null) {
-							lambdaBody= returnExpression;
+					CompilationUnit root= cuRewrite.getRoot();
+					int extendedStart= root.getExtendedStartPosition(statement);
+					int extendedLength= root.getExtendedLength(statement);
+					// verify no line comment exists at the end of the node in which case
+					// we can use short form - otherwise use original block with comments
+					if (extendedStart + extendedLength <= statement.getStartPosition() + statement.getLength()) {
+						if (statement instanceof ExpressionStatement) {
+							lambdaBody= ((ExpressionStatement) statement).getExpression();
+						} else if (statement instanceof ReturnStatement) {
+							Expression returnExpression= ((ReturnStatement) statement).getExpression();
+							if (returnExpression != null) {
+								lambdaBody= returnExpression;
+							}
 						}
 					}
 				}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -7053,4 +7053,52 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected }, null);
 
 	}
+
+	@Test
+	public void testConvertToLambdaIssue1999() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String original= """
+				package test1;
+
+				import java.util.Iterator;
+				import java.util.List;
+
+				public class E {
+					void setRunnable(Runnable r) {
+					}
+					void test1() {
+						setRunnable(new Runnable() {
+							@Override
+							public void run() {
+								System.out.println("abc"); //$NON-NLS-1$
+							}
+						});
+					}
+				}
+				""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", original, false, null);
+
+		enable(CleanUpConstants.CONVERT_FUNCTIONAL_INTERFACES);
+		enable(CleanUpConstants.USE_LAMBDA);
+
+		String expected= """
+				package test1;
+
+				import java.util.Iterator;
+				import java.util.List;
+
+				public class E {
+					void setRunnable(Runnable r) {
+					}
+					void test1() {
+						setRunnable(() -> {
+				        	System.out.println("abc"); //$NON-NLS-1$
+				        });
+					}
+				}
+				""";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected }, null);
+
+	}
 }


### PR DESCRIPTION
- modify LambdaExpressionsFixCore to not convert a single expression statement into a lambda specifying expression if the statement has a line comment such as a non-NLS marker
- add new test to CleanUpTest1d8
- fixes #1999

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
