### PR TITLE
Ensure forceReconciling is called after initialProcess if it was ignored

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaReconciler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaReconciler.java
@@ -22,6 +22,8 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IMarkerDelta;
@@ -281,7 +283,9 @@ public class JavaReconciler extends MonoReconciler {
 	 */
 	private IPropertyChangeListener fPropertyChangeListener;
 
-	private boolean fIninitalProcessDone= false;
+	private boolean fIninitalProcessDone;
+
+	private boolean fDeferForceReconcile;
 
 	/**
 	 * The element that this reconciler reconciles.
@@ -382,7 +386,7 @@ public class JavaReconciler extends MonoReconciler {
 	 */
 	@Override
 	protected void forceReconciling() {
-		if (!fIninitalProcessDone)
+		if (!isInitialProcessDone())
 			return;
 
 		super.forceReconciling();
@@ -420,8 +424,43 @@ public class JavaReconciler extends MonoReconciler {
 		synchronized (fMutex) {
 			super.initialProcess();
 		}
-		fIninitalProcessDone= true;
+		if (initialProcessDone()) {
+			Job.createSystem("Reconciler init", (ICoreRunnable) monitor -> forceReconciling()).schedule();  //$NON-NLS-1$
+		}
 	}
+
+	/**
+	 * This is called by {@link #initialProcess()} to indicate that it is has finished and returns
+	 * true if a call to {@link #forceReconciling()} is necessary because it was previously ignored.
+	 *
+	 * @return whether there has been a call to {@link #forceReconciling()} that was ignored because
+	 *         {@link #fIninitalProcessDone} was false.
+	 */
+	private synchronized boolean initialProcessDone() {
+		fIninitalProcessDone= true;
+		if (fDeferForceReconcile) {
+			fDeferForceReconcile= false;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * This is called by {@link #forceReconciling()} to determine whether
+	 * {@link #initialProcessDone()} has completed. It sets {@link #fDeferForceReconcile} to true if
+	 * {@link #fIninitalProcessDone} is false so that {@link #initialProcessDone()} will return
+	 * true and will subsequently call {@link #forceReconciling()} again.
+	 *
+	 * @return whether {@link #initialProcessDone()} has completed.
+	 */
+	private synchronized boolean isInitialProcessDone() {
+		if (!fIninitalProcessDone) {
+			fDeferForceReconcile= true;
+			return false;
+		}
+		return true;
+	}
+
 
 	/**
 	 * Tells whether the Java Model has changed or not.


### PR DESCRIPTION
## What it does

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2074

## How to test

See the issue and this PR:

https://github.com/eclipse-pde/eclipse.pde/pull/1711

Basically in a self-hosted launch, create some plugin projects,  leave an editor on one source file open, and restart.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)