### PR TITLE
Add conditional expression support to pattern instanceof cleanup

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -14,13 +14,17 @@
 package org.eclipse.jdt.internal.corext.fix;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.text.edits.TextEditGroup;
 
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -28,14 +32,18 @@ import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ConditionalExpression;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InfixExpression.Operator;
 import org.eclipse.jdt.core.dom.InstanceofExpression;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
+import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.PatternInstanceofExpression;
 import org.eclipse.jdt.core.dom.PrefixExpression;
 import org.eclipse.jdt.core.dom.SimpleName;
@@ -48,7 +56,9 @@ import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.TargetSourceRangeComputer;
 
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
 import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
 
@@ -58,9 +68,9 @@ import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 
 public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteOperationsFixCore {
 	public static final class PatternMatchingForInstanceofFinder extends ASTVisitor {
-		private List<PatternMatchingForInstanceofFixOperation> fResult;
+		private List<CompilationUnitRewriteOperation> fResult;
 
-		public PatternMatchingForInstanceofFinder(List<PatternMatchingForInstanceofFixOperation> ops) {
+		public PatternMatchingForInstanceofFinder(List<CompilationUnitRewriteOperation> ops) {
 			fResult= ops;
 		}
 
@@ -74,6 +84,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 		final class InstanceofVisitor extends ASTVisitor {
 			private final Block startNode;
 			private boolean result= true;
+			private final Set<String> excludedNames= new HashSet<>();
 
 			public InstanceofVisitor(final Block startNode) {
 				this.startNode= startNode;
@@ -101,9 +112,14 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 				boolean isPositiveCaseToAnalyze= true;
 				ASTNode currentNode= visited;
 
+				if (visited.getLocationInParent() == ConditionalExpression.EXPRESSION_PROPERTY) {
+
+				}
 				while (currentNode.getParent() != null
 						&& (!(currentNode.getParent() instanceof IfStatement)
-						|| currentNode.getLocationInParent() != IfStatement.EXPRESSION_PROPERTY)) {
+						|| currentNode.getLocationInParent() != IfStatement.EXPRESSION_PROPERTY)
+						&& (!(currentNode.getParent() instanceof ConditionalExpression)
+						|| currentNode.getLocationInParent() != ConditionalExpression.EXPRESSION_PROPERTY)) {
 					switch (currentNode.getParent().getNodeType()) {
 						case ASTNode.PARENTHESIZED_EXPRESSION:
 							break;
@@ -143,22 +159,103 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 					}
 				}
 
-				IfStatement ifStatement= (IfStatement) currentNode.getParent();
+				if (currentNode.getParent() instanceof ConditionalExpression condExp
+						&& visited.getLeftOperand() instanceof SimpleName name) {
+					ConditionalCollector collector= new ConditionalCollector(visited, name, excludedNames);
+					if (isPositiveCaseToAnalyze) {
+						condExp.getThenExpression().accept(collector);
+					} else {
+						condExp.getElseExpression().accept(collector);
+					}
+					if (collector.hasResult()) {
+						fResult.add(collector.build());
+						return false;
+					}
+				} else {
+					IfStatement ifStatement= (IfStatement) currentNode.getParent();
 
-				ResultCollector collector = new ResultCollector(visited);
-				if (isPositiveCaseToAnalyze) {
-					collector.collect(ifStatement.getThenStatement());
-				} else if (ifStatement.getElseStatement() != null) {
-					collector.collect(ifStatement.getElseStatement());
-				} else if (ASTNodes.fallsThrough(ifStatement.getThenStatement())) {
-					collector.collect(ASTNodes.getNextSibling(ifStatement));
-				}
+					ResultCollector collector= new ResultCollector(visited);
+					if (isPositiveCaseToAnalyze) {
+						collector.collect(ifStatement.getThenStatement());
+					} else if (ifStatement.getElseStatement() != null) {
+						collector.collect(ifStatement.getElseStatement());
+					} else if (ASTNodes.fallsThrough(ifStatement.getThenStatement())) {
+						collector.collect(ASTNodes.getNextSibling(ifStatement));
+					}
 
-				if (collector.hasResult()) {
-					fResult.add(collector.build());
-					return false;
+					if (collector.hasResult()) {
+						fResult.add(collector.build());
+						return false;
+					}
 				}
 				return true;
+			}
+
+			static class ConditionalCollector extends ASTVisitor {
+				final InstanceofExpression visited;
+				final Set<String> excludedNames;
+				final SimpleName variableName;
+				String replacementName= null;
+				final List<Expression> expressionsToReplace = new ArrayList<>();
+
+				ConditionalCollector(InstanceofExpression visited, SimpleName name, Set<String> excludedNames) {
+					this.visited = visited;
+					this.excludedNames= excludedNames;
+					this.variableName= name;				}
+
+				public PatternMatchingForConditionalInstanceofFixOperation build() {
+					return new PatternMatchingForConditionalInstanceofFixOperation(visited, expressionsToReplace, replacementName);
+				}
+
+				private String getIdentifierName(Expression expression) {
+					if (expression instanceof SimpleName simpleName) {
+						return simpleName.getIdentifier();
+					}
+					return null;
+				}
+
+				boolean hasResult() {
+					return replacementName != null && !expressionsToReplace.isEmpty();
+				}
+
+				void addMatching(final CastExpression castExp, final SimpleName name) {
+					Expression expressionToReplace= castExp;
+					ITypeBinding castBinding= castExp.resolveTypeBinding();
+					if (this.variableName.getIdentifier().equals(name.getIdentifier())
+							&& castBinding != null && castBinding.isEqualTo(visited.getRightOperand().resolveBinding())) {
+						while (expressionToReplace.getLocationInParent() == ParenthesizedExpression.EXPRESSION_PROPERTY) {
+							expressionToReplace= (Expression) expressionToReplace.getParent();
+						}
+						if (replacementName == null) {
+							String baseName= castBinding.getName().toLowerCase().substring(0, 1);
+							MethodDeclaration methodDecl= ASTNodes.getFirstAncestorOrNull(name, MethodDeclaration.class);
+							if (methodDecl != null) {
+								CompilationUnit cu= (CompilationUnit) name.getRoot();
+								IJavaProject project= cu.getJavaElement().getJavaProject();
+								replacementName= proposeLocalName(baseName, cu, project, methodDecl, excludedNames.toArray(new String[0]));
+							}
+						}
+						this.expressionsToReplace.add(expressionToReplace);
+					}
+				}
+
+				private String proposeLocalName(String baseName, CompilationUnit root, IJavaProject javaProject, MethodDeclaration methodDecl, String[] usedNames) {
+					// don't propose names that are already in use:
+					Collection<String> variableNames= new ScopeAnalyzer(root).getUsedVariableNames(methodDecl.getStartPosition(), methodDecl.getLength());
+					String[] names = new String[variableNames.size() + usedNames.length];
+					variableNames.toArray(names);
+					System.arraycopy(usedNames, 0, names, variableNames.size(), usedNames.length);
+					return StubUtility.getLocalNameSuggestions(javaProject, baseName, 0, names)[0];
+				}
+
+				@Override
+				public boolean visit(SimpleName node) {
+					if (node.getLocationInParent() == CastExpression.EXPRESSION_PROPERTY) {
+						addMatching((CastExpression)node.getParent(), node);
+					}
+					return false;
+				}
+
 			}
 
 			static class ResultCollector {
@@ -256,6 +353,46 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 		}
 	}
 
+	public static class PatternMatchingForConditionalInstanceofFixOperation extends CompilationUnitRewriteOperation {
+		private final InstanceofExpression nodeToComplete;
+		private final List<Expression> expressionsToReplace;
+		private final String replacementName;
+
+		public PatternMatchingForConditionalInstanceofFixOperation(final InstanceofExpression nodeToComplete, final List<Expression> expressionsToReplace, final String replacementName) {
+			this.nodeToComplete= nodeToComplete;
+			this.expressionsToReplace= expressionsToReplace;
+			this.replacementName= replacementName;
+		}
+
+		@SuppressWarnings("deprecation")
+		@Override
+		public void rewriteAST(final CompilationUnitRewrite cuRewrite, final LinkedProposalModelCore linkedModel) throws CoreException {
+			ASTRewrite rewrite= cuRewrite.getASTRewrite();
+			AST ast= rewrite.getAST();
+			TextEditGroup group= createTextEditGroup(MultiFixMessages.PatternMatchingForInstanceofCleanup_description, cuRewrite);
+
+			PatternInstanceofExpression newInstanceof= ast.newPatternInstanceofExpression();
+			newInstanceof.setLeftOperand(ASTNodes.createMoveTarget(rewrite, nodeToComplete.getLeftOperand()));
+			SingleVariableDeclaration newSVDecl= ast.newSingleVariableDeclaration();
+			newSVDecl.setName(ast.newSimpleName(replacementName));
+			newSVDecl.setType(ASTNodes.createMoveTarget(rewrite, nodeToComplete.getRightOperand()));
+			if ((ast.apiLevel() == AST.JLS20 && ast.isPreviewEnabled()) || ast.apiLevel() > AST.JLS20) {
+				TypePattern newTypePattern= ast.newTypePattern();
+				newTypePattern.setPatternVariable((VariableDeclaration) newSVDecl);
+				newInstanceof.setPattern(newTypePattern);
+			} else {
+				newInstanceof.setRightOperand(newSVDecl);
+			}
+			ASTNodes.replaceButKeepComment(rewrite, nodeToComplete, newInstanceof, group);
+
+			ASTNodes.replaceButKeepComment(rewrite, nodeToComplete, newInstanceof, group);
+			for (Expression expressionToReplace : expressionsToReplace) {
+				SimpleName name= ast.newSimpleName(replacementName);
+				rewrite.replace(expressionToReplace, name, group);
+			}
+		}
+	}
+
 	public static class PatternMatchingForInstanceofFixOperation extends CompilationUnitRewriteOperation {
 		private final InstanceofExpression nodeToComplete;
 		private final List<VariableDeclarationStatement> statementsToRemove;
@@ -325,7 +462,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 
 
 	public static ICleanUpFix createCleanUp(final CompilationUnit compilationUnit) {
-		List<PatternMatchingForInstanceofFixOperation> operations= new ArrayList<>();
+		List<CompilationUnitRewriteOperation> operations= new ArrayList<>();
 		PatternMatchingForInstanceofFinder finder= new PatternMatchingForInstanceofFinder(operations);
 		compilationUnit.accept(finder);
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -207,13 +207,6 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 					return new PatternMatchingForConditionalInstanceofFixOperation(visited, expressionsToReplace, replacementName);
 				}
 
-				private String getIdentifierName(Expression expression) {
-					if (expression instanceof SimpleName simpleName) {
-						return simpleName.getIdentifier();
-					}
-					return null;
-				}
-
 				boolean hasResult() {
 					return replacementName != null && !expressionsToReplace.isEmpty();
 				}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -591,7 +591,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 						System.out.println(s);
 					}
 				}
-				public void foo4(Object o, Object p) {
+				public int foo4(Object o, Object p) {
 					if (o instanceof String && p instanceof Integer) {
 						if (o != p) {
 							String s = (String) o;
@@ -602,6 +602,20 @@ public class CleanUpTest16 extends CleanUpTestCase {
 						Integer i = (Integer) p;
 						i = 7;
 					}
+					return o instanceof String ? ((String)o).length() : i;
+				}
+				public int foo5(Object o, Object p) {
+					if (o instanceof String && p instanceof Integer) {
+						if (o != p) {
+							String s = (String) o;
+							Integer i = (Integer) p;
+							System.out.println(s.trim() + i.toString());
+							i = 3;
+						}
+						Integer i = (Integer) p;
+						i = 7;
+					}
+					return !(o instanceof String) ? i : ((String)o).length();
 				}
 			}
 			""";
@@ -650,7 +664,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 							System.out.println(s);
 						}
 					}
-					public void foo4(Object o, Object p) {
+					public int foo4(Object o, Object p) {
 						if (o instanceof String s && p instanceof Integer i) {
 							if (o != p) {
 								System.out.println(s.trim() + i.toString());
@@ -659,6 +673,18 @@ public class CleanUpTest16 extends CleanUpTestCase {
 							i = (Integer) p;
 							i = 7;
 						}
+						return o instanceof String s2 ? s2.length() : i;
+					}
+					public int foo5(Object o, Object p) {
+						if (o instanceof String s && p instanceof Integer i) {
+							if (o != p) {
+								System.out.println(s.trim() + i.toString());
+								i = 3;
+							}
+							i = (Integer) p;
+							i = 7;
+						}
+						return !(o instanceof String s2) ? i : s2.length();
 					}
 				}
 				""";


### PR DESCRIPTION
- modify PatternMatchingForInstanceofFixCore to handle conditional expressions in addition to if statements
- add new scenarios to CleanUpTest16
- fixes #2094

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test scenarios.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
