### PR TITLE
Do not add always add final field qualifier when compilation unit has errors

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,7 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.text.edits.TextEditGroup;
 
+import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
@@ -524,6 +525,12 @@ public class VariableDeclarationFixCore extends CompilationUnitRewriteOperations
 
 	public static VariableDeclarationFixCore createChangeModifierToFinalFix(final CompilationUnit compilationUnit, ASTNode[] selectedNodes) {
 		HashMap<IBinding, List<SimpleName>> writtenNames= new HashMap<>();
+		IProblem[] problems= compilationUnit.getProblems();
+		for (IProblem problem : problems) {
+			if (problem.isError()) {
+				return null;
+			}
+		}
 		WrittenNamesFinder finder= new WrittenNamesFinder(writtenNames);
 		compilationUnit.accept(finder);
 		List<ModifierChangeOperation> ops= new ArrayList<>();
@@ -554,6 +561,12 @@ public class VariableDeclarationFixCore extends CompilationUnitRewriteOperations
 		if (!addFinalFields && !addFinalParameters && !addFinalLocals)
 			return null;
 
+		IProblem[] problems= compilationUnit.getProblems();
+		for (IProblem problem : problems) {
+			if (problem.isError()) {
+				return null;
+			}
+		}
 		HashMap<IBinding, List<SimpleName>> writtenNames= new HashMap<>();
 		WrittenNamesFinder finder= new WrittenNamesFinder(writtenNames);
 		compilationUnit.accept(finder);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
@@ -6723,7 +6723,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal02() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private final int i= 0;
 			    private void foo() {
@@ -6749,7 +6749,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal03() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public int i= 0;
 			    private void foo() {
@@ -6767,7 +6767,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertProposalDoesNotExist(proposals, CHANGE_MODIFIER_TO_FINAL);
 
 		String expected1= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    private void foo() {
@@ -6788,7 +6788,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal04() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private void foo() {
 			        int i= 0, j= 0;
@@ -6808,7 +6808,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertCorrectLabels(proposals);
 
 		String str1= """
-			package test;
+			package test1;
 			public class E {
 			    private void foo() {
 			        final int i= 0;
@@ -6825,7 +6825,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal05() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private void foo(int i, int j) {
 			        System.out.println(i);
@@ -6844,7 +6844,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertCorrectLabels(proposals);
 
 		String str1= """
-			package test;
+			package test1;
 			public class E {
 			    private void foo(final int i, int j) {
 			        System.out.println(i);
@@ -6859,7 +6859,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal06() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 0;
@@ -6885,7 +6885,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal07() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    public void foo() {
@@ -6911,7 +6911,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal08() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    public void foo() {
@@ -6939,7 +6939,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal09() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    public void foo() {
@@ -6967,7 +6967,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal10() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    public void foo() {
@@ -6995,7 +6995,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal11() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        for (int j= 0, i= 0; j < (new int[0]).length; j++) {
@@ -7021,7 +7021,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal12() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 1, j= i + 1, h= j + 1;
@@ -7042,7 +7042,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertCorrectLabels(proposals);
 
 		String str1= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        final int i= 1;
@@ -7060,7 +7060,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal13() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 1, j= i + 1, h= j + 1;
@@ -7081,7 +7081,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertCorrectLabels(proposals);
 
 		String ex1= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 1;
@@ -7095,7 +7095,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 			""";
 
 		String ex2= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 1, j, h= j + 1;
@@ -7114,7 +7114,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal14() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 1, j= i + 1, h= j + 1;
@@ -7135,7 +7135,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertCorrectLabels(proposals);
 
 		String ex1= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 1, j= i + 1;
@@ -7148,7 +7148,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 			""";
 
 		String ex2= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 1, j= i + 1, h;
@@ -7167,7 +7167,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal15() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			import java.io.Serializable;
 			public class E {
 			    public void foo() {
@@ -7193,7 +7193,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertCorrectLabels(proposals);
 
 		String expected1= """
-			package test;
+			package test1;
 			import java.io.Serializable;
 			public class E {
 			    public void foo() {
@@ -7218,7 +7218,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal16() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo() {
 			        int i= 0;
@@ -7241,7 +7241,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal17() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    private void foo() {
@@ -7259,7 +7259,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertProposalDoesNotExist(proposals, CHANGE_MODIFIER_TO_FINAL);
 
 		String str1= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    private void foo() {
@@ -7280,7 +7280,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal18() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private int i= 0;
 			    private void foo() {
@@ -7305,7 +7305,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinal19() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    private void foo() {
 			        int i= 0;
@@ -7328,7 +7328,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 	public void testMakeFinalBug148373() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String str= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo(Integer i) {
 			    }
@@ -7345,7 +7345,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		assertCorrectLabels(proposals);
 
 		String str1= """
-			package test;
+			package test1;
 			public class E {
 			    public void foo(final Integer i) {
 			    }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -27972,6 +27972,28 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testAddFinalIssue2164() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= """
+			package test;
+			public class E {
+				private int x = 1;
+
+				public void foo() {
+				    if (true) {
+				       x = 4;
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL);
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_PRIVATE_FIELDS);
+
+		assertRefactoringHasNoChangeEventWithError(new ICompilationUnit[] {cu1});
+	}
+
+	@Test
 	public void testAddFinalBug129807() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """


### PR DESCRIPTION
- modify VariableDeclarationFixCore to not add final qualifier when there are errors in the file and we are not able to determine if a variable is modified or not
- add new test to CleanUpTest
- fixes #2166

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes add final qualifier cleanup to not perform a change if the compilation unit has errors.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
