### PR TITLE
javadoc Markdown issues

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -958,4 +958,45 @@ public class MarkdownCommentTests extends CoreTests {
 		String actualHtmlContent= getHoverHtmlContent(cu, method);
 		assertHtmlContent(expectedContent, actualHtmlContent);
 	}
+
+
+	@Test
+	public void testArrayReferenceInCode() throws CoreException {
+		String source= """
+				/// In the following indented code block, `[i]` is program text,
+				/// and not a hyper link:
+				///
+				///     int i = 3;
+				///     int[] d = new int[i];
+				///
+				/// Likewise, in the following fenced code block, `[i]` is program text,
+				/// and not a hyper link:
+				///
+				/// ```
+				/// int i = 3;
+				/// int[] d = new int[i];
+				/// ```
+				public class ArrayInCode {
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/ArrayInCode.java", source, null);
+		assertNotNull("ArrayInCode.java", cu);
+
+		String expectedContent= """
+				<p>In the following indented code block, <code>[i]</code> is program text,
+				and not a hyper link:</p>
+				<pre><code>int i = 3;
+				int[] d = new int[i];
+				</code></pre>
+				<p>Likewise, in the following fenced code block, <code>[i]</code> is program text,
+				and not a hyper link:</p>
+				<pre><code>int i = 3;
+				int[] d = new int[i];
+				</code></pre>
+				""";
+		IType type= cu.getType("ArrayInCode");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+		assertHtmlContent(expectedContent, actualHtmlContent);
+	}
+
 }


### PR DESCRIPTION
Regards item 9, handling of array references within code: 

Test added for fix in
    https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3761

Relates to https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1800
