### PR TITLE
Fix add block to handle if expressions over multiple lines

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ControlStatementsFix.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ControlStatementsFix.java
@@ -224,7 +224,8 @@ public class ControlStatementsFix extends CompilationUnitRewriteOperationsFixCor
 
 			TextEditGroup group= createTextEditGroup(label, cuRewrite);
 			List<Comment> commentsToPreserve= new ArrayList<>();
-			int controlStatementLine= cuRoot.getLineNumber(fControlStatement.getStartPosition());
+			int startPosition= expression == null ? defaultStartPosition : (expression.getStartPosition() + cuRoot.getExtendedLength(expression));
+			int controlStatementLine= cuRoot.getLineNumber(startPosition);
 			int bodyLine= cuRoot.getLineNumber(fBody.getStartPosition());
 			IBuffer cuBuffer= cuRewrite.getCu().getBuffer();
 			// Get extended body text and convert multiple indent tabs to be just one tab as they will be relative to control statement
@@ -235,7 +236,6 @@ public class ControlStatementsFix extends CompilationUnitRewriteOperationsFixCor
 			// If single body statement is on next line, we need to preserve any comments pertaining to the
 			// control statement (e.g. NLS comment for if expression)
 			if (controlStatementLine != bodyLine) {
-				int startPosition= expression == null ? defaultStartPosition : (expression.getStartPosition() + cuRoot.getExtendedLength(expression));
 				List<Comment> comments= cuRoot.getCommentList();
 				for (Comment comment : comments) {
 					int commentLine= cuRoot.getLineNumber(comment.getStartPosition());

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -20652,6 +20652,41 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testAddParenthesesIssue2060() throws Exception {
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+			public class E {
+				public void foo(String x) {
+					if (x.equals("abc") || //$NON-NLS-1$
+					        x.equals("def")) //$NON-NLS-1$
+					    System.out.println("def"); //$NON-NLS-1$
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_USE_BLOCKS);
+		enable(CleanUpConstants.CONTROL_STATEMENTS_USE_BLOCKS_ALWAYS);
+
+		sample= """
+			package test1;
+			public class E {
+				public void foo(String x) {
+					if (x.equals("abc") || //$NON-NLS-1$
+					        x.equals("def")) { //$NON-NLS-1$
+			        \tSystem.out.println("def"); //$NON-NLS-1$
+			        }
+				}
+			}
+			""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] {cu1}, new String[] {expected1}, null);
+	}
+
+	@Test
 	public void testRemoveParentheses01() throws Exception {
 
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);


### PR DESCRIPTION
- add logic to ControlStatementsFix to look at the last line of the expression instead of the if statement start
- add new test to CleanUpTest
- fixes #2060

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
