### PR TITLE
Spare control characters from content assist trigger

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -105,7 +105,7 @@ Require-Bundle:
  org.eclipse.compare;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.team.ui;bundle-version="[3.4.100,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.4.100,4.0.0)",
- org.eclipse.jface.text;bundle-version="[3.20.0,4.0.0)",
+ org.eclipse.jface.text;bundle-version="[3.28.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.117.0,4.0.0)",
  org.eclipse.ui.console;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.ui.workbench;bundle-version="[3.131.0,4.0.0)",


### PR DESCRIPTION
## What it does

On some versions of MacOS, the Ctrl+S hotkey is realized as a key event with 'S' as character and 'Ctrl' as state mask, rather than the 'XOFF' character (0x13, also with the 'Ctrl' state mask).

If the auto-activation trigger for Java include the character 's', this then causes the completion box to show up when the user tries to save the editor while it's already in a clean state.

This was previously fixed on the platform [1], but needs to be reverted as generic source viewers might also check for the 'Ctrl' key [2]. In order to avoid a regression, the check therefore needs to be moved to the JDT component.

[1] https://github.com/eclipse-platform/eclipse.platform.ui/pull/1556
[2] https://github.com/eclipse-platform/eclipse.platform.ui/issues/2723

## How to test

In the Java Content Assist preference page, update the auto activation triggers for Java to include the character 'S' (or '' on most other platforms). In a clean Java editor, press Ctrl+S. On older versions of the Eclipse IDE (likely pre 2022-03), this would cause the code completion box to show up.

![image](https://github.com/user-attachments/assets/92025fe4-17fe-4c0a-b416-5377449b9eae)

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
