### PR TITLE
Replace usages of new Image(device, width, height)

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/RenameLinkedMode.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/reorg/RenameLinkedMode.java
@@ -387,7 +387,7 @@ public class RenameLinkedMode {
 					Point size;
 					try {
 						size= composite.getSize();
-						image= new Image(gc.getDevice(), size.x, size.y);
+						image= new Image(gc.getDevice(), (iGc, width, height) -> {}, size.x, size.y) ;
 						gc.copyArea(image, 0, 0);
 					} finally {
 						gc.dispose();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/BreadcrumbItemDropDown.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/BreadcrumbItemDropDown.java
@@ -31,6 +31,7 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.graphics.Rectangle;
@@ -104,16 +105,22 @@ class BreadcrumbItemDropDown {
 			Display display= fParentComposite.getDisplay();
 
 			ImageDataProvider imageProvider= zoom -> {
-				Image image= new Image(display, ARROW_SIZE, ARROW_SIZE * 2);
+				ImageGcDrawer drawer = new ImageGcDrawer() {
+				    @Override
+				    public void drawOn(GC gc, int iWidth, int iHeight) {
+				    		gc.setAntialias(SWT.ON);
+						Color triangleColor= createColor(SWT.COLOR_LIST_FOREGROUND, SWT.COLOR_LIST_BACKGROUND, 20, display);
+						gc.setBackground(triangleColor);
+						gc.fillPolygon(new int[] { 0, 0, ARROW_SIZE, ARROW_SIZE, 0, ARROW_SIZE * 2 });
+						triangleColor.dispose();
+				    }
 
-				GC gc= new GC(image, fLTR ? SWT.LEFT_TO_RIGHT : SWT.RIGHT_TO_LEFT);
-				gc.setAntialias(SWT.ON);
-
-				Color triangleColor= createColor(SWT.COLOR_LIST_FOREGROUND, SWT.COLOR_LIST_BACKGROUND, 20, display);
-				gc.setBackground(triangleColor);
-				gc.fillPolygon(new int[] { 0, 0, ARROW_SIZE, ARROW_SIZE, 0, ARROW_SIZE * 2 });
-				gc.dispose();
-				triangleColor.dispose();
+				    @Override
+				    public int getGcStyle() {
+				        return fLTR ? SWT.LEFT_TO_RIGHT : SWT.RIGHT_TO_LEFT;
+				    }
+				};
+				Image image= new Image(display, drawer, ARROW_SIZE, ARROW_SIZE * 2);
 
 				ImageData imageData= image.getImageData(zoom);
 				image.dispose();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/javadoc/SignatureStylingColorPreferenceMenuItem.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/javadoc/SignatureStylingColorPreferenceMenuItem.java
@@ -19,10 +19,10 @@ import java.util.function.Function;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageDataProvider;
+import org.eclipse.swt.graphics.ImageGcDrawer;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.ColorDialog;
 import org.eclipse.swt.widgets.Shell;
@@ -54,16 +54,14 @@ class SignatureStylingColorPreferenceMenuItem extends Action implements ImageDat
 
 	@Override
 	public ImageData getImageData(int zoom) {
-		Image image= new Image(shell.getDisplay(), 16, 16);
-		GC gc= new GC(image);
-
-		gc.setForeground(shell.getDisplay().getSystemColor(SWT.COLOR_WIDGET_BORDER));
-		gc.setBackground(new Color(shell.getDisplay(), getCurrentColor()));
-		gc.fillRectangle(image.getBounds());
-		gc.setLineWidth(2);
-		gc.drawRectangle(image.getBounds());
-		gc.dispose();
-
+		final ImageGcDrawer imageGcDrawer = (gc, width, height) -> {
+			gc.setForeground(shell.getDisplay().getSystemColor(SWT.COLOR_WIDGET_BORDER));
+			gc.setBackground(new Color(shell.getDisplay(), getCurrentColor()));
+			gc.fillRectangle(0, 0, width, height);
+			gc.setLineWidth(2);
+			gc.drawRectangle(0, 0, width, height);
+		};
+		Image image= new Image(shell.getDisplay(), imageGcDrawer, 16, 16);
 		ImageData data= image.getImageData(zoom);
 		image.dispose();
 		return data;


### PR DESCRIPTION
Replacing it with imageGcDrawer constructor Image(device, imageGcDrawer, width, height). Later Image(device, width, height) is set to be deprecated. 

## Requires
- [x] https://github.com/eclipse-platform/eclipse.platform.swt/pull/1948

## Author checklist

- [ x ] I have thoroughly tested my changes
- [ x ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ x ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
