### PR TITLE
Fix `Create new member record preview`: formatting is off

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
@@ -512,6 +512,7 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 	@Override
 	public Object getAdditionalProposalInfo(IProgressMonitor monitor) {
 		StringBuilder buf= new StringBuilder();
+		boolean noSpacingNeeded = false;
 		switch (fTypeKind) {
 			case K_CLASS:
 				buf.append(CorrectionMessages.NewCUCompletionUsingWizardProposal_createclass_info);
@@ -525,9 +526,14 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 			case K_ANNOTATION:
 				buf.append(CorrectionMessages.NewCUCompletionUsingWizardProposal_createannotation_info);
 				break;
+			default:
+				noSpacingNeeded = true;
 		}
-		buf.append("<br>"); //$NON-NLS-1$
-		buf.append("<br>"); //$NON-NLS-1$
+		// #2183: newlines at the start of the preview String mess with the formatting
+		if (!noSpacingNeeded) {
+			buf.append("<br>"); //$NON-NLS-1$
+			buf.append("<br>"); //$NON-NLS-1$
+		}
 		if (fTypeContainer instanceof IType) {
 			buf.append(CorrectionMessages.NewCUCompletionUsingWizardProposal_tooltip_enclosingtype);
 		} else {


### PR DESCRIPTION
Two superflous newlines (`<br>`) where causing the bold font styling to be place on the wrong chars.

fixes #2183

---

Like I said in https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2183#issue-3021815464, this should probably also be fixed upstream, but I don't know where to look. Either way I think this fix makes sense since we don't want to start the preview with two newlines.