### PR TITLE
Fix Pattern instanceof cleanup to handle casts in the if statement

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -617,6 +617,20 @@ public class CleanUpTest16 extends CleanUpTestCase {
 					}
 					return !(o instanceof String) ? i : ((String)o).length();
 				}
+				public int foo6(Object o) {
+					if (o instanceof String && ((String)o).length() > 3) {
+						String s = (String) o;
+						return s.length - 3();
+					}
+					return !(o instanceof String) ? 0 : ((String)o).length();
+				}
+				public int foo7(Object o) {
+					if (!(o instanceof String) || ((String)o).length() > 3) {
+						return -1;
+					}
+					String s = (String)o;
+					return !(o instanceof String) ? 0 : ((String)o).length();
+				}
 			}
 			""";
 		ICompilationUnit cu= pack.createCompilationUnit("E.java", given, false, null);
@@ -685,6 +699,18 @@ public class CleanUpTest16 extends CleanUpTestCase {
 							i = 7;
 						}
 						return !(o instanceof String s2) ? i : s2.length();
+					}
+					public int foo6(Object o) {
+						if (o instanceof String s && s.length() > 3) {
+							return s.length - 3();
+						}
+						return !(o instanceof String s2) ? 0 : s2.length();
+					}
+					public int foo7(Object o) {
+						if (!(o instanceof String s) || s.length() > 3) {
+							return -1;
+						}
+						return !(o instanceof String s2) ? 0 : s2.length();
 					}
 				}
 				""";


### PR DESCRIPTION
- modify PatterMatchingForInstanceofFixCore to handle casts in the if statement of the instanceof expression
- add new scenario to CleanUpTest16
- fixes #2094

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
