### PR TITLE
Fix convert to lambda method reference to recognize a lambda parm

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2024 IBM Corporation and others.
+ * Copyright (c) 2013, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -5036,6 +5036,35 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 			}
 			""";
 		assertExpectedExistInProposals(proposals, new String[] { expected1 });
+	}
+
+	@Test
+	public void testConvertLambdaToMethodReference7() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str= """
+			package test1;
+			import java.util.function.Function;
+
+			public class E7 {
+				 public static void main(String[] args) {
+				     f(s -> s.m(s));
+				 }
+
+				 static void f(Function<X, X> f) {}
+
+				 interface X {
+				     X m(X x);
+				 }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E7.java", str, false, null);
+
+		int offset= str.indexOf("s ->");
+		AssistContext context= getCorrectionContext(cu, offset, 4);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		assertProposalDoesNotExist(proposals, CorrectionMessages.QuickAssistProcessor_convert_to_method_reference);
 	}
 
 	@Test


### PR DESCRIPTION
- modify ConvertLambdaToMethodReferenceFixCore to recognize when a method invocation in the lambda body has an expression that is a lambda parameter so is not a true variable to base a method reference off of
- add new test to AssistQuickFixTest1d8
- fixes #2152

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
