### PR TITLE
Fix Standard Comparison clean-up false positive for enablement

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -29182,6 +29182,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			package test1;
 
 			import java.util.Comparator;
+			import java.util.Random;
 
 			public class E implements Comparator<Double> {
 			    public boolean doNotRefactorValidCases() {
@@ -29240,6 +29241,19 @@ public class CleanUpTest extends CleanUpTestCase {
 			    public int compare(Double o1, Double o2) {
 			        return Double.compare(o1, o2) + 100;
 			    }
+
+			    public void doNotRefactorIssue2221() {
+				    if (getVal().intValue() == 1)
+					    System.out.println("1");
+					if (getVal().intValue() == 2)
+						System.out.println("2");
+					if (getVal().intValue() == -1)
+						System.out.println("-1");
+				}
+
+				private Integer getVal() {
+					return new Random().nextInt();
+				}
 			}
 			""";
 		ICompilationUnit cu= pack.createCompilationUnit("E.java", sample, false, null);


### PR DESCRIPTION
- fix StandardComparisonFixCore.StandardComparisonFinder to look for known comparisons (Comparable.compareTo, Comparator.compare, and String.compareToIgnoreCase)
- add new test to CleanUpTest
- fixes #2221

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
