### PR TITLE
Add support for trailing return or throws for pattern instanceof cleanup

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest21.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest21.java
@@ -695,6 +695,70 @@ public class CleanUpTest21 extends CleanUpTestCase {
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}
 
+	@Test
+	public void testPatternInstanceofToSwitchExpression5() throws Exception {
+		Hashtable<String, String> options= JavaCore.getOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);
+		JavaCore.setOptions(options);
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class E {
+				int i;
+				double d;
+				boolean b;
+
+				public int square(int x) {
+					return x*x;
+				}
+				public int foo(Object y) {
+					if (y instanceof final Integer xint) {
+						return xint;
+					}
+					if (y instanceof final Double xdouble) {
+						return square(8); // square
+					} else if (y instanceof final Boolean xboolean) {
+						throw new NullPointerException();
+					} else if (y == null) {
+						return 7;
+					}
+					return 11;
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.USE_SWITCH_FOR_INSTANCEOF_PATTERN);
+
+		sample= """
+			package test1;
+
+			public class E {
+				int i;
+				double d;
+				boolean b;
+
+				public int square(int x) {
+					return x*x;
+				}
+				public int foo(Object y) {
+					return switch (y) {
+						case Integer xint -> xint;
+						case Double xdouble -> square(8); // square
+						case Boolean xboolean -> throw new NullPointerException();
+						case null -> 7;
+						default -> 11;
+					};
+				}
+			}
+			""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
 	public void testNoPatternInstanceofToSwitch1() throws Exception {
 		Hashtable<String, String> options= JavaCore.getOptions();
 		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.TAB);


### PR DESCRIPTION
- modify PatternInstanceofToSwitchFixCore to recgonize the absence of an else for the last if statement and if the following statement is a return or throws statement, treat it as if it were in an else
- add tests to CleanUpTest21 and CleanUpTest22
- fixes #2143

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
