### PR TITLE
Fix waiting for AST

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.23.100.qualifier
+Bundle-Version: 1.24.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CoreASTProvider.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CoreASTProvider.java
@@ -471,7 +471,7 @@ public final class CoreASTProvider {
 	/**
 	 * @return The active java element.
 	 */
-	public ITypeRoot getActiveJavaElement () {
+	public synchronized ITypeRoot getActiveJavaElement () {
 		return fActiveJavaElement;
 	}
 
@@ -479,7 +479,7 @@ public final class CoreASTProvider {
 	 * Set the active java element that is currently active.
 	 * @param activeJavaElement the java element.
 	 */
-	public void setActiveJavaElement (ITypeRoot activeJavaElement) {
+	public synchronized void setActiveJavaElement (ITypeRoot activeJavaElement) {
 		fActiveJavaElement = activeJavaElement;
 	}
 
@@ -511,6 +511,19 @@ public final class CoreASTProvider {
 		}
 	}
 
+	/**
+	 * Check if the given java element needs to clear the reconciliation
+	 * @since 1.24
+	 */
+	public void clearReconciliation(ITypeRoot javaElement) {
+		synchronized (fReconcileState) {
+			if (fReconcileState.fIsReconciling && (fReconcileState.fReconcilingJavaElement == null || !fReconcileState.fReconcilingJavaElement.equals(javaElement))
+					|| javaElement == null) {
+				clearReconciliation();
+			}
+		}
+	}
+
 	private static final class ReconcileState {
 		ITypeRoot fReconcilingJavaElement;
 		boolean fIsReconciling;
@@ -526,4 +539,5 @@ public final class CoreASTProvider {
 			return javaElement != null && javaElement.equals(fReconcilingJavaElement) && fIsReconciling;
 		}
 	}
+
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ASTProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ASTProvider.java
@@ -229,10 +229,7 @@ public final class ASTProvider implements IASTSharedValues {
 		if (JavaPlugin.DEBUG_AST_PROVIDER)
 			System.out.println(CoreASTProvider.getThreadName() + " - " + CoreASTProvider.DEBUG_PREFIX + "active editor is: " + INSTANCE.toString(javaElement)); //$NON-NLS-1$ //$NON-NLS-2$
 
-		if (INSTANCE.isReconciling() && (INSTANCE.getReconcilingJavaElement() == null || !INSTANCE.getReconcilingJavaElement().equals(javaElement))
-				|| javaElement == null) {
-			INSTANCE.clearReconciliation();
-		}
+		INSTANCE.clearReconciliation(javaElement);
 	}
 
 	/**


### PR DESCRIPTION
Currently the waitLock is used in a wrong way:

1) To prevent from spurious wakeups one has to check the condition in a loop
2) No way to notice if a a breakout happens due to timeout 3) There are code path where it might never signal waiting threads

This now:

- uses a while loop to check if further sleep is required
- checks for a deadline and emits an error in case it elapsed
- make sure a notification happens always in case any of the observed fields change

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2323

FYI @iloveeclipse 