### PR TITLE
Use class names for selectors to avoid locking in classloader

### DIFF
--- a/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit5.runtime;singleton:=true
-Bundle-Version: 1.1.300.qualifier
+Bundle-Version: 1.1.400.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit5.runner;x-internal:=true
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.jdt.junit5.runtime/pom.xml
+++ b/org.eclipse.jdt.junit5.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit5.runtime</artifactId>
-  <version>1.1.300-SNAPSHOT</version>
+  <version>1.1.400-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestLoader.java
+++ b/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestLoader.java
@@ -75,7 +75,7 @@ public class JUnit5TestLoader implements ITestLoader {
 	}
 
 	private ITestReference createUnfilteredTest(Class<?> clazz, String[][] includeExcludeTags, String[] failureNames) {
-		LauncherDiscoveryRequestBuilder requestBuilder= LauncherDiscoveryRequestBuilder.request().selectors(DiscoverySelectors.selectClass(clazz)).filters(getTagFilters(includeExcludeTags));
+		LauncherDiscoveryRequestBuilder requestBuilder= LauncherDiscoveryRequestBuilder.request().selectors(DiscoverySelectors.selectClass(clazz.getName())).filters(getTagFilters(includeExcludeTags));
 		if (failureNames != null && failureNames.length > 0) {
 			String failureNamesString= ""; //$NON-NLS-1$
 			for (String failureName : failureNames) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2257


## What it does

Use the class name in the selector, rather than a class object, to avoid 'locking in' the classloader of the class. Locking in the class prevents thread context classloaders being used in the discovery phase to load classes.


## How to test

To reproduce the original problem, there are two options:
- Write a JUnit DiscoveryListener which sets a thread context classloader; confirm that with the changes, tests are being loaded with the thread context classloader
- Create a minimal Quarkus application using https://code.quarkus.io/, load it into Eclipse, and then run `GreetingResourceTest` by right clicking on the class name. Without the fix the launch fails, with the fix the launch succeeds.

I've used the Oomph SDK and run an Eclipse with my changes and confirmed they fix the problem.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
