### PR TITLE
Updated test to open plain text editor

### DIFF
--- a/org.eclipse.jdt.ui.tests/leaks/org/eclipse/jdt/ui/tests/leaks/JavaLeakTest.java
+++ b/org.eclipse.jdt.ui.tests/leaks/org/eclipse/jdt/ui/tests/leaks/JavaLeakTest.java
@@ -87,18 +87,18 @@ public class JavaLeakTest extends LeakTestCase {
 
 	@Test
 	public void testTextEditorClose() throws Exception {
-		IFile file= createTestFile("Test.txt");
+		IFile file= createTestFile("Test");
 		internalTestEditorClose(file, TextEditor.class, false);
 	}
 
 	@Test
 	public void testTextEditorCloseOneOfTwo() throws Exception {
-		IFile file1= createTestFile("Test1.txt");
+		IFile file1= createTestFile("Test1");
 		IEditorPart editor1= EditorUtility.openInEditor(file1);
 		assertEquals(editor1.getClass(), TextEditor.class);
 		assertInstanceCount(TextEditor.class, 1);
 
-		IFile file2= createTestFile("Test2.txt");
+		IFile file2= createTestFile("Test2");
 		IEditorPart editor2= EditorUtility.openInEditor(file2);
 		assertEquals(editor2.getClass(), TextEditor.class);
 		assertInstanceCount(TextEditor.class, 2);
@@ -116,7 +116,7 @@ public class JavaLeakTest extends LeakTestCase {
 
 	@Test
 	public void testTextEditorCloseAll() throws Exception {
-		IFile file= createTestFile("Test.txt");
+		IFile file= createTestFile("Test");
 		internalTestEditorClose(file, TextEditor.class, true);
 	}
 


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.ui/pull/2881, .txt files are opened by default with more advanced "generic code editor" so changed the file names to make sure they are not known by content types catalog and so still opened with "old default" plain text editor.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2129
