### PR TITLE
Fix pattern instanceof clean-up to remove all if statements

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternInstanceofToSwitchFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternInstanceofToSwitchFixCore.java
@@ -596,7 +596,9 @@ public class PatternInstanceofToSwitchFixCore extends CompilationUnitRewriteOper
 			} else {
 				rewrite.replace(ifStatements.get(0), newExpressionStatement, group);
 			}
-
+			for (int i= 1; i< ifStatements.size(); ++i) {
+				rewrite.remove(ifStatements.get(i), group);
+			}
 		}
 
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest21.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest21.java
@@ -369,6 +369,75 @@ public class CleanUpTest21 extends CleanUpTestCase {
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}
 
+	@Test
+	public void testPatternInstanceofToSwitchExpression3() throws Exception {
+		Hashtable<String, String> options= JavaCore.getOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);
+		JavaCore.setOptions(options);
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class E {
+				int i;
+				double d;
+				boolean b;
+
+				public int square(int x) {
+					return x*x;
+				}
+				public int foo(Object y) {
+					if (y instanceof final Integer xint) {
+						return xint;
+					}
+					if (y instanceof final Double xdouble) {
+						return square(8); // square
+					} else if (y instanceof final Boolean xboolean) {
+						throw new NullPointerException();
+					} else {
+						i = 0;
+						d = 0.0D;
+						b = false;
+						return 11;
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.USE_SWITCH_FOR_INSTANCEOF_PATTERN);
+
+		sample= """
+			package test1;
+
+			public class E {
+				int i;
+				double d;
+				boolean b;
+
+				public int square(int x) {
+					return x*x;
+				}
+				public int foo(Object y) {
+					return switch (y) {
+						case Integer xint -> xint;
+						case Double xdouble -> square(8); // square
+						case Boolean xboolean -> throw new NullPointerException();
+						case null, default -> {
+							i = 0;
+							d = 0.0D;
+							b = false;
+							yield 11;
+						}
+					};
+				}
+			}
+			""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
 	public void testNoPatternInstanceofToSwitch1() throws Exception {
 		Hashtable<String, String> options= JavaCore.getOptions();
 		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);


### PR DESCRIPTION
- fix PatternInstanceofToSwitchFixCore.PatternToSwitchExpressionOperation to remove all if statements at end of rewriteAST() method
- add new test to CleanUpTest21
- fixes #2012

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
