### PR TITLE
Fix Bug 240537

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2210.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2210.java
@@ -1,0 +1,29 @@
+package bugs_in;
+
+public class Test_issue_2210 {
+	enum EntityType{X}
+	static class Case extends Bug{}
+	static class Leaf extends Bug{}
+	static class CaseNote extends Leaf{}
+	static class SuperView extends Leaf{}
+	static class CaseEntity extends Leaf{
+		EntityType getEntityType(){return null;}
+	}
+	public static void main(String...args){
+		System.out.println(fetch(new Case()));
+	}
+	static String /*]*/getId/*[*/(final Leaf leaf){ // LINE 13
+		return leaf instanceof CaseNote?"a":
+	       leaf instanceof CaseEntity?
+		   editorId(((CaseEntity)leaf).
+		   getEntityType()):"b";
+	}
+	static String editorId(final EntityType type){
+		return""+type;
+	}
+	static String fetch(final Bug record){
+		return record instanceof SuperView?"c":
+			   record instanceof Case?
+			   "DONE!":getId((Leaf)record);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2210.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2210.java
@@ -1,0 +1,27 @@
+package bugs_in;
+
+public class Test_issue_2210 {
+	enum EntityType{X}
+	static class Case extends Bug{}
+	static class Leaf extends Bug{}
+	static class CaseNote extends Leaf{}
+	static class SuperView extends Leaf{}
+	static class CaseEntity extends Leaf{
+		EntityType getEntityType(){return null;}
+	}
+	public static void main(String...args){
+		System.out.println(fetch(new Case()));
+	}
+	static String editorId(final EntityType type){
+		return""+type;
+	}
+	static String fetch(final Bug record){
+		final Leaf leaf = record instanceof Leaf ? (Leaf)record : null;
+		return record instanceof SuperView?"c":
+			   record instanceof Case?
+			   "DONE!":leaf instanceof CaseNote?"a":
+			   leaf instanceof CaseEntity?
+			   editorId(((CaseEntity)leaf).
+			   getEntityType()):"b";
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -527,6 +527,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_2210() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- add checks in CallInliner.computeRealArguments() when adding local variables to add instanceof check for the variable if it is a cast expression and the initial invocation is in a conditional with instanceof checking
- add new test to InlineMethodTests
- fixes #2210

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue or bug.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or bug or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
