### PR TITLE
Allow instanceof to pattern matching cleanup to check inner ifs

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -220,7 +220,7 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 
 					if (collector.hasResult()) {
 						fResult.add(collector.build());
-						return false;
+						return true;
 					}
 				}
 				return true;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -631,6 +631,29 @@ public class CleanUpTest16 extends CleanUpTestCase {
 					String s = (String)o;
 					return !(o instanceof String) ? 0 : ((String)o).length();
 				}
+				public int foo8(Object x, Object y, boolean b) {
+					if (b || !(x instanceof String) || ((String)x).length() > 3) {
+						if (y instanceof Double) {
+							Double d = (Double)y;
+							System.out.println(d.isNaN());
+						}
+						return 7;
+					}
+					String s = (String)x;
+					return s.length();
+				}
+				public int foo9(Object x, Object y, boolean b) {
+					if (b || !(x instanceof String) || ((String)x).length() > 3) {
+						if (!(y instanceof Double)) {
+							return 6;
+						}
+						Double d = (Double)y;
+						System.out.println(d.isNaN());
+						return 7;
+					}
+					String s = (String)x;
+					return s.length();
+				}
 			}
 			""";
 		ICompilationUnit cu= pack.createCompilationUnit("E.java", given, false, null);
@@ -711,6 +734,25 @@ public class CleanUpTest16 extends CleanUpTestCase {
 							return -1;
 						}
 						return !(o instanceof String s2) ? 0 : s2.length();
+					}
+					public int foo8(Object x, Object y, boolean b) {
+						if (b || !(x instanceof String s) || s.length() > 3) {
+							if (y instanceof Double d) {
+								System.out.println(d.isNaN());
+							}
+							return 7;
+						}
+						return s.length();
+					}
+					public int foo9(Object x, Object y, boolean b) {
+						if (b || !(x instanceof String s) || s.length() > 3) {
+							if (!(y instanceof Double d)) {
+								return 6;
+							}
+							System.out.println(d.isNaN());
+							return 7;
+						}
+						return s.length();
 					}
 				}
 				""";


### PR DESCRIPTION
- fix PatternMatchingForInstanceofFixCore to continue parsing inner ifs
- add new tests to CleanUpTest16
- fixes #2105

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
