### PR TITLE
Fix make static anonymous class handling

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/InstanceUsageRewriter.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/makestatic/InstanceUsageRewriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Vector Informatik GmbH and others.
+ * Copyright (c) 2023, 2025 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License 2.0 which accompanies this distribution, and is available at
@@ -143,13 +143,7 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 
 		Name qualifier= node.getQualifier();
 
-		if (qualifier != null) {
-			IBinding qualifierBinding= qualifier.resolveBinding();
-			ITypeBinding typeBinding= (ITypeBinding) qualifierBinding;
-			if (isAccessToAnonymousClass(node, typeBinding)) {
-				return super.visit(node);
-			}
-		} else {
+		if (qualifier == null) {
 			if (parentIsAnonymousClass(parentNode)) {
 				return super.visit(node);
 			}
@@ -201,7 +195,9 @@ public final class InstanceUsageRewriter extends ASTVisitor {
 
 	private void modifyFieldUsage(SimpleName node, IVariableBinding variableBinding) {
 		if (isAccessToAnonymousClass(node, variableBinding.getDeclaringClass())) {
-			return;
+			if (!variableBinding.isField() || !Modifier.isPrivate(variableBinding.getModifiers())) {
+				return;
+			}
 		}
 
 		if (variableBinding.isField() && !Modifier.isStatic(variableBinding.getModifiers())) {

--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.tests.refactoring
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.jdt.ui.tests.refactoring; singleton:=true
-Bundle-Version: 3.16.100.qualifier
+Bundle-Version: 3.16.200.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.tests.refactoring.infra.RefactoringTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Plugin.providerName

--- a/org.eclipse.jdt.ui.tests.refactoring/pom.xml
+++ b/org.eclipse.jdt.ui.tests.refactoring/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.tests.refactoring</artifactId>
-  <version>3.16.100-SNAPSHOT</version>
+  <version>3.16.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass/in/Foo.java
@@ -1,0 +1,26 @@
+public class Foo {
+    private final int counter;
+
+    public Foo(int initialCounter) {
+        counter = initialCounter;
+    }
+
+    void toBeRefactored() { // make static refactoring on this method
+        new Foo(counter + 10) {
+            void toImplement() {
+            	System.out.println(counter);
+                // Calling outer class method directly
+                Foo.this.toCall();
+            }
+        }.toImplement();
+    }
+
+    void toCall() {
+        System.out.println("Counter: " + counter);
+    }
+
+    public static void main(String[] args) {
+        Foo foo = new Foo(5);
+        foo.toBeRefactored();
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass/out/Foo.java
@@ -1,0 +1,26 @@
+public class Foo {
+    private final int counter;
+
+    public Foo(int initialCounter) {
+        counter = initialCounter;
+    }
+
+    static void toBeRefactored(Foo foo) { // make static refactoring on this method
+        new Foo(foo.counter + 10) {
+            void toImplement() {
+            	System.out.println(foo.counter);
+                // Calling outer class method directly
+                foo.toCall();
+            }
+        }.toImplement();
+    }
+
+    void toCall() {
+        System.out.println("Counter: " + counter);
+    }
+
+    public static void main(String[] args) {
+        Foo foo = new Foo(5);
+        Foo.toBeRefactored(foo);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass2/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass2/in/Foo.java
@@ -1,0 +1,26 @@
+public class Foo {
+    public final int counter;
+
+    public Foo(int initialCounter) {
+        counter = initialCounter;
+    }
+
+    void toBeRefactored() { // make static refactoring on this method
+        new Foo(counter + 10) {
+            void toImplement() {
+            	System.out.println(counter);
+                // Calling outer class method directly
+                Foo.this.toCall();
+            }
+        }.toImplement();
+    }
+
+    void toCall() {
+        System.out.println("Counter: " + counter);
+    }
+
+    public static void main(String[] args) {
+        Foo foo = new Foo(5);
+        foo.toBeRefactored();
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass2/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testFieldAccessInAnonymousClassExtendingRefactoredClass2/out/Foo.java
@@ -1,0 +1,26 @@
+public class Foo {
+    public final int counter;
+
+    public Foo(int initialCounter) {
+        counter = initialCounter;
+    }
+
+    static void toBeRefactored(Foo foo) { // make static refactoring on this method
+        new Foo(foo.counter + 10) {
+            void toImplement() {
+            	System.out.println(counter);
+                // Calling outer class method directly
+                foo.toCall();
+            }
+        }.toImplement();
+    }
+
+    void toCall() {
+        System.out.println("Counter: " + counter);
+    }
+
+    public static void main(String[] args) {
+        Foo foo = new Foo(5);
+        Foo.toBeRefactored(foo);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testInnerFieldAccessInAnonymousClass3/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testInnerFieldAccessInAnonymousClass3/in/Foo.java
@@ -1,0 +1,18 @@
+public class Foo {
+
+	String instance;
+
+	void bar(int i) {
+
+		this.instance= "";
+
+		new Thread() {
+			void innerMethod() {
+			};
+
+			public void foo() {
+				this.innerMethod();
+			}
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testInnerFieldAccessInAnonymousClass3/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MakeStatic/testInnerFieldAccessInAnonymousClass3/out/Foo.java
@@ -1,0 +1,18 @@
+public class Foo {
+
+	String instance;
+
+	static void bar(Foo foo, int i) {
+
+		foo.instance= "";
+
+		new Thread() {
+			void innerMethod() {
+			};
+
+			public void foo() {
+				this.innerMethod();
+			}
+		};
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MakeStaticRefactoringTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023, 2024 Vector Informatik GmbH and others.
+ * Copyright (c) 2023, 2025 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License 2.0 which accompanies this distribution, and is available at
@@ -384,6 +384,20 @@ public class MakeStaticRefactoringTests extends GenericRefactoringTest {
 	public void testInnerFieldAccessInAnonymousClass() throws Exception {
 		//Method of anonymous class invokes another method of anonymous class -> Refactoring should ignore this invocation
 		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 5, 10, 5, 13);
+		assertHasNoCommonErrors(status);
+	}
+
+	@Test
+	public void testFieldAccessInAnonymousClassExtendingRefactoredClass() throws Exception {
+		//Method of anonymous class invokes another method of anonymous class -> Refactoring should ignore this invocation
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 8, 10, 8, 24);
+		assertHasNoCommonErrors(status);
+	}
+
+	@Test
+	public void testFieldAccessInAnonymousClassExtendingRefactoredClass2() throws Exception {
+		//Method of anonymous class invokes another method of anonymous class -> Refactoring should ignore this invocation
+		RefactoringStatus status= performRefactoringAndMatchFiles(new String[] { "p.Foo" }, 8, 10, 8, 24);
 		assertHasNoCommonErrors(status);
 	}
 


### PR DESCRIPTION
- modify InstanceUsageRewriter.visit(ThisExpression) to not leave qualified this instances in an anonymous class alone
- modify InstanceUsageRewriter.modifyFieldUsage() to modify any anonymous field accesses that are private
- add new tests to MakeStaticRefactoringTests
- fixes #1824

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
