### PR TITLE
Fix `Create new member record`: preview is missing `record` keyword

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewCUUsingWizardProposal.java
@@ -552,6 +552,9 @@ public class NewCUUsingWizardProposal extends ChangeCorrectionProposal {
 			case K_ANNOTATION:
 				buf.append("@interface <b>"); //$NON-NLS-1$
 				break;
+			case K_RECORD:
+				buf.append("record <b>"); //$NON-NLS-1$
+				break;
 		}
 		if (fTypeNameWithParameters != null) {
 			nameToHTML(fTypeNameWithParameters, buf);


### PR DESCRIPTION
fixes #2185