### PR TITLE
Fix NPE when opening quick type hierarchy twice #2002

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
@@ -137,18 +137,19 @@ public class HierarchyInformationControl extends AbstractInformationControl {
 			private Set<Object> visited;
 
 			@Override
-			protected void inputChanged(Object input, Object oldInput) {
-				visited= new HashSet<>();
-				super.inputChanged(input, oldInput);
-				visited= null;
-			}
-
-			@Override
 			protected void internalExpandToLevel(Widget node, int level) {
+				boolean reset = false;
+				if (visited == null) {
+					reset = true;
+					visited = new HashSet<>();
+				}
 				if (!shouldExpand(node))
 					return;
 
 				super.internalExpandToLevel(node, level);
+				if (reset) {
+					visited = null;
+				}
 			}
 
 			private boolean shouldExpand(Widget widget) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2002

See https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2005#pullrequestreview-2605627182

Supersedes https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2005