### PR TITLE
Fix Pattern Matching clean-up name algorithm for conditionals

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/PatternMatchingForInstanceofFixCore.java
@@ -267,16 +267,16 @@ public class PatternMatchingForInstanceofFixCore extends CompilationUnitRewriteO
 							if (methodDecl != null) {
 								CompilationUnit cu= (CompilationUnit) name.getRoot();
 								IJavaProject project= cu.getJavaElement().getJavaProject();
-								replacementName= proposeLocalName(baseName, cu, project, methodDecl, excludedNames.toArray(new String[0]));
+								replacementName= proposeLocalName(baseName, cu, project, castExp, excludedNames.toArray(new String[0]));
 							}
 						}
 						this.expressionsToReplace.add(expressionToReplace);
 					}
 				}
 
-				private String proposeLocalName(String baseName, CompilationUnit root, IJavaProject javaProject, MethodDeclaration methodDecl, String[] usedNames) {
+				private String proposeLocalName(String baseName, CompilationUnit root, IJavaProject javaProject, ASTNode node, String[] usedNames) {
 					// don't propose names that are already in use:
-					Collection<String> variableNames= new ScopeAnalyzer(root).getUsedVariableNames(methodDecl.getStartPosition(), methodDecl.getLength());
+					Collection<String> variableNames= new ScopeAnalyzer(root).getUsedVariableNames(node.getStartPosition(), node.getLength());
 					String[] names= new String[variableNames.size() + usedNames.length];
 					variableNames.toArray(names);
 					System.arraycopy(usedNames, 0, names, variableNames.size(), usedNames.length);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest16.java
@@ -654,6 +654,10 @@ public class CleanUpTest16 extends CleanUpTestCase {
 					String s = (String)x;
 					return s.length();
 				}
+				public String foo10(Object s) {
+					String string = s instanceof String ? (String) s : "";
+					return string;
+				}
 			}
 			""";
 		ICompilationUnit cu= pack.createCompilationUnit("E.java", given, false, null);
@@ -710,7 +714,7 @@ public class CleanUpTest16 extends CleanUpTestCase {
 							i = (Integer) p;
 							i = 7;
 						}
-						return o instanceof String s2 ? s2.length() : i;
+						return o instanceof String s ? s.length() : i;
 					}
 					public int foo5(Object o, Object p) {
 						if (o instanceof String s && p instanceof Integer i) {
@@ -721,13 +725,13 @@ public class CleanUpTest16 extends CleanUpTestCase {
 							i = (Integer) p;
 							i = 7;
 						}
-						return !(o instanceof String s2) ? i : s2.length();
+						return !(o instanceof String s) ? i : s.length();
 					}
 					public int foo6(Object o) {
 						if (o instanceof String s && s.length() > 3) {
 							return s.length - 3();
 						}
-						return !(o instanceof String s2) ? 0 : s2.length();
+						return !(o instanceof String s) ? 0 : s.length();
 					}
 					public int foo7(Object o) {
 						if (!(o instanceof String s) || s.length() > 3) {
@@ -753,6 +757,10 @@ public class CleanUpTest16 extends CleanUpTestCase {
 							return 7;
 						}
 						return s.length();
+					}
+					public String foo10(Object s) {
+						String string = s instanceof String s2 ? s2 : "";
+						return string;
 					}
 				}
 				""";


### PR DESCRIPTION
- fix PatternMatchingForInstanceofFixCore conditional support to use the cast expression offset for name scope analysis, rather than the method declaration
- modify test in CleanUpTest16
- fixes #2270

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or modified test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
