### PR TITLE
Allow "Mark Occurrence" job to start "immediately"

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/SelectionListenerWithASTManager.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/SelectionListenerWithASTManager.java
@@ -150,7 +150,7 @@ public class SelectionListenerWithASTManager {
 					}
 				}
 			};
-			fCurrentJob.setPriority(Job.DECORATE);
+			fCurrentJob.setPriority(Job.INTERACTIVE);
 			fCurrentJob.setSystem(true);
 			fCurrentJob.schedule();
 		}


### PR DESCRIPTION
This should help "Mark Occurrence" to feel "snappy" also with high number of scheduled jobs, of course with no guarantee.

See discussion on https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2323
