### PR TITLE
Fix Push down refactoring to check for method usage in other classes

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/testFail16/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/testFail16/in/A.java
@@ -1,0 +1,11 @@
+package p;
+
+class A {
+	void m() {
+	}
+}
+class B extends A {
+	public static void main(String[] args) {
+		new A().m();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1267,6 +1267,25 @@ public class PushDownTests extends GenericRefactoringTest {
 
 	@Test
 	public void testFail15() throws Exception {
+		String[] selectedMethodNames= {"m"};
+		String[][] selectedMethodSignatures= { new String[0]};
+		String[] selectedFieldNames= {};
+		String[] namesOfMethodsToPushDown= {};
+		String[][] signaturesOfMethodsToPushDown= {};
+		String[] namesOfFieldsToPushDown= selectedFieldNames;
+		String[] namesOfMethodsToDeclareAbstract= {};
+		String[][] signaturesOfMethodsToDeclareAbstract= {};
+
+		failInputHelper(selectedMethodNames, selectedMethodSignatures,
+				selectedFieldNames,
+				namesOfMethodsToPushDown, signaturesOfMethodsToPushDown,
+				namesOfFieldsToPushDown,
+				namesOfMethodsToDeclareAbstract, signaturesOfMethodsToDeclareAbstract,
+				RefactoringStatus.ERROR);
+	}
+
+	@Test
+	public void testFail16() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2041
 		String[] selectedMethodNames= {"m"};
 		String[][] selectedMethodSignatures= { new String[0]};
 		String[] selectedFieldNames= {};


### PR DESCRIPTION
- modify PushDownRefactoringProcessor to add new getReferencingElementsFromProject which checks for method references outside of the declaring class that refer to the original class to access the method which is being moved and flag an error in that case
- add new test to PushDownTests
- fixes #2041

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue or original bug.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
