### PR TITLE
Validate the names of the methods in the call hierarchy filter dialog

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.java
@@ -75,6 +75,7 @@ public final class CallHierarchyMessages extends NLS {
 	public static String FiltersDialog_filterOnNamesSubCaption;
 	public static String FiltersDialog_maxCallDepth;
 	public static String FiltersDialog_messageMaxCallDepthInvalid;
+	public static String FiltersDialog_messageFilterNamesInvalid;
 	public static String FiltersDialog_filterTestCode;
 	public static String CallHierarchyContentProvider_searchError_title;
 	public static String CallHierarchyContentProvider_searchError_message;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
@@ -72,6 +72,7 @@ FiltersDialog_filterOnNames= &Name filter patterns (matching names will be hidde
 FiltersDialog_filterOnNamesSubCaption= Patterns are separated by commas (* = any string, ? = any character)
 FiltersDialog_maxCallDepth= &Max call depth:
 FiltersDialog_messageMaxCallDepthInvalid= The max call depth must be in range [1..99]
+FiltersDialog_messageFilterNamesInvalid= The filter pattern for the names is invalid. 
 FiltersDialog_filterTestCode= Filter &Test Code
 CallHierarchyContentProvider_searchError_title=Exception
 CallHierarchyContentProvider_searchError_message=Unexpected exception.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/FiltersDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/FiltersDialog.java
@@ -14,9 +14,12 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.callhierarchy;
 
+import java.util.Arrays;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -36,6 +39,8 @@ import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.dialogs.StatusInfo;
 
 class FiltersDialog extends StatusDialog {
+	private static final String METHOD_NAME_GLOB_PATTERN = "^[a-zA-Z0-9*?]*$"; //$NON-NLS-1$
+
     private Label fNamesHelpText;
     private Button fFilterOnNames;
     private Text fNames;
@@ -99,12 +104,15 @@ class FiltersDialog extends StatusDialog {
         fFilterOnNames = createCheckbox(parent,
                 CallHierarchyMessages.FiltersDialog_filterOnNames, true);
 
+        fFilterOnNames.addSelectionListener(SelectionListener.widgetSelectedAdapter(e -> validateInput()));
+//        fFilterOnNames.addListener(SWT.Modify, e -> validateInput());
+
         fNames= new Text(parent, SWT.SINGLE | SWT.BORDER);
         fNames.setFont(parent.getFont());
         fNames.addModifyListener(e -> validateInput());
 
         GridData gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL | GridData.GRAB_HORIZONTAL);
-        gridData.widthHint = convertWidthInCharsToPixels(60);
+        gridData.widthHint = convertWidthInCharsToPixels(80);
         fNames.setLayoutData(gridData);
 
         fNamesHelpText= new Label(parent, SWT.LEFT);
@@ -205,7 +213,7 @@ class FiltersDialog extends StatusDialog {
 		fFilterOnNames.setSelection(CallHierarchy.getDefault().isFilterEnabled());
 
 		setSelection();
-		
+
 		updateEnabledState();
 	}
 
@@ -243,11 +251,40 @@ class FiltersDialog extends StatusDialog {
         }
     }
 
+	private boolean isFilterNamesValid() {
+		if (!fFilterOnNames.getSelection()) {
+			return true;
+		}
+		String namesGlob = fNames.getText().trim();
+
+		if (namesGlob.isEmpty()) {
+			return true;
+		}
+
+		// Split into several patterns separated by commas
+		String[] allPatterns= namesGlob.split(","); //$NON-NLS-1$
+
+		return Arrays.stream(allPatterns).map(String::trim).allMatch(this::isValidMethodNameGlob);
+	}
+
+	private boolean isValidMethodNameGlob(String input) {
+        return input != null && input.matches(METHOD_NAME_GLOB_PATTERN);
+    }
+
+
     private void validateInput() {
         StatusInfo status= new StatusInfo();
-        if (!isMaxCallDepthValid()) {
-            status.setError(CallHierarchyMessages.FiltersDialog_messageMaxCallDepthInvalid);
+        String errorMessage = ""; //$NON-NLS-1$
+        if (!isFilterNamesValid()) {
+			errorMessage+= CallHierarchyMessages.FiltersDialog_messageFilterNamesInvalid;
         }
+        if (!isMaxCallDepthValid()) {
+            errorMessage+= CallHierarchyMessages.FiltersDialog_messageMaxCallDepthInvalid;
+        }
+
+		if (!errorMessage.isEmpty()) {
+			status.setError(errorMessage);
+		}
         updateStatus(status);
     }
 }


### PR DESCRIPTION
## What it does
They can only be valid java method names and they accept * and ? (they are globs),

## What it **doesn't** do
Sadly, the functionality itself (filtering) does not work yet. I'm going to try and come back to that when I have more time.

## How to test
- Open the filter dialog for the call hierarchy
- Play around with the names: 
  - Add valid and invalid names
  - Use globs
  - Add several patterns separated by commas
  - Add several whitespaces
  - Introduce errors in the _max depth_ too
  - Check / Uncheck the checkbox to see if the validation reacts properly
  - etc

## Expected behavior
- The validation should be updated every time something in the UI changes (names filter, the checkbox, the max depth)
- Error messages should contain all errors

![name_filter_call_hierarchy](https://github.com/user-attachments/assets/d97f481a-8346-423d-af97-3be9e32fed2c)

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
