### PR TITLE
Ensure unused suppress warnings cleanup uses it own compiler options

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.22.100.qualifier
+Bundle-Version: 1.23.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
@@ -91,6 +91,7 @@ public class UnusedSuppressWarningsCleanUp extends AbstractMultiFix {
 		Map<String, String> result= new Hashtable<>();
 
 		if (isEnabled(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS)) {
+			result.putAll(JavaCore.getDefaultOptions());
 			result.put(JavaCore.COMPILER_PB_SUPPRESS_WARNINGS, JavaCore.ENABLED);
 			result.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
 			result.put(JavaCore.COMPILER_PB_UNUSED_WARNING_TOKEN, JavaCore.ERROR); // do not change to WARNING

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
@@ -60,7 +60,7 @@ public class UnusedSuppressWarningsCleanUp extends AbstractMultiFix {
 		boolean requireAST= requireAST();
 		Map<String, String> requiredOptions= requireAST ? getRequiredOptions() : null;
 		// ask for fresh AST as we are setting all default options on and we run as last cleanup
-		return new CleanUpRequirements(requireAST, requireAST, false, true, requiredOptions);
+		return new CleanUpRequirements(requireAST, requireAST, false, requireAST, requiredOptions);
 	}
 
 	private boolean requireAST() {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.fix;
 
+import java.util.Hashtable;
 import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
@@ -69,7 +70,7 @@ public class UnusedSuppressWarningsCleanUp extends AbstractMultiFix {
 
 	@Override
 	protected ICleanUpFix createFix(CompilationUnit compilationUnit) throws CoreException {
-		if (compilationUnit == null)
+		if (compilationUnit == null || !isEnabled(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS))
 			return null;
 
 		ICleanUpFix coreFix= fLiteral != null ? UnusedSuppressWarningsFixCore.createAllFix(fSavedCompilationUnit == null ? compilationUnit : fSavedCompilationUnit,
@@ -79,7 +80,7 @@ public class UnusedSuppressWarningsCleanUp extends AbstractMultiFix {
 
 	@Override
 	protected ICleanUpFix createFix(CompilationUnit compilationUnit, IProblemLocation[] problems) throws CoreException {
-		if (compilationUnit == null)
+		if (compilationUnit == null || !isEnabled(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS))
 			return null;
 
 		ICleanUpFix coreFix= UnusedSuppressWarningsFixCore.createAllFix(compilationUnit, fLiteral);
@@ -87,10 +88,7 @@ public class UnusedSuppressWarningsCleanUp extends AbstractMultiFix {
 	}
 
 	private Map<String, String> getRequiredOptions() {
-		// This cleanup is run last and can require using all default options to maximize
-		// chance of finding an unused suppress warnings annotation.
-		// We ask for a fresh AST so all other cleanups are complete before we do this
-		Map<String, String> result= JavaCore.getOptions();
+		Map<String, String> result= new Hashtable<>();
 
 		if (isEnabled(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS)) {
 			result.put(JavaCore.COMPILER_PB_SUPPRESS_WARNINGS, JavaCore.ENABLED);

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
@@ -60,7 +60,7 @@ public class UnusedSuppressWarningsCleanUp extends AbstractMultiFix {
 		boolean requireAST= requireAST();
 		Map<String, String> requiredOptions= requireAST ? getRequiredOptions() : null;
 		// ask for fresh AST as we are setting all default options on and we run as last cleanup
-		return new CleanUpRequirements(requireAST, requireAST, false, requiredOptions);
+		return new CleanUpRequirements(requireAST, requireAST, false, true, requiredOptions);
 	}
 
 	private boolean requireAST() {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/ui/cleanup/CleanUpRequirements.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/ui/cleanup/CleanUpRequirements.java
@@ -37,6 +37,7 @@ public final class CleanUpRequirements {
 
 	protected final boolean fRequiresChangedRegions;
 
+	protected final boolean fRequiresSeparateOptions;
 
 	/**
 	 * Create a new instance
@@ -47,11 +48,28 @@ public final class CleanUpRequirements {
 	 * @param compilerOptions map of compiler options or <code>null</code> if no requirements
 	 */
 	public CleanUpRequirements(boolean requiresAST, boolean requiresFreshAST, boolean requiresChangedRegions, Map<String, String> compilerOptions) {
+		this(requiresAST, requiresFreshAST, requiresChangedRegions, false, compilerOptions);
+	}
+
+	/**
+	 * Create a new instance
+	 *
+	 * @param requiresAST <code>true</code> if an AST is required
+	 * @param requiresFreshAST <code>true</code> if a fresh AST is required
+	 * @param requiresChangedRegions <code>true</code> if changed regions are required
+	 * @param requiresSeparateOptions <code>true</code> if clean up has options that should not be shared
+	 * @param compilerOptions map of compiler options or <code>null</code> if no requirements
+	 * @since 1.22
+	 */
+	public CleanUpRequirements(boolean requiresAST, boolean requiresFreshAST, boolean requiresChangedRegions,
+			boolean requiresSeparateOptions, Map<String, String> compilerOptions) {
 		Assert.isLegal(!requiresFreshAST || requiresAST, "Must not request fresh AST if no AST is required"); //$NON-NLS-1$
 		Assert.isLegal(compilerOptions == null || requiresAST, "Must not provide options if no AST is required"); //$NON-NLS-1$
+		Assert.isLegal(!requiresSeparateOptions || requiresFreshAST, "Must not require separate options if fresh AST not required"); //$NON-NLS-1$
 		fRequiresAST= requiresAST;
 		fRequiresFreshAST= requiresFreshAST;
 		fRequiresChangedRegions= requiresChangedRegions;
+		fRequiresSeparateOptions= requiresSeparateOptions;
 
 		fCompilerOptions= compilerOptions;
 		// Make sure that compile warnings are not suppressed since some clean ups work on reported warnings
@@ -84,6 +102,17 @@ public final class CleanUpRequirements {
 	 */
 	public boolean requiresFreshAST() {
 		return fRequiresFreshAST;
+	}
+
+	/**
+	 * Tells whether separate compiler options are required as the options should not be shared with
+	 * other cleanups.
+	 *
+	 * @return <code>true</code> if the cleanup has its own options.
+	 * @since 1.22
+	 */
+	public boolean requiresSeparateOptions() {
+		return fRequiresSeparateOptions;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/ui/cleanup/CleanUpRequirements.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/ui/cleanup/CleanUpRequirements.java
@@ -59,7 +59,7 @@ public final class CleanUpRequirements {
 	 * @param requiresChangedRegions <code>true</code> if changed regions are required
 	 * @param requiresSeparateOptions <code>true</code> if clean up has options that should not be shared
 	 * @param compilerOptions map of compiler options or <code>null</code> if no requirements
-	 * @since 1.22
+	 * @since 1.23
 	 */
 	public CleanUpRequirements(boolean requiresAST, boolean requiresFreshAST, boolean requiresChangedRegions,
 			boolean requiresSeparateOptions, Map<String, String> compilerOptions) {
@@ -109,7 +109,7 @@ public final class CleanUpRequirements {
 	 * other cleanups.
 	 *
 	 * @return <code>true</code> if the cleanup has its own options.
-	 * @since 1.22
+	 * @since 1.23
 	 */
 	public boolean requiresSeparateOptions() {
 		return fRequiresSeparateOptions;

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
@@ -395,6 +395,7 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 
 							Map<String, String> options= RefactoringASTParser.getCompilerOptions(project);
 							if (!fSeparateOptions.isEmpty()) {
+								System.out.println("separate options"); //$NON-NLS-1$
 								options.putAll(fSeparateOptions);
 							} else {
 								options.putAll(fCleanUpOptions);
@@ -426,7 +427,7 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 				// undone elements will start with a cleanup that needs a fresh AST so
 				// check if it requires separate options in which case, set up special options.
 				fCleanUpOptions.clear();
-				if (!fParseList.isEmpty()) {
+				if (fParseList != null && !fParseList.isEmpty()) {
 					ParseListElement element= fParseList.get(0);
 					if (element.getCleanUps() != null && element.getCleanUps().length > 0) {
 						ICleanUp cleanUp= element.getCleanUps()[0];

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
@@ -82,6 +82,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 import org.eclipse.jdt.ui.JavaElementLabels;
 import org.eclipse.jdt.ui.cleanup.CleanUpContext;
 import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
+import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUp;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
@@ -344,8 +345,9 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 
 			fCleanUpOptions= new Hashtable<>();
 			for (ICleanUp cleanUp : cleanUps) {
-				Map<String, String> currentCleanUpOption= cleanUp.getRequirements().getCompilerOptions();
-				boolean needsSeparateOptions= cleanUp.getRequirements().requiresSeparateOptions();
+				CleanUpRequirements requirements= cleanUp.getRequirements();
+				Map<String, String> currentCleanUpOption= requirements.getCompilerOptions();
+				boolean needsSeparateOptions= requirements.requiresSeparateOptions();
 				if (currentCleanUpOption != null && !needsSeparateOptions)
 					fCleanUpOptions.putAll(currentCleanUpOption);
 			}
@@ -395,7 +397,6 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 
 							Map<String, String> options= RefactoringASTParser.getCompilerOptions(project);
 							if (!fSeparateOptions.isEmpty()) {
-								System.out.println("separate options"); //$NON-NLS-1$
 								options.putAll(fSeparateOptions);
 							} else {
 								options.putAll(fCleanUpOptions);
@@ -424,9 +425,7 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 				}
 
 				fParseList= requestor.getUndoneElements();
-				// undone elements will start with a cleanup that needs a fresh AST so
-				// check if it requires separate options in which case, set up special options.
-				fCleanUpOptions.clear();
+				// check if undone cleanup requires separate options in which case, set up special options.
 				if (fParseList != null && !fParseList.isEmpty()) {
 					ParseListElement element= fParseList.get(0);
 					if (element.getCleanUps() != null && element.getCleanUps().length > 0) {


### PR DESCRIPTION
- modify CleanUpRequirements to have a new boolean setting regarding separate compiler options and add new constructor that sets it explicitly (otherwise, it defaults to false)
- modify CleanUpRefactoring.CleanUpFixpointIterator to not merge options from a cleanup that requires its own options and also modify the next() method to use these special options for such a cleanup which must also request a fresh AST and must be at the end of the cleanup list with others that do the same
- fixes #2123

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run tests already in place.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
