### PR TITLE
Reset source to result group source when using search in push down

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PushDownRefactoringProcessor.java
@@ -393,6 +393,7 @@ public final class PushDownRefactoringProcessor extends HierarchyProcessor {
 		String source= cu.getSource();
 		CompilationUnit cuRoot= null;
 		for (SearchResultGroup group : (SearchResultGroup[]) engine.getResults()) {
+			source= group.getCompilationUnit().getSource();
 			for (SearchMatch searchResult : group.getSearchResults()) {
 				if (source.charAt(searchResult.getOffset() - 1) == '.') {
 					if (cuRoot == null) {


### PR DESCRIPTION
- fix PushDownRefactoringProcessor.getReferencingElementsFromProject() method to reset the source string each time we look at a SearchResultGroup as the source may change from group to group and is not guaranteed to be the original compilation unit

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes push down to properly look at the right source when searching for references.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
