### PR TITLE
Bump up JDT UI dependency on JDT core

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -97,7 +97,7 @@ Require-Bundle:
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.core.resources;bundle-version="[3.14.0,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.2.200,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.40.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.42.0,4.0.0)",
  org.eclipse.search;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.debug.ui;bundle-version="[3.11.0,4.0.0)",


### PR DESCRIPTION
Dependency on new API added via https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2155 
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3918
