### PR TITLE
Completion within markdown should escape array brackets #3773

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/FillArgumentNamesCompletionProposalCollector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/FillArgumentNamesCompletionProposalCollector.java
@@ -66,7 +66,7 @@ public final class FillArgumentNamesCompletionProposalCollector extends Completi
 	}
 
 	private IJavaCompletionProposal createMethodReferenceProposal(CompletionProposal methodProposal) {
-		String completion= String.valueOf(methodProposal.getCompletion());
+		String completion= String.valueOf(methodProposal.getDisplayString());
 		// super class' behavior if this is not a normal completion or has no
 		// parameters
 		if ((completion.length() == 0) || ((completion.length() == 1) && completion.charAt(0) == ')') || Signature.getParameterCount(methodProposal.getSignature()) == 0 || getContext().isInJavadoc())

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/CompletionProposalLabelProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/CompletionProposalLabelProvider.java
@@ -319,7 +319,7 @@ public class CompletionProposalLabelProvider {
 		StyledString nameBuffer= new StyledString();
 
 		// method name
-		nameBuffer.append(methodProposal.getCompletion());
+		nameBuffer.append(methodProposal.getDisplayString());
 
 		// declaring type
 		nameBuffer.append(QUALIFIER_SEPARATOR, StyledString.QUALIFIER_STYLER);


### PR DESCRIPTION
Get the new display string for completion proposal via new API CompletionProposal#getDisplayString()

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3773

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
