### PR TITLE
Touch org.eclipse.jdt.ui to reflect compiler changes

### DIFF
--- a/org.eclipse.jdt.ui/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.ui/forceQualifierUpdate.txt
@@ -23,3 +23,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/19
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 Pick up changes from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2972


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2972