### PR TITLE
Fix NPE when opening quick type hierarchy twice #2002

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
@@ -138,9 +138,23 @@ public class HierarchyInformationControl extends AbstractInformationControl {
 
 			@Override
 			protected void inputChanged(Object input, Object oldInput) {
-				visited= new HashSet<>();
-				super.inputChanged(input, oldInput);
-				visited= null;
+				runWithVisited(() -> super.inputChanged(input, oldInput));
+			}
+
+
+			@Override
+			public void expandToLevel(Object elementOrTreePath, int level, boolean disableRedraw) {
+				runWithVisited(
+						() -> super.expandToLevel(elementOrTreePath, level, disableRedraw));
+			}
+
+			private void runWithVisited(Runnable r) {
+				try {
+					visited= new HashSet<>();
+					r.run();
+				} finally {
+					visited= null;
+				}
 			}
 
 			@Override
@@ -156,7 +170,7 @@ public class HierarchyInformationControl extends AbstractInformationControl {
 					return false;
 				}
 				Object data= widget.getData();
-				return data == null || visited.add(data);
+				return data == null || visited == null || visited.add(data);
 			}
 		};
 		treeViewer.addFilter(new ViewerFilter() {


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2002

## Changes
- Introduce private method `runWithVisited`
- Override `expandToLevel(Object, int, boolean)` and let it use `runWithVisited`