### PR TITLE
Fix save actions that include remove unused suppress warnings

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2023 IBM Corporation and others.
+ * Copyright (c) 2007, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1246,5 +1246,62 @@ public class SaveParticipantTest extends CleanUpTestCase {
 		editCUInEditor(cu1, fileOnEditor);
 
 		assertChangedFromTo(cu1, fileOnDisk, fileOnEditor, expected1);
+	}
+
+	@Test
+	public void testIssue2288() throws Exception {
+		// Given
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String fileOnDisk= """
+			package test1;
+			import java.util.List;
+			import java.util.ArrayList;
+
+			@SuppressWarnings("removal")
+			public class E1 {
+
+			    private void m1() {
+					List<String> myList = new ArrayList<String>();
+			    }
+			}
+			"""; //
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", fileOnDisk, false, null);
+
+		String fileOnEditor= """
+			package test1;
+			import java.util.List;
+			import java.util.ArrayList;
+
+			@SuppressWarnings("removal")
+			public class E1 {
+
+			    private void m1() {
+					List<String> myList = new ArrayList<String>();
+			    }
+			}
+			"""; //
+
+		String expected1= """
+			package test1;
+			import java.util.List;
+			import java.util.ArrayList;
+
+			public class E1 {
+
+			    private void m1() {
+					List<String> myList = new ArrayList<>();
+			    }
+			}
+			"""; //
+
+		enable(CleanUpConstants.REMOVE_UNNECESSARY_SUPPRESS_WARNINGS);
+		enable(CleanUpConstants.REMOVE_REDUNDANT_TYPE_ARGUMENTS);
+
+		// When
+		editCUInEditor(cu1, fileOnEditor);
+
+		assertChangedFromTo(cu1, fileOnDisk, fileOnEditor, expected1);
+
 	}
 }

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -361,12 +361,17 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
     					return;
 
     				Map<String, String> options= new HashMap<>();
-					for (ICleanUp cleanUp : cleanUps) {
-						Map<String, String> map= cleanUp.getRequirements().getCompilerOptions();
-						if (map != null) {
-							options.putAll(map);
-						}
-					}
+    				if (cleanUps[0].getRequirements().requiresSeparateOptions()) {
+    					options.putAll(cleanUps[0].getRequirements().getCompilerOptions());
+    				} else {
+    					for (ICleanUp cleanUp : cleanUps) {
+    						CleanUpRequirements requirements= cleanUp.getRequirements();
+    						Map<String, String> map= requirements.getCompilerOptions();
+    						if (map != null && !requirements.requiresSeparateOptions()) {
+    							options.putAll(map);
+    						}
+    					}
+    				}
 
     				CompilationUnit ast= null;
     				if (requiresAST(cleanUps)) {


### PR DESCRIPTION
- fix CleanUpPostSaveListener.saved() method to recognize the new cleanup requirement that separate options are required and not to add them to the conglomerate of options for all cleanups
- as well if the first cleanup requires separate option, then use those options only as such cleanups will also require fresh asts and must be at the end of the cleanup list so will be performed one at a time
- add new test to SaveParticipantTest
- fixes #2288

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
