### PR TITLE
Fix inlining to support method references

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -73,6 +73,7 @@ import org.eclipse.jdt.core.dom.LabeledStatement;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
 import org.eclipse.jdt.core.dom.Name;
@@ -660,6 +661,20 @@ public class CallInliner {
 				if (fTargetNode.getLocationInParent() == LambdaExpression.BODY_PROPERTY) {
 					ASTNode newNode= fRewrite.createStringPlaceholder("{}", ASTNode.BLOCK); //$NON-NLS-1$
 					fRewrite.replace(fTargetNode, newNode, textEditGroup);
+				} else if (fTargetNode instanceof MethodReference methodRef) {
+					IMethodBinding binding= methodRef.resolveMethodBinding();
+					if (binding != null) {
+						StringBuilder builder= new StringBuilder("("); //$NON-NLS-1$
+						String[] parmNames= binding.getParameterNames();
+						String separator= ""; //$NON-NLS-1$
+						for (String parmName : parmNames) {
+							builder.append(separator + parmName);
+							separator= ", "; //$NON-NLS-1$
+						}
+						builder.append(") -> {}"); //$NON-NLS-1$
+					ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.LAMBDA_EXPRESSION);
+					fRewrite.replace(fTargetNode, newNode, textEditGroup);
+					}
 				} else {
 					fRewrite.remove(fTargetNode, textEditGroup);
 				}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/Invocations.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/Invocations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.refactoring.code;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -27,6 +28,7 @@ import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.SuperConstructorInvocation;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
@@ -52,7 +54,11 @@ public class Invocations {
 				return ((ClassInstanceCreation)invocation).arguments();
 			case ASTNode.ENUM_CONSTANT_DECLARATION:
 				return ((EnumConstantDeclaration)invocation).arguments();
-
+			case ASTNode.EXPRESSION_METHOD_REFERENCE:
+			case ASTNode.TYPE_METHOD_REFERENCE:
+			case ASTNode.SUPER_METHOD_REFERENCE:
+			case ASTNode.CREATION_REFERENCE:
+				return Collections.EMPTY_LIST;
 			default:
 				throw new IllegalArgumentException(invocation.toString());
 		}
@@ -95,6 +101,12 @@ public class Invocations {
 			case ASTNode.CLASS_INSTANCE_CREATION:
 				return ((ClassInstanceCreation)invocation).getExpression();
 			case ASTNode.ENUM_CONSTANT_DECLARATION:
+				return null;
+
+			case ASTNode.CREATION_REFERENCE:
+			case ASTNode.EXPRESSION_METHOD_REFERENCE:
+			case ASTNode.SUPER_METHOD_REFERENCE:
+			case ASTNode.TYPE_METHOD_REFERENCE:
 				return null;
 
 			default:
@@ -141,6 +153,12 @@ public class Invocations {
 				return ((ClassInstanceCreation)invocation).resolveConstructorBinding();
 			case ASTNode.ENUM_CONSTANT_DECLARATION:
 				return ((EnumConstantDeclaration)invocation).resolveConstructorBinding();
+
+			case ASTNode.CREATION_REFERENCE:
+			case ASTNode.EXPRESSION_METHOD_REFERENCE:
+			case ASTNode.SUPER_METHOD_REFERENCE:
+			case ASTNode.TYPE_METHOD_REFERENCE:
+				return ((MethodReference)invocation).resolveMethodBinding();
 
 			default:
 				throw new IllegalArgumentException(invocation.toString());

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/TargetProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/TargetProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -44,8 +44,10 @@ import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.ConstructorInvocation;
+import org.eclipse.jdt.core.dom.CreationReference;
 import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
 import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.ExpressionMethodReference;
 import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
@@ -53,8 +55,11 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
+import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeMethodReference;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
 import org.eclipse.jdt.core.search.IJavaSearchConstants;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
@@ -260,6 +265,28 @@ public abstract class TargetProvider {
 
 		@Override
 		public boolean visit(MethodInvocation node) {
+			if (node.resolveTypeBinding() != null && matches(node.resolveMethodBinding()) && fCurrent != null) {
+				fCurrent.addInvocation(node);
+			}
+			return true;
+		}
+		@Override
+		public boolean visit(ExpressionMethodReference node) {
+			return handle(node);
+		}
+		@Override
+		public boolean visit(CreationReference node) {
+			return handle(node);
+		}
+		@Override
+		public boolean visit(SuperMethodReference node) {
+			return handle(node);
+		}
+		@Override
+		public boolean visit(TypeMethodReference node) {
+			return handle(node);
+		}
+		private boolean handle(MethodReference node) {
 			if (node.resolveTypeBinding() != null && matches(node.resolveMethodBinding()) && fCurrent != null) {
 				fCurrent.addInvocation(node);
 			}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2118_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2118_1.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_2111_1 {
+	public interface A {
+		void doSomething(int a, int b);
+	}
+
+	protected void foo() {
+		A t = this::b;
+	}
+
+	public void /*]*/b/*[*/(int x, int y) {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2118_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2118_2.java
@@ -1,0 +1,10 @@
+package bugs_in;
+
+public class Test_issue_2111_2 {
+	protected void foo() {
+		Runnable t = this::b;
+	}
+
+	public void /*]*/b/*[*/() {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2118_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2118_1.java
@@ -1,0 +1,11 @@
+package bugs_in;
+
+public class Test_issue_2111_1 {
+	public interface A {
+		void doSomething(int a, int b);
+	}
+
+	protected void foo() {
+		A t = (x, y) -> {};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2118_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2118_2.java
@@ -1,0 +1,7 @@
+package bugs_in;
+
+public class Test_issue_2111_2 {
+	protected void foo() {
+		Runnable t = () -> {};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -507,6 +507,16 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_2118_1() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_2118_2() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- fix Invocations to handle method references for various methods (e.g. method binding)
- add method reference support to CallInliner.replaceCall()
- add method reference support to TargetProvider.InvocationFinder
- add new tests to InlineMethodTests
- fixes #2118

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
