### PR TITLE
Fix annotated type reference for type that moves packages

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/MoveCuUpdateCreator.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/reorg/MoveCuUpdateCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -168,7 +168,7 @@ public class MoveCuUpdateCreator {
 						rewrite.removeImport(importDecl.getElementName());
 						rewrite.addImport(createStringForNewImport(movedUnit, importDecl));
 					}
-				} else if (reference.isQualified()) {
+				} else if (reference.isQualified(referencingCu)) {
 					TextChange textChange= changeManager.get(referencingCu);
 					String changeName= RefactoringCoreMessages.MoveCuUpdateCreator_update_references;
 					TextEdit replaceEdit= new ReplaceEdit(reference.getOffset(), reference.getSimpleNameStart() - reference.getOffset(), fNewPackage);
@@ -417,8 +417,16 @@ public class MoveCuUpdateCreator {
 			return SearchUtils.getEnclosingJavaElement(this).getAncestor(IJavaElement.IMPORT_DECLARATION) != null;
 		}
 
-		public boolean isQualified() {
-			return fSimpleNameStart != -1;
+		public boolean isQualified(ICompilationUnit cu) {
+			if (fSimpleNameStart != -1) {
+				try {
+					return cu.getBuffer().getText(fSimpleNameStart-1, 1).equals("."); //$NON-NLS-1$
+				} catch (JavaModelException e) {
+					// do nothing
+				}
+				return true;
+			}
+			return false;
 		}
 
 		/**

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveCu/test_Issue1887/in/MovingClass.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveCu/test_Issue1887/in/MovingClass.java
@@ -1,0 +1,5 @@
+package p1;
+
+public class MovingClass {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveCu/test_Issue1887/in/TestMovingClass.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveCu/test_Issue1887/in/TestMovingClass.java
@@ -1,0 +1,20 @@
+package p3;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import p1.MovingClass;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+@interface MyAnnotation {
+}
+
+public class TestMoving {
+
+	public List<@MyAnnotation MovingClass> list;
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveCu/test_Issue1887/out/TestMovingClass.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveCu/test_Issue1887/out/TestMovingClass.java
@@ -1,0 +1,20 @@
+package p3;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import p2.MovingClass;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+@interface MyAnnotation {
+}
+
+public class TestMoving {
+
+	public List<@MyAnnotation MovingClass> list;
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AllRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AllRefactoringTests.java
@@ -75,6 +75,9 @@ import org.junit.platform.suite.api.Suite;
 	//-- generics
 	InferTypeArgumentsTests.class,
 
+	//-- compilation units
+	MoveCompilationUnitTests.class,
+
 	//--methods
 	RenameVirtualMethodInClassTests.class,
 	RenameMethodInInterfaceTests.class,

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveCompilationUnitTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveCompilationUnitTests.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.refactoring;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.Test;
+
+import org.eclipse.core.runtime.Assert;
+
+import org.eclipse.core.resources.IResource;
+
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.MoveRefactoring;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.eclipse.jdt.internal.corext.refactoring.reorg.IReorgPolicy.IMovePolicy;
+import org.eclipse.jdt.internal.corext.refactoring.reorg.JavaMoveProcessor;
+import org.eclipse.jdt.internal.corext.refactoring.reorg.ReorgDestinationFactory;
+import org.eclipse.jdt.internal.corext.refactoring.reorg.ReorgPolicyFactory;
+
+import org.eclipse.jdt.ui.tests.refactoring.ccp.MockReorgQueries;
+import org.eclipse.jdt.ui.tests.refactoring.rules.RefactoringTestSetup;
+
+public class MoveCompilationUnitTests extends GenericRefactoringTest {
+
+	private static final String REFACTORING_PATH= "MoveCu/";
+
+	public MoveCompilationUnitTests() {
+		this.rts= new RefactoringTestSetup();
+	}
+
+	protected MoveCompilationUnitTests(RefactoringTestSetup rts) {
+		super(rts);
+	}
+
+	@Override
+	protected String getRefactoringPath() {
+		return REFACTORING_PATH;
+	}
+
+	private String getQualifier(String qualifiedName) {
+		int dot= qualifiedName.lastIndexOf('.');
+		return qualifiedName.substring(0, dot != -1 ? dot : 0);
+	}
+
+	private String getSimpleName(String qualifiedName) {
+		return qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
+	}
+
+	private ICompilationUnit[] createCUs(String[] qualifiedNames) throws Exception {
+		ICompilationUnit[] cus= new ICompilationUnit[qualifiedNames.length];
+		for (int i= 0; i < qualifiedNames.length; i++) {
+			Assert.isNotNull(qualifiedNames[i]);
+			String qualifier= getQualifier(qualifiedNames[i]);
+			String[] sections= qualifier.split("[.]");
+			if (sections.length == 2) {
+				cus[i]= createCUfromTestFile(getRoot().createPackageFragment(getQualifier(qualifiedNames[i]), true, null), getSimpleName(qualifiedNames[i]), sections[1] + "/");
+			} else {
+				cus[i]= createCUfromTestFile(getRoot().createPackageFragment(getQualifier(qualifiedNames[i]), true, null), getSimpleName(qualifiedNames[i]));
+			}
+		}
+		return cus;
+	}
+
+	protected void doExecuteRefactoring(ICompilationUnit cunit, String destinationPackage) throws Exception {
+		IMovePolicy policy= ReorgPolicyFactory.createMovePolicy((new IResource[0]), (new IJavaElement[] {cunit}));
+		JavaMoveProcessor processor= (policy.canEnable() ? new JavaMoveProcessor(policy) : null);
+		IPackageFragment destination= this.rts.getDefaultSourceFolder().createPackageFragment(destinationPackage, false, null);
+		processor.setDestination(ReorgDestinationFactory.createDestination(destination));
+		processor.setReorgQueries(new MockReorgQueries());
+		processor.setUpdateReferences(true);
+		MoveRefactoring ref= new MoveRefactoring(processor);
+		RefactoringStatus status= performRefactoringWithStatus(ref);
+		assertTrue(status.isOK());
+	}
+
+	@Test
+	public void test_Issue1887() throws Exception {
+		ICompilationUnit[] cus= createCUs(new String[] { "p1.MovingClass", "p3.TestMovingClass" });
+		doExecuteRefactoring(cus[0], "p2");
+		String output= cus[1].getSource();
+		String outputTestFileName= getOutputTestFileName("TestMovingClass");
+		String expectedOutput= getFileContents(outputTestFileName);
+		assertEqualLines("move ", output, expectedOutput);
+	}
+
+}


### PR DESCRIPTION
- fix MoveCuUpdateCreator.isQualified() logic to not report an annotated simple name type reference as qualified
- add new MoveCompilationUnitTests class
- fixes #1887

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
