### PR TITLE
Add new quick-fix/clean-up to replace deprecated fields if possible

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.java
@@ -159,6 +159,7 @@ public class MultiFixMessages extends NLS {
 	public static String RedundantModifiersCleanup_description;
 	public static String SubstringCleanUp_description;
 	public static String InlineDeprecatedMethodCleanUp_description;
+	public static String ReplaceDeprecatedFieldsCleanUp_description;
 	public static String JoinCleanup_description;
 	public static String ArraysFillCleanUp_description;
 	public static String EvaluateNullableCleanUp_description;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/MultiFixMessages.properties
@@ -140,6 +140,7 @@ HashCleanup_description=Use Objects.hash()
 RedundantModifiersCleanup_description=Remove redundant modifiers
 SubstringCleanUp_description=Remove redundant String.substring() parameter
 InlineDeprecatedMethodCleanUp_description=Replace deprecated calls with inlined content where possible
+ReplaceDeprecatedFieldsCleanUp_description=Replace deprecated fields where possible
 JoinCleanup_description=Use String.join()
 ArraysFillCleanUp_description=Use Arrays.fill() when possible
 EvaluateNullableCleanUp_description=Evaluate without null check

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ReplaceDeprecatedFieldCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ReplaceDeprecatedFieldCleanUpCore.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.fix;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation;
+import org.eclipse.jdt.internal.corext.fix.ReplaceDeprecatedFieldFixCore;
+
+import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+
+import org.eclipse.jdt.internal.ui.text.correction.QuickAssistProcessorUtil;
+
+public class ReplaceDeprecatedFieldCleanUpCore extends AbstractMultiFix {
+
+	public ReplaceDeprecatedFieldCleanUpCore() {
+		this(Collections.emptyMap());
+	}
+
+	public ReplaceDeprecatedFieldCleanUpCore(final Map<String, String> options) {
+		super(options);
+	}
+
+	@Override
+	public CleanUpRequirements getRequirements() {
+		boolean requireAST= isEnabled(CleanUpConstants.REPLACE_DEPRECATED_FIELDS);
+		return new CleanUpRequirements(requireAST, false, false, null);
+	}
+
+	@Override
+	public String[] getStepDescriptions() {
+		if (isEnabled(CleanUpConstants.REPLACE_DEPRECATED_FIELDS)) {
+			return new String[] { MultiFixMessages.ReplaceDeprecatedFieldsCleanUp_description };
+		}
+		return new String[0];
+	}
+
+	@Override
+	public String getPreview() {
+		StringBuilder bld= new StringBuilder();
+		bld.append("Class E {\n"); //$NON-NLS-1$
+		bld.append("  /**\n"); //$NON-NLS-1$
+		bld.append("   * @deprecated use {@link K#field2} instead\n"); //$NON-NLS-1$
+		bld.append("   */\n"); //$NON-NLS-1$
+		bld.append("  @Deprecated\n"); //$NON-NLS-1$
+		bld.append("  public int field1;\n"); //$NON-NLS-1$
+		bld.append("}\n\n"); //$NON-NLS-1$
+		if (isEnabled(CleanUpConstants.REPLACE_DEPRECATED_FIELDS)) {
+			bld.append("return K.field2;\n"); //$NON-NLS-1$
+		} else {
+			bld.append("return E.field1;\n"); //$NON-NLS-1$
+		}
+		return bld.toString();
+	}
+
+	@Override
+	public boolean canFix(ICompilationUnit compilationUnit, IProblemLocation problem) {
+		return false;
+	}
+
+	@Override
+	protected ICleanUpFix createFix(CompilationUnit compilationUnit) throws CoreException {
+		if (!isEnabled(CleanUpConstants.REPLACE_DEPRECATED_FIELDS)) {
+			return null;
+		}
+		if (compilationUnit == null)
+			return null;
+
+		final List<ReplaceDeprecatedFieldFixCore.ReplaceDeprecatedFieldProposalOperation> deprecatedFields= new ArrayList<>();
+		ASTVisitor visitor= new ASTVisitor() {
+			@Override
+			public boolean visit(QualifiedName node) {
+				String replacement= QuickAssistProcessorUtil.getDeprecatedFieldReplacement(node);
+				if (replacement != null) {
+					deprecatedFields.add(new ReplaceDeprecatedFieldFixCore.ReplaceDeprecatedFieldProposalOperation(node, replacement));
+				}
+				return false;
+			}
+			@Override
+			public boolean visit(SimpleName node) {
+				if (node.getLocationInParent() == VariableDeclarationFragment.NAME_PROPERTY) {
+					return true;
+				}
+				String replacement= QuickAssistProcessorUtil.getDeprecatedFieldReplacement(node);
+				if (replacement != null) {
+					deprecatedFields.add(new ReplaceDeprecatedFieldFixCore.ReplaceDeprecatedFieldProposalOperation(node, replacement));
+				}
+				return false;
+			}
+			@Override
+			public boolean visit(FieldAccess node) {
+				String replacement= QuickAssistProcessorUtil.getDeprecatedFieldReplacement(node);
+				if (replacement != null) {
+					deprecatedFields.add(new ReplaceDeprecatedFieldFixCore.ReplaceDeprecatedFieldProposalOperation(node, replacement));
+				}
+				return false;
+			}
+			@Override
+			public boolean visit(SuperFieldAccess node) {
+				String replacement= QuickAssistProcessorUtil.getDeprecatedFieldReplacement(node);
+				if (replacement != null) {
+					deprecatedFields.add(new ReplaceDeprecatedFieldFixCore.ReplaceDeprecatedFieldProposalOperation(node, replacement));
+				}
+				return false;
+			}
+		};
+		compilationUnit.accept(visitor);
+		if (deprecatedFields.isEmpty()) {
+			return null;
+		}
+		return new ReplaceDeprecatedFieldFixCore(getPreview(), compilationUnit, deprecatedFields.toArray(new CompilationUnitRewriteOperation[0]));
+	}
+
+	@Override
+	public int computeNumberOfFixes(CompilationUnit compilationUnit) {
+		if (!isEnabled(CleanUpConstants.REPLACE_DEPRECATED_FIELDS)) {
+			return 0;
+		}
+		if (compilationUnit == null)
+			return 0;
+
+		final List<ASTNode> deprecatedFields= new ArrayList<>();
+		ASTVisitor visitor= new ASTVisitor() {
+			@Override
+			public boolean visit(QualifiedName node) {
+				if (QuickAssistProcessorUtil.getDeprecatedFieldReplacement(node) != null) {
+					deprecatedFields.add(node);
+				}
+				return true;
+			}
+			@Override
+			public boolean visit(FieldAccess node) {
+				if (QuickAssistProcessorUtil.getDeprecatedFieldReplacement(node) != null) {
+					deprecatedFields.add(node);
+				}
+				return true;
+			}
+			@Override
+			public boolean visit(SuperFieldAccess node) {
+				if (QuickAssistProcessorUtil.getDeprecatedFieldReplacement(node) != null) {
+					deprecatedFields.add(node);
+				}
+				return true;
+			}
+		};
+		compilationUnit.accept(visitor);
+		return deprecatedFields.size();
+	}
+
+	@Override
+	protected ICleanUpFix createFix(CompilationUnit unit, IProblemLocation[] problems) throws CoreException {
+		return null;
+	}
+
+}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/IProposalRelevance.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/IProposalRelevance.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -58,6 +58,7 @@ public interface IProposalRelevance {
 	int CREATE_OPTIONAL= 9;
 	int CREATE_OPTIONAL_OF_NULLABLE= 9;
 	int INLINE_DEPRECATED_METHOD= 9;
+	int REPLACE_DEPRECATED_FIELD= 9;
 
 	int ADD_ABSTRACT_MODIFIER= 8;
 	int ADD_STATIC_MODIFIER= 8;

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessorUtil.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessorUtil.java
@@ -27,6 +27,7 @@ import org.eclipse.jface.text.link.LinkedPositionGroup;
 
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
@@ -41,6 +42,8 @@ import org.eclipse.jdt.core.dom.CreationReference;
 import org.eclipse.jdt.core.dom.Expression;
 import org.eclipse.jdt.core.dom.ExpressionMethodReference;
 import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IDocElement;
@@ -49,6 +52,7 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.LambdaExpression;
+import org.eclipse.jdt.core.dom.MemberRef;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.MethodRef;
@@ -56,9 +60,11 @@ import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.SuperMethodReference;
 import org.eclipse.jdt.core.dom.TagElement;
@@ -728,6 +734,108 @@ public class QuickAssistProcessorUtil {
 		if (methodDecl == null) {
 			// is methodDecl defined in another CU?
 			ITypeBinding declaringTypeDecl= methodBinding.getDeclaringClass().getTypeDeclaration();
+			if (declaringTypeDecl.isFromSource()) {
+				ICompilationUnit targetCU= null;
+				try {
+					targetCU= ASTResolving.findCompilationUnitForBinding(cu, compilationUnit, declaringTypeDecl);
+				} catch (JavaModelException e) { /* can't do better */
+				}
+				if (targetCU != null) {
+					return ASTResolving.createQuickFixAST(targetCU, null);
+				}
+			}
+			return null;
+		}
+		return compilationUnit;
+	}
+
+	public static String getDeprecatedFieldReplacement(ASTNode node) {
+		IBinding binding= null;
+		switch (node) {
+			case QualifiedName q:
+				binding= q.resolveBinding();
+				break;
+			case SimpleName s:
+				if (s.getLocationInParent() == QualifiedName.NAME_PROPERTY) {
+					node= s.getParent();
+					binding= ((QualifiedName)node).resolveBinding();
+				} else {
+					binding= s.resolveBinding();;
+				}
+				break;
+			case FieldAccess f:
+//				if (f.getExpression() instanceof MethodInvocation) {
+//					return null;
+//				}
+				binding= f.resolveFieldBinding();
+				break;
+			case SuperFieldAccess sf:
+				binding= sf.resolveFieldBinding();
+				break;
+			default:
+				return null;
+		}
+		if (binding instanceof IVariableBinding varBinding && varBinding.isField()) {
+			IField field= (IField)varBinding.getJavaElement();
+			if (field == null) {
+				return null;
+			}
+			IAnnotationBinding[] annotations= varBinding.getAnnotations();
+			for (IAnnotationBinding annotation : annotations) {
+				if (annotation.getAnnotationType().getQualifiedName().equals("java.lang.Deprecated")) { //$NON-NLS-1$
+					CompilationUnit sourceCu= (CompilationUnit)node.getRoot();
+					CompilationUnit cu= findCUForField(sourceCu, (ICompilationUnit)sourceCu.getJavaElement(), varBinding);
+					if (cu == null) {
+						return null;
+					}
+					try {
+						FieldDeclaration fieldDeclaration= ASTNodeSearchUtil.getFieldDeclarationNode(field, cu);
+						Javadoc javadoc= fieldDeclaration.getJavadoc();
+						if (javadoc == null) {
+							return null;
+						}
+						List<TagElement> tags= javadoc.tags();
+						for (TagElement tag : tags) {
+							if ("@deprecated".equals(tag.getTagName())) { //$NON-NLS-1$
+								List<IDocElement> fragments= tag.fragments();
+								if (fragments.size() < 2) {
+									return null;
+								}
+								if (fragments.get(0) instanceof TextElement textElement) {
+									String text= textElement.getText().toLowerCase().trim();
+									if (text.endsWith("use") || text.endsWith("replace by")) { //$NON-NLS-1$ //$NON-NLS-2$
+										if (fragments.get(1) instanceof TagElement tagElement) {
+											if ("@link".equals(tagElement.getTagName())) { //$NON-NLS-1$
+												List<IDocElement> linkFragments= tagElement.fragments();
+												if (linkFragments.size() == 1) {
+													IDocElement linkFragment= linkFragments.get(0);
+													if (linkFragment instanceof MemberRef methodRef) {
+														IBinding refBinding= methodRef.resolveBinding();
+														if (refBinding instanceof IVariableBinding replaceBinding && replaceBinding.isField()) {
+															return replaceBinding.getDeclaringClass().getQualifiedName() + "." + replaceBinding.getName(); //$NON-NLS-1$
+														}
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					} catch (JavaModelException e) {
+						// ignore
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	public static CompilationUnit findCUForField(CompilationUnit compilationUnit, ICompilationUnit cu, IVariableBinding fieldBinding) {
+		ASTNode fieldDecl= compilationUnit.findDeclaringNode(fieldBinding.getVariableDeclaration());
+		if (fieldDecl == null) {
+			// is field defined in another CU?
+			ITypeBinding declaringTypeDecl= fieldBinding.getDeclaringClass().getTypeDeclaration();
 			if (declaringTypeDecl.isFromSource()) {
 				ICompilationUnit targetCU= null;
 				try {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1301,9 +1301,20 @@ public class CleanUpConstants {
 	 *
 	 * @see CleanUpOptions#TRUE
 	 * @see CleanUpOptions#FALSE
-	 * @since 4.30
+	 * @since 4.37
 	 */
 	public static final String REPLACE_DEPRECATED_CALLS= "cleanup.replace_deprecated_calls"; //$NON-NLS-1$
+
+	/**
+	 * Replace deprecated fields with specified replacement fields if possible.
+	 * <p>
+	 * Possible values: {TRUE, FALSE}
+	 *
+	 * @see CleanUpOptions#TRUE
+	 * @see CleanUpOptions#FALSE
+	 * @since 4.30
+	 */
+	public static final String REPLACE_DEPRECATED_FIELDS= "cleanup.replace_deprecated_fields"; //$NON-NLS-1$
 
 	/**
 	 * Replaces {@code String.replaceAll()} by {@code String.replace()}.

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.java
@@ -186,6 +186,7 @@ public final class FixMessages extends NLS {
 	public static String StringConcatToTextBlockFix_convert_msg;
 	public static String LambdaExpressionAndMethodRefFix_clean_up_expression_msg;
 	public static String InlineDeprecatedMethod_msg;
+	public static String ReplaceDeprecatedField_msg;
 
 	static {
 		// initialize resource bundle

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.properties
@@ -165,6 +165,7 @@ StringBufferToStringBuilderFix_convert_msg=Convert StringBuffer to StringBuilder
 StringConcatToTextBlockFix_convert_msg=Convert String concatenation to Text Block
 LambdaExpressionAndMethodRefFix_clean_up_expression_msg=Clean up lambda expression
 InlineDeprecatedMethod_msg=Replace with inlined method
+ReplaceDeprecatedField_msg=Replace deprecated field
 
 OneIfRatherThanDuplicateBlocksThatFallThroughFix_description=Single 'if' statement rather than duplicate blocks that fall through
 PullOutIfFromIfElseFix_description=Pull out a duplicate 'if' from an if/else

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ReplaceDeprecatedFieldFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ReplaceDeprecatedFieldFixCore.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.corext.fix;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.IImportDeclaration;
+import org.eclipse.jdt.core.IPackageDeclaration;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SuperFieldAccess;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+
+import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
+
+public class ReplaceDeprecatedFieldFixCore extends CompilationUnitRewriteOperationsFixCore {
+
+	public ReplaceDeprecatedFieldFixCore(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperation operation) {
+		super(name, compilationUnit, operation);
+	}
+
+	public ReplaceDeprecatedFieldFixCore(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperation operations[]) {
+		super(name, compilationUnit, operations);
+	}
+
+	public static ReplaceDeprecatedFieldFixCore create(String name, String replacement, CompilationUnit compilationUnit, ASTNode node) {
+		return new ReplaceDeprecatedFieldFixCore(name, compilationUnit, new ReplaceDeprecatedFieldProposalOperation(node, replacement));
+	}
+
+	public static class ReplaceDeprecatedFieldProposalOperation extends CompilationUnitRewriteOperation {
+
+		private final ASTNode fNode;
+		private final String fReplacement;
+
+		public ReplaceDeprecatedFieldProposalOperation(ASTNode node, String name) {
+			this.fNode= node;
+			this.fReplacement= name;
+		}
+
+		@Override
+		public void rewriteAST(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel) throws CoreException {
+			AST ast= cuRewrite.getAST();
+			ASTRewrite rewrite= cuRewrite.getASTRewrite();
+			ImportRewrite importRewrite= cuRewrite.getImportRewrite();
+			ImportRemover importRemover= cuRewrite.getImportRemover();
+			IPackageDeclaration[] packageDecls= cuRewrite.getCu().getPackageDeclarations();
+
+			IVariableBinding fieldBinding= null;
+			switch (fNode.getNodeType()) {
+				case ASTNode.QUALIFIED_NAME:
+					fieldBinding= (IVariableBinding) ((QualifiedName)fNode).resolveBinding();
+					break;
+				case ASTNode.SIMPLE_NAME:
+					fieldBinding= (IVariableBinding) ((SimpleName)fNode).resolveBinding();
+					break;
+				case ASTNode.FIELD_ACCESS:
+					fieldBinding= ((FieldAccess)fNode).resolveFieldBinding();
+					break;
+				case ASTNode.SUPER_FIELD_ACCESS:
+					fieldBinding= ((SuperFieldAccess)fNode).resolveFieldBinding();
+					break;
+				default:
+					break;
+			}
+
+			boolean sameClass= false;
+			boolean mustQualify= false;
+			int simpleNameQualifierIndex= -1;
+			String simpleNameQualifier= ""; //$NON-NLS-1$
+			int lastDot= fReplacement.lastIndexOf('.');
+			if (lastDot > 0) {
+				int startIndex= lastDot - 1;
+				while (startIndex >= 0 && Character.isJavaIdentifierPart(fReplacement.charAt(startIndex))) {
+					--startIndex;
+				}
+				simpleNameQualifierIndex= startIndex + 1;
+				simpleNameQualifier= fReplacement.substring(simpleNameQualifierIndex, lastDot);
+				if (fieldBinding != null) {
+					ITypeBinding classBinding= fieldBinding.getDeclaringClass();
+					String className= classBinding.getQualifiedName();
+					if (className != null && className.equals(fReplacement.substring(0, lastDot))) {
+						sameClass= true;
+					}
+				}
+				IImportDeclaration[] importDecls= cuRewrite.getCu().getImports();
+				for (IImportDeclaration importDecl : importDecls) {
+					String elementName= importDecl.getElementName();
+					if (!importDecl.isOnDemand()) {
+						int elementLastDot= elementName.lastIndexOf('.');
+						if (elementLastDot > 0) {
+							String importName= elementName.substring(elementLastDot + 1);
+							if (importName.equals(simpleNameQualifier) && !elementName.equals(fReplacement.substring(0, lastDot))
+									&& !fReplacement.substring(0, lastDot).equals(packageDecls[0].getElementName())) {
+								mustQualify= !sameClass;
+								break;
+							}
+						}
+					}
+				}
+			}
+
+			if (mustQualify) {
+				Name newName= ast.newName(fReplacement);
+				rewrite.replace(fNode, newName, null);
+			} else if (sameClass) {
+				class GetSimpleNameVisitor extends ASTVisitor {
+					private SimpleName nameToReplace= fNode instanceof SimpleName simpleName ? simpleName : null;
+					@Override
+					public boolean visit(SimpleName node) {
+						if (node.getLocationInParent() == FieldAccess.NAME_PROPERTY
+								|| node.getLocationInParent() == SuperFieldAccess.NAME_PROPERTY
+								|| node.getLocationInParent() == QualifiedName.NAME_PROPERTY) {
+							nameToReplace= node;
+						}
+						return true;
+					}
+					public SimpleName getNameToReplace() {
+						return nameToReplace;
+					}
+				}
+				GetSimpleNameVisitor visitor= new GetSimpleNameVisitor();
+				fNode.accept(visitor);
+				SimpleName nameToReplace= visitor.getNameToReplace();
+				SimpleName newName= ast.newSimpleName(fReplacement.substring(lastDot + 1));
+				rewrite.replace(nameToReplace, newName, null);
+			} else {
+				importRewrite.addImport(fReplacement.substring(0, lastDot));
+				Name newName= ast.newName(fReplacement.substring(simpleNameQualifierIndex));
+				rewrite.replace(fNode, newName, null);
+			}
+			importRemover.registerRemovedNode(fNode);
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest1d8.java
@@ -3372,4 +3372,144 @@ public class QuickFixTest1d8 extends QuickFixTest {
 		assertExpectedExistInProposals(proposals, new String[] {expected1});
 	}
 
+	@Test
+	public void testIssue2242_fixDeprecatedField1() throws Exception {
+		Hashtable<String, String> options = JavaCore.getOptions();
+		options.put(JavaCore.COMPILER_PB_DEPRECATION, CompilerOptions.WARNING);
+		JavaCore.setOptions(options);
+		IPackageFragment pack2= fSourceFolder.createPackageFragment("test2", false, null);
+
+		String str2= """
+			package test2;
+
+			public interface K {
+				String field1= "abc";
+				String field2= "def";
+			}
+			""";
+		pack2.createCompilationUnit("K.java", str2, false, null);
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str1= """
+			package test1;
+
+			import test2.K;
+
+			public interface B {
+
+				/**
+				 * field to use
+				 *
+				 * @deprecated use {@link K#field2} instead
+				 */
+				@Deprecated	String field= "blah";
+			}
+			""";
+		pack1.createCompilationUnit("B.java", str1, false, null);
+
+		String str= """
+			package test1;
+
+			class E {
+			    public void foo() {
+			        String x = B.field;
+			        System.out.println(x);
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 1, null);
+		assertCorrectLabels(proposals);
+
+		String expected1= """
+				package test1;
+
+				import test2.K;
+
+				class E {
+				    public void foo() {
+				        String x = K.field2;
+				        System.out.println(x);
+				    }
+				}
+				""";
+
+		assertExpectedExistInProposals(proposals, new String[] {expected1});
+	}
+
+	@Test
+	public void testIssue2242_fixDeprecatedField2() throws Exception {
+		Hashtable<String, String> options = JavaCore.getOptions();
+		options.put(JavaCore.COMPILER_PB_DEPRECATION, CompilerOptions.WARNING);
+		JavaCore.setOptions(options);
+		IPackageFragment pack2= fSourceFolder.createPackageFragment("test2", false, null);
+
+		String str2= """
+			package test2;
+
+			public interface K {
+				String field1= "abc";
+				String field2= "def";
+			}
+			""";
+		pack2.createCompilationUnit("K.java", str2, false, null);
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str1= """
+			package test1;
+
+			import test2.K;
+
+			public interface B {
+
+				/**
+				 * field to use
+				 *
+				 * @deprecated use {@link K#field2} instead
+				 */
+				@Deprecated	String field= "blah";
+			}
+			""";
+		pack1.createCompilationUnit("B.java", str1, false, null);
+
+		String str= """
+			package test1;
+
+			class E {
+				private class Z implements B {
+				}
+
+				public void foo() {
+					String x = new Z().field;
+					System.out.println(x);
+				}
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", str, false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot, 2, null);
+		assertCorrectLabels(proposals);
+
+		String expected1= """
+				package test1;
+
+				import test2.K;
+
+				class E {
+					private class Z implements B {
+					}
+
+					public void foo() {
+						String x = K.field2;
+						System.out.println(x);
+					}
+				}
+				""";
+
+		assertExpectedExistInProposals(proposals, new String[] {expected1});
+	}
+
 }

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
@@ -171,6 +171,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(STANDARD_COMPARISON, CleanUpOptions.FALSE);
 		options.setOption(CHECK_SIGN_OF_BITWISE_OPERATION, CleanUpOptions.FALSE);
 		options.setOption(REPLACE_DEPRECATED_CALLS, CleanUpOptions.FALSE);
+		options.setOption(REPLACE_DEPRECATED_FIELDS, CleanUpOptions.FALSE);
 
 		// Duplicate Code
 		options.setOption(OPERAND_FACTORIZATION, CleanUpOptions.FALSE);
@@ -361,6 +362,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(STANDARD_COMPARISON, CleanUpOptions.FALSE);
 		options.setOption(CHECK_SIGN_OF_BITWISE_OPERATION, CleanUpOptions.FALSE);
 		options.setOption(REPLACE_DEPRECATED_CALLS, CleanUpOptions.FALSE);
+		options.setOption(REPLACE_DEPRECATED_FIELDS, CleanUpOptions.FALSE);
 
 		// Duplicate Code
 		options.setOption(OPERAND_FACTORIZATION, CleanUpOptions.FALSE);

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7134,10 +7134,15 @@
             id="org.eclipse.jdt.ui.cleanup.replace_deprecated_calls"
             runAfter="org.eclipse.jdt.ui.cleanup.add_all">
       </cleanUp>
+       <cleanUp
+            class="org.eclipse.jdt.internal.ui.fix.ReplaceDeprecatedFieldCleanUpCore"
+            id="org.eclipse.jdt.ui.cleanup.replace_deprecated_fields"
+            runAfter="org.eclipse.jdt.ui.cleanup.replace_deprecated_calls">
+      </cleanUp>
       <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.VariableDeclarationCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.variables"
-            runAfter="org.eclipse.jdt.ui.cleanup.replace_deprecated_calls">
+            runAfter="org.eclipse.jdt.ui.cleanup.replace_deprecated_fields">
       </cleanUp>
       <cleanUp
             class="org.eclipse.jdt.internal.ui.fix.ElseIfCleanUpCore"

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.java
@@ -180,6 +180,7 @@ public class CleanUpMessages extends NLS {
 	public static String SourceFixingTabPage_CheckboxName_StandardComparison;
 
 	public static String SourceFixingTabPage_CheckboxName_ReplaceDeprecatedMethodCall;
+	public static String SourceFixingTabPage_CheckboxName_ReplaceDeprecatedField;
 
 	public static String DuplicateCodeTabPage_GroupName_DuplicateCode;
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpMessages.properties
@@ -150,13 +150,14 @@ UnnecessaryCodeTabPage_CheckboxName_UnloopedWhile=Convert loop into if when poss
 SourceFixingTabPage_warning=These cleanups may change runtime behavior. Use them carefully.
 
 SourceFixingTabPage_GroupName_standardCode=Code standardization
-SourceFixingTabPage_GroupName_deprecated=Deprecated Method Calls
+SourceFixingTabPage_GroupName_deprecated=Deprecated Method Calls and Fields
 
 SourceFixingTabPage_CheckboxName_InvertEquals=Avoid Object.equals() or String.equalsIgnoreCase() on null objects
 SourceFixingTabPage_CheckboxName_StandardComparison=Compare to zero
 SourceFixingTabPage_CheckboxName_CheckSignOfBitwiseOperation=&Compare with != 0 for bitwise expressions
 
-SourceFixingTabPage_CheckboxName_ReplaceDeprecatedMethodCall=Replace with inlined method where possible
+SourceFixingTabPage_CheckboxName_ReplaceDeprecatedMethodCall=Replace deprecated call with inlined content where possible
+SourceFixingTabPage_CheckboxName_ReplaceDeprecatedField=Replace deprecated field where possible
 
 DuplicateCodeTabPage_GroupName_DuplicateCode=Duplicate code
 DuplicateCodeTabPage_CheckboxName_OperandFactorization=Factorize operands

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/SourceFixingTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/SourceFixingTabPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2023 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,6 +29,7 @@ import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
 import org.eclipse.jdt.internal.ui.fix.BitwiseConditionalExpressionCleanup;
 import org.eclipse.jdt.internal.ui.fix.InlineDeprecatedMethodCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.InvertEqualsCleanUpCore;
+import org.eclipse.jdt.internal.ui.fix.ReplaceDeprecatedFieldCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.StandardComparisonCleanUpCore;
 
 public final class SourceFixingTabPage extends AbstractCleanUpTabPage {
@@ -40,7 +41,8 @@ public final class SourceFixingTabPage extends AbstractCleanUpTabPage {
 				new InvertEqualsCleanUpCore(values),
 				new StandardComparisonCleanUpCore(values),
 				new BitwiseConditionalExpressionCleanup(values),
-				new InlineDeprecatedMethodCleanUpCore(values)
+				new InlineDeprecatedMethodCleanUpCore(values),
+				new ReplaceDeprecatedFieldCleanUpCore(values)
 		};
 	}
 
@@ -66,5 +68,8 @@ public final class SourceFixingTabPage extends AbstractCleanUpTabPage {
 
 		final CheckboxPreference inlineDeprecatedMethodCallPref= createCheckboxPref(deprecatedCodeGroup, numColumns, CleanUpMessages.SourceFixingTabPage_CheckboxName_ReplaceDeprecatedMethodCall, CleanUpConstants.REPLACE_DEPRECATED_CALLS, CleanUpModifyDialog.FALSE_TRUE);
 		registerPreference(inlineDeprecatedMethodCallPref);
+
+		final CheckboxPreference replaceDeprecatedFieldsPref= createCheckboxPref(deprecatedCodeGroup, numColumns, CleanUpMessages.SourceFixingTabPage_CheckboxName_ReplaceDeprecatedField, CleanUpConstants.REPLACE_DEPRECATED_FIELDS, CleanUpModifyDialog.FALSE_TRUE);
+		registerPreference(replaceDeprecatedFieldsPref);
 	}
 }


### PR DESCRIPTION
- add new ReplaceDeprecatedFieldCleanUpCore and ReplaceDeprecatedFieldFixCore classes
- add new method QuickAssistProcessorUtil.getDeprecatedFieldReplacement
- add new logic to QuickFixProcessor and QuickAssistProcessor
- add new option to SourceFixingTabPage to perform replace fields clean-up
- add new tests to CleanUpTest1d8
- fixes #2242

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
