### PR TITLE
Initially fold anonymous classes with new folding

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -477,7 +477,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 		@Override
 		public boolean visit(AnonymousClassDeclaration node) {
-			createFoldingRegion(node, ctx.collapseMembers());
+			createFoldingRegion(node, ctx.collapseInnerTypes());
 			return true;
 		}
 


### PR DESCRIPTION
## What it does
If the preferences say that "Inner Types" should be folded by default then anonymous classes should be folded.

## How to test
- Open the preferences
- Go to `Java > Editor > Folding` and check `Inner Types` and `Extended folding >  activate feature`

![image](https://github.com/user-attachments/assets/76e958f2-62f5-4f63-831e-e6037108efcb)

When opening a new file, anonymous classes should be folded.

You can try with this snippet:

```java
class MyClass {
	public static void main(String arg[]) {
		
		// Should be folded by default
		AutoCloseable ac = new AutoCloseable() {
			
			@Override
			public void close() throws Exception {
				// TODO Auto-generated method stub
			}
		};
	}
}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
