### PR TITLE
Fix some pattern instanceof to switch cleanup errors

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternInstanceofToSwitchFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternInstanceofToSwitchFixCore.java
@@ -437,7 +437,8 @@ public class PatternInstanceofToSwitchFixCore extends CompilationUnitRewriteOper
 				final boolean isNameUsed,
 				final List<Statement> innerStatements) {
 			List<Statement> switchStatements= switchStatement.statements();
-			boolean needBlock= innerStatements.size() > 1 || (innerStatements.size() == 1 && innerStatements.get(0) instanceof ReturnStatement);
+			boolean needBlock= innerStatements.size() == 0 || innerStatements.size() > 1 || (innerStatements.size() == 1
+					&& !(innerStatements.get(0) instanceof ExpressionStatement) && !(innerStatements.get(0) instanceof ThrowStatement));
 
 			// Add the case statement(s)
 			if (caseValueOrNullForDefault != null) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest21.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest21.java
@@ -243,6 +243,196 @@ public class CleanUpTest21 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testPatternInstanceofToSwitch4() throws Exception {
+		Hashtable<String, String> options= JavaCore.getOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);
+		JavaCore.setOptions(options);
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class E {
+				public int square(int x) {
+					return x * x;
+				}
+				public int foo(Object x, Object y) {
+					int i, j;
+					double d;
+					boolean b;
+					if (y instanceof Integer xint) {
+						return 7;
+					} else if (y instanceof final Double xdouble) {
+						return square(8); // square
+					} else if (y instanceof final Boolean xboolean) {
+						throw new NullPointerException();
+					} else {
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.USE_SWITCH_FOR_INSTANCEOF_PATTERN);
+		sample= """
+				package test1;
+
+				public class E {
+					public int square(int x) {
+						return x * x;
+					}
+					public int foo(Object x, Object y) {
+						int i, j;
+						double d;
+						boolean b;
+						switch (y) {
+							case Integer xint -> {
+								return 7;
+							}
+							case Double xdouble -> {
+								return square(8); // square
+							}
+							case Boolean xboolean -> throw new NullPointerException();
+							case null, default -> {
+							}
+						}
+					}
+				}
+				""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testPatternInstanceofToSwitch5() throws Exception {
+		Hashtable<String, String> options= JavaCore.getOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);
+		JavaCore.setOptions(options);
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class E {
+				public int square(int x) {
+					return x * x;
+				}
+				public int foo(Object x, Object y) {
+					int i, j;
+					double d;
+					boolean b;
+					if (y instanceof Integer xint) {
+						return 7;
+					} else if (y instanceof final Double xdouble) {
+						return square(8); // square
+					} else if (y instanceof final Boolean xboolean) {
+						throw new NullPointerException();
+					} else if (obj == null) {
+						System.out.println("null");
+					} else {
+						System.out.println("unknown");
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.USE_SWITCH_FOR_INSTANCEOF_PATTERN);
+		sample= """
+				package test1;
+
+				public class E {
+					public int square(int x) {
+						return x * x;
+					}
+					public int foo(Object x, Object y) {
+						int i, j;
+						double d;
+						boolean b;
+						switch (y) {
+							case Integer xint -> {
+								return 7;
+							}
+							case Double xdouble -> {
+								return square(8); // square
+							}
+							case Boolean xboolean -> throw new NullPointerException();
+							case null, default -> {
+								if (obj == null) {
+									System.out.println("null");
+								} else {
+									System.out.println("unknown");
+								}
+							}
+						}
+					}
+				}
+				""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
+	public void testPatternInstanceofToSwitch6() throws Exception {
+		Hashtable<String, String> options= JavaCore.getOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);
+		JavaCore.setOptions(options);
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class E {
+				public int square(int x) {
+					return x * x;
+				}
+				public int foo(Object x, Object y) {
+					int i, j;
+					double d;
+					boolean b;
+					if (y instanceof Integer xint) {
+						return 7;
+					} else if (y instanceof final Double xdouble) {
+						return square(8); // square
+					} else if (y instanceof final Boolean xboolean) {
+						throw new NullPointerException();
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.USE_SWITCH_FOR_INSTANCEOF_PATTERN);
+		sample= """
+				package test1;
+
+				public class E {
+					public int square(int x) {
+						return x * x;
+					}
+					public int foo(Object x, Object y) {
+						int i, j;
+						double d;
+						boolean b;
+						switch (y) {
+							case Integer xint -> {
+								return 7;
+							}
+							case Double xdouble -> {
+								return square(8); // square
+							}
+							case Boolean xboolean -> throw new NullPointerException();
+							case null, default -> {
+							}
+						}
+					}
+				}
+				""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
 	public void testPatternInstanceofToSwitchExpression1() throws Exception {
 		Hashtable<String, String> options= JavaCore.getOptions();
 		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);


### PR DESCRIPTION
- fix PatternInstanceofToSwitchFixCore to create a block for no statements or one statement that is not an expression statement or a throw statement
- add new tests to CleanUpTest21
- fixes #2066

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
