### PR TITLE
Add editor hyperlink option for 'Open in new editor' for Types & Methods

### DIFF
--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -1238,6 +1238,7 @@ JavaElementHyperlinkDeclaredTypeDetector= Open Declared Type
 JavaElementHyperlinkReturnTypeDetector= Open Return Type 
 JavaElementHyperlinkSuperImplementationDetector= Open Super Implementation 
 OpenCallHierarchyHyperlinkDetector=Open Call Hierarchy
+JavaElementOpenInNewHyperlinkDetector= Open In New Tab
 
 #--- Clean Up ---
 CleanUpTabPage.CodeStyle.name = &Code Style

--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -1238,6 +1238,7 @@ JavaElementHyperlinkDeclaredTypeDetector= Open Declared Type
 JavaElementHyperlinkReturnTypeDetector= Open Return Type 
 JavaElementHyperlinkSuperImplementationDetector= Open Super Implementation 
 OpenCallHierarchyHyperlinkDetector=Open Call Hierarchy
+JavaElementOpenInNewHyperlinkDetector= Open In New Editor
 
 #--- Clean Up ---
 CleanUpTabPage.CodeStyle.name = &Code Style

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.0"?>
 <!--
-     Copyright (c) 2000, 2021 IBM Corporation and others.
+     Copyright (c) 2000, 2026 IBM Corporation and others.
 
      This program and the accompanying materials
      are made available under the terms of the Eclipse Public License 2.0
@@ -1635,6 +1635,12 @@
             id="org.eclipse.jdt.internal.ui.propertiesfileeditor.PropertyKeyHyperlinkDetector"
             name="%PropertyKeyHyperlinkDetector"
             targetId="org.eclipse.jdt.ui.PropertiesFileEditor">
+      </hyperlinkDetector>
+      <hyperlinkDetector
+	        class="org.eclipse.jdt.internal.ui.javaeditor.JavaElementOpenInNewHyperlinkDetector"
+            id="org.eclipse.jdt.internal.ui.javaeditor.JavaElementOpenInNewHyperlinkDetector"
+            name="%JavaElementOpenInNewHyperlinkDetector"
+            targetId="org.eclipse.jdt.ui.javaCode">
       </hyperlinkDetector>
    </extension>
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -174,6 +174,8 @@ final class JavaEditorMessages extends NLS {
 	public static String JavaElementSuperImplementationHyperlink_hyperlinkText;
 	public static String JavaElementSuperImplementationHyperlink_hyperlinkText_qualified;
 	public static String AnnotateClassFile_label;
+	public static String JavaElementOpenHyperlink_hyperlinkText;
+	public static String JavaElementOpenHyperlink_hyperlinkText_qualified;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, JavaEditorMessages.class);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2020 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -159,6 +159,8 @@ JavaElementReturnTypeHyperlink_hyperlinkText=Open Return Type
 JavaElementReturnTypeHyperlink_error_msg=Cannot open the return type as it cannot be resolved.
 JavaElementSuperImplementationHyperlink_hyperlinkText_qualified= Open Super Implementation for ''{0}''
 JavaElementSuperImplementationHyperlink_hyperlinkText= Open Super Implementation
+JavaElementOpenHyperlink_hyperlinkText= Open In New Tab
+JavaElementOpenHyperlink_hyperlinkText_qualified=Open In New Tab for ''{0}''
 
 Editor_OpenPropertiesFile_error_keyNotFound= The key "{0}" is not defined in this properties file
 Editor_OpenPropertiesFile_error_fileNotFound_dialogMessage= Could not determine properties file

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditorMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2020 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -159,6 +159,8 @@ JavaElementReturnTypeHyperlink_hyperlinkText=Open Return Type
 JavaElementReturnTypeHyperlink_error_msg=Cannot open the return type as it cannot be resolved.
 JavaElementSuperImplementationHyperlink_hyperlinkText_qualified= Open Super Implementation for ''{0}''
 JavaElementSuperImplementationHyperlink_hyperlinkText= Open Super Implementation
+JavaElementOpenHyperlink_hyperlinkText= Open In New Editor
+JavaElementOpenHyperlink_hyperlinkText_qualified=Open In New Editor for ''{0}''
 
 Editor_OpenPropertiesFile_error_keyNotFound= The key "{0}" is not defined in this properties file
 Editor_OpenPropertiesFile_error_fileNotFound_dialogMessage= Could not determine properties file

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewHyperlinkDetector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewHyperlinkDetector.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import java.util.List;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import org.eclipse.ui.IEditorPart;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.ITypeRoot;
+
+import org.eclipse.jdt.ui.actions.SelectionDispatchAction;
+
+
+/**
+ * Java element open in new tab hyperlink detector for types and methods.
+ */
+public class JavaElementOpenInNewHyperlinkDetector extends JavaElementHyperlinkDetector {
+
+	@Override
+	protected void addHyperlinks(List<IHyperlink> hyperlinksCollector, IRegion wordRegion, SelectionDispatchAction openAction, IJavaElement element, boolean qualify, JavaEditor editor) {
+		if (isDeclaredInCurrentEditor(element, editor)) {
+			hyperlinksCollector.add(new JavaElementOpenInNewImplementationHyperlink(wordRegion, element, editor, qualify));
+		}
+	}
+
+	private boolean isDeclaredInCurrentEditor(IJavaElement typeOrMethod, IEditorPart editor) {
+		int type= typeOrMethod.getElementType();
+		if (type != IJavaElement.METHOD && type != IJavaElement.TYPE) {
+			return false;
+		}
+
+		IJavaElement editorElement= EditorUtility.getEditorInputJavaElement(editor, false);
+		if (editorElement instanceof ITypeRoot editorTypeRoot) {
+
+			ITypeRoot elementTypeRoot= (ITypeRoot) typeOrMethod.getAncestor(IJavaElement.COMPILATION_UNIT);
+			if (elementTypeRoot == null) {
+				elementTypeRoot= (ITypeRoot) typeOrMethod.getAncestor(IJavaElement.CLASS_FILE);
+			}
+			return elementTypeRoot.equals(editorTypeRoot);
+		}
+		return false;
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewHyperlinkDetector.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewHyperlinkDetector.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import java.util.List;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import org.eclipse.ui.IEditorPart;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.ITypeRoot;
+
+import org.eclipse.jdt.ui.actions.SelectionDispatchAction;
+
+
+/**
+ * Java element open in new editor hyperlink detector for types and methods.
+ */
+public class JavaElementOpenInNewHyperlinkDetector extends JavaElementHyperlinkDetector {
+
+	@Override
+	protected void addHyperlinks(List<IHyperlink> hyperlinksCollector, IRegion wordRegion, SelectionDispatchAction openAction, IJavaElement element, boolean qualify, JavaEditor editor) {
+		if (isDeclaredInCurrentEditor(element, editor)) {
+			hyperlinksCollector.add(new JavaElementOpenInNewImplementationHyperlink(wordRegion, element, editor, qualify));
+		}
+	}
+
+	private boolean isDeclaredInCurrentEditor(IJavaElement typeOrMethod, IEditorPart editor) {
+		int type= typeOrMethod.getElementType();
+		if (type != IJavaElement.METHOD && type != IJavaElement.TYPE) {
+			return false;
+		}
+
+		IJavaElement editorElement= EditorUtility.getEditorInputJavaElement(editor, false);
+		if (editorElement instanceof ITypeRoot editorTypeRoot) {
+
+			ITypeRoot elementTypeRoot= (ITypeRoot) typeOrMethod.getAncestor(IJavaElement.COMPILATION_UNIT);
+			if (elementTypeRoot == null) {
+				elementTypeRoot= (ITypeRoot) typeOrMethod.getAncestor(IJavaElement.CLASS_FILE);
+			}
+			return elementTypeRoot.equals(editorTypeRoot);
+		}
+		return false;
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewImplementationHyperlink.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewImplementationHyperlink.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import org.eclipse.core.runtime.Assert;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+
+import org.eclipse.jdt.internal.corext.util.Messages;
+
+import org.eclipse.jdt.ui.JavaElementLabels;
+import org.eclipse.jdt.ui.JavaUI;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+
+/**
+ * Java element open in new tab implementation hyperlink.
+ */
+public class JavaElementOpenInNewImplementationHyperlink implements IHyperlink {
+
+	private final IRegion region;
+	private final IJavaElement javaElement;
+	private final boolean qualify;
+
+	/**
+	 * Creates a new Java element open new tab hyperlink for types and methods.
+	 *
+	 * @param region the region of the link
+	 * @param javaElement the element (type or method) to open
+	 *            element
+	 * @param editor the editor
+	 */
+	public JavaElementOpenInNewImplementationHyperlink(IRegion region, IJavaElement javaElement, IEditorPart editor, boolean qualify) {
+		Assert.isNotNull(region);
+		Assert.isNotNull(javaElement);
+		Assert.isTrue(javaElement instanceof IMethod || javaElement instanceof IType);
+		this.qualify = qualify;
+		this.region= region;
+		this.javaElement= javaElement;
+	}
+
+	@Override
+	public IRegion getHyperlinkRegion() {
+		return region;
+	}
+
+	@Override
+	public String getHyperlinkText() {
+		if (qualify) {
+			String elementLabel= JavaElementLabels.getElementLabel(javaElement, JavaElementLabels.ALL_FULLY_QUALIFIED);
+			return Messages.format(JavaEditorMessages.JavaElementOpenHyperlink_hyperlinkText_qualified, new Object[] { elementLabel });
+		}
+		return JavaEditorMessages.JavaElementOpenHyperlink_hyperlinkText;
+	}
+
+	@Override
+	public String getTypeLabel() {
+		return null;
+	}
+
+	/**
+	 * Opens the given implementation hyperlink for types and methods in a new cloned tab.
+	 */
+	@Override
+	public void open() {
+		openInNewTab(javaElement);
+	}
+
+	/**
+	 * Opens the method or type in a new cloned tab
+	 *
+	 * @param javaElement the method or type
+	 */
+	public static void openInNewTab(final IJavaElement javaElement) {
+		try {
+			IEditorPart existingEditor = EditorUtility.isOpenInEditor(javaElement);
+			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+			if (existingEditor == null || window == null) {
+				return;
+			}
+			IWorkbenchPage page= window.getActivePage();
+			if (page == null) {
+				return;
+			}
+			IEditorPart target = page.openEditor(
+					existingEditor.getEditorInput(),
+					existingEditor.getSite().getId(),
+					true,
+					IWorkbenchPage.MATCH_NONE);
+
+			JavaUI.revealInEditor(target, javaElement);
+		} catch (PartInitException e) {
+			JavaPlugin.log(e);
+		}
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewImplementationHyperlink.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaElementOpenInNewImplementationHyperlink.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import org.eclipse.core.runtime.Assert;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+
+import org.eclipse.jdt.internal.corext.util.Messages;
+
+import org.eclipse.jdt.ui.JavaElementLabels;
+import org.eclipse.jdt.ui.JavaUI;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+
+/**
+ * Java element open in new tab implementation hyperlink.
+ */
+public class JavaElementOpenInNewImplementationHyperlink implements IHyperlink {
+
+	private final IRegion region;
+	private final IJavaElement javaElement;
+	private final boolean qualify;
+
+	/**
+	 * Creates a new Java element open new tab hyperlink for types and methods.
+	 *
+	 * @param region the region of the link
+	 * @param javaElement the element (type or method) to open
+	 *            element
+	 * @param editor the editor
+	 */
+	public JavaElementOpenInNewImplementationHyperlink(IRegion region, IJavaElement javaElement, IEditorPart editor, boolean qualify) {
+		Assert.isNotNull(region);
+		Assert.isNotNull(javaElement);
+		Assert.isTrue(javaElement instanceof IMethod || javaElement instanceof IType);
+		this.qualify = qualify;
+		this.region= region;
+		this.javaElement= javaElement;
+	}
+
+	@Override
+	public IRegion getHyperlinkRegion() {
+		return region;
+	}
+
+	@Override
+	public String getHyperlinkText() {
+		if (qualify) {
+			String elementLabel= JavaElementLabels.getElementLabel(javaElement, JavaElementLabels.ALL_FULLY_QUALIFIED);
+			return Messages.format(JavaEditorMessages.JavaElementOpenHyperlink_hyperlinkText_qualified, new Object[] { elementLabel });
+		}
+		return JavaEditorMessages.JavaElementOpenHyperlink_hyperlinkText;
+	}
+
+	@Override
+	public String getTypeLabel() {
+		return null;
+	}
+
+	/**
+	 * Opens the given implementation hyperlink for types and methods in a new cloned editor.
+	 */
+	@Override
+	public void open() {
+		openInNewEditor(javaElement);
+	}
+
+	/**
+	 * Opens the method or type in a new cloned editor
+	 *
+	 * @param javaElement the method or type
+	 */
+	public static void openInNewEditor(final IJavaElement javaElement) {
+		try {
+			IEditorPart existingEditor = EditorUtility.isOpenInEditor(javaElement);
+			IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+			if (existingEditor == null || window == null) {
+				return;
+			}
+			IWorkbenchPage page= window.getActivePage();
+			if (page == null) {
+				return;
+			}
+			IEditorPart target = page.openEditor(
+					existingEditor.getEditorInput(),
+					existingEditor.getSite().getId(),
+					true,
+					IWorkbenchPage.MATCH_NONE);
+
+			JavaUI.revealInEditor(target, javaElement);
+		} catch (PartInitException e) {
+			JavaPlugin.log(e);
+		}
+	}
+}


### PR DESCRIPTION
Allows opening a method or type in a new editor tab from the hyperlink options (cmd+selection) if the element's implementation in the same editor . Improves code navigation, especially when working with large files or understanding multiple methods or types in parallel.

<img width="217" height="156" alt="image" src="https://github.com/user-attachments/assets/0b82c30c-7580-477e-860e-7210ad734430" />


Fixes : https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2265



https://github.com/user-attachments/assets/8baa7a67-82a8-4a48-9809-2bb9bf358ad0




See discussion - https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2265

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test

Right click context menu on methods -> "open method"

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
