### PR TITLE
Fix remove unused imports cleanup to be smarter

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnusedCodeFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnusedCodeFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -63,6 +63,7 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.MethodReference;
 import org.eclipse.jdt.core.dom.Modifier;
+import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NodeFinder;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.PostfixExpression;
@@ -85,6 +86,7 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.core.manipulation.dom.NecessaryParenthesesChecker;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
 import org.eclipse.jdt.internal.corext.dom.LinkedNodeFinder;
 import org.eclipse.jdt.internal.corext.dom.ReplaceRewrite;
 import org.eclipse.jdt.internal.corext.dom.StatementRewrite;
@@ -905,11 +907,42 @@ public class UnusedCodeFixCore extends CompilationUnitRewriteOperationsFixCore {
 		for (IProblemLocation problem : problems) {
 			int id= problem.getProblemId();
 
-			if (removeUnusedImports && (id == IProblem.UnusedImport || id == IProblem.DuplicateImport || id == IProblem.ConflictingImport ||
-					id == IProblem.CannotImportPackage || id == IProblem.ImportNotFound)) {
+			if (removeUnusedImports && (id == IProblem.UnusedImport || id == IProblem.DuplicateImport || id == IProblem.ConflictingImport)) {
 				ImportDeclaration node= UnusedCodeFixCore.getImportDeclaration(problem, compilationUnit);
 				if (node != null) {
 					result.add(new RemoveImportOperation(node));
+				}
+			}
+
+			if (removeUnusedImports && (id == IProblem.CannotImportPackage || id == IProblem.ImportNotFound)) {
+				ImportDeclaration node= UnusedCodeFixCore.getImportDeclaration(problem, compilationUnit);
+				if (node != null && !node.isOnDemand()) {
+					Name name= node.getName();
+					String nameString= name.getFullyQualifiedName();
+					if (name.isQualifiedName()) {
+						int dotIndex= nameString.lastIndexOf('.');
+						if (dotIndex != -1) {
+							nameString= nameString.substring(dotIndex + 1);
+						}
+					}
+					final String nameToLookFor= nameString;
+					ASTVisitor nameVisitor= new ASTVisitor() {
+						@Override
+						public boolean visit(SimpleName nameNode) {
+							if (nameNode.getFullyQualifiedName().equals(nameToLookFor)) {
+								if (ASTNodes.getFirstAncestorOrNull(nameNode, ImportDeclaration.class) == null) {
+									throw new AbortSearchException();
+								}
+							}
+							return false;
+						}
+					};
+					try {
+						compilationUnit.accept(nameVisitor);
+						result.add(new RemoveImportOperation(node));
+					} catch (AbortSearchException e) {
+						// don't add remove import operation as name might be used
+					}
 				}
 			}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -30740,4 +30740,34 @@ public class CleanUpTest extends CleanUpTestCase {
 
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected }, null);
 	}
+
+	@Test
+	public void testUnusedCodeIssue2320() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+			import foo.Bar;
+			public class E1 {
+			    public void foo() {
+				    Bar x = new Bar();
+			    }
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
+
+		enable(CleanUpConstants.REMOVE_UNUSED_CODE_IMPORTS);
+
+		sample= """
+			package test1;
+			import foo.Bar;
+			public class E1 {
+			    public void foo() {
+				    Bar x = new Bar();
+			    }
+			}
+			""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] {cu1}, new String[] {expected1}, null);
+	}
 }


### PR DESCRIPTION
- do not remove an import that has a package that cannot be loaded or an import that cannot be found iff the name of the import is used in a non-import
- add new test to CleanUpTest
- fixes #2320

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue or commit comment.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
