### PR TITLE
Fix Unnecessary Array cleanup to remove unneeded imports

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnwrapNewArrayOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnwrapNewArrayOperation.java
@@ -23,6 +23,7 @@ import org.eclipse.text.edits.TextEditGroup;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ArrayCreation;
+import org.eclipse.jdt.core.dom.ArrayType;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
@@ -37,6 +38,7 @@ import org.eclipse.jdt.internal.corext.refactoring.nls.NLSElement;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSLine;
 import org.eclipse.jdt.internal.corext.refactoring.nls.NLSScanner;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
 
 /**
  * Unwrap a new array with initializer used as input for varargs and replace with initializer elements.
@@ -55,8 +57,10 @@ public class UnwrapNewArrayOperation extends CompilationUnitRewriteOperation {
 		ASTRewrite rewrite= cuRewrite.getASTRewrite();
 		List<Expression> expressionsInArray= node != null && node.getInitializer() != null && node.getInitializer().expressions() != null ?
 				node.getInitializer().expressions() : Collections.EMPTY_LIST;
+		ArrayType arrayType= node != null ? node.getType() : null;
 		ICompilationUnit cu= cuRewrite.getCu();
 		CompilationUnit root= cuRewrite.getRoot();
+		ImportRemover remover= cuRewrite.getImportRemover();
 
 		boolean tagged= false;
 		try {
@@ -137,6 +141,9 @@ public class UnwrapNewArrayOperation extends CompilationUnitRewriteOperation {
 			}
 
 			rewrite.replace(call, replacementNode, group);
+		}
+		if (arrayType != null) {
+			remover.registerRemovedNode(arrayType);
 		}
 	}
 }


### PR DESCRIPTION
- use ImportRemover in UnwrapNewArrayOperation.java
- add new test to CleanUpTest1d5
- fixes #2222

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
