### PR TITLE
Do not offer convert to static import when name collision exists

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
@@ -10426,6 +10426,36 @@ public class AssistQuickFixTest extends QuickFixTest {
 	}
 
 	@Test
+	public void testConvertToStaticImportShouldNotBeOffered() throws Exception { // Issue 2045
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str= """
+			package test1;
+			import java.util.Currency;
+			public class T {
+				public void foo() {
+				    if (Currency.getAvailableCurrencies() != null) {
+					    System.out.println("available currencies");
+					}
+				}
+				private int getAvailableCurrencies() {
+					return 3;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("T.java", str, false, null);
+
+		String selection= "getAvailableCurrencies";
+		int offset= str.lastIndexOf(selection);
+		AssistContext context= getCorrectionContext(cu, offset, selection.length());
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+
+		assertCorrectLabels(proposals);
+
+		assertProposalDoesNotExist(proposals, "Convert to static import");
+		assertProposalDoesNotExist(proposals, "Convert to static import (replace all occurrences)");
+	}
+
+	@Test
 	public void testConvertToStaticImportDoesRemoveUnusedImport() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """


### PR DESCRIPTION
- modify QuickAssistProcessor.getAddStaticImportProposals() to check for a collision with an unqualified reference
- add new UnqualifiedReferencesFinder class to QuickAssistProcessorUtil
- add new test to AssistQuickFixTest
- fixes #2045

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
