### PR TITLE
Fix ClassCastException when switching tabs

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/BuildPathBasePage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/buildpaths/BuildPathBasePage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -405,11 +407,20 @@ public abstract class BuildPathBasePage {
 			JavaPlugin.logErrorMessage("Page does not support tab switching: "+this.getClass()); //$NON-NLS-1$
 			return null;
 		}
-		TabFolder tabFolder= (TabFolder) fSWTControl.getParent();
-		for (TabItem tabItem : tabFolder.getItems()) {
-			if (tabClass.isInstance(tabItem.getData())) {
-				tabFolder.setSelection(tabItem);
-				return (BuildPathBasePage) tabItem.getData();
+		if(fSWTControl.getParent() instanceof TabFolder tabFolder) {
+			for (TabItem tabItem : tabFolder.getItems()) {
+				if (tabClass.isInstance(tabItem.getData())) {
+					tabFolder.setSelection(tabItem);
+					return (BuildPathBasePage) tabItem.getData();
+				}
+			}
+		}
+		if(fSWTControl.getParent() instanceof CTabFolder cTabFolder) {
+			for (CTabItem ctabItem : cTabFolder.getItems()) {
+				if (tabClass.isInstance(ctabItem.getData())) {
+					cTabFolder.setSelection(ctabItem);
+					return (BuildPathBasePage) ctabItem.getData();
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
This PR resolves the exception that occurs when Control.getParent() returns a CTabFolder instead of a TabItem. This fix ensures that the Module Dependencies Tab view is displayed correctly.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2146

After fix 
On pressing `Switch to tab`
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/8f82df0b-d49d-4417-81a9-3383de9552fb" />


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
