### PR TITLE
Add checking for import collision when moving methods

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -2517,7 +2517,7 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 			list.insertLast(node, null);
 		}
 		IMethodBinding method= declaration.resolveBinding();
-		if (method != null) {
+		if (method != null && method.getJavaElement() != null) {
 			Set<String> importedTypeNames=
 					MoveStaticMembersProcessor.getImportedTypeNames((ICompilationUnit) method.getJavaElement().getAncestor(IJavaElement.COMPILATION_UNIT),
 							getTargetType().getCompilationUnit());

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -2518,7 +2518,13 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 		}
 		IMethodBinding method= declaration.resolveBinding();
 		if (method != null) {
+			Set<String> importedTypeNames=
+					MoveStaticMembersProcessor.getImportedTypeNames((ICompilationUnit) method.getJavaElement().getAncestor(IJavaElement.COMPILATION_UNIT),
+							getTargetType().getCompilationUnit());
 			Type returnType= rewriter.getImportRewrite().addImport(method.getReturnType(), rewriter.getRoot().getAST(), context, TypeLocation.RETURN_TYPE);
+			if (returnType.isSimpleType() && importedTypeNames.contains(method.getReturnType().getName())) {
+				returnType= ast.newSimpleType(ast.newName(method.getReturnType().getQualifiedName()));
+			}
 			rewrite.set(declaration, MethodDeclaration.RETURN_TYPE2_PROPERTY, returnType, null);
 		}
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/A.java
@@ -1,0 +1,21 @@
+package p1;
+
+import p2.B;
+import p1.a.T;
+
+public class A {
+	public B fB;
+
+	/**
+	 * This is a comment
+	 * @param j a float
+	 * @param foo a foo
+	 * @param bar a bar
+	 */
+	public T mA1(float j, int foo, String bar) {
+		System.out.println(bar + j);
+		return new T();
+	}
+	
+	public void mA2() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/B.java
@@ -1,0 +1,10 @@
+package p2;
+
+import p2.b.T;
+
+public class B {
+	@T
+	public void mB1() {}
+	
+	public void mB2() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/a/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/a/T.java
@@ -1,0 +1,5 @@
+package p1.a;
+
+public class T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/b/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/in/b/T.java
@@ -1,0 +1,5 @@
+package p2.b;
+
+public @interface T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/A.java
@@ -1,0 +1,9 @@
+package p1;
+
+import p2.B;
+
+public class A {
+	public B fB;
+
+	public void mA2() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/B.java
@@ -1,0 +1,21 @@
+package p2;
+
+import p2.b.T;
+
+public class B {
+	@T
+	public void mB1() {}
+	
+	public void mB2() {}
+
+	/**
+	 * This is a comment
+	 * @param j a float
+	 * @param foo a foo
+	 * @param bar a bar
+	 */
+	public p1.a.T mA1(float j, int foo, String bar) {
+		System.out.println(bar + j);
+		return new p1.a.T();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/a/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/a/T.java
@@ -1,0 +1,5 @@
+package p1.a;
+
+public class T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/b/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test81/out/b/T.java
@@ -1,0 +1,5 @@
+package p2.b;
+
+public @interface T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/A.java
@@ -1,0 +1,18 @@
+package p1;
+
+import p2.B;
+import p1.a.T;
+
+public class A {
+	public B fB;
+
+	/**
+	 * This is a comment
+	 */
+	public static T m() {
+		System.out.println("abc");
+		return new T();
+	}
+	
+	public void mA2() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/B.java
@@ -1,0 +1,10 @@
+package p2;
+
+import p2.b.T;
+
+public class B {
+	@T
+	public void mB1() {}
+	
+	public void mB2() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/a/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/a/T.java
@@ -1,0 +1,5 @@
+package p1.a;
+
+public class T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/b/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/in/b/T.java
@@ -1,0 +1,5 @@
+package p2.b;
+
+public @interface T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/A.java
@@ -1,0 +1,9 @@
+package p1;
+
+import p2.B;
+
+public class A {
+	public B fB;
+
+	public void mA2() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/B.java
@@ -1,0 +1,18 @@
+package p2;
+
+import p2.b.T;
+
+public class B {
+	@T
+	public void mB1() {}
+	
+	public void mB2() {}
+
+	/**
+	 * This is a comment
+	 */
+	public static p1.a.T m() {
+		System.out.println("abc");
+		return new p1.a.T();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/a/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/a/T.java
@@ -1,0 +1,5 @@
+package p1.a;
+
+public class T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/b/T.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveMembers/test64/out/b/T.java
@@ -1,0 +1,5 @@
+package p2.b;
+
+public @interface T {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -91,7 +91,13 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 		ICompilationUnit[] cus= new ICompilationUnit[qualifiedNames.length];
 		for (int i= 0; i < qualifiedNames.length; i++) {
 			Assert.isNotNull(qualifiedNames[i]);
-			cus[i]= createCUfromTestFile(getRoot().createPackageFragment(getQualifier(qualifiedNames[i]), true, null), getSimpleName(qualifiedNames[i]));
+			String qualifier= getQualifier(qualifiedNames[i]);
+			String[] sections= qualifier.split("[.]");
+			if (sections.length == 2) {
+				cus[i]= createCUfromTestFile(getRoot().createPackageFragment(getQualifier(qualifiedNames[i]), true, null), getSimpleName(qualifiedNames[i]), sections[1] + "/");
+			} else {
+				cus[i]= createCUfromTestFile(getRoot().createPackageFragment(getQualifier(qualifiedNames[i]), true, null), getSimpleName(qualifiedNames[i]));
+			}
 		}
 		return cus;
 	}
@@ -200,8 +206,16 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 		performChange(ref, false);
 
 		for (int i= 0; i < cus.length; i++) {
-			String outputTestFileName= getOutputTestFileName(getSimpleName(cuQNames[i]));
-			assertEqualLines("Incorrect inline in " + outputTestFileName, getFileContents(outputTestFileName), cus[i].getSource());
+			String cuName= cuQNames[i];
+			String[] sections= cuName.split("[.]");
+
+			if (sections.length == 3) {
+				String outputTestFileName= getOutputTestFileName(getSimpleName(cuQNames[i]), sections[1] + "/");
+				assertEqualLines("Incorrect inline in " + outputTestFileName, getFileContents(outputTestFileName), cus[i].getSource());
+			} else {
+				String outputTestFileName= getOutputTestFileName(getSimpleName(cuQNames[i]));
+				assertEqualLines("Incorrect inline in " + outputTestFileName, getFileContents(outputTestFileName), cus[i].getSource());
+			}
 		}
 	}
 
@@ -714,6 +728,11 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 		helper1(new String[] { "A" }, "A", 6, 10, 6, 16, FIELD, "b", true, true);
 	}
 
+	// Issue 2030
+	@Test
+	public void test81() throws Exception {
+		helper1(new String[] { "p1.A", "p1.a.T", "p2.B", "p2.b.T"}, "p1.A", 15, 14, 15, 17, FIELD, "fB", true, true);
+	}
 
 	// Move mA1 to field fB, do not inline delegator
 	@Test

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -575,6 +575,49 @@ public class MoveMembersTests extends GenericRefactoringTest {
 		methodHelper_passing(new String[] { "m" }, new String[][] { new String[0] });
 	}
 
+	@Test
+	public void test64() throws Exception { // test for Issue 2030
+			ParticipantTesting.reset();
+			IPackageFragment p1= getRoot().createPackageFragment("p1", false, null);
+			IPackageFragment p1a= getRoot().createPackageFragment("p1.a", false, null);
+			IPackageFragment p2= getRoot().createPackageFragment("p2", false, null);
+			IPackageFragment p2b= getRoot().createPackageFragment("p2.b", false, null);
+			ICompilationUnit cuA= createCUfromTestFile(p1, "A");
+			ICompilationUnit cuT1= createCUfromTestFile(p1a, "T", "a/");
+			ICompilationUnit cuB= createCUfromTestFile(p2, "B");
+			ICompilationUnit cuT2= createCUfromTestFile(p2b, "T", "b/");
+			IType typeA= getType(cuA, "A");
+			IType typeB= getType(cuB, "B");
+			IMethod[] methods= getMethods(typeA, new String[] {"m"}, new String[][] { new String[0]});
+
+			IType destinationType= typeB;
+			IMember[] members= merge(methods, new IMember[0], new IMember[0]);
+			String[] handles= ParticipantTesting.createHandles(members);
+			MoveArguments[] args= new MoveArguments[handles.length];
+			for (int i = 0; i < args.length; i++) {
+				args[i]= new MoveArguments(destinationType, true);
+			}
+			MoveRefactoring ref= createRefactoring(members, destinationType);
+
+			IDelegateUpdating delUp= ref.getProcessor().getAdapter(IDelegateUpdating.class);
+			delUp.setDelegateUpdating(false);
+
+			RefactoringStatus result= performRefactoringWithStatus(ref);
+			assertTrue("precondition was supposed to pass", result.getSeverity() <= RefactoringStatus.WARNING);
+			ParticipantTesting.testMove(handles, args);
+
+			String expected;
+			String actual;
+
+			expected= getFileContents(getOutputTestFileName("A"));
+			actual= cuA.getSource();
+			assertEqualLines("incorrect modification of  A", expected, actual);
+
+			expected= getFileContents(getOutputTestFileName("B"));
+			actual= cuB.getSource();
+			assertEqualLines("incorrect modification of  B", expected, actual);
+			//tearDown() deletes resources and does performDummySearch();
+	}
 	//---
 	@Test
 	public void testFail0() throws Exception{

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveMembersTests.java
@@ -583,9 +583,9 @@ public class MoveMembersTests extends GenericRefactoringTest {
 			IPackageFragment p2= getRoot().createPackageFragment("p2", false, null);
 			IPackageFragment p2b= getRoot().createPackageFragment("p2.b", false, null);
 			ICompilationUnit cuA= createCUfromTestFile(p1, "A");
-			ICompilationUnit cuT1= createCUfromTestFile(p1a, "T", "a/");
+			createCUfromTestFile(p1a, "T", "a/");
 			ICompilationUnit cuB= createCUfromTestFile(p2, "B");
-			ICompilationUnit cuT2= createCUfromTestFile(p2b, "T", "b/");
+			createCUfromTestFile(p2b, "T", "b/");
 			IType typeA= getType(cuA, "A");
 			IType typeB= getType(cuB, "B");
 			IMethod[] methods= getMethods(typeA, new String[] {"m"}, new String[][] { new String[0]});


### PR DESCRIPTION
- modify MoveStaticMembersProcessor and MoveInstanceMethodProcessor to look for simple types that collide with classes that are already imported in the target
- add new test to MoveMembersTests and MoveInstanceMethodTests
- fixes #2030

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue or original bug.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
