### PR TITLE
Fix required compiler options for UnusedSuppressWarningsCleanUp

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedSuppressWarningsCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 Red Hat Inc. and others.
+ * Copyright (c) 2024, 2025 Red Hat Inc. and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -91,10 +91,95 @@ public class UnusedSuppressWarningsCleanUp extends AbstractMultiFix {
 		Map<String, String> result= new Hashtable<>();
 
 		if (isEnabled(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS)) {
-			result.putAll(JavaCore.getDefaultOptions());
+//			result.putAll(JavaCore.getOptions());
+			result.put(JavaCore.COMPILER_PB_DEPRECATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_TERMINAL_DEPRECATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_DEPRECATION_IN_DEPRECATED_CODE, JavaCore.ENABLED);
 			result.put(JavaCore.COMPILER_PB_SUPPRESS_WARNINGS, JavaCore.ENABLED);
 			result.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
 			result.put(JavaCore.COMPILER_PB_UNUSED_WARNING_TOKEN, JavaCore.ERROR); // do not change to WARNING
+			// API LEAK
+			result.put(JavaCore.COMPILER_PB_API_LEAKS, JavaCore.WARNING);
+			// BOXING
+			result.put(JavaCore.COMPILER_PB_AUTOBOXING, JavaCore.WARNING);
+			// CAST
+			result.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.WARNING);
+			// PREVIEW
+			result.put(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.WARNING);
+			// RAW
+			result.put(JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE, JavaCore.WARNING);
+			// SERIAL
+			result.put(JavaCore.COMPILER_PB_MISSING_SERIAL_VERSION, JavaCore.WARNING);
+			// SYNCHRONIZED
+			result.put(JavaCore.COMPILER_PB_MISSING_SYNCHRONIZED_ON_INHERITED_METHOD, JavaCore.WARNING);
+			// SUPER
+			result.put(JavaCore.COMPILER_PB_OVERRIDING_METHOD_WITHOUT_SUPER_INVOCATION, JavaCore.WARNING);
+			// NLS
+			result.put(JavaCore.COMPILER_PB_NON_NLS_STRING_LITERAL, JavaCore.WARNING);
+			// HIDING
+			result.put(JavaCore.COMPILER_PB_HIDDEN_CATCH_BLOCK, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_FIELD_HIDING, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_LOCAL_VARIABLE_HIDING, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_TYPE_PARAMETER_HIDING, JavaCore.WARNING);
+			// NULL options
+			result.put(JavaCore.COMPILER_PB_NULL_REFERENCE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_NULL_ANNOTATION_INFERENCE_CONFLICT, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_NONNULL_PARAMETER_ANNOTATION_DROPPED, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_MISSING_NONNULL_BY_DEFAULT_ANNOTATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_PESSIMISTIC_NULL_ANALYSIS_FOR_FREE_TYPE_VARIABLES, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_NONNULL_TYPEVAR_FROM_LEGACY_INVOCATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_ANNOTATED_TYPE_ARGUMENT_TO_UNANNOTATED, JavaCore.WARNING);
+			// RESTRICTION
+			result.put(JavaCore.COMPILER_PB_FORBIDDEN_REFERENCE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_DISCOURAGED_REFERENCE, JavaCore.WARNING);
+			// STATIC ACCESS
+			result.put(JavaCore.COMPILER_PB_STATIC_ACCESS_RECEIVER, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_INDIRECT_STATIC_ACCESS, JavaCore.WARNING);
+			// UNUSED
+			result.put(JavaCore.COMPILER_PB_UNUSED_LOCAL, getPreview());
+			result.put(JavaCore.COMPILER_PB_UNUSED_PARAMETER, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_EXCEPTION_PARAMETER, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_DECLARED_THROWN_EXCEPTION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_LABEL, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_IMPORT, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_TYPE_ARGUMENTS_FOR_METHOD_INVOCATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_REDUNDANT_SUPERINTERFACE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_DEAD_CODE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_OBJECT_ALLOCATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_TYPE_PARAMETER, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_REDUNDANT_TYPE_ARGUMENTS, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNUSED_LAMBDA_PARAMETER, JavaCore.WARNING);
+			// STATIC_METHOD
+			result.put(JavaCore.COMPILER_PB_MISSING_STATIC_ON_METHOD, JavaCore.WARNING);
+		    result.put(JavaCore.COMPILER_PB_POTENTIALLY_MISSING_STATIC_ON_METHOD, JavaCore.WARNING);
+		    // RESOURCE
+		    result.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_EXPLICITLY_CLOSED_AUTOCLOSEABLE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_RECOMMENDED_RESOURCE_MANAGEMENT, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_INCOMPATIBLE_OWNING_CONTRACT, JavaCore.WARNING);
+			// INCOMPLETE_SWITCH
+			result.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
+			// UNCHECKED
+			result.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.WARNING);
+			String suppressRawWhenUnchecked = System.getProperty("suppressRawWhenUnchecked"); //$NON-NLS-1$
+			if (suppressRawWhenUnchecked != null && "true".equalsIgnoreCase(suppressRawWhenUnchecked)) { //$NON-NLS-1$
+				result.put(JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE, JavaCore.WARNING);
+			}
+		    // JAVADOC
+			result.put(JavaCore.COMPILER_PB_INVALID_JAVADOC, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_MISSING_JAVADOC_COMMENTS, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_MISSING_JAVADOC_TAGS, JavaCore.WARNING);
+			// UNLIKELY_ARGUMENT_TYPE
+			result.put(JavaCore.COMPILER_PB_UNLIKELY_COLLECTION_METHOD_ARGUMENT_TYPE, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_UNLIKELY_EQUALS_ARGUMENT_TYPE, JavaCore.WARNING);
 		}
 
 		return result;


### PR DESCRIPTION
- add options found in compiler irritant set for the various possible problems that can be targetted by SuppressWarnings to UnusedSuppressWarningsCleanUp.getRequiredOptions()
- add new test to CleanUpTest10
- fixes #2271

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
