### PR TITLE
Fix indirection refactoring when extending a generic class

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/in/C.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/in/C.java
@@ -1,0 +1,10 @@
+package p;
+
+class C<T> {
+	void f(T t1) {
+	}
+
+	void g() {
+		C.this.f(null);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/in/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/in/Foo.java
@@ -1,0 +1,7 @@
+package p;
+
+public class Foo extends C<Integer> {
+	@Override
+	void f(Integer i1) {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/out/C.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/out/C.java
@@ -1,0 +1,10 @@
+package p;
+
+class C<T> {
+	void f(T t1) {
+	}
+
+	void g() {
+		Foo.h(C.this, null);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/out/Foo.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/IntroduceIndirection/test18_07/out/Foo.java
@@ -1,0 +1,15 @@
+package p;
+
+public class Foo extends C<Integer> {
+	/**
+	 * @param foo
+	 * @param i1
+	 */
+	public static void h(Foo foo, Integer i1) {
+		foo.f(i1);
+	}
+
+	@Override
+	void f(Integer i1) {
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceIndirectionTests1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/IntroduceIndirectionTests1d8.java
@@ -60,4 +60,9 @@ public class IntroduceIndirectionTests1d8 extends IntroduceIndirectionTests {
 	public void test18_06() throws Exception {
 		helperPass(new String[] { "p.Foo", "p.C" }, "d", "p.C", 5, 17, 5, 18);
 	}
+
+	@Test
+	public void test18_07() throws Exception {
+		helperPass(new String[] { "p.Foo", "p.C" }, "h", "p.Foo", 5, 10, 5, 11);
+	}
 }


### PR DESCRIPTION
- fix IntroduceIndirectionRefactoring.checkFinalConditions() to handle the case where the declaring class is generic
- add new test to IntroduceIndirectionTests1d8
- fixes #2240

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
