### PR TITLE
Add check for release less than JRE in JavaSearchPage

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -154,6 +154,7 @@ public final class SearchMessages extends NLS {
 	public static String JavaSearchPage_match_location_link_label;
 	public static String JavaSearchPage_match_location_link_label_tooltip;
 	public static String JavaSearchPage_match_locations_label;
+	public static String JavaSearchPage_release_warning_message;
 	public static String JavaElementAction_typeSelectionDialog_title;
 	public static String JavaElementAction_typeSelectionDialog_message;
 	public static String JavaElementAction_error_open_message;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/search/SearchMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2022 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -157,6 +157,7 @@ JavaSearchOperation_pluralOccurrencesPostfix=''{0}'' - {1} occurrences in {2}
 JavaSearchPage_match_location_link_label=(<a>{0} of {1} selected</a>)
 JavaSearchPage_match_location_link_label_tooltip=Configure the selected match locations
 JavaSearchPage_match_locations_label=M&atch locations
+JavaSearchPage_release_warning_message=Warning: cannot reliably get source code for release {0} from JRE {1}
 JavaElementAction_typeSelectionDialog_title=Search
 JavaElementAction_typeSelectionDialog_message=&Select the type to search:
 JavaElementAction_error_open_message=An exception occurred while opening the type.


### PR DESCRIPTION
- modify JavaSearchPage.updateOKStatus() to check if release set is less than the default JRE in which case, issue a warning message on the page
- fixes #2017

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds warning if searching in JRE libraries when the release is set lower than JRE version.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
