### PR TITLE
Fixed too strict test assumptions in SearchLeakTest

### DIFF
--- a/org.eclipse.jdt.ui.tests/leaks/org/eclipse/jdt/ui/leaktest/LeakTestCase.java
+++ b/org.eclipse.jdt.ui.tests/leaks/org/eclipse/jdt/ui/leaktest/LeakTestCase.java
@@ -53,7 +53,11 @@ public class LeakTestCase {
 	}
 
 	private InstancesOfTypeCollector collect(String requestedTypeName) {
-		InstancesOfTypeCollector requestor= new InstancesOfTypeCollector(requestedTypeName, false);
+		return collect(requestedTypeName, false);
+	}
+
+	private InstancesOfTypeCollector collect(String requestedTypeName, boolean includeSubtypes) {
+		InstancesOfTypeCollector requestor= new InstancesOfTypeCollector(requestedTypeName, includeSubtypes);
 		calmDown();
 		new ReferenceTracker(requestor).start(getClass().getClassLoader());
 		return requestor;
@@ -129,6 +133,26 @@ public class LeakTestCase {
 			assertNotEquals("Expected instance count: " + expected + ", actual: " + actual + "\n" + requestor.getResultString(), 0, numTries);
   		}
 	}
+
+  	/**
+  	 * Asserts that the instance count of the given class is as expected.
+  	 *
+  	 * @param clazz the class of the instances to count
+  	 * @param includeSubtypes true to include subtypes
+  	 * @param expected the expected instance count
+  	 */
+  	public void assertInstanceCount(final Class<?> clazz, boolean includeSubtypes, final int expected) {
+  		int numTries= 2;
+  		while (true) {
+  			InstancesOfTypeCollector requestor= collect(clazz.getName(), includeSubtypes);
+  			int actual= requestor.getNumberOfResults();
+  			if (expected == actual) {
+  				return;
+  			}
+  			numTries--;
+  			assertNotEquals("Expected instance count: " + expected + ", actual: " + actual + "\n" + requestor.getResultString(), 0, numTries);
+  		}
+  	}
 
 
   	/**

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/search/SearchLeakTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/search/SearchLeakTest.java
@@ -70,7 +70,7 @@ public class SearchLeakTest extends LeakTestCase {
 
 	@Test
 	public void testSearchResultEditorClose() throws Exception {
-		assertInstanceCount(TextEditor.class, 0);
+		assertInstanceCount(TextEditor.class, true, 0);
 
 		FileTextSearchScope scope= FileTextSearchScope.newWorkspaceScope(null, false);
 		FileSearchQuery query= new FileSearchQuery("projectDescription", false, false, scope);
@@ -81,11 +81,11 @@ public class SearchLeakTest extends LeakTestCase {
 		DisplayHelper.sleep(Display.getDefault(), 2000);
 		page.gotoNextMatch();
 
-		assertInstanceCount(TextEditor.class, 1);
+		assertInstanceCount(TextEditor.class, true, 1);
 
 		assertTrue(JavaPlugin.getActivePage().closeAllEditors(false));
 
-		assertInstanceCount(TextEditor.class, 0);
+		assertInstanceCount(TextEditor.class, true, 0);
 
 		NewSearchUI.removeQuery(query);
 	}


### PR DESCRIPTION
The SearchLeakTest starts search, opens an editor and expects it is **exactly** `TextEditor.class`.

Now after changes in
https://github.com/eclipse-platform/eclipse.platform.ui/pull/2881 it finds `ExtensionBasedTextEditor` class, which is a subclass of `TextEditor`, but test logic doesn't like that.

Fixed test expectation and allow opened editor be a subclass of `TextEditor`.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2132
