### PR TITLE
fix custom folding regions end ignored end of comments are reached

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
@@ -644,6 +644,36 @@ public class CustomFoldingRegionTest {
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 12, 13);//second
 	}
 
+	@Test
+	public void testSameStartAndEndMarkerWithNestedFoldingRegionsAfterwards() throws Exception {
+		assumeTrue(extendedFoldingActive);
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START, "reg");
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END, "reg");
+
+		String str= """
+				package org.example.test;
+
+				public class Repro {
+
+					// reg a folding region should start here
+
+					public String test(boolean b) {
+						if (b)
+
+							return "a";
+						return "b";
+					}
+
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		assertEquals(3, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 11);//custom region
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 10);//test
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 7, 8);//if
+	}
+
 	private List<IRegion> getProjectionRangesOfFile(String str) throws Exception {
 		return FoldingTestUtils.getProjectionRangesOfFile(fPackageFragment, "Test.java", str);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1427,6 +1427,16 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 							currentFoldingPositions, openCustomRegionStartPositions, nonCommentFoldingRegion.getOffset()
 					);
 					if (currentCommentIndex >= comments.size()) {
+						while(!openCustomRegionStartPositions.isEmpty()) {
+							Deque<Integer> activeFoldingRegions= openCustomRegionStartPositions.removeLast();
+							Position region= currentFoldingPositions.pollLast();
+							int endPosition = sourceArray.length - 1;
+							if (region != null) {
+								endPosition= region.getOffset() + region.getLength() - 1;
+							}
+							endAllActiveFoldingRegions(sourceArray, visitor, activeFoldingRegions, endPosition);
+						}
+
 						return;
 					}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
In #2282, I implemented folding of custom regions if the start and end region markers are the same.
This stops processing when the last comment is reached. In that case, I forgot to ensure that all remaining open folding regions need to be created appropriately.

For example, consider the following reproducer:
- Enable extended folding (if disabled)
- Enable custom folding regions
- Set both the start and end region marker comments to `-----` in `Window > Preferences > Java > Editor > Folding`
- Create the following class:
```
package org.example.test;

public class Repro {
	
	// ----- getters/setters -----

	public String test(boolean b) {
		if (b)
			
			return "a";
		return "b";
	}

}
```

The region for the `// ----- getters/setters -----` comment is missing.

## How to test

Use the reproducer above (or similar) and see that the region is present.

This is also included as a text case.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
