### PR TITLE
more Junit 4 to Junit 5 migrations

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractSemanticHighlightingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AbstractSemanticHighlightingTest.java
@@ -13,11 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.text.tests.performance.EditorTestHelper;
@@ -49,7 +51,7 @@ import org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightings;
 
 public class AbstractSemanticHighlightingTest {
 
-	protected static class SemanticHighlightingTestSetup extends ExternalResource {
+	protected static class SemanticHighlightingTestSetup implements BeforeEachCallback, AfterEachCallback {
 
 		private IJavaProject fJavaProject;
 		private final String fTestFilename;
@@ -59,7 +61,7 @@ public class AbstractSemanticHighlightingTest {
 		}
 
 		@Override
-		public void before() throws Exception {
+		public void beforeEach(ExtensionContext context) throws Exception {
 			fJavaProject= EditorTestHelper.createJavaProject(PROJECT, LINKED_FOLDER);
 
 			disableAllSemanticHighlightings();
@@ -82,7 +84,7 @@ public class AbstractSemanticHighlightingTest {
 		}
 
 		@Override
-		public void after() {
+		public void afterEach(ExtensionContext context) {
 			EditorTestHelper.closeEditor(fEditor);
 			fEditor= null;
 			fSourceViewer= null;
@@ -113,7 +115,7 @@ public class AbstractSemanticHighlightingTest {
 
 	private static SourceViewer fSourceViewer;
 
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		disableAllSemanticHighlightings();
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AutoboxingSemanticHighlightingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/AutoboxingSemanticHighlightingTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.jface.text.Position;
 
@@ -22,7 +22,7 @@ import org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightings;
 
 public class AutoboxingSemanticHighlightingTest extends AbstractSemanticHighlightingTest {
 
-	@Rule
+	@RegisterExtension
 	public SemanticHighlightingTestSetup shts=new SemanticHighlightingTestSetup("/SHTest/src/Autoboxing.java");
 
 	@Test

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/BracketInserterTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/BracketInserterTest.java
@@ -13,18 +13,17 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.text.tests.performance.DisplayHelper;
@@ -73,8 +72,12 @@ import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
  * @since 3.1
  */
 public class BracketInserterTest {
-	@Rule
-	public TestName tn= new TestName();
+	private String testName;
+
+	@BeforeEach
+	void init(TestInfo testInfo) {
+		this.testName= testInfo.getDisplayName();
+	}
 
 	private static final String SRC= "src";
 	private static final String SEP= "/";
@@ -115,7 +118,7 @@ public class BracketInserterTest {
 	private Accessor fAccessor;
 	private IJavaProject fProject;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
 		store.setValue(PreferenceConstants.EDITOR_CLOSE_BRACKETS, true);
@@ -124,15 +127,15 @@ public class BracketInserterTest {
 	}
 
 	private void setUpProject(String sourceLevel) throws CoreException, JavaModelException {
-		fProject= JavaProjectHelper.createJavaProject(tn.getMethodName(), "bin");
+		fProject= JavaProjectHelper.createJavaProject(testName, "bin");
 		fProject.setOption(JavaCore.COMPILER_SOURCE, sourceLevel);
 		JavaProjectHelper.addSourceContainer(fProject, SRC);
-		IPackageFragment fragment= fProject.findPackageFragment(new Path(SEP + tn.getMethodName() + SEP + SRC));
+		IPackageFragment fragment= fProject.findPackageFragment(new Path(SEP + testName + SEP + SRC));
 		fragment.createCompilationUnit(CU_NAME, CU_CONTENTS, true, new NullProgressMonitor());
 	}
 
 	private void setUpEditor() {
-		fEditor= openJavaEditor(new Path(SEP + tn.getMethodName() + SEP + SRC + SEP + CU_NAME));
+		fEditor= openJavaEditor(new Path(SEP + testName + SEP + SRC + SEP + CU_NAME));
 		assertNotNull(fEditor);
 		fTextWidget= fEditor.getViewer().getTextWidget();
 		assertNotNull(fTextWidget);
@@ -154,7 +157,7 @@ public class BracketInserterTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		EditorTestHelper.closeEditor(fEditor);
 		fEditor= null;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/BreakIteratorTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/BreakIteratorTest.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.BreakIterator;
 

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/CompilationUnitDocumentProviderTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/CompilationUnitDocumentProviderTest.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
@@ -73,7 +73,7 @@ public class CompilationUnitDocumentProviderTest {
 	 *
 	 * @throws CoreException if deletion fails
 	 */
-	@After
+	@AfterEach
 	public void tearDown() throws CoreException {
 		if (fJavaProject != null)
 			JavaProjectHelper.delete(fJavaProject);

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JUnitProjectTestSetup.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JUnitProjectTestSetup.java
@@ -13,9 +13,11 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
@@ -34,7 +36,7 @@ import org.eclipse.jdt.core.IJavaProject;
  *
  * @since 3.1
  */
-public class JUnitProjectTestSetup extends ExternalResource {
+public class JUnitProjectTestSetup implements BeforeEachCallback, AfterEachCallback {
 
 	private static IJavaProject fgProject;
 
@@ -44,13 +46,13 @@ public class JUnitProjectTestSetup extends ExternalResource {
 	}
 
 	@Override
-	public void before() throws Exception {
+	public void beforeEach(ExtensionContext context) throws Exception {
 		String projectName= "JUnit_" + System.currentTimeMillis();
 		fgProject= JavaProjectHelper.createJavaProjectWithJUnitSource(projectName, "src", "bin");
 	}
 
 	@Override
-	public void after() {
+	public void afterEach(ExtensionContext context) {
 		if (fgProject != null) {
 			try {
 				JavaProjectHelper.delete(fgProject);

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/Java24SemanticHighlightingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/Java24SemanticHighlightingTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.jface.text.Position;
 
@@ -23,10 +23,10 @@ import org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightingsCore;
 
 public class Java24SemanticHighlightingTest extends AbstractSemanticHighlightingTest {
 
-	@Rule
+	@RegisterExtension
 	public SemanticHighlightingTestSetup shts= new SemanticHighlightingTestSetup( "/SHTest/src/Java24.java");
 
-	@Before
+	@BeforeEach
 	public void updateCompliance() {
 		shts.updateCompliance("24", true);
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaAutoIndentStrategyTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaAutoIndentStrategyTest.java
@@ -13,12 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IStatus;
@@ -453,12 +453,12 @@ public class JavaAutoIndentStrategyTest implements ILogListener {
 		assertEquals(str, fDocument.get());
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		JavaPlugin.getDefault().getLog().addLogListener(this);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		JavaPlugin.getDefault().getLog().removeLogListener(this);
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaBreakIteratorTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaBreakIteratorTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jdt.internal.ui.text.JavaBreakIterator;
 
@@ -23,7 +23,7 @@ import org.eclipse.jdt.internal.ui.text.JavaBreakIterator;
  */
 public class JavaBreakIteratorTest extends BreakIteratorTest {
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fBreakIterator= new JavaBreakIterator();
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaColoringTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaColoringTest.java
@@ -13,13 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.custom.StyleRange;
 
@@ -47,7 +47,7 @@ public class JavaColoringTest {
 	protected IDocument fDocument;
 	protected JavaTextTools fTextTools;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		IPreferenceStore store= new PreferenceStore();
 		fTextTools= new JavaTextTools(store);
@@ -69,7 +69,7 @@ public class JavaColoringTest {
 		System.out.print("------ next ---------\n");
 	}
 
-	@After
+	@AfterEach
 	public void tearDown () {
 		fTextTools.dispose();
 		fTextTools= null;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaDoc2HTMLTextReaderTester.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaDoc2HTMLTextReaderTester.java
@@ -15,13 +15,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -37,8 +37,12 @@ import org.eclipse.jdt.internal.corext.javadoc.JavaDocCommentReader;
 import org.eclipse.jdt.internal.ui.text.javadoc.JavaDoc2HTMLTextReader;
 
 public class JavaDoc2HTMLTextReaderTester {
-	@Rule
-	public TestName tn= new TestName();
+	private String testName;
+
+	@BeforeEach
+	void init(TestInfo testInfo) {
+		this.testName= testInfo.getDisplayName();
+	}
 
 	private static final boolean DEBUG= false;
 
@@ -112,7 +116,7 @@ public class JavaDoc2HTMLTextReaderTester {
 	@Test
 	public void test7(){
 		if (DEBUG) {
-			System.out.println(getClass().getName()+"::" + tn.getMethodName() +" disabled(corner case - @see tag inside <a> tag)"); //$NON-NLS-1$ //$NON-NLS-2$
+			System.out.println(getClass().getName()+"::" + testName +" disabled(corner case - @see tag inside <a> tag)"); //$NON-NLS-1$ //$NON-NLS-2$
 			return;
 		}
 		String string= "/**@author Foo Bar<a href=\"mailto:foobar@see.org\">foobar@see.org</a>*/"; //$NON-NLS-1$
@@ -123,7 +127,7 @@ public class JavaDoc2HTMLTextReaderTester {
 	@Test
 	public void test8(){
 		if (DEBUG) {
-			System.out.println(getClass().getName()+"::" + tn.getMethodName() +" disabled(corner case - @see tag inside <a> tag)"); //$NON-NLS-1$ //$NON-NLS-2$
+			System.out.println(getClass().getName()+"::" + testName +" disabled(corner case - @see tag inside <a> tag)"); //$NON-NLS-1$ //$NON-NLS-2$
 			return;
 		}
 		String string= "/**@author Foo Bar<a href=\"mailto:foobar@see.org\">foobar@eclipse.org</a>*/"; //$NON-NLS-1$

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaDoubleClickSelectorTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaDoubleClickSelectorTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaElementPrefixPatternMatcherTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaElementPrefixPatternMatcherTest.java
@@ -16,7 +16,7 @@ package org.eclipse.jdt.text.tests;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jdt.testplugin.StringAsserts;
 

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaHeuristicScannerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaHeuristicScannerTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Hashtable;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -47,7 +47,7 @@ public class JavaHeuristicScannerTest {
 	private JavaIndenter fScanner;
 	private JavaHeuristicScanner fHeuristicScanner;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		if (JavaCore.getPlugin() != null) {
 			Hashtable<String, String> options= JavaCore.getDefaultOptions();
@@ -78,7 +78,7 @@ public class JavaHeuristicScannerTest {
 		fScanner= new JavaIndenter(fDocument, fHeuristicScanner);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		fDocument.setDocumentPartitioner(IJavaPartitions.JAVA_PARTITIONING, null);
 		fPartitioner.disconnect();
@@ -904,7 +904,7 @@ public class JavaHeuristicScannerTest {
 	    	assertFalse(fHeuristicScanner.looksLikeClassInstanceCreationBackward(offset, JavaHeuristicScanner.UNBOUND));
     }
 
-	@Ignore("enable when https://bugs.eclipse.org/bugs/show_bug.cgi?id=65463 is fixed")
+	@Disabled("enable when https://bugs.eclipse.org/bugs/show_bug.cgi?id=65463 is fixed")
 	@Test
 	public void testConditional1() throws Exception {
     	fDocument.set(
@@ -919,7 +919,7 @@ public class JavaHeuristicScannerTest {
     	assertEquals("			                      ", indent);
     }
 
-	@Ignore("enable when https://bugs.eclipse.org/bugs/show_bug.cgi?id=65463 is fixed")
+	@Disabled("enable when https://bugs.eclipse.org/bugs/show_bug.cgi?id=65463 is fixed")
 	@Test
 	public void testConditional2() throws Exception {
     	fDocument.set(

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaModelOpCompundUndoTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaModelOpCompundUndoTest.java
@@ -13,17 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.text.tests.performance.EditorTestHelper;
@@ -65,8 +64,12 @@ import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
  * @since 3.5
  */
 public class JavaModelOpCompundUndoTest {
-	@Rule
-	public TestName tn= new TestName();
+	private String testName;
+
+	@BeforeEach
+	void init(TestInfo testInfo) {
+		this.testName= testInfo.getDisplayName();
+	}
 
 	private static final String SRC= "src";
 	private static final String SEP= "/";
@@ -95,21 +98,21 @@ public class JavaModelOpCompundUndoTest {
 	private IUndoManager fUndoManager;
 
 	private void setUpProject() throws CoreException, JavaModelException {
-		fProject= JavaProjectHelper.createJavaProject(tn.getMethodName(), "bin");
+		fProject= JavaProjectHelper.createJavaProject(testName, "bin");
 		fProject.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
 		JavaProjectHelper.addSourceContainer(fProject, SRC);
-		IPackageFragment fragment= fProject.findPackageFragment(new Path(SEP + tn.getMethodName() + SEP + SRC));
+		IPackageFragment fragment= fProject.findPackageFragment(new Path(SEP + testName + SEP + SRC));
 		fCompilationUnit= fragment.createCompilationUnit(CU_NAME, CU_CONTENTS, true, new NullProgressMonitor());
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		setUpProject();
 		setUpEditor();
 	}
 
 	private void setUpEditor() {
-		fEditor= openJavaEditor(new Path(SEP + tn.getMethodName() + SEP + SRC + SEP + CU_NAME));
+		fEditor= openJavaEditor(new Path(SEP + testName + SEP + SRC + SEP + CU_NAME));
 		assertNotNull(fEditor);
 		fUndoManager= ((ITextViewerExtension6)fEditor.getViewer()).getUndoManager();
 		assertNotNull(fUndoManager);
@@ -130,7 +133,7 @@ public class JavaModelOpCompundUndoTest {
 		}
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		EditorTestHelper.closeEditor(fEditor);
 		fEditor= null;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaParameterListValidatorTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaParameterListValidatorTest.java
@@ -13,17 +13,17 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyleRange;
@@ -42,14 +42,14 @@ public class JavaParameterListValidatorTest {
 	protected IDocument fDocument;
 	protected JavaParameterListValidator fValidator;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		fTextViewer= new TestTextViewer();
 		fDocument= new Document();
 		fValidator= new JavaParameterListValidator();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown () {
 		fTextViewer= null;
 		fDocument= null;
@@ -233,14 +233,14 @@ public class JavaParameterListValidatorTest {
 
 	private static void assertEquals(TextPresentation expected, TextPresentation actual) {
 		// check lengths
-		Assert.assertEquals(expected.getDenumerableRanges(), actual.getDenumerableRanges());
+		Assertions.assertEquals(expected.getDenumerableRanges(), actual.getDenumerableRanges());
 		// check default range
-		Assert.assertEquals(expected.getDefaultStyleRange(), actual.getDefaultStyleRange());
+		Assertions.assertEquals(expected.getDefaultStyleRange(), actual.getDefaultStyleRange());
 		// check rest
 		Iterator<StyleRange> e1= expected.getAllStyleRangeIterator();
 		Iterator<StyleRange> e2= actual.getAllStyleRangeIterator();
 		while (e1.hasNext())
-			Assert.assertEquals(e1.next(), e2.next());
+			Assertions.assertEquals(e1.next(), e2.next());
 	}
 
 	protected String print(TextPresentation presentation) {

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPartitionerExtensionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPartitionerExtensionTest.java
@@ -13,16 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.preference.PreferenceStore;
 
@@ -62,7 +62,7 @@ public class JavaPartitionerExtensionTest {
 	protected boolean fDocumentPartitioningChanged;
 	protected IRegion fChangedDocumentPartitioning;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 
 		fTextTools= new JavaTextTools(new PreferenceStore());
@@ -77,7 +77,7 @@ public class JavaPartitionerExtensionTest {
 		fDocument.addDocumentPartitioningListener(new PartitioningListener());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown () {
 		fTextTools.dispose();
 		fTextTools= null;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPartitionerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaPartitionerTest.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.preference.PreferenceStore;
 
@@ -39,7 +39,7 @@ public class JavaPartitionerTest {
 	private Document fDocument;
 	protected boolean fDocumentPartitioningChanged;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 
 		fTextTools= new JavaTextTools(new PreferenceStore());
@@ -54,7 +54,7 @@ public class JavaPartitionerTest {
 		fDocument.addDocumentPartitioningListener(document -> fDocumentPartitioningChanged= true);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown () {
 		fTextTools.dispose();
 		fTextTools= null;
@@ -70,12 +70,12 @@ public class JavaPartitionerTest {
 
 	protected void checkPartitioning(ITypedRegion[] expectation, ITypedRegion[] result) {
 
-		assertEquals("invalid number of partitions", expectation.length, result.length);
+		assertEquals(expectation.length, result.length, "invalid number of partitions");
 
 		for (int i= 0; i < expectation.length; i++) {
 			ITypedRegion e= expectation[i];
 			ITypedRegion r= result[i];
-			assertEquals(print(r) + " != " + print(e), r, e);
+			assertEquals(r, e, print(r) + " != " + print(e));
 		}
 
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaStringDoubleClickStrategyTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaStringDoubleClickStrategyTest.java
@@ -14,9 +14,9 @@
 
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
@@ -69,7 +69,7 @@ public class JavaStringDoubleClickStrategyTest {
 		IDocument document= new Document(text);
 		TestStrategy strategy= new TestStrategy(partition, delimiterLength);
 		IRegion selection= strategy.findWord(document, offset);
-		assertEquals("Click at " + offset + " in: " + text, expected, selection);
+		assertEquals(expected, selection, "Click at " + offset + " in: " + text);
 	}
 
 	private void assertDoubleClick(String text, int offset, IRegion expected, String version) {
@@ -77,7 +77,7 @@ public class JavaStringDoubleClickStrategyTest {
 		TestStrategy strategy= new TestStrategy(null, 1);
 		strategy.setSourceVersion(version);
 		IRegion selection= strategy.findWord(document, offset);
-		assertEquals("Click at " + offset + " in: " + text, expected, selection);
+		assertEquals(expected, selection, "Click at " + offset + " in: " + text);
 	}
 
 	@Test

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaWordIteratorTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaWordIteratorTest.java
@@ -13,8 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jdt.internal.ui.text.JavaWordIterator;
 
@@ -23,7 +23,7 @@ import org.eclipse.jdt.internal.ui.text.JavaWordIterator;
  */
 public class JavaWordIteratorTest extends BreakIteratorTest {
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fBreakIterator= new JavaWordIterator();
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
@@ -14,17 +14,17 @@
 
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.jdt.text.tests.performance.DisplayHelper;
 import org.eclipse.jdt.text.tests.performance.EditorTestHelper;
@@ -89,10 +89,10 @@ public class MarkOccurrenceTest {
 	private IRegion fMatch;
 	private StyledText fTextWidget;
 
-	@Rule
+	@RegisterExtension
 	public JUnitProjectTestSetup jpts=new JUnitProjectTestSetup();
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		assertNotNull(fgHighlightRGB);
 		JavaPlugin.getDefault().getPreferenceStore().setValue(PreferenceConstants.EDITOR_MARK_OCCURRENCES, true);
@@ -137,7 +137,7 @@ public class MarkOccurrenceTest {
 		SelectionListenerWithASTManager.getDefault().addListener(fEditor, fSelWASTListener);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		SelectionListenerWithASTManager.getDefault().removeListener(fEditor, fSelWASTListener);
 		EditorTestHelper.closeAllEditors();

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/OverrideIndicatorTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/OverrideIndicatorTest.java
@@ -14,18 +14,18 @@
 
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.jdt.text.tests.performance.EditorTestHelper;
 
@@ -53,7 +53,7 @@ import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
  * @since 3.1
  */
 public class OverrideIndicatorTest {
-	@Rule
+	@RegisterExtension
 	public JUnitProjectTestSetup jpts= new JUnitProjectTestSetup();
 
 	private static final String OVERRIDE_INDICATOR_ANNOTATION= "org.eclipse.jdt.ui.overrideIndicator";
@@ -64,7 +64,7 @@ public class OverrideIndicatorTest {
 	private StyledText fTextWidget;
 	private Annotation[] fOverrideAnnotations;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		fEditor= openJavaEditor(new Path("/" + JUnitProjectTestSetup.getProject().getElementName() + "/src/junit/framework/TestCase.java"));
 		assertNotNull(fEditor);
@@ -75,7 +75,7 @@ public class OverrideIndicatorTest {
 		fAnnotationModel= fEditor.getDocumentProvider().getAnnotationModel(fEditor.getEditorInput());
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		EditorTestHelper.closeAllEditors();
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PartitionTokenScannerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PartitionTokenScannerTest.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
@@ -41,7 +41,7 @@ public class PartitionTokenScannerTest {
 	private IPartitionTokenScanner fReference;
 	private IPartitionTokenScanner fTestee;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		fReference= new JavaPartitionScanner();
 		fTestee= new FastJavaPartitionScanner(true);
@@ -182,12 +182,12 @@ public class PartitionTokenScannerTest {
 			final int testeeOffset= fTestee.getTokenOffset();
 			message.append(", offset = " + referenceOffset);
 			message.append(", " + extractString(document, referenceOffset));
-			assertEquals(message.toString(), referenceOffset, testeeOffset);
+			assertEquals(referenceOffset, testeeOffset, message.toString());
 
 			final int referenceLength= fReference.getTokenLength();
 			final int testeeLength= fTestee.getTokenLength();
 			message.append(", length = " + referenceLength);
-			assertEquals(message.toString(), referenceLength, testeeLength);
+			assertEquals(referenceLength, testeeLength, message.toString());
 
 			if (referenceToken.isEOF())
 				break;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
@@ -13,20 +13,21 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.osgi.framework.Bundle;
 
 import org.eclipse.jdt.text.tests.performance.EditorTestHelper;
@@ -183,11 +184,11 @@ public class PluginsNotLoadedTest {
 
 	private JavaEditor fEditor;
 
-	@Rule
+	@RegisterExtension
 	public JUnitProjectTestSetup jpts=new JUnitProjectTestSetup() {
 			@Override
-			public void before() throws Exception {
-				super.before();
+			public void beforeEach(ExtensionContext context) throws Exception {
+				super.beforeEach(context);
 				/* Since https://bugs.eclipse.org/484795 in EGit 4.2, org.eclipse.egit.ui/plugin.xml contributes:
 				 * <extension point="org.eclipse.ui.services">
 				 *   <sourceProvider provider="org.eclipse.egit.ui.internal.selection.RepositorySourceProvider">
@@ -222,7 +223,7 @@ public class PluginsNotLoadedTest {
 		NOT_LOADED_BUNDLES= l;
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		EditorTestHelper.showView(EditorTestHelper.INTRO_VIEW_ID, false);
 		JavaPlugin.getDefault().getPreferenceStore().setValue(PreferenceConstants.EDITOR_MARK_OCCURRENCES, true);
@@ -230,7 +231,7 @@ public class PluginsNotLoadedTest {
 		assertNotNull(fEditor);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		EditorTestHelper.closeAllEditors();
 		fEditor= null;
@@ -247,7 +248,7 @@ public class PluginsNotLoadedTest {
 		}
 	}
 
-	@Ignore("Author: Dani Megert <dmegert> 2007-11-07 16:13:14 - Test more plug-ins.")
+	@Disabled("Author: Dani Megert <dmegert> 2007-11-07 16:13:14 - Test more plug-ins.")
 	@Test
 	public void printNotLoaded() {
 		Bundle bundle= Platform.getBundle("org.eclipse.jdt.text.tests");
@@ -275,6 +276,6 @@ public class PluginsNotLoadedTest {
 				buf.append('\n');
 			}
 		}
-		assertEquals("Wrong bundles loaded:\n" + buf, 0, buf.length());
+		assertEquals(0, buf.length(), "Wrong bundles loaded:\n" + buf);
 	}
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PropertiesFilePartitionerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PropertiesFilePartitionerTest.java
@@ -13,14 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.preference.PreferenceStore;
 
@@ -42,7 +42,7 @@ public class PropertiesFilePartitionerTest {
 	private Document fDocument;
 	protected boolean fDocumentPartitioningChanged;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 
 		fTextTools= new JavaTextTools(new PreferenceStore());
@@ -56,7 +56,7 @@ public class PropertiesFilePartitionerTest {
 		fDocument.addDocumentPartitioningListener(document -> fDocumentPartitioningChanged= true);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown () {
 		fTextTools.dispose();
 		fTextTools= null;
@@ -72,12 +72,12 @@ public class PropertiesFilePartitionerTest {
 
 	protected void checkPartitioning(ITypedRegion[] expectation, ITypedRegion[] result) {
 
-		assertEquals("invalid number of partitions:", expectation.length, result.length);
+		assertEquals(expectation.length, result.length, "invalid number of partitions:");
 
 		for (int i= 0; i < expectation.length; i++) {
 			ITypedRegion e= expectation[i];
 			ITypedRegion r= result[i];
-			assertEquals("was: "+ print(r) + ", expected: " + print(e), r, e);
+			assertEquals(r, e, "was: " + print(r) + ", expected: " + print(e));
 		}
 
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/SemanticHighlightingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/SemanticHighlightingTest.java
@@ -15,15 +15,15 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.jface.text.Position;
 
 import org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightings;
 
 public class SemanticHighlightingTest extends AbstractSemanticHighlightingTest {
-	@Rule
+	@RegisterExtension
 	public SemanticHighlightingTestSetup shts= new SemanticHighlightingTestSetup( "/SHTest/src/SHTest.java");
 
 	@Test

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/SmartSemicolonAutoEditStrategyTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/SmartSemicolonAutoEditStrategyTest.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
@@ -96,7 +96,7 @@ public class SmartSemicolonAutoEditStrategyTest {
 		verifySemicolonPosition(5, 20);
 	}
 
-	@Ignore("testGoToExisting disabled - unwanted functionality")
+	@Disabled("testGoToExisting disabled - unwanted functionality")
 	@Test
 	public void testGoToExisting() throws BadLocationException {
 		fDocument.set("public void; foobar()");
@@ -121,7 +121,7 @@ public class SmartSemicolonAutoEditStrategyTest {
 		verifySemicolonPosition(12, 21);
 	}
 
-	@Ignore("testWithExistingAtInsertPosition disabled - existing characters handled by framework")
+	@Disabled("testWithExistingAtInsertPosition disabled - existing characters handled by framework")
 	@Test
 	public void testWithExistingAtInsertPosition() throws BadLocationException {
 		fDocument.set("public void foobar(); // comment\r\n");

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/CodeMiningTriggerTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/CodeMiningTriggerTest.java
@@ -10,7 +10,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests.codemining;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -20,9 +20,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.text.tests.performance.DisplayHelper;
@@ -109,7 +109,7 @@ public class CodeMiningTriggerTest {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void setUp() throws CoreException {
 		fPreferenceStore= JavaPlugin.getDefault().getPreferenceStore();
 		this.wasCodeMiningEnabled = fPreferenceStore.getBoolean(PreferenceConstants.EDITOR_CODEMINING_ENABLED);
@@ -122,7 +122,7 @@ public class CodeMiningTriggerTest {
 		TestCodeMiningProvider.isOn = true;
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		TestCodeMiningProvider.isOn = false;
 		this.fPreferenceStore.setValue(PreferenceConstants.EDITOR_CODEMINING_ENABLED, wasCodeMiningEnabled);
@@ -158,36 +158,34 @@ public class CodeMiningTriggerTest {
 	}
 
 	private void assertCodeMiningAnnotation(ISourceViewer viewer, String message, int timeout) throws Exception {
-		assertTrue("Cannot find CodeMining header line annotation with text `" + message + "`",
-			new DisplayHelper() {
-				@SuppressWarnings("restriction")
-				@Override
-				protected boolean condition() {
-					for (Iterator<Annotation> itr = viewer.getAnnotationModel().getAnnotationIterator(); itr.hasNext();) {
-						Annotation a = itr.next();
-						if (a instanceof org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation) {
-							Field f;
-							try {
-								f= org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation.class.getDeclaredField("fMinings");
-								f.setAccessible(true);
-								List<ICodeMining> minings = (List<ICodeMining>)f.get(a);
-								for (ICodeMining m : minings) {
-									if (m instanceof TestCodeMining) {
-										if (message.equals(m.getLabel())) {
-											return true;
-										}
+		assertTrue(new DisplayHelper() {
+			@SuppressWarnings("restriction")
+			@Override
+			protected boolean condition() {
+				for (Iterator<Annotation> itr= viewer.getAnnotationModel().getAnnotationIterator(); itr.hasNext();) {
+					Annotation a= itr.next();
+					if (a instanceof org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation) {
+						Field f;
+						try {
+							f= org.eclipse.jface.internal.text.codemining.CodeMiningLineHeaderAnnotation.class.getDeclaredField("fMinings");
+							f.setAccessible(true);
+							List<ICodeMining> minings= (List<ICodeMining>) f.get(a);
+							for (ICodeMining m : minings) {
+								if (m instanceof TestCodeMining) {
+									if (message.equals(m.getLabel())) {
+										return true;
 									}
 								}
-							} catch (Exception e) {
-								ILog.of(Platform.getBundle("org.eclipse.jdt.text.tests")).log(
-									new Status(IStatus.ERROR, "org.eclipse.jdt.text.tests", e.getMessage(), e)
-								);
-								return false;
 							}
+						} catch (Exception e) {
+							ILog.of(Platform.getBundle("org.eclipse.jdt.text.tests")).log(new Status(IStatus.ERROR, "org.eclipse.jdt.text.tests", e.getMessage(), e));
+							return false;
 						}
 					}
-					return false;
 				}
-		}.waitForCondition(Display.getDefault(), timeout));
+				return false;
+			}
+		}.waitForCondition(Display.getDefault(), timeout),
+			"Cannot find CodeMining header line annotation with text `" + message + "`");
 	}
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -13,9 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests.codemining;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -24,9 +24,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
@@ -74,7 +74,7 @@ public class ParameterNamesCodeMiningTest {
 	private JavaMethodParameterCodeMiningProvider fParameterNameCodeMiningProvider;
 	private boolean wasCodeMiningEnabled;
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		if(!welcomeClosed) {
 			closeIntro(PlatformUI.getWorkbench());
@@ -93,7 +93,7 @@ public class ParameterNamesCodeMiningTest {
 		PreferenceConstants.getPreferenceStore().setValue(PreferenceConstants.EDITOR_CODEMINING_ENABLED, true);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() throws Exception {
 		PreferenceConstants.getPreferenceStore().setValue(PreferenceConstants.EDITOR_CODEMINING_ENABLED, wasCodeMiningEnabled);
 		IWorkbenchPage workbenchPage= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
@@ -103,12 +103,12 @@ public class ParameterNamesCodeMiningTest {
 	}
 
 	private void waitReconciled(JavaSourceViewer viewer) {
-		assertTrue("Editor not reconciled", new DisplayHelper() {
+		assertTrue(new DisplayHelper() {
 			@Override
 			protected boolean condition() {
 				return JavaCodeMiningReconciler.isReconciled(viewer);
 			}
-		}.waitForCondition(viewer.getTextWidget().getDisplay(), 2000));
+		}.waitForCondition(viewer.getTextWidget().getDisplay(), 2000), "Editor not reconciled");
 	}
 
 	@Test
@@ -258,29 +258,27 @@ public class ParameterNamesCodeMiningTest {
 		//
 		StyledText widget= viewer.getTextWidget();
 		int charWidth= widget.getTextBounds(0, 1).width;
-		assertTrue("Code mining not available on expected chars", new DisplayHelper() {
+		assertTrue(new DisplayHelper() {
 			@Override
 			protected boolean condition() {
-				return Arrays.stream(widget.getStyleRanges(widget.getText().indexOf(", 2"), 3)).anyMatch(style ->
-						style.metrics != null && style.metrics.width > charWidth);
+				return Arrays.stream(widget.getStyleRanges(widget.getText().indexOf(", 2"), 3)).anyMatch(style -> style.metrics != null && style.metrics.width > charWidth);
 			}
-		}.waitForCondition(widget.getDisplay(), 2000));
+		}.waitForCondition(widget.getDisplay(), 2000), "Code mining not available on expected chars");
 		//
 		viewer.doOperation(ProjectionViewer.COLLAPSE_ALL);
-		assertTrue("Code mining not available on expected chars after collapsing", new DisplayHelper() {
+		assertTrue(new DisplayHelper() {
 			@Override
 			protected boolean condition() {
-				return Arrays.stream(widget.getStyleRanges(widget.getText().indexOf(", 2"), 3)).anyMatch(style ->
-						style.metrics != null && style.metrics.width > charWidth);
+				return Arrays.stream(widget.getStyleRanges(widget.getText().indexOf(", 2"), 3)).anyMatch(style -> style.metrics != null && style.metrics.width > charWidth);
 			}
-		}.waitForCondition(widget.getDisplay(), 2000));
+		}.waitForCondition(widget.getDisplay(), 2000), "Code mining not available on expected chars after collapsing");
 		//
 		viewer.setSelectedRange(viewer.getDocument().get().indexOf("divideUnsigned") + 1, 0);
 		IPreferenceStore preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
 		boolean initial= preferenceStore.getBoolean(PreferenceConstants.EDITOR_MARK_OCCURRENCES);
 		try {
 			preferenceStore.setValue(PreferenceConstants.EDITOR_MARK_OCCURRENCES, true);
-			assertTrue("Occurence annotation not added", new org.eclipse.jdt.text.tests.performance.DisplayHelper() {
+			assertTrue(new org.eclipse.jdt.text.tests.performance.DisplayHelper() {
 				@Override
 				protected boolean condition() {
 					AtomicInteger annotationCount= new AtomicInteger();
@@ -291,18 +289,16 @@ public class ParameterNamesCodeMiningTest {
 					});
 					return annotationCount.get() != 0;
 				}
-			}.waitForCondition(widget.getDisplay(), 2000));
-			assertTrue("Code mining space at undesired offset after collapsing", new DisplayHelper() {
+			}.waitForCondition(widget.getDisplay(), 2000), "Occurence annotation not added");
+			assertTrue(new DisplayHelper() {
 				@Override
 				protected boolean condition() {
-					return Arrays.stream(widget.getStyleRanges())
-							.filter(range -> range.metrics != null && range.metrics.width > charWidth)
-							.allMatch(style -> {
-								char c= widget.getText().charAt(style.start + 1);
-								return c == '1' || c == '2';
-							});
+					return Arrays.stream(widget.getStyleRanges()).filter(range -> range.metrics != null && range.metrics.width > charWidth).allMatch(style -> {
+						char c= widget.getText().charAt(style.start + 1);
+						return c == '1' || c == '2';
+					});
 				}
-			}.waitForCondition(widget.getDisplay(), 2000));
+			}.waitForCondition(widget.getDisplay(), 2000), "Code mining space at undesired offset after collapsing");
 		} finally {
 			preferenceStore.setValue(PreferenceConstants.EDITOR_MARK_OCCURRENCES, initial);
 		}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/semantictokens/SemanticTokensProviderTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/semantictokens/SemanticTokensProviderTest.java
@@ -11,8 +11,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.text.tests.semantictokens;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import org.eclipse.jdt.text.tests.AbstractSemanticHighlightingTest;
 
@@ -22,7 +22,7 @@ import org.eclipse.jdt.internal.ui.javaeditor.SemanticHighlightings;
 
 public class SemanticTokensProviderTest extends AbstractSemanticHighlightingTest {
 
-	@Rule
+	@RegisterExtension
 	public SemanticHighlightingTestSetup shts= new SemanticHighlightingTestSetup( "/SHTest/src/STTest.java");
 
 	@Test


### PR DESCRIPTION

some classes are not part of any suite and contain failing tests even before migrating

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Make use of Junit 5 instead of Junit 4.
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
Run Tests through. There should be no difference.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
