### PR TITLE
[Build] Migrate to new tycho-apitools log and list javadoc/maven issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
 	stages {
 		stage('Build') {
 			steps {
-				wrap([$class: 'Xvnc', useXauthority: true]) {
+				xvnc(useXauthority: true) {
 					sh """
 					mvn -U -e -DskipTests=false -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						clean verify --batch-mode --fail-at-end \
@@ -31,14 +31,15 @@ pipeline {
 					// The following lines use the newest build on master that did not fail a reference
 					// To not fail master build on failed test maven needs to be started with "-Dmaven.test.failure.ignore=true" it will then only marked unstable.
 					// To not fail the build also "unstable: true" is used to only mark the build unstable instead of failing when qualityGates are missed
-					// Also do not record mavenConsole() as failing tests are logged with ERROR duplicating the failure into the "Maven" plugin
 					// To accept unstable builds (test errors or new warnings introduced by third party changes) as reference using "ignoreQualityGate:true"
 					// To only show warnings related to the PR on a PR using "publishAllIssues:false"
-					// The eclipse compiler name is changed because the logfile not only contains ECJ but also API warnings.
-					// "pattern:" is used to collect warnings in dedicated files avoiding output of junit tests treated as warnings  
-					junit '**/target/surefire-reports/*.xml'
 					discoverGitReferenceBuild referenceJob: 'eclipse.jdt.ui-github/master'
-					recordIssues publishAllIssues:false, ignoreQualityGate:true, tool: eclipse(name: 'Compiler and API Tools', pattern: '**/target/compilelogs/*.xml'), qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
+					junit allowEmptyResults: true, testResults: '**/target/surefire-reports/*.xml'
+					recordIssues publishAllIssues: false, ignoreQualityGate: true, enabledForFailure: true, tools: [
+							eclipse(name: 'Compiler', pattern: '**/target/compilelogs/*.xml'),
+							issues(name: 'API Tools', id: 'apitools', pattern: '**/target/apianalysis/*.xml'),
+						], qualityGates: [[threshold: 1, type: 'DELTA', unstable: true]]
+					recordIssues tools: [javaDoc(), mavenConsole()]
 				}
 			}
 		}


### PR DESCRIPTION
## What it does

Also make sure the issues are published even in case of a failed build, as otherwise they are not visualized and improve order of post-actions.

Additionally record javadoc and maven issues, but don't add a quality-gate for them.

This is similar to
- https://github.com/eclipse-platform/eclipse.platform.swt/pull/1932

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
