### PR TITLE
Skip import quickfix hierarchy check if base type is unresolved

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
@@ -1007,7 +1007,7 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 			if ((elem.getKind() & TypeKinds.ALL_TYPES) != 0) {
 				String fullName= elem.getName();
 				if (!fullName.equals(resolvedTypeName)) {
-					if (simpleBinding != null && !simpleBinding.isPrimitive()) {
+					if (simpleBinding != null && !simpleBinding.isPrimitive() && !simpleBinding.isRecovered()) {
 						// If we have an expected type, we should verify that any classes we suggest to import
 						// inherit directly or indirectly from the type
 						ITypeBinding qualifiedTypeBinding= null;


### PR DESCRIPTION
## What it does

The commit 546a6978432fa5f2b01083919364848dd89805dc extended the import check to compare the interfaces of the suggested types with the interface of the missing type.

In case the base type is unresolved, this then skips all suggestions, even though it should let all pass so that the user can decide which one to pick.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2119

## How to test

Use the quickfix to add the imports for the Eclipse `IPath` and `Path` in the following snippet.

```
package test;

class Test {
	private IPath p = new Path("...");
}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
