### PR TITLE
Fix pull up refactoring to properly replace this argument when needed

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test56/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test56/out/A.java
@@ -4,6 +4,6 @@ class A {
 	void a(A a){}
 	public void a(B b){}
 	protected void m(B b) {
-		a(this);
+		a(b);
 	}
 }

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test57/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test57/out/A.java
@@ -4,7 +4,7 @@ class A {
 	void a(A a){}
 	public void a(B b){}
 	protected void m(B b) {
-		a(this);
+		a(b);
 	}
 	protected void foo2(B b) {
 		m(b);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test58/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test58/out/A.java
@@ -5,7 +5,7 @@ class A {
 	public void a(B b){}
 	protected void m(B b) {
 		foo2(b);
-		a(this);
+		a(b);
 	}
 	protected void foo2(B b) {
 		m(b);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test59/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test59/out/A.java
@@ -5,7 +5,7 @@ class A {
 	public void a(B b){}
 	protected void m(B b) {
 		foo2(b);
-		a(this);
+		a(b);
 	}
 	protected void foo2(B b) {
 		m(b);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/in/A.java
@@ -1,0 +1,6 @@
+package p;
+
+class A {
+	void a(A a){}
+	void a(B b){}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/in/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/in/B.java
@@ -1,0 +1,7 @@
+package p;
+
+class B extends A {
+	public void m() {
+		a(this);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/out/A.java
@@ -1,0 +1,9 @@
+package p;
+
+class A {
+	void a(A a){}
+	void a(B b){}
+	public void m(B b) {
+		a(b);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/out/B.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/test63/out/B.java
@@ -1,0 +1,4 @@
+package p;
+
+class B extends A {
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
@@ -1493,6 +1493,41 @@ public class PullUpTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void test63() throws Exception {
+		// test for bug 241035
+		ICompilationUnit cuA= createCUfromTestFile(getPackageP(), "A");
+		ICompilationUnit cuB= createCUfromTestFile(getPackageP(), "B");
+
+		IType typeA= getType(cuA, "A");
+		IType typeB= getType(cuB, "B");
+		String[] methodNames= new String[] { "m" };
+		String[][] signatures= new String[][] { new String[0] };
+		IMethod[] methods= getMethods(typeB, methodNames, signatures);
+
+		PullUpRefactoringProcessor processor= createRefactoringProcessor(methods);
+		Refactoring ref= processor.getRefactoring();
+		FussyProgressMonitor testMonitor= new FussyProgressMonitor();
+		assertTrue("activation", ref.checkInitialConditions(testMonitor).isOK());
+		testMonitor.assertUsedUp();
+		testMonitor.prepare();
+
+		setTargetClass(processor, 0);
+		processor.setDestinationType(typeA);
+		processor.setMembersToMove(methods);
+		processor.setDeletedMethods(methods);
+		processor.setReplace(true);
+
+		assertTrue("final", ref.checkFinalConditions(testMonitor).isOK());
+		testMonitor.assertUsedUp();
+		testMonitor.prepare();
+
+		performChange(ref, false);
+
+		assertEqualLines("A", getFileContents(getOutputTestFileName("A")), cuA.getSource());
+		assertEqualLines("B", getFileContents(getOutputTestFileName("B")), cuB.getSource());
+	}
+
+	@Test
 	public void testFail0() throws Exception {
 //		printTestDisabledMessage("6538: searchDeclarationsOf* incorrect");
 		helper2(new String[] { "m" }, new String[][] { new String[0] }, true, false, 0);


### PR DESCRIPTION
- modify PullUpRefactoringProcessor.PullUASTNodeMapper to replace a this argument to a method with the new argument that gets added
- modify existing PullUpTests where the behavior has been fixed
- add new test to PullUpTests
- fixes #2192

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
