### PR TITLE
Allow inlining in lambda to support multiple statement methods

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -716,7 +716,7 @@ public class CallInliner {
 			builder.append(separator + "}"); //$NON-NLS-1$
 			ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.LAMBDA_EXPRESSION);
 			fRewrite.replace(fTargetNode, newNode, textEditGroup);
-		} else if (fTargetNode.getLocationInParent() == LambdaExpression.BODY_PROPERTY) {
+		} else if (fTargetNode != null && fTargetNode.getLocationInParent() == LambdaExpression.BODY_PROPERTY) {
 			String allblocks= ""; //$NON-NLS-1$
 			for (int i= 0; i < blocks.length; ++i) {
 				allblocks += blocks[i];

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -376,9 +376,9 @@ public class CallInliner {
 					RefactoringStatusCodes.INLINE_METHOD_EXECUTION_FLOW, severity);
 				return;
 			}
-			if (isAssignment(parent) || isSingleDeclaration(parent)) {
-				// we support inlining expression in assigment and initializers as
-				// long as the execution flow isn't interrupted.
+			if (isAssignment(parent) || isSingleDeclaration(parent) || isLambda(parent)) {
+				// we support inlining expression in assignment and initializers as
+				// long as the execution flow isn't interrupted.  we also aupport lambda bodies.
 				return;
 			} else {
 				boolean isFieldDeclaration= ASTNodes.getParent(fInvocation, FieldDeclaration.class) != null;
@@ -445,6 +445,13 @@ public class CallInliner {
 				return vs.fragments().size() == 1;
 			}
 		}
+		return false;
+	}
+
+	private static boolean isLambda(ASTNode node) {
+		int type= node.getNodeType();
+		if (type == ASTNode.LAMBDA_EXPRESSION)
+			return true;
 		return false;
 	}
 
@@ -672,13 +679,61 @@ public class CallInliner {
 							separator= ", "; //$NON-NLS-1$
 						}
 						builder.append(") -> {}"); //$NON-NLS-1$
-					ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.LAMBDA_EXPRESSION);
-					fRewrite.replace(fTargetNode, newNode, textEditGroup);
+						ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.LAMBDA_EXPRESSION);
+						fRewrite.replace(fTargetNode, newNode, textEditGroup);
 					}
 				} else {
 					fRewrite.remove(fTargetNode, textEditGroup);
 				}
 			}
+		} else if (fTargetNode instanceof MethodReference methodRef) {
+			IMethodBinding binding= methodRef.resolveMethodBinding();
+			if (binding == null) {
+				status.addError(RefactoringCoreMessages.CallInliner_unexpected_model_exception,
+						JavaStatusContext.create(fCUnit, fInvocation));
+				return;
+			}
+			StringBuilder builder= new StringBuilder("("); //$NON-NLS-1$
+			String[] parmNames= binding.getParameterNames();
+			String separator= ""; //$NON-NLS-1$
+			for (String parmName : parmNames) {
+				builder.append(separator + parmName);
+				separator= ", "; //$NON-NLS-1$
+			}
+			builder.append(") -> {"); //$NON-NLS-1$
+			String allblocks= ""; //$NON-NLS-1$
+			for (int i= 0; i < blocks.length; ++i) {
+				allblocks += blocks[i];
+			}
+			String[] lines= allblocks.split("\n"); //$NON-NLS-1$
+			separator= lines.length == 1 ? "" : "\n\t"; //$NON-NLS-1$ //$NON-NLS-2$
+			for (int i= 0; i < lines.length; ++i) {
+				builder.append(separator);
+				builder.append(lines[i]);
+				separator= "\n\t"; //$NON-NLS-1$
+			}
+			separator= lines.length == 1 ? "" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$
+			builder.append(separator + "}"); //$NON-NLS-1$
+			ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.LAMBDA_EXPRESSION);
+			fRewrite.replace(fTargetNode, newNode, textEditGroup);
+		} else if (fTargetNode.getLocationInParent() == LambdaExpression.BODY_PROPERTY) {
+			String allblocks= ""; //$NON-NLS-1$
+			for (int i= 0; i < blocks.length; ++i) {
+				allblocks += blocks[i];
+			}
+			StringBuilder builder= new StringBuilder();
+			builder.append("{"); //$NON-NLS-1$
+			String[] lines= allblocks.split("\n"); //$NON-NLS-1$
+			String separator= lines.length == 1 ? "" : "\n\t"; //$NON-NLS-1$ //$NON-NLS-2$
+			for (int i= 0; i < lines.length; ++i) {
+				builder.append(separator);
+				builder.append(lines[i]);
+				separator= "\n\t"; //$NON-NLS-1$
+			}
+			separator= lines.length == 1 ? "" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$
+			builder.append(separator + "}"); //$NON-NLS-1$
+			ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.BLOCK);
+			fRewrite.replace(fTargetNode, newNode, textEditGroup);
 		} else {
 			ASTNode node= null;
 			boolean needsMethodInvocation= true;

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2111_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2111_2.java
@@ -1,0 +1,16 @@
+package bugs_in;
+
+public class Test_issue_2111_2 {
+	public interface A {
+		void doSomething(int a, int b);
+	}
+
+	protected void foo() {
+		A a = (m, n) -> b(m, n);
+	}
+
+	public void /*]*/b/*[*/(int x, int y) {
+		System.out.println(x);
+		System.out.println(y);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2118_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2118_3.java
@@ -1,0 +1,16 @@
+package bugs_in;
+
+public class Test_issue_2118_3 {
+	public interface A {
+		void doSomething(int a, int b);
+	}
+
+	protected void foo() {
+		A a = this::b;
+	}
+
+	public void /*]*/b/*[*/(int x, int y) {
+		System.out.println(x);
+		System.out.println(y);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2111_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2111_2.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_2111_2 {
+	public interface A {
+		void doSomething(int a, int b);
+	}
+
+	protected void foo() {
+		A a = (m, n) -> {
+			System.out.println(m);
+			System.out.println(n);
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2118_3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2118_3.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_2118_3 {
+	public interface A {
+		void doSomething(int a, int b);
+	}
+
+	protected void foo() {
+		A a = (x, y) -> {
+			System.out.println(x);
+			System.out.println(y);
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -508,12 +508,22 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void test_issue_2111_2() throws Exception {
+		performBugTest();
+	}
+
+	@Test
 	public void test_issue_2118_1() throws Exception {
 		performBugTest();
 	}
 
 	@Test
 	public void test_issue_2118_2() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_2118_3() throws Exception {
 		performBugTest();
 	}
 


### PR DESCRIPTION
- modify CallInliner.checkInvocationContext() to allow a non-simple method in a lambda body
- also modify CallInliner.replaceCall() to add support for replacing a lambda body or a method reference with the contents of a non-simple method
- add new tests to InlineMethodTests
- fixes #2111

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds support for more complex methods to inline into lambda.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
