### PR TITLE
Change Junit name comparator to use display name instead of full name

### DIFF
--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.17.100.qualifier
+Bundle-Version: 3.17.200.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -561,9 +561,11 @@ public class TestViewer {
 	}
 
 	private int compareName(Object o1, Object o2) {
-		String testName1= ((TestElement)o1).getDisplayName();
-		String testName2= ((TestElement)o2).getDisplayName();
-		return testName1.toLowerCase().compareTo(testName2.toLowerCase());
+		String testName1Display= ((TestElement)o1).getDisplayName();
+		String testName2Display= ((TestElement)o2).getDisplayName();
+		if (testName1Display != null && testName2Display != null)
+			return testName1Display.toLowerCase().compareTo(testName2Display.toLowerCase());
+		return ((TestElement)o1).getTestName().toLowerCase().compareTo(((TestElement)o2).getTestName().toLowerCase());
 	}
 
 	/**

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -561,8 +561,8 @@ public class TestViewer {
 	}
 
 	private int compareName(Object o1, Object o2) {
-		String testName1= ((TestElement)o1).getTestName();
-		String testName2= ((TestElement)o2).getTestName();
+		String testName1= ((TestElement)o1).getDisplayName();
+		String testName2= ((TestElement)o2).getDisplayName();
 		return testName1.toLowerCase().compareTo(testName2.toLowerCase());
 	}
 


### PR DESCRIPTION
- modify TestViewer.compareName() to use the display names of the elements rather than the full qualified names as the qualified class name is not shown and the user has no idea about why the ordering isn't as expected
- fixes #2244

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
