### PR TITLE
Add method reference support to Call hierarchy callee tree

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CalleeAnalyzerVisitor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CalleeAnalyzerVisitor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -42,6 +42,7 @@ import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
@@ -168,6 +169,27 @@ class CalleeAnalyzerVisitor extends HierarchicalASTVisitor {
      */
     @Override
 	public boolean visit(MethodInvocation node) {
+        progressMonitorWorked(1);
+        if (!isFurtherTraversalNecessary(node)) {
+            return false;
+        }
+
+        if (isNodeWithinMethod(node)) {
+            addMethodCall(node.resolveMethodBinding(), node);
+        }
+
+        return true;
+    }
+
+    /**
+     * Find all method invocations from the called method. Since we only traverse into
+     * the AST on the wanted method declaration, this method should not hit on more
+     * method invocations than those in the wanted method.
+     *
+     * @see org.eclipse.jdt.core.dom.ASTVisitor#visit(org.eclipse.jdt.core.dom.MethodInvocation)
+     */
+    @Override
+	public boolean visit(MethodReference node) {
         progressMonitorWorked(1);
         if (!isFurtherTraversalNecessary(node)) {
             return false;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyContentProviderTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyContentProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -273,6 +273,24 @@ public class CallHierarchyContentProviderTest {
 		assertEquals(
 				6, thirdLevelChildren.length, "Wrong number of third level children");
 	}
+
+	/*
+     * Tests getChildren and hasChildren on a callee tree with lambda method reference.
+     */
+    @Test
+    public void testLambdaCalleesWithMethodReference() throws Exception {
+		helper.createClassWithLambdaCalls();
+
+        TreeRoot root= wrapCalleeRoot(helper.getMethod3());
+        Object[] children= fProvider.getChildren(root);
+        assertEquals(1, children.length, "Wrong number of children");
+        helper.assertCalls(new IMember[] { helper.getMethod3()}, children);
+        assertEquals(helper.getMethod3(), ((MethodWrapper) children[0]).getMember(), "Wrong method");
+        assertTrue(fProvider.hasChildren(root), "root's hasChildren");
+
+        Object[] secondLevelChildren= fProvider.getChildren(children[0]);
+        assertNotNull(helper.findMethodWrapper(helper.getMethod2(), secondLevelChildren), "Did not find transform call");
+    }
 
     private void assertCalleeMethodWrapperChildren(Object[] children) {
     	for (Object child : children) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyTestHelper.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/callhierarchy/CallHierarchyTestHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -300,23 +300,23 @@ public class CallHierarchyTestHelper {
 			public class Snippet {
 				static Function<? super String, ? extends String> mapper1 = y -> transform(y);
 				Function<? super String, ? extends String> mapper2 = y -> transform(y);
-			
+
 				static {
 					 mapper1 = y -> transform(y);
 				}
-			
+
 				public Snippet() {
 					mapper2 = y -> transform(y);
 				}
-			
+
 				public static void main(String[] args) {
-					mapper1 = y -> transform(y);
+					mapper1 = Snippet::transform;
 				}
-			
+
 				Object[] funcCall() {
-					return List.of("aaa").stream().map(y -> transform(y)).toArray();
+					return List.of("aaa").stream().map(Snippet::transform).toArray();
 				}
-			
+
 				static String transform(String s) {
 			     x();
 					return s.toUpperCase();
@@ -332,8 +332,10 @@ public class CallHierarchyTestHelper {
 		cu.createImport("java.util.function.Function", fType1, null);
 		fMethod1= fType1.getMethod("x", EMPTY);
 		fMethod2= fType1.getMethod("transform", new String[] { "QString;" });
+		fMethod3= fType1.getMethod("funcCall", EMPTY);
 		Assertions.assertNotNull(fMethod1);
 		Assertions.assertNotNull(fMethod2);
+		Assertions.assertNotNull(fMethod3);
 		assertBuildWithoutErrors(fPack1);
 	}
 
@@ -460,14 +462,14 @@ public class CallHierarchyTestHelper {
 						public class P {
 						  private A handler;
 						  private Abs absHandler;
-						
+
 						  public void callFoo() {
 						     handler.foo();
 						  }
 						  public void callAbsFoo() {
 						     absHandler.absFoo();
 						  }
-						
+
 						}""",
                     null,
                     true,


### PR DESCRIPTION
- modify CallAnalyzerVisitor to handle MethodReference
- add new test to CallHierarchyContentProviderTest and add support for this in CallHierarchyTestHelper
- fixes #2029

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
