### PR TITLE
Add version bumps for 4.37

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
 					sh """
 					mvn -U -e -DskipTests=false -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						clean verify --batch-mode --fail-at-end \
-						-Pbree-libs -Papi-check -Pjavadoc -Pbuild-individual-bundles \
+						-Pbree-libs -Papi-check -Pjavadoc \
 						-Dmaven.test.failure.ignore=true \
 						-Dcompare-version-with-baselines.skip=false
 					"""
@@ -45,3 +45,5 @@ pipeline {
 		}
 	}
 }
+
+// A dummy change to be removed, just to provoke version increments


### PR DESCRIPTION
Provoke version increment for 4.37.

Part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3093

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
