### PR TITLE
allow overlapping start and end markers for custom folding regions

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -54,7 +54,7 @@ public class FoldingTest {
 
 	private IPackageFragment packageFragment;
 
-	@Parameters(name = "New folding active: {0}")
+	@Parameters(name = "Extended folding active: {0}")
 	public static Object[] data() {
 		return new Object[] { true, false };
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
@@ -68,14 +68,20 @@ public final class FoldingTestUtils {
 		int endLineBegin= findLineStartIndex(input, endLine);
 		int endLineEnd= findNextLineStart(input, endLineBegin);
 		endLineEnd= getLengthIfNotFound(input, endLineEnd);
+		int expectedRegionOffset= startLineBegin + 1;
+		int expectedRegionLength= endLineEnd + 1;
+		assertContainsRegionWithOffsetAndLength(projectionRanges, startLine, endLine, expectedRegionOffset, expectedRegionLength);
+	}
+
+	static void assertContainsRegionWithOffsetAndLength(List<IRegion> projectionRanges, int startLine, int endLine, int expectedRegionOffset, int expectedRegionLength) {
 		for (IRegion region : projectionRanges) {
-			if (region.getOffset() == startLineBegin + 1 && region.getOffset() + region.getLength() == endLineEnd + 1) {
+			if (region.getOffset() == expectedRegionOffset && region.getOffset() + region.getLength() == expectedRegionLength) {
 				return;
 			}
 		}
 		fail(
-				"missing region from line " + startLine + " (index " + (startLineBegin + 1) + ") " +
-						"to line " + endLine + " (index " + (endLineEnd + 1) + ")" +
+				"missing region from line " + startLine + " (index " + expectedRegionOffset + ") " +
+						"to line " + endLine + " (index " + expectedRegionLength + ")" +
 						", actual regions: " + projectionRanges
 		);
 	}
@@ -87,7 +93,7 @@ public final class FoldingTestUtils {
 		return startLineEnd;
 	}
 
-	private static int findLineStartIndex(String input, int lineNumber) {
+	static int findLineStartIndex(String input, int lineNumber) {
 		int currentInputIndex= 0;
 		for (int i= 0; i < lineNumber; i++) {
 			currentInputIndex= findNextLineStart(input, currentInputIndex);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -356,6 +356,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	private class FoldingVisitor extends ASTVisitor {
 
 		private FoldingStructureComputationContext ctx;
+		private List<Position> topLevelTypes = new ArrayList<>();
 
 		public FoldingVisitor(FoldingStructureComputationContext ctx) {
 			this.ctx= ctx;
@@ -380,6 +381,8 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				int start= node.getName().getStartPosition();
 				int end= node.getStartPosition() + node.getLength();
 				createFoldingRegion(start, end - start, ctx.collapseMembers());
+			} else {
+				topLevelTypes.add(new Position(node.getStartPosition(), node.getLength()-1));
 			}
 			return true;
 		}
@@ -1093,6 +1096,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	private boolean fCustomFoldingRegionsEnabled;
 	private char[] fCustomFoldingRegionBegin;
 	private char[] fCustomFoldingRegionEnd;
+	private boolean fCustomFoldingRegionMarkersCanOverlap;
 
 	/* filters */
 	/** Member filter, matches nested members (but not top-level types). */
@@ -1276,8 +1280,9 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		fCustomFoldingRegionBegin=customFoldingRegionBegin.toCharArray();
 		fCustomFoldingRegionEnd=customFoldingRegionEnd.toCharArray();
 		fCustomFoldingRegionsEnabled = store.getBoolean(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED) &&
-				!customFoldingRegionBegin.isEmpty() && !customFoldingRegionEnd.isEmpty() &&
-				!customFoldingRegionBegin.startsWith(customFoldingRegionEnd) && !customFoldingRegionEnd.startsWith(customFoldingRegionBegin);
+				!customFoldingRegionBegin.isEmpty() && !customFoldingRegionEnd.isEmpty();
+		// do not include the end region marker in the folded region if the start and end markers are not mutually exclusive
+		fCustomFoldingRegionMarkersCanOverlap = customFoldingRegionBegin.startsWith(customFoldingRegionEnd) || customFoldingRegionEnd.startsWith(customFoldingRegionBegin);
 		fNewFolding = store.getBoolean(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED);
 	}
 
@@ -1414,7 +1419,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				Deque<Deque<Integer>> openCustomRegionStartPositions= new ArrayDeque<>();
 				openCustomRegionStartPositions.add(new ArrayDeque<>());
 
-				for (Position nonCommentFoldingRegion : List.copyOf(ctx.fMap.values())) {
+				for (Position nonCommentFoldingRegion : merge(visitor.topLevelTypes, ctx.fMap.values())) {
 
 					// process regions depth-first until reaching the current region
 					currentCommentIndex= processFoldingRegionsForCustomCommentFolding(
@@ -1426,17 +1431,39 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 					}
 
 					// process comments before current region starts
-					currentCommentIndex= checkCustomFoldingCommitsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peekLast(), nonCommentFoldingRegion.getOffset());
+					currentCommentIndex= checkCustomFoldingCommentsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peekLast(), nonCommentFoldingRegion.getOffset());
 
 					currentFoldingPositions.addLast(nonCommentFoldingRegion);
 					openCustomRegionStartPositions.addLast(new ArrayDeque<>());
 				}
 				// process all leftover comments at the end
 				currentCommentIndex= processFoldingRegionsForCustomCommentFolding(sourceArray, visitor, comments, currentCommentIndex, currentFoldingPositions, openCustomRegionStartPositions, Integer.MAX_VALUE);
-				checkCustomFoldingCommitsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peek(), Integer.MAX_VALUE);
+				checkCustomFoldingCommentsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peek(), Integer.MAX_VALUE);
+
+				for (Deque<Integer> activeFoldingRegions : openCustomRegionStartPositions) {
+					endAllActiveFoldingRegions(sourceArray, visitor, activeFoldingRegions, sourceArray.length - 1);
+				}
 			}
 		} catch (JavaModelException | IllegalStateException e) {
 		}
+	}
+
+	private List<Position> merge(List<Position> topLevelTypes, Collection<Position> nonCustomFoldingRegions) {
+		List<Position> merged = new ArrayList<>(topLevelTypes.size() + nonCustomFoldingRegions.size());
+
+		int topLevelIndex = 0;
+		for (Position region : nonCustomFoldingRegions) {
+			while (topLevelIndex < topLevelTypes.size() && topLevelTypes.get(topLevelIndex).getOffset() < region.getOffset()) {
+				merged.add(topLevelTypes.get(topLevelIndex++));
+			}
+			merged.add(region);
+		}
+
+		while (topLevelIndex < topLevelTypes.size()) {
+			merged.add(topLevelTypes.get(topLevelIndex++));
+		}
+
+		return merged;
 	}
 
 	/**
@@ -1459,15 +1486,37 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			currentFoldingPositions.removeLast();
 			Deque<Integer> innerOpenStartPositions= openCustomRegionStartPositions.removeLast();
 
-			currentCommentIndex= checkCustomFoldingCommitsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, innerOpenStartPositions, currentFoldingPosition.getOffset() + currentFoldingPosition.getLength());
+			int currentFoldingPositionEnd= currentFoldingPosition.getOffset() + currentFoldingPosition.getLength();
+			currentCommentIndex= checkCustomFoldingCommentsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, innerOpenStartPositions, currentFoldingPositionEnd);
+
+			if (fCustomFoldingRegionMarkersCanOverlap) {
+				endAllActiveFoldingRegions(sourceArray, visitor, innerOpenStartPositions, currentFoldingPositionEnd);
+			}
 
 			if (currentCommentIndex >= comments.size()) {
+				if (fCustomFoldingRegionMarkersCanOverlap) {
+					// end all remaining custom folding regions of all remaining blocks if last comment reached
+					while (!currentFoldingPositions.isEmpty() && !openCustomRegionStartPositions.isEmpty()) {
+						currentFoldingPosition= currentFoldingPositions.removeLast();
+						innerOpenStartPositions= openCustomRegionStartPositions.removeLast();
+						endAllActiveFoldingRegions(sourceArray, visitor, innerOpenStartPositions, currentFoldingPosition.getOffset() + currentFoldingPosition.getLength());
+					}
+				}
 				return currentCommentIndex;
 			}
 
 			currentFoldingPosition= currentFoldingPositions.peekLast();
 		}
 		return currentCommentIndex;
+	}
+
+	private void endAllActiveFoldingRegions(char[] sourceArray, FoldingVisitor visitor, Deque<Integer> openRegionsToEnd, int foldingRegionEnd) {
+		if (fCustomFoldingRegionMarkersCanOverlap) {
+			for (Integer startPosition : openRegionsToEnd) {
+				IRegion region= new Region(startPosition, foldingRegionEnd - startPosition);
+				checkIncludeLastLineAndCreateCustomFoldingRegion(sourceArray, visitor, region, false);
+			}
+		}
 	}
 
 
@@ -1482,7 +1531,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	 * @param limit only regions before this position are scanned
 	 * @return the new index of the next comment to process (after limit)
 	 */
-	private int checkCustomFoldingCommitsBeforePosition(char[] sourceArray, FoldingVisitor visitor, List<Comment> comments, int currentCommentIndex,
+	private int checkCustomFoldingCommentsBeforePosition(char[] sourceArray, FoldingVisitor visitor, List<Comment> comments, int currentCommentIndex,
 			Deque<Integer> innerOpenStartPositions, int limit) {
 		while (currentCommentIndex < comments.size() && comments.get(currentCommentIndex).getStartPosition() < limit) {
 			Comment comment= comments.get(currentCommentIndex);
@@ -1503,14 +1552,19 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				comment.getStartPosition(), comment.getStartPosition() + comment.getLength()
 		);
 		if (customFoldingRegion != null) {
-			if (includeLastLineInCustomFoldingRegion(sourceArray, customFoldingRegion.getOffset() + customFoldingRegion.getLength())) {
-				includelastLine= true;
-			}
-			visitor.createFoldingRegion(customFoldingRegion.getOffset(), customFoldingRegion.getLength(), fCollapseCustomRegions);
+			checkIncludeLastLineAndCreateCustomFoldingRegion(sourceArray, visitor, customFoldingRegion, fCustomFoldingRegionMarkersCanOverlap);
 		}
 	}
 
-	private boolean includeLastLineInCustomFoldingRegion(char[] sourceArray, int regionEnd) {
+	private void checkIncludeLastLineAndCreateCustomFoldingRegion(char[] sourceArray, FoldingVisitor visitor, IRegion customFoldingRegion, boolean excludeEndregionComment) {
+		includelastLine = includeLastLineInCustomFoldingRegion(sourceArray, customFoldingRegion.getOffset() + customFoldingRegion.getLength(), excludeEndregionComment);
+		visitor.createFoldingRegion(customFoldingRegion.getOffset(), customFoldingRegion.getLength(), fCollapseCustomRegions);
+	}
+
+	private boolean includeLastLineInCustomFoldingRegion(char[] sourceArray, int regionEnd, boolean excludeEndregionComment) {
+		if (excludeEndregionComment) {
+			return false;
+		}
 		char firstCharacter = sourceArray[regionEnd];
 		if (firstCharacter == '\n' || firstCharacter == '\r') {
 			return true;
@@ -1631,7 +1685,11 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			int offset= document.getLineOffset(start);
 			int endOffset;
 			if (includelastLine) {
-				endOffset= document.getLineOffset(end + 1);
+				if (document.getNumberOfLines() == end + 1) {
+					endOffset = document.getLength() - 1;
+				} else {
+					endOffset= document.getLineOffset(end + 1);
+				}
 				includelastLine = false;
 			}
 			else {
@@ -1733,7 +1791,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 						boolean commentCollapse;
 						if (i == 0 && (regions.length > 2 || ctx.hasHeaderComment()) && element == ctx.getFirstType()) {
 							commentCollapse= ctx.collapseHeaderComments();
-						} else if(ctx.fCurrentCustomRegions.contains(region)) {
+						} else if (ctx.fCurrentCustomRegions.contains(region)) {
 							commentCollapse= ctx.collapseCustomRegions();
 						} else {
 							commentCollapse= ctx.collapseJavadoc();
@@ -1884,7 +1942,9 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				if (fCustomFoldingRegionsEnabled) {
 					if (reference instanceof IParent parent && !parent.hasChildren()) {
 						// if the element has no children, check content for custom folding region markers
-						checkCustomFoldingUntilScannerEnd(ctx, regions, new ArrayDeque<>(), scanner);
+						Deque<Integer> openCustomRegionStartPositions= new ArrayDeque<>();
+						checkCustomFoldingUntilScannerEnd(ctx, regions, openCustomRegionStartPositions, scanner);
+						addRemainingOpenCustomFoldingRegions(range, regions, ctx, openCustomRegionStartPositions, false);
 					}
 					ctx.fLastScannedIndex= scanner.getCurrentTokenEndPosition();
 					if (reference instanceof IJavaElement javaElement && javaElement.getParent() != null &&
@@ -1898,6 +1958,8 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 							int regionEnd= parentRange.getOffset() + parentRange.getLength();
 							scanner.resetTo(regionStart, regionEnd);
 							checkCustomFoldingUntilScannerEnd(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner);
+
+							addRemainingOpenCustomFoldingRegions(range, regions, ctx, ctx.fOpenCustomRegionStartPositions, true);
 						}
 					}
 				}
@@ -1910,9 +1972,19 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		return new IRegion[0];
 	}
 
+	private void addRemainingOpenCustomFoldingRegions(ISourceRange range, List<IRegion> regions, FoldingStructureComputationContext ctx, Deque<Integer> openCustomRegionStartPositions, boolean includeLastLine) {
+		if (fCustomFoldingRegionMarkersCanOverlap) {
+			for (Integer openRegion : openCustomRegionStartPositions) {
+				Region region= new Region(openRegion, range.getOffset() + range.getLength() - openRegion);
+				this.includelastLine= includeLastLine;
+				regions.add(Math.max(regions.size() - 1, 0), alignRegion(region, ctx));
+			}
+		}
+	}
+
 	private void checkCustomFoldingUntilScannerEnd(FoldingStructureComputationContext ctx, List<IRegion> regions, Deque<Integer> openCustomRegionStartPositions, IScanner scanner) throws InvalidInputException {
-		for(int token = scanner.getNextToken(); token != ITerminalSymbols.TokenNameEOF; token=scanner.getNextToken()) {
-			if(isCommentToken(token)) {
+		for (int token = scanner.getNextToken(); token != ITerminalSymbols.TokenNameEOF; token=scanner.getNextToken()) {
+			if (isCommentToken(token)) {
 				checkCustomFolding(ctx, regions, openCustomRegionStartPositions, scanner, token, Math.max(regions.size() - 1, 0));
 			}
 		}
@@ -1934,7 +2006,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 		IRegion region= checkCustomFolding(openCustomRegionStartPositions, commentTextStart, source, currentTokenStartPosition, currentTokenEndPosition);
 		if (region != null) {
-			if (!includeLastLineInCustomFoldingRegion(source, currentTokenEndPosition)) {
+			if (!includeLastLineInCustomFoldingRegion(source, currentTokenEndPosition, fCustomFoldingRegionMarkersCanOverlap)) {
 				includelastLine= false;
 				region= alignRegion(region, ctx);
 			}
@@ -1946,17 +2018,17 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	private Region checkCustomFolding(Deque<Integer> openCustomRegionStartPositions, int commentTextStart, char[] source, int currentTokenStartPosition, int currentTokenEndPosition) {
 		int currentTokenLengthStartingAtCommentTextStart= currentTokenEndPosition - commentTextStart;
 
-		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCustomFoldingRegionBegin)) {
-			openCustomRegionStartPositions.add(currentTokenStartPosition);
-		}
-
+		Region returnedRegion= null;
 		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCustomFoldingRegionEnd) && !openCustomRegionStartPositions.isEmpty()) {
 			int end= currentTokenEndPosition;
 			Integer regionStart= openCustomRegionStartPositions.removeLast();
-			return new Region(regionStart, end - regionStart);
-
+			returnedRegion= new Region(regionStart, end - regionStart);
 		}
-		return null;
+
+		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCustomFoldingRegionBegin)) {
+			openCustomRegionStartPositions.add(currentTokenStartPosition);
+		}
+		return returnedRegion;
 	}
 
 	private int findPossibleRegionCommentStart(IScanner scanner, int token) {
@@ -1972,7 +2044,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	}
 
 	private int skipLeadingWhitespace(char[] source, int start) {
-		while (Character.isWhitespace(source[start])) {
+		while (start < source.length && Character.isWhitespace(source[start])) {
 			start++;
 		}
 		return start;
@@ -1982,7 +2054,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		if (length < prefix.length) {
 			return false;
 		}
-		for(int i=0;i<prefix.length;i++) {
+		for (int i=0; i < prefix.length; i++) {
 			if (source[offset+i] != prefix[i]) {
 				return false;
 			}


### PR DESCRIPTION
## What it does

In #1825, I contributed custom folding regions but this does not allow using the same marker/prefix for the start and end marker comments.

Looking at classes like [`AddDelegateMethodsAction`](https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/e25880c065ecc1534a94da98dd10f7c957b73719/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/AddDelegateMethodsAction.java), I can see comments splitting the code into different regions where one region ending and another one starting is indicated with the same comment.

Assuming that there are also other projects that would like to use that, I am changing custom folding regions to allow using the same text for start and end markers. The same comment is allowed to be both the end and start of a region.

If the region marker texts aren't mutually exclusive (i.e. if one of them starts with another), the last line is not included in the region.

## Questions for reviewers/maintainers (asking for opinions)

In cases like the one I mentioned, there is typically no comment ending the last region. So I guess it would be good to automatically end custom folding regions if there is no corresponding comment/end marker at the end of the surrounding element. Should I add this?
If so, should this be the case only for non-exclusive start/end regions (e.g. `----` as opposed to `startregion`/`endregion`)? Should this be the case only if the start and end markers are the same or also if one has additional text (e.g. `region`/`regionend`)?
In principle, this could also be a preference but to be honest, I guess there's no need to configure this.

For now, I implemented it in a way that
- If the start and end region markers are overlapping (one starts with another):
  - The end marker comment is excluded from folding e.g. if a region starts and ends with `// ---- ...`, both are visible if the regions are collapsed
  - All non-closed regions end automatically at the end of the block

Doing this for all regions ensures that the end comments are either always shown or never shown for a project (or everything with the same configuration (region markers)).

This includes a change of behavior of custom folding regions shown in `CustomFoldingRegionTest#testCustomFoldingRegionsMultipleLevels()` (see the diff of the test) if the extended folding is active. Before, it allowed custom folding regions spanning spanning over different top level types or starting outside of a top level type and ending within that top level type. Since this PR requires tracking top level types anyway, this confusing behavior is not there any more and custom folding regions behave the same way (in this regard) no matter whether enhanced folding is active or not.

## How to test

- Enable Window > Preferences > Java > Editor > Folding > Enable Folding of custom regions
- In the same preference window, set the start and end region comment text to the same string.
- Edit a Java file like the following:
  ```java
  public class Test {
      // region start first
      
      // region end first, start second
      
      // region end second
  }
  ```

This should add folding regions like this:
![image](https://github.com/user-attachments/assets/e6ae43e8-5ec7-4899-b015-5f80c9e094a6)

This should work both with and without the "Extended Folding" of control structures.

One simple example where this can be used is a class like the following (using `----` as both the start and end region marker):
```java
package org.example.test;

import java.time.LocalDateTime;
import java.util.Objects;

class Test {
	
	// ---- variables ---------------------------------------------
	
	private int i;
	private String s;
	
	private LocalDateTime currentDateTime = LocalDateTime.now();
	
	// ---- constructors ------------------------------------------
	
	public Test() {
		i = 0;
		s = "";
	}
	
	public Test(int i, String s) {
		this.i = i;
		this.s = s;
	}

	// ---- getters/setters ---------------------------------------

	public String getS() {
		return s;
	}

	public void setS(String s) {
		this.s = s;
	}

	public LocalDateTime getCurrentDateTime() {
		return currentDateTime;
	}

	public void setCurrentDateTime(LocalDateTime currentDateTime) {
		this.currentDateTime = currentDateTime;
	}
	
	// ---- equals, hashCode, toString ----------------------------
	
	@Override
	public String toString() {
		return "Test [i=" + i + ", s=" + s + ", currentDateTime=" + currentDateTime + "]";
	}

	@Override
	public int hashCode() {
		return Objects.hash(currentDateTime, i, s);
	}

	@Override
	public boolean equals(Object obj) {
		if (this == obj)
			return true;
		if (obj == null)
			return false;
		if (getClass() != obj.getClass())
			return false;
		Test other = (Test) obj;
		return Objects.equals(currentDateTime, other.currentDateTime) && i == other.i && Objects.equals(s, other.s);
	} 
	
} 
```

![image](https://github.com/user-attachments/assets/2d638418-eaf5-441c-b765-dc83ded9379d)


## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
