### PR TITLE
Fix too many folding regions in anonymous class

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -458,8 +458,6 @@ public class FoldingTest {
 
 	@Test
 	public void testAnonymousClassDeclarationFolding() throws Exception {
-		// FIXME this test should work for both foldings. See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2022
-		assumeTrue("Currently broken for the 'old' folding. See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2022", newFoldingActive);
 		String str= """
 				package org.example.test;
 				public class M {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1470,7 +1470,6 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		boolean collapse= false;
 		boolean collapseCode= true;
 		switch (element.getElementType()) {
-
 			case IJavaElement.IMPORT_CONTAINER:
 				collapse= ctx.collapseImportContainer();
 				includelastLine= true;
@@ -1479,8 +1478,13 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				collapseCode= isInnerType((IType) element) && !isAnonymousEnum((IType) element);
 				collapse= ctx.collapseInnerTypes() && collapseCode;
 				break;
-			case IJavaElement.METHOD:
 			case IJavaElement.FIELD:
+				if (containsAnonymousChild(element)) {
+					return;
+				}
+				collapse= ctx.collapseMembers();
+				break;
+			case IJavaElement.METHOD:
 			case IJavaElement.INITIALIZER:
 				collapse= ctx.collapseMembers();
 				break;
@@ -1524,6 +1528,23 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				}
 			}
 		}
+	}
+
+	private boolean containsAnonymousChild(IJavaElement element) {
+		if (!(element instanceof IParent parent)) {
+			return false;
+		}
+
+		try {
+			for (IJavaElement child : parent.getChildren()) {
+				if (child instanceof IType t && t.isAnonymous()) {
+					return true;
+				}
+			}
+		} catch (JavaModelException e) {
+			JavaPlugin.log(e);
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes the issue of double folding when a field declares an anonymous class. Previously, both the field and the anonymous class were folded, resulting in overlapping fold regions. With this change, only the anonymous class is folded, eliminating the duplicate region.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2022

Test:
1. Set a breakpoint at the end of org.eclipse.jdt.text.tests.folding.FoldingTestUtils.getProjectionRangesOfFile(IPackageFragment, String, String).
2. Skip the first visit because that covers the new folding test.
3. Inspect the regions list: there should be exactly two entries, confirming that fields with anonymous classes no longer produce double folding