### PR TITLE
Fix folding of 2 consecutive methods

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1496,7 +1496,6 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				includelastLine= true;
 				IRegion normalized= alignRegion(regions[i], ctx);
 				if (normalized != null) {
-					includelastLine= true;
 					Position position= createCommentPosition(normalized);
 					if (position != null) {
 						boolean commentCollapse;


### PR DESCRIPTION
If the second method starts on the same line where the first one ends, there will still be two foldings. (I accidentally set includeLastLine to true a second time, which caused the issue).

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1992

Testing:

1. Disabled new/experimental folding
2. Fold a, now b should be visible
```java
package org.example.test;

class X {
	/*
	 * a b
	 */
	void a() {

	} void b() {
	}
}
```