### PR TITLE
Add SVGs to org.eclipse.jdt.jeview

### DIFF
--- a/org.eclipse.jdt.jeview.feature/feature.xml
+++ b/org.eclipse.jdt.jeview.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.jeview.feature"
       label="Java Element View"
-      version="1.1.600.qualifier"
+      version="1.1.700.qualifier"
       provider-name="Eclipse.org"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.jeview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.jeview/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.jeview
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.jeview; singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.100.qualifier
 Bundle-Activator: org.eclipse.jdt.jeview.JEViewPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.jeview/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.jeview/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.jdt.jeview;x-internal:=true,
  org.eclipse.jdt.jeview.properties;x-internal:=true,
  org.eclipse.jdt.jeview.views;x-internal:=true
+Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/org.eclipse.jdt.jeview/icons/c/children.svg
+++ b/org.eclipse.jdt.jeview/icons/c/children.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="children.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4894-7-7">
+      <stop
+         id="stop4896-4-4"
+         offset="0"
+         style="stop-color:#b4d1e5;stop-opacity:1" />
+      <stop
+         style="stop-color:#5395be;stop-opacity:1"
+         offset="0.5"
+         id="stop4898-0-0" />
+      <stop
+         id="stop4900-9-9"
+         offset="1"
+         style="stop-color:#91bcd7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4894-7-7-8">
+      <stop
+         id="stop4896-4-4-8"
+         offset="0"
+         style="stop-color:#c6c6c6;stop-opacity:1" />
+      <stop
+         style="stop-color:#adadad;stop-opacity:1"
+         offset="0.5"
+         id="stop4898-0-0-2" />
+      <stop
+         id="stop4900-9-9-4"
+         offset="1"
+         style="stop-color:#adadad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4113"
+       xlink:href="#linearGradient4894-7-7-8"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.88889189,0,0,0.88889189,1.4166489,1039.3622)" />
+    <linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4113-0"
+       xlink:href="#linearGradient4894-7-7-8"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.88889189,0,0,0.88889189,-0.58335202,1042.3622)" />
+    <linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4113-1"
+       xlink:href="#linearGradient4894-7-7-8"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.88889189,0,0,0.88889189,3.4166313,1042.3622)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="46.916529"
+     inkscape:cx="10.000009"
+     inkscape:cy="9.7051734"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="14"
+       id="image4187"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAB3RJTUUH2wIRDC8teJG4qgAAAAlw
+SFlzAAAK8AAACvABQqw0mAAAAwBQTFRFe3uEe4SEe4SMhISMjIyUlJSUnJyUnJycpaWlra2tra21
+rbW1tbW1tbW9vb29xsbG////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////smOrswAA
+ABF0Uk5T/////////////////////wAlrZliAAAATUlEQVR42p2PQQrAIAwEY9XqBhP7/9eWVEvE
+o4G5DMxC6NmOzoXkW1chpfcii0hNtSUXFsyIPBgReTCiT4QK1GBMwRdAMP5RjpGNs19erCMOCtFv
+9kIAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="15.999973"
+       width="16" />
+    <circle
+       style="display:inline;fill:url(#linearGradient4113);fill-opacity:1;stroke:#7b8484;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4035-4-5-4-5"
+       cx="9.0000086"
+       cy="1043.3622"
+       r="2.5000088" />
+    <circle
+       style="display:inline;fill:url(#linearGradient4113-1);fill-opacity:1;stroke:#7b8484;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4035-4-5-4-5-1"
+       cx="10.999991"
+       cy="1046.3622"
+       r="2.5000088" />
+    <circle
+       style="display:inline;fill:url(#linearGradient4113-0);fill-opacity:1;stroke:#7b8484;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4035-4-5-4-5-8"
+       cx="7.0000086"
+       cy="1046.3622"
+       r="2.5000088" />
+  </g>
+</svg>

--- a/org.eclipse.jdt.jeview/icons/c/codeSelect.svg
+++ b/org.eclipse.jdt.jeview/icons/c/codeSelect.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="codeSelect.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3829" />
+      <stop
+         id="stop3835"
+         offset="0.60149658"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3831" />
+    </linearGradient>
+    <linearGradient
+       y2="462.11539"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#91c168;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="34.26454"
+     inkscape:cx="14.239044"
+     inkscape:cy="6.8300097"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3950" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="5,3.25"
+       id="guide3797" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="10,4"
+       id="guide3801" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="12.0625,5.3125"
+       id="guide3803" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4221"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAPxJREFU
+OI2lksFtwzAMRb+N7FEt0BVKa4DefXORi0+dIR2iZ1E79B7JHSEZoOndM4i5RIpUqy6MEiBEEuID
+8ckmzAH/sfZnwZ6stO9tcnuysgZo8gn0h5bpewI9UKrF3D27pkoIc0CYA8zRCN4gxCTuy0k0YhIa
+SMzRSPyb+z24NR8c3xuZCkgNsNCgU6rMbbdNRH+5lPmLXwXsYmCeDPaf+xtEpcbOdoAHhmGoAhZb
+gAeQT+0BKAX3yutbSGICsubjOIpzLgm6qwCb6Tz9ejxaa/R9v9QgN3qk6rg18GILm612HNWLA4Ro
+kPwtLvEvZ+ZCTGbeBsghsTnMAVcvXjJEKBmBjwAAAABJRU5ErkJggg==
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <g
+       transform="matrix(-0.66772063,0,0,0.66772063,11.566565,349.54035)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+         id="g6438">
+        <circle
+           r="8.9586821"
+           cy="468.23718"
+           cx="388.125"
+           style="display:inline;fill:url(#linearGradient3929-5);fill-opacity:1;stroke:#14733c;stroke-width:2.23487449;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path10796-2-6-2"
+           transform="matrix(0.66884336,0,0,0.67139756,-267.18268,722.47026)" />
+        <g
+           transform="scale(0.94400511,1.0593163)"
+           style="font-size:15.56941891px;font-family:Sans;fill:#ffffff"
+           id="text3782" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <path
+       d="m 7.547904,1041.2515 c -0.04659,-0.2691 -0.153032,-0.4719 -0.319362,-0.6082 -0.163011,-0.1363 -0.375917,-0.2042 -0.638722,-0.2042 -0.349303,0 -0.628744,0.1181 -0.838323,0.3552 -0.206256,0.2334 -0.309383,0.3859 -0.309382,0.9373 -1e-6,0.6129 0.104787,0.8858 0.314372,1.1389 0.212904,0.253 0.497335,0.3794 0.853294,0.3794 0.26613,0 0.484029,-0.073 0.653691,-0.2189 0.169658,-0.1493 0.289418,-0.4038 0.359283,-0.7639 L 9,1042.2542 c -0.143054,0.6162 -0.417503,1.3215 -0.823354,1.6361 -0.40586,0.3147 -0.94977,0.4719 -1.631735,0.4719 -0.775119,0 -1.393881,-0.2383 -1.856287,-0.7151 C 4.22954,1043.1704 4,1042.6704 4,1041.8271 c 0,-0.853 0.231205,-1.2763 0.693614,-1.7497 0.462406,-0.4769 1.087821,-0.7152 1.876246,-0.7152 0.645373,0 1.156212,0.1381 1.536928,0.4087 0.381103,0.2709 0.699367,0.9009 0.865705,1.4554 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.56941891px;line-height:125%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="path3817"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscscccsscscsscc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 10.943454,1049.8622 3.047152,0 -1.523441,2 z"
+       id="path4271"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3.9999999,1045.8622 8.5000001,0 0,4.5"
+       id="path4269"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/org.eclipse.jdt.jeview/icons/c/info.svg
+++ b/org.eclipse.jdt.jeview/icons/c/info.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="info.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4894-7-7">
+      <stop
+         id="stop4896-4-4"
+         offset="0"
+         style="stop-color:#b4d1e5;stop-opacity:1" />
+      <stop
+         style="stop-color:#5395be;stop-opacity:1"
+         offset="0.5"
+         id="stop4898-0-0" />
+      <stop
+         id="stop4900-9-9"
+         offset="1"
+         style="stop-color:#91bcd7;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4894-7-7-8">
+      <stop
+         id="stop4896-4-4-8"
+         offset="0"
+         style="stop-color:#c6c6c6;stop-opacity:1" />
+      <stop
+         style="stop-color:#adadad;stop-opacity:1"
+         offset="0.5"
+         id="stop4898-0-0-2" />
+      <stop
+         id="stop4900-9-9-4"
+         offset="1"
+         style="stop-color:#adadad;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="6.8716693"
+       x2="8.7378912"
+       y1="2.1550355"
+       x1="8.7378912"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4113"
+       xlink:href="#linearGradient4894-7-7-8"
+       inkscape:collect="always"
+       gradientTransform="matrix(0.88889189,0,0,0.88889189,2.4166487,1040.3622)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="35.812498"
+     inkscape:cx="5.6684102"
+     inkscape:cy="10.502364"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <circle
+       style="display:inline;fill:url(#linearGradient4113);fill-opacity:1;stroke:#7b8484;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4035-4-5-4-5"
+       cx="10.000009"
+       cy="1044.3622"
+       r="2.5000088" />
+  </g>
+</svg>

--- a/org.eclipse.jdt.jeview/icons/c/properties.svg
+++ b/org.eclipse.jdt.jeview/icons/c/properties.svg
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="properties.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient7491">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7493" />
+      <stop
+         style="stop-color:#a0b0cc;stop-opacity:1;"
+         offset="1"
+         id="stop7495" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7254">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7254"
+       id="linearGradient7260"
+       x1="15.000595"
+       y1="2"
+       x2="-8"
+       y2="1.375"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.03125,1035.7997)" />
+    <linearGradient
+       id="linearGradient7254-6">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3976,-3.562483)"
+       y2="2"
+       x2="-3.2642515"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7277"
+       xlink:href="#linearGradient7254-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-62">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-0" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-0" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-16.03125,1037.8622)"
+       y2="2"
+       x2="-17.187742"
+       y1="2"
+       x1="15.000595"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7328"
+       xlink:href="#linearGradient7254-62"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient7254-6-4">
+      <stop
+         style="stop-color:#5b6c89;stop-opacity:1;"
+         offset="0"
+         id="stop7256-5-4" />
+      <stop
+         style="stop-color:#95a3ba;stop-opacity:1;"
+         offset="1"
+         id="stop7258-7-4" />
+    </linearGradient>
+    <linearGradient
+       y2="2"
+       x2="-28.335314"
+       y1="2"
+       x1="15.000595"
+       gradientTransform="matrix(0.93721973,0,0,1,1036.3977,-16.624983)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient7362"
+       xlink:href="#linearGradient7254-6-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7491"
+       id="linearGradient7497"
+       x1="1.9445436"
+       y1="3.0732041"
+       x2="14.142135"
+       y2="3.0732041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99637681,0,0,1,0.01998962,1035.7997)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="-14.579407"
+     inkscape:cy="-27.845113"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1171"
+     inkscape:window-height="959"
+     inkscape:window-x="927"
+     inkscape:window-y="397"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4046" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4188"
+       transform="translate(0,0.92807765)">
+      <rect
+         y="1037.3481"
+         x="0.9410218"
+         height="13.169864"
+         width="14.142136"
+         id="rect7499"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         transform="matrix(0,-1,1,0,0,0)"
+         y="1.96875"
+         x="-1042.5184"
+         height="12.09375"
+         width="1.125"
+         id="rect7415-2"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3487395;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         y="1037.4247"
+         x="5"
+         height="12.9375"
+         width="1.03125"
+         id="rect7415"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3487395;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         transform="matrix(0,1,-1,0,0,0)"
+         y="-15.0625"
+         x="1037.3934"
+         height="1"
+         width="13.0625"
+         id="rect7244-4-4"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient7362);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         transform="matrix(0,1,-1,0,0,0)"
+         y="-2"
+         x="1037.3934"
+         height="1"
+         width="13.0625"
+         id="rect7244-4"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient7277);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         y="1038.2762"
+         x="1.9574878"
+         height="1.1932427"
+         width="12.153398"
+         id="rect7489"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.67558528;fill:url(#linearGradient7497);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         y="1037.3622"
+         x="1.03125"
+         height="1"
+         width="13.9375"
+         id="rect7244"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient7260);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         transform="scale(-1,1)"
+         y="1039.4247"
+         x="-14.96875"
+         height="1"
+         width="13.9375"
+         id="rect7244-7"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient7328);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         y="1049.4247"
+         x="1.03125"
+         height="1"
+         width="14.0625"
+         id="rect7244-4-4-8"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         transform="matrix(0,-1,1,0,0,0)"
+         y="1.9375"
+         x="-1044.4469"
+         height="12.125"
+         width="1"
+         id="rect7415-2-4"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3487395;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         transform="matrix(0,-1,1,0,0,0)"
+         y="1.96875"
+         x="-1046.4325"
+         height="12.09375"
+         width="1.03125"
+         id="rect7415-2-4-3"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3487395;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+      <rect
+         transform="matrix(0,-1,1,0,0,0)"
+         y="2"
+         x="-1048.4623"
+         height="12.0625"
+         width="1"
+         id="rect7415-2-4-3-9"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3487395;fill:#5b6c89;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.jdt.jeview/icons/c/refresh.svg
+++ b/org.eclipse.jdt.jeview/icons/c/refresh.svg
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="nav_refresh.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7134">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7136" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7138" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5-1"
+       id="linearGradient7608-3-3"
+       gradientUnits="userSpaceOnUse"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7584-5-1">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1-2"
+       id="linearGradient7610-5-8"
+       gradientUnits="userSpaceOnUse"
+       x1="23.551146"
+       y1="1037.3622"
+       x2="23.551146"
+       y2="1045.3622" />
+    <linearGradient
+       id="linearGradient7592-1-2">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6-7" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9-7" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-9-3-2"
+       id="linearGradient7608-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7584-9-3-2">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7134"
+       id="linearGradient7140"
+       x1="25.363291"
+       y1="1044.7311"
+       x2="25.363291"
+       y2="1037.7311"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7584-5-1"
+       id="linearGradient3788"
+       gradientUnits="userSpaceOnUse"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7592-1-2"
+       id="linearGradient3790"
+       gradientUnits="userSpaceOnUse"
+       x1="23.551146"
+       y1="1037.3622"
+       x2="23.551146"
+       y2="1045.3622" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.999999"
+     inkscape:cx="2.6093314"
+     inkscape:cy="-0.20876635"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1241"
+     inkscape:window-height="814"
+     inkscape:window-x="1220"
+     inkscape:window-y="704"
+     inkscape:window-maximized="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="translate(-12.551145,-3.0000001e-7)">
+      <g
+         id="g3784"
+         transform="translate(-0.56250003,0.68750004)">
+        <path
+           style="fill:url(#linearGradient3788);fill-opacity:1;stroke:url(#linearGradient3790);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+           d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 1.546796,1.4584 1.546796,0.088 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.694788,0.3552 2.039845,0.6884 0.345482,0.3336 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.174793,-1.2439 -0.71875,-1.9687 -0.293544,-0.3911 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+           id="path7582"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccssscscsssszcc" />
+        <path
+           style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 23.069359,2.3660973 0,-0.5966213 c 0,0 0.110485,-0.3756505 -0.220971,-0.243068 -0.331456,0.1325826 -0.972272,0.6629126 -1.038563,0.773398 -0.06629,0.1104855 -0.751301,0.5966214 -0.596622,0.8175923 0.15468,0.2209709 1.458408,0.066291 1.458408,0.066291 z"
+           id="path7602"
+           inkscape:connector-curvature="0"
+           transform="translate(0,1036.3622)"
+           sodipodi:nodetypes="ccssscc" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g7604-6"
+       transform="matrix(-1,0,0,-1,29.113291,2089.2183)">
+      <path
+         sodipodi:nodetypes="ccssscsscsssszcc"
+         inkscape:connector-curvature="0"
+         id="path7582-7"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 0.404271,0.3812 0.799458,0.5707 0.37782,0.1811 0.747338,0.1871 0.747338,-0.4827 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.727345,0.3446 2.039845,0.6884 0.3125,0.3437 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.09375,-1.3125 -0.71875,-1.9687 -0.625,-0.6563 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-9-7-1);fill-opacity:1;stroke:url(#linearGradient7140);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         sodipodi:nodetypes="ccssscc"
+         inkscape:connector-curvature="0"
+         id="path7602-2"
+         d="m 23.069359,1042.9731 0,0.5966 c 0,0 0.110485,0.3757 -0.220971,0.2431 -0.331456,-0.1326 -0.972272,-0.6629 -1.038563,-0.7734 -0.06629,-0.1105 -0.751301,-0.5966 -0.596622,-0.8176 0.15468,-0.221 1.458408,-0.066 1.458408,-0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+</svg>

--- a/org.eclipse.jdt.jeview/icons/c/setfocus.svg
+++ b/org.eclipse.jdt.jeview/icons/c/setfocus.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="setfocus.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="0"
+         id="stop3829" />
+      <stop
+         id="stop3835"
+         offset="0.60149658"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3831" />
+    </linearGradient>
+    <linearGradient
+       y2="462.11539"
+       x2="388.63736"
+       y1="478.18777"
+       x1="388.63736"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929-5"
+       xlink:href="#linearGradient10798-1-9-3-7-6-8-9-0-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient10798-1-9-3-7-6-8-9-0-9-1">
+      <stop
+         style="stop-color:#4f9e55;stop-opacity:1"
+         offset="0"
+         id="stop10800-5-2-1-8-20-6-4-9-8-2" />
+      <stop
+         id="stop10806-6-8-5-3-9-24-8-4-3-2"
+         offset="0.5"
+         style="stop-color:#418a4d;stop-opacity:1" />
+      <stop
+         style="stop-color:#91c168;stop-opacity:1;"
+         offset="1"
+         id="stop10802-1-5-3-0-4-8-4-2-9-2" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="43.202736"
+     inkscape:cx="10.172679"
+     inkscape:cy="7.5045753"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3950" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="5,3.25"
+       id="guide3797" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="10,4"
+       id="guide3801" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="12.0625,5.3125"
+       id="guide3803" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.9762888,1040.8622 3.0471512,0 -1.52344,2 z"
+       id="path4271"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <g
+       transform="matrix(-0.66772063,0,0,0.66772063,13.566565,355.54035)"
+       style="display:inline"
+       id="g6124-3">
+      <g
+         transform="scale(-1,1)"
+         style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
+         id="text6430" />
+      <g
+         transform="scale(-1,1)"
+         style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+         id="g6438">
+        <circle
+           r="8.9586821"
+           cy="468.23718"
+           cx="388.125"
+           style="display:inline;fill:url(#linearGradient3929-5);fill-opacity:1;stroke:#14733c;stroke-width:2.23487449;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="path10796-2-6-2"
+           transform="matrix(0.66884336,0,0,0.67139756,-267.18268,722.47026)" />
+        <g
+           transform="scale(0.94400511,1.0593163)"
+           style="font-size:15.56941891px;font-family:Sans;fill:#ffffff"
+           id="text3782" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
+       style="display:inline"
+       id="g11331-3-1-1">
+      <g
+         id="g13408-8"
+         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
+    </g>
+    <image
+       y="1036.3622"
+       x="16"
+       id="image4260"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAO5JREFU
+OI2lktGtwjAMRW8Qe5BJcLpF/wJ8dQuYJG4XIeYt8mAS8wN5SZogPWHJqm50fWwnNaqKb2KTC2OM
+1jlNk4pIt8s2FzHGlWEYBozj2J2gADjnTK4/dU6hqs0EoERe82/T1wMwswJIycz/A+SQXvFHQLgG
+xQUpwzU0Iab1H7jZ6e1xA+0onb21HKS46G5nYtL4G/UdxKTkaTXJeqdX8TnyXyFTAcn9m3r8tIa1
+9VpNXxcg93upD9L0beuDsA84/ZxeEJsK3ewAAbz3hb/7ChAA+dQCwFrIZS5eoQkAAI6sy7Ik7b3H
+cTia2vcEjMlIk17TWsYAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+    <path
+       d="m 9.547904,1047.2515 c -0.04659,-0.2691 -0.153032,-0.4719 -0.319362,-0.6082 -0.163011,-0.1363 -0.375917,-0.2042 -0.638722,-0.2042 -0.349303,0 -0.628744,0.1181 -0.838323,0.3552 -0.206256,0.2334 -0.309383,0.3859 -0.309382,0.9373 -1e-6,0.6129 0.104787,0.8858 0.314372,1.1389 0.212904,0.253 0.497335,0.3794 0.853294,0.3794 0.26613,0 0.484029,-0.073 0.653691,-0.2189 0.169658,-0.1493 0.289418,-0.4038 0.359283,-0.7639 L 11,1048.2542 c -0.143054,0.6162 -0.417503,1.3215 -0.823354,1.6361 -0.40586,0.3147 -0.94977,0.4719 -1.631735,0.4719 -0.775119,0 -1.393881,-0.2383 -1.856287,-0.7151 C 6.22954,1049.1704 6,1048.6704 6,1047.8271 c 0,-0.853 0.231205,-1.2763 0.693614,-1.7497 0.462406,-0.4769 1.087821,-0.7152 1.876246,-0.7152 0.645373,0 1.156212,0.1381 1.536928,0.4087 0.381103,0.2709 0.699367,0.9009 0.865705,1.4554 z"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15.56941891px;line-height:125%;font-family:Arial;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
+       id="path3817"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccscscscccsscscsscc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 2,1037.8167 6.5000001,0 0,4.5"
+       id="path4269"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/org.eclipse.jdt.jeview/icons/view.svg
+++ b/org.eclipse.jdt.jeview/icons/view.svg
@@ -1,0 +1,290 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="view.svg"
+   inkscape:export-filename="C:\Users\jmietling\Documents\rect3997-9-1.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4974"
+       inkscape:collect="always">
+      <stop
+         id="stop4976"
+         offset="0"
+         style="stop-color:#5f5f5f;stop-opacity:1" />
+      <stop
+         id="stop4978"
+         offset="1"
+         style="stop-color:#3f3f5f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4968"
+       x1="11"
+       y1="1048.8622"
+       x2="14"
+       y2="1048.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4970"
+       x1="11"
+       y1="1044.8622"
+       x2="14"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4972"
+       x1="7"
+       y1="1040.8622"
+       x2="14"
+       y2="1040.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4256"
+       x1="2.6421733"
+       y1="1042.6832"
+       x2="7.6789141"
+       y2="1047.72"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59562329,0,0,0.59562329,1.42626,418.31576)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4288"
+       x1="3.9999998"
+       y1="1044.8622"
+       x2="7"
+       y2="1044.8622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4296"
+       x1="3.9999998"
+       y1="1048.8621"
+       x2="7"
+       y2="1048.8621"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4314"
+       x1="7"
+       y1="1043.3622"
+       x2="10"
+       y2="1046.3622"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4974"
+       id="linearGradient4322"
+       x1="7"
+       y1="1047.3622"
+       x2="10"
+       y2="1050.3622"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#e5e5e5"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="50.64652"
+     inkscape:cx="5.5427968"
+     inkscape:cy="7.9808044"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1391"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3999" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:url(#linearGradient4970);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 11,1044.3622 3,0 0,1 -3,0 z"
+       id="rect4035-1-1-5-2-2-6-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient4968);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 11,1048.3622 3,0 0,1 -3,0 z"
+       id="rect4035-1-1-5-2-2-6-5-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:url(#linearGradient4256);fill-opacity:1;stroke:none"
+       d="m 3,1039.3622 0,3 3,0 0,-3 z m 0.9999998,1 0.9999999,0 0,1 -0.9999999,0 z"
+       id="rect4035-17" />
+    <g
+       transform="matrix(0.33333824,0,0,0.33333217,2.999985,692.24268)"
+       id="g4094"
+       style="fill:#ffffff;fill-opacity:1">
+      <rect
+         y="1044.3622"
+         x="3"
+         height="3.0000174"
+         width="3"
+         id="rect4035-1-1"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4035-1-7-1"
+         d="m 3,1044.3622 1,1 0,2 -1,0 z"
+         style="display:inline;opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4035-1-7-4-5"
+         d="m 3,1044.3622 1,1 2,0 0,-1 z"
+         style="display:inline;opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:url(#linearGradient4314);fill-opacity:1;stroke:none"
+       d="m 7,1043.3622 0,3 3,0 0,-3 z m 0.9999998,1 0.9999999,0 0,1 -0.9999999,0 z"
+       id="rect4035-17-2" />
+    <g
+       transform="matrix(0.33333824,0,0,0.33333217,6.999985,696.24268)"
+       id="g4094-4"
+       style="fill:#ffffff;fill-opacity:1">
+      <rect
+         y="1044.3622"
+         x="3"
+         height="3.0000174"
+         width="3"
+         id="rect4035-1-1-5"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4035-1-7-1-5"
+         d="m 3,1044.3622 1,1 0,2 -1,0 z"
+         style="display:inline;opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4035-1-7-4-5-1"
+         d="m 3,1044.3622 1,1 2,0 0,-1 z"
+         style="display:inline;opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:url(#linearGradient4322);fill-opacity:1;stroke:none"
+       d="m 7,1047.3622 0,3 3,0 0,-3 z m 1,1.0073 1,0 0,1.0074 -1,0 z"
+       id="rect4035-17-2-6" />
+    <g
+       transform="matrix(0.33333824,0,0,0.33333217,6.999985,700.24268)"
+       id="g4094-4-1"
+       style="fill:#ffffff;fill-opacity:1">
+      <rect
+         y="1044.3622"
+         x="3"
+         height="3.0000174"
+         width="3"
+         id="rect4035-1-1-5-4"
+         style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4035-1-7-1-5-2"
+         d="m 3,1044.3622 1,1 0,2 -1,0 z"
+         style="display:inline;opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4035-1-7-4-5-1-3"
+         d="m 3,1044.3622 1,1 2,0 0,-1 z"
+         style="display:inline;opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <path
+       style="fill:#5f5f5f;fill-opacity:1;stroke:none;display:inline"
+       d="m 3.9999997,1042.3622 1.0000146,0 0,7 -1.0000146,0 z"
+       id="rect4035-1-1-5-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4288);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 3.9999997,1044.3622 3.0000003,0 0,1 -3.0000003,0 z"
+       id="rect4035-1-1-5-2-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4296);fill-opacity:1.0;stroke:none;display:inline"
+       d="m 3.9999997,1048.3622 3.0000003,0 0,0.9999 -3.0000003,0 z"
+       id="rect4035-1-1-5-2-2-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:url(#linearGradient4972);fill-opacity:1;stroke:none;display:inline"
+       d="m 7,1040.3622 7,0 0,1 -7,0 z"
+       id="rect4035-1-1-5-2-2-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <image
+       y="1036.3622"
+       x="-16"
+       id="image4247"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAIVJREFU
+OI3Fk90JwCAMhM/SRZxEN4mjOYqjuMn1odj6A5LWQg/uQSGfyRENSaxoW6r+ArDXhxACASBnIKVo
+HgMAIMYI70MDLNBa5QFTh+j9XaDtACQbiwj7u5mHEWppMhkAOZ+F1loAYyYliws4G8E5YfGrETRB
+/p9Bswe9NHsxBWi0/JkOKWKlewqFOVsAAAAASUVORK5CYII=
+"
+       style="image-rendering:optimizeSpeed"
+       preserveAspectRatio="none"
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/org.eclipse.jdt.jeview/plugin.xml
+++ b/org.eclipse.jdt.jeview/plugin.xml
@@ -6,7 +6,7 @@
          point="org.eclipse.ui.views">
       <view
             name="%je.view.name"
-            icon="icons/view.png"
+            icon="icons/view.svg"
             category="org.eclipse.jdt.ui.java"
             class="org.eclipse.jdt.jeview.views.JavaElementView"
             id="org.eclipse.jdt.jeview.views.JavaElementView">

--- a/org.eclipse.jdt.jeview/src/org/eclipse/jdt/jeview/JEPluginImages.java
+++ b/org.eclipse.jdt.jeview/src/org/eclipse/jdt/jeview/JEPluginImages.java
@@ -21,12 +21,12 @@ public class JEPluginImages {
 
 	private static final String fgIconBase= "/icons/c/";
 
-	public static final String CHILDREN= "children.png";
-	public static final String INFO= "info.png";
-	public static final String PROPERTIES= "properties.png";
-	public static final String REFRESH= "refresh.png";
-	public static final String SET_FOCUS= "setfocus.png";
-	public static final String CODE_SELECT= "codeSelect.png";
+	public static final String CHILDREN= "children.svg";
+	public static final String INFO= "info.svg";
+	public static final String PROPERTIES= "properties.svg";
+	public static final String REFRESH= "refresh.svg";
+	public static final String SET_FOCUS= "setfocus.svg";
+	public static final String CODE_SELECT= "codeSelect.svg";
 
 	public static final ImageDescriptor IMG_CHILDREN= create(CHILDREN);
 	public static final ImageDescriptor IMG_INFO= create(INFO);


### PR DESCRIPTION
This PR adds SVGs for all icons in the bundle `org.eclipse.jdt.jeview`.

See also this [PR](https://github.com/eclipse-platform/eclipse.platform/pull/1797) for more information.