### PR TITLE
Allow an empty method to be inlined in a lambda expression body

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -70,6 +70,7 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.LabeledStatement;
+import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Modifier;
@@ -656,7 +657,12 @@ public class CallInliner {
 			if (fNeedsStatement) {
 				fRewrite.replace(fTargetNode, fTargetNode.getAST().newEmptyStatement(), textEditGroup);
 			} else {
-				fRewrite.remove(fTargetNode, textEditGroup);
+				if (fTargetNode.getLocationInParent() == LambdaExpression.BODY_PROPERTY) {
+					ASTNode newNode= fRewrite.createStringPlaceholder("{}", ASTNode.BLOCK); //$NON-NLS-1$
+					fRewrite.replace(fTargetNode, newNode, textEditGroup);
+				} else {
+					fRewrite.remove(fTargetNode, textEditGroup);
+				}
 			}
 		} else {
 			ASTNode node= null;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
@@ -256,9 +256,11 @@ public class SourceProvider {
 
 	public boolean isSimpleFunction() {
 		List<Statement> statements= fDeclaration.getBody().statements();
-		if (statements.size() != 1)
+		if (statements.size() > 1)
 			return false;
-		return statements.get(0) instanceof ReturnStatement;
+		if (statements.size() == 1)
+			return statements.get(0) instanceof ReturnStatement;
+		return true;
 	}
 
 	public boolean isLastStatementReturn() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2111_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2111_1.java
@@ -1,0 +1,9 @@
+package bugs_in;
+
+public class Test_issue_2111_1 {
+	protected void a() {
+		new Thread(() -> /*]*/b()/*[*/);
+	}
+
+	private void b() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2111_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2111_1.java
@@ -1,0 +1,9 @@
+package bugs_in;
+
+public class Test_issue_2111_1 {
+	protected void a() {
+		new Thread(() -> /*]*/{}/*[*/);
+	}
+
+	private void b() {}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -502,6 +502,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_2111_1() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- modify SourceProvider.isSimpleFunction() to allow an empty method
- fix CallInliner.replaceCall() to handle an empty method being inlined into a lambda body
- add new test to InlineMethodTests
- fixes #2111

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
