### PR TITLE
[24] Remove Y-build reference from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2012, 2024 Eclipse Foundation and others.
+  Copyright (c) 2012, 2025 Eclipse Foundation and others.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Distribution License v1.0
   which accompanies this distribution, and is available at
   http://www.eclipse.org/org/documents/edl-v10.php
- 
-  This is an implementation of an early-draft specification developed under the Java
-  Community Process (JCP) and is made available for testing and evaluation purposes
-  only. The code is not compatible with any specification of the JCP.
  
   Contributors:
      Igor Fedorenko - initial implementation
@@ -40,10 +36,6 @@
   <profiles>
     <profile>
       <id>build-individual-bundles</id>
-      <properties>
-      	<eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/Y-builds</eclipse-p2-repo.url>
-      	<skipAPIAnalysis>true</skipAPIAnalysis>
-      </properties>
       <repositories>
         <repository>
           <releases>


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2075

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
