### PR TITLE
Remove warnings on unused api filter

### DIFF
--- a/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
+++ b/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.ui.unittest.junit.feature"
       label="%featureName"
-      version="1.1.600.qualifier"
+      version="1.1.700.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.ui.unittest.junit.feature/pom.xml
+++ b/org.eclipse.jdt.ui.unittest.junit.feature/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.jdt.feature</groupId>
   <artifactId>org.eclipse.jdt.ui.unittest.junit.feature</artifactId>
-  <version>1.1.600-SNAPSHOT</version>
+  <version>1.1.700-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <build>
      <plugins>

--- a/org.eclipse.jdt.ui.unittest.junit/.settings/.api_filters
+++ b/org.eclipse.jdt.ui.unittest.junit/.settings/.api_filters
@@ -17,18 +17,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="src/org/eclipse/jdt/ui/unittest/junit/launcher/Messages.java" type="org.eclipse.jdt.ui.unittest.junit.launcher.Messages">
-        <filter comment="Messages are not api" id="338755678">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.ui.unittest.junit.launcher.Messages"/>
-                <message_argument value="JUnitLaunchConfigurationTab_error_JDK15_required"/>
-            </message_arguments>
-        </filter>
-        <filter comment="Messages are not api" id="338755678">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.ui.unittest.junit.launcher.Messages"/>
-                <message_argument value="JUnitLaunchConfigurationTab_error_JDK18_required"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.unittest.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui.unittest.junit;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.unittest.junit.JUnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui.unittest.junit/pom.xml
+++ b/org.eclipse.jdt.ui.unittest.junit/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.unittest.junit</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Remove warnings on unused api filter

## How to test
Hopefully, the build will be green

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
