### PR TITLE
Fix line delimiter used by text block input assistants

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/AddTextBlockAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/AddTextBlockAction.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.text.IDocumentExtension3;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.jface.text.source.ISourceViewer;
 
 import org.eclipse.ui.IEditorInput;
@@ -155,15 +156,16 @@ public class AddTextBlockAction extends SelectionDispatchAction {
 				//do nothing
 			}
 		}
+		String delimiter= TextUtilities.getDefaultLineDelimiter(document);
 		cmd.offset= selection.getOffset();
 		cmd.length= selection.getLength();
-		cmd.text= IndentAction.TEXT_BLOCK_STR + System.lineSeparator() + indentStr;
+		cmd.text= IndentAction.TEXT_BLOCK_STR + delimiter + indentStr;
 		cmd.doit= true;
 		cmd.shiftsCaret= true;
 		cmd.caretOffset= selection.getOffset() + selection.getLength() + cmd.text.length();
 		cmd.text+= selection.getText();
 		if (JavaMultiLineStringAutoIndentStrategy.isCloseStringsPreferenceSet(javaProject)) {
-			cmd.text+= System.lineSeparator() + indentStr + IndentAction.TEXT_BLOCK_STR;
+			cmd.text+= delimiter + indentStr + IndentAction.TEXT_BLOCK_STR;
 		}
 
 		return cmd;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMultiLineStringAutoIndentStrategy.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMultiLineStringAutoIndentStrategy.java
@@ -68,7 +68,7 @@ public class JavaMultiLineStringAutoIndentStrategy extends JavaStringAutoIndentS
 				if (isCloseStringsPreferenceSet(fProject)) {
 					command.caretOffset= command.offset + command.text.length();
 					command.shiftsCaret= false;
-					command.text= command.text + System.lineSeparator() + IndentAction.getTextBlockIndentationString(document, offset, command.offset, 0, fProject) + IndentAction.TEXT_BLOCK_STR;
+					command.text= command.text + delimiter + IndentAction.getTextBlockIndentationString(document, offset, command.offset, 0, fProject) + IndentAction.TEXT_BLOCK_STR;
 				}
 			}
 		} else if (command.text.length() > 1 && !isLineDelimiter && isEditorEscapeStrings()) {


### PR DESCRIPTION
The change corrects the line delimiter inserted by the auto edit strategy for text blocks and the action to add text blocks.