### PR TITLE
Fix extract local to not create tmp variables for certain assignments

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/util/ChangedValueChecker.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/util/ChangedValueChecker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -36,6 +36,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTMatcher;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -44,6 +45,7 @@ import org.eclipse.jdt.core.dom.CastExpression;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.DoStatement;
 import org.eclipse.jdt.core.dom.EnhancedForStatement;
+import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.FieldAccess;
 import org.eclipse.jdt.core.dom.ForStatement;
 import org.eclipse.jdt.core.dom.IBinding;
@@ -95,8 +97,19 @@ public class ChangedValueChecker extends AbstractChecker {
 
 	private String fEnclosingMethodSignature;
 
+	private ASTNode fAssignmentExpressionToIgnore;
+
+	private boolean fIgnoreAssignmentUpdates;
+
 	public ChangedValueChecker(ASTNode selectedExpression, String enclosingMethodSignature) {
 		this.fEnclosingMethodSignature= enclosingMethodSignature;
+		analyzeSelectedExpression(selectedExpression);
+	}
+
+	public ChangedValueChecker(ASTNode selectedExpression, String enclosingMethodSignature, boolean ignoreAssignmentUpdates) {
+		this.fEnclosingMethodSignature= enclosingMethodSignature;
+		this.fAssignmentExpressionToIgnore= ignoreAssignmentUpdates ? selectedExpression : null;
+		this.fIgnoreAssignmentUpdates= ignoreAssignmentUpdates;
 		analyzeSelectedExpression(selectedExpression);
 	}
 
@@ -134,7 +147,8 @@ public class ChangedValueChecker extends AbstractChecker {
 					Position pos= new Position(node.getStartPosition(), node.getLength());
 					if (fPosSet.add(pos)) {
 						threadPool.execute(() -> {
-							UpdateVisitor uv= new UpdateVisitor(fDependSet, true);
+							UpdateVisitor uv= new UpdateVisitor(fDependSet, true, (Expression) fAssignmentExpressionToIgnore);
+							System.out.println(node);
 							node.accept(uv);
 							if (uv.hasConflict()) {
 								fConflict= true;
@@ -555,9 +569,12 @@ public class ChangedValueChecker extends AbstractChecker {
 
 		private boolean visitMethodCall;
 
-		public UpdateVisitor(Set<Elem> dependSet, boolean visitMethodCall) {
+		private Expression ignoreAssignmentToExpression;
+
+		public UpdateVisitor(Set<Elem> dependSet, boolean visitMethodCall, Expression ignoreAssignmentToExpression) {
 			this.updateSet= new HashSet<>();
 			this.visitMethodCall= visitMethodCall;
+			this.ignoreAssignmentToExpression= ignoreAssignmentToExpression;
 			this.dependSet= dependSet;
 		}
 
@@ -579,6 +596,11 @@ public class ChangedValueChecker extends AbstractChecker {
 
 		@Override
 		public boolean visit(Assignment assignment) {
+			if (ignoreAssignmentToExpression != null) {
+				if (assignment.getLeftHandSide().subtreeMatch(new ASTMatcher(), ignoreAssignmentToExpression)) {
+					return super.visit(assignment);
+				}
+			}
 			ReadVisitor v= new ReadVisitor(visitMethodCall);
 			assignment.getLeftHandSide().accept(v);
 			for (Elem e : v.readSet) {
@@ -622,7 +644,7 @@ public class ChangedValueChecker extends AbstractChecker {
 			}
 			MethodDeclaration md= findFunctionDefinition(resolveMethodBinding.getDeclaringClass(), resolveMethodBinding);
 			if (md != null && md.getLength() < THRESHOLD) {
-				UpdateVisitor uv= new UpdateVisitor(dependSet, false);
+				UpdateVisitor uv= new UpdateVisitor(dependSet, false, ignoreAssignmentToExpression);
 				md.accept(uv);
 				for (Elem e : uv.updateSet) {
 					addToList(new Elem(methodInvocation, visitMethodCall, e));

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/util/ChangedValueChecker.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/util/ChangedValueChecker.java
@@ -99,8 +99,6 @@ public class ChangedValueChecker extends AbstractChecker {
 
 	private ASTNode fAssignmentExpressionToIgnore;
 
-	private boolean fIgnoreAssignmentUpdates;
-
 	public ChangedValueChecker(ASTNode selectedExpression, String enclosingMethodSignature) {
 		this.fEnclosingMethodSignature= enclosingMethodSignature;
 		analyzeSelectedExpression(selectedExpression);
@@ -109,7 +107,6 @@ public class ChangedValueChecker extends AbstractChecker {
 	public ChangedValueChecker(ASTNode selectedExpression, String enclosingMethodSignature, boolean ignoreAssignmentUpdates) {
 		this.fEnclosingMethodSignature= enclosingMethodSignature;
 		this.fAssignmentExpressionToIgnore= ignoreAssignmentUpdates ? selectedExpression : null;
-		this.fIgnoreAssignmentUpdates= ignoreAssignmentUpdates;
 		analyzeSelectedExpression(selectedExpression);
 	}
 

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test127_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test127_out.java
@@ -7,8 +7,8 @@ class A {
 			System.out.println(v2);
 		}
 		if (b instanceof C) {
-			int v22= ((C) b).getV2();
-			System.out.println(v22);
+			int v3= ((C) b).getV2();
+			System.out.println(v3);
 		}
 
 	}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test162_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test162_in.java
@@ -1,0 +1,17 @@
+package p; // 9, 13, 9, 17
+
+import java.util.ArrayList;
+
+public class A {
+	private ArrayList list = null;
+
+	public void updateBug() {
+		if (list == null) {
+			list = new ArrayList<>();
+		}
+		int index = 0;
+		while (index < list.size()) {
+			Object it = list.get(index++);
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test162_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract/A_test162_out.java
@@ -1,0 +1,18 @@
+package p; // 9, 13, 9, 17
+
+import java.util.ArrayList;
+
+public class A {
+	private ArrayList list = null;
+
+	public void updateBug() {
+		ArrayList list2= list;
+		if (list2 == null) {
+			list2= list = new ArrayList<>();
+		}
+		int index = 0;
+		while (index < list2.size()) {
+			Object it = list2.get(index++);
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
@@ -1114,6 +1114,12 @@ public class ExtractTempTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void test162() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1901
+		helper1(9, 13, 9, 17, true, false, "list2", "list2");
+	}
+
+	@Test
 	public void testZeroLengthSelection0() throws Exception {
 //		printTestDisabledMessage("test for bug 30146");
 		helper1(4, 18, 4, 18, true, false, "temp", "j");
@@ -1272,11 +1278,7 @@ public class ExtractTempTests extends GenericRefactoringTest {
 		failHelper1(4, 15, 4, 20, false, false, "temp", RefactoringStatus.FATAL);
 	}
 
-	@Test
-	public void testFail27() throws Exception {
-//		printTestDisabledMessage("test for bug 29513");
-		failHelper1(7, 13, 7, 24, true, false, "temp", RefactoringStatus.WARNING);
-	}
+	// testFail27() available as it is no longer a failure case
 
 	@Test
 	public void testFail28() throws Exception {


### PR DESCRIPTION
- fix ChangedValueChecker to accept an Expression to ignore if assigned to
- fix ChangedValueChecker.UpdateVisitor to ignore the specified Expression on left side of Assignment, if specified
- add new test to ExtractTempTests and fix test cases which behave different with new logic
- fix ExtractTempRefactoring to pass the selected expression to ignore if assigned to and if assigned to, replace with a double assignment (x = y = zzzz)
- also fix ExtractTempRefactoring name logic to bump up the end number rather than concatenating a new digit
- fixes #1901

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
