### PR TITLE
Make the new folding default

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/FoldingMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/folding/FoldingMessages.properties
@@ -27,8 +27,8 @@ DefaultJavaFoldingPreferenceBlock_customRegionStart=Region start comment text
 defaultJavaFoldingPreferenceBlock_customRegionEnd=Region end comment text
 
 DefaultJavaFoldingPreferenceBlock_New = &Activate feature
-DefaultJavaFoldingPreferenceBlock_New_Setting_Title = &Extended folding (Experimental)
+DefaultJavaFoldingPreferenceBlock_New_Setting_Title = &Extended folding
 JavaFoldingStructureProviderRegistry_warning_providerNotFound_resetToDefault= The ''{0}'' folding provider could not be found. Resetting to the default folding provider.
-DefaultJavaFoldingPreferenceBlock_Warning_New_Feature= &Enable folding for other code blocks. Activating this feature may cause a significant performance degradation.
+DefaultJavaFoldingPreferenceBlock_Warning_New_Feature= &Enable folding for other code blocks.
 
 EmptyJavaFoldingPreferenceBlock_emptyCaption=

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -4453,7 +4453,7 @@ public class PreferenceConstants {
 		store.setDefault(EDITOR_JAVA_CODEMINING_DEFAULT_FILTER_FOR_PARAMETER_NAMES, true);
 		store.setDefault(EDITOR_JAVA_CODEMINING_SHOW_PARAMETER_NAME_SINGLE_ARG, true);
 
-		store.setDefault(EDITOR_NEW_FOLDING_ENABLED, false);
+		store.setDefault(EDITOR_NEW_FOLDING_ENABLED, true);
 
 		// Javadoc hover & view
 		JavaElementLinks.initDefaultPreferences(store);


### PR DESCRIPTION
This PR makes the new folding the default and removes the references to its experimental status, as mentioned in #2084.

What I changed:
![image](https://github.com/user-attachments/assets/1dde2990-ad42-416e-a70c-59f24455ac7f)


Before:
![image](https://github.com/user-attachments/assets/f2fd5bd2-3f40-443b-8955-c6d6dedb15bc)

After:
![image](https://github.com/user-attachments/assets/428d720e-60ef-4090-af1f-f6c9aeef8588)

How to test:
1. Start a clear workspace
2. Go to the settings and check if the extended folding is activated