### PR TITLE
Fix folding of local classes

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -498,4 +498,22 @@ public class FoldingTest {
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // while
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 6, 6); // do
 	}
+
+	@Test
+	public void testLocalClass() throws Exception {
+		String str= """
+				package org.example.test;
+				class Outer {
+					void a() {						//here should be an annotation
+						class Inner2{				//here should be an annotation
+
+						}
+					}
+				}
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // inner class
+	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -353,8 +353,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 		@Override
 		public boolean visit(TypeDeclaration node) {
-			boolean isInnerClass= node.isMemberTypeDeclaration();
-			if (isInnerClass) {
+			if (node.isMemberTypeDeclaration() || node.isLocalTypeDeclaration()) {
 				int start= node.getName().getStartPosition();
 				int end= node.getStartPosition() + node.getLength();
 				createFoldingRegion(start, end - start, ctx.collapseMembers());


### PR DESCRIPTION
Currently, the new folding feature does not support folding for local classes, whereas the old folding mechanism does. This fix ensures that local classes can be folded as expected. Additionally, I add a test case for the scenario.

Test:
1. Activate the new folding
2. Fold inner2, now it should be folded
```java
class Outer {
	void a() {
		class Inner2{
			
		}
	}
}
```
