### PR TITLE
Breadcrumb should not inspect disposed controls

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/EditorBreadcrumb.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/EditorBreadcrumb.java
@@ -462,7 +462,8 @@ public abstract class EditorBreadcrumb implements IBreadcrumb {
 	private boolean isChild(Control child, Control parent) {
 		if (child == null)
 			return false;
-
+		if (child.isDisposed())
+			return false;
 		if (child == parent)
 			return true;
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2071
