### PR TITLE
Move getCreateInSuperClassProposals(..) to jdt.core.manipulation.

### DIFF
--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/NewDefiningMethodProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/NewDefiningMethodProposalCore.java
@@ -56,6 +56,14 @@ public class NewDefiningMethodProposalCore extends AbstractMethodCorrectionPropo
 		return fMethod.isConstructor();
 	}
 
+	public IMethodBinding getMethodBinding () {
+		return fMethod;
+	}
+
+	public String[] getParameterNames () {
+		return fParamNames;
+	}
+
 	@Override
 	protected void addNewParameters(ASTRewrite rewrite, List<String> takenNames, List<SingleVariableDeclaration> params, ImportRewriteContext context) throws CoreException {
 		AST ast= rewrite.getAST();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -139,7 +140,6 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.manipulation.util.Strings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
 import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
@@ -230,6 +230,7 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.GenerateForLoopAssi
 import org.eclipse.jdt.internal.ui.text.correction.proposals.LinkedCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.LinkedNamesAssistProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewDefiningMethodProposal;
+import org.eclipse.jdt.internal.ui.text.correction.proposals.NewDefiningMethodProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewInterfaceImplementationProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.RefactoringCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.RefactoringCorrectionProposalCore;
@@ -2631,51 +2632,18 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 	}
 
 	public static boolean getCreateInSuperClassProposals(IInvocationContext context, ASTNode node, Collection<ICommandAccess> resultingCollections, boolean addOverride) throws CoreException {
-		if (!(node instanceof SimpleName) || !(node.getParent() instanceof MethodDeclaration)) {
-			return false;
-		}
-		MethodDeclaration decl= (MethodDeclaration) node.getParent();
-		if (decl.getName() != node || decl.resolveBinding() == null || Modifier.isPrivate(decl.getModifiers())) {
-			return false;
-		}
-
-		ICompilationUnit cu= context.getCompilationUnit();
-		CompilationUnit astRoot= context.getASTRoot();
-
-		IMethodBinding binding= decl.resolveBinding();
-		ITypeBinding[] paramTypes= binding.getParameterTypes();
-
-		ITypeBinding[] superTypes= Bindings.getAllSuperTypes(binding.getDeclaringClass());
-		if (resultingCollections == null) {
-			for (ITypeBinding curr : superTypes) {
-				if (curr.isFromSource() && Bindings.findOverriddenMethodInType(curr, binding) == null) {
-					return true;
-				}
-			}
-			return false;
-		}
-		List<SingleVariableDeclaration> params= decl.parameters();
-		String[] paramNames= new String[paramTypes.length];
-		for (int i= 0; i < params.size(); i++) {
-			SingleVariableDeclaration param= params.get(i);
-			paramNames[i]= param.getName().getIdentifier();
-		}
-
-		for (ITypeBinding curr : superTypes) {
-			if (curr.isFromSource()) {
-				IMethodBinding method= Bindings.findOverriddenMethodInType(curr, binding);
-				if (method == null) {
-					ITypeBinding typeDecl= curr.getTypeDeclaration();
-					ICompilationUnit targetCU= ASTResolving.findCompilationUnitForBinding(cu, astRoot, typeDecl);
-					if (targetCU != null) {
-						String label= Messages.format(CorrectionMessages.QuickAssistProcessor_createmethodinsuper_description,
-								new String[] { BasicElementLabels.getJavaElementName(curr.getName()), BasicElementLabels.getJavaElementName(binding.getName()) });
-						resultingCollections.add(new NewDefiningMethodProposal(label, targetCU, astRoot, typeDecl, binding, paramNames, addOverride, IProposalRelevance.CREATE_METHOD_IN_SUPER));
-					}
-				}
+		Collection<Object> newResults = new LinkedList<>();
+		boolean result = QuickAssistProcessorUtil.getCreateInSuperClassProposals(context, node, newResults);
+		for (Object res : newResults) {
+			if (res instanceof NewDefiningMethodProposalCore proposal) {
+				resultingCollections.add(new NewDefiningMethodProposal(
+						proposal.getName(), proposal.getCompilationUnit(),
+						proposal.getInvocationNode(), proposal.getSenderBinding(),
+						proposal.getMethodBinding(), proposal.getParameterNames(),
+						addOverride, proposal.getRelevance()));
 			}
 		}
-		return true;
+		return result;
 	}
 
 	private static boolean getConvertEnhancedForLoopProposal(IInvocationContext context, ASTNode node, Collection<ICommandAccess> resultingCollections) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewDefiningMethodProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewDefiningMethodProposal.java
@@ -107,6 +107,10 @@ public class NewDefiningMethodProposal extends AbstractMethodCorrectionProposal 
 		}
 	}
 
+	public boolean canAddOverridenAnnotation () {
+		return fAddOverrideAnnotation;
+	}
+
 	@Override
 	protected void addNewExceptions(ASTRewrite rewrite, List<Type> exceptions, ImportRewriteContext context) throws CoreException {
 		((NewDefiningMethodProposalCore) getDelegate()).addNewExceptions(rewrite, exceptions, context);


### PR DESCRIPTION
- Addresses https://github.com/redhat-developer/vscode-java/issues/4064
- Move QuickAssistProcessor.getCreateInSuperClassProposals(..) into jdt.core.manipulation for ease of reuse

The methods being refactored are tested by `testCreateMethodWhenOverrideAnnotation`, `testOverrideAnnotationButNotOverriding` from `ModifierCorrectionsQuickFixTest`, and `testCreateInSuperInGeneric`, `testCreateInSuper` from `AssistQuickFixTest`

- [x] Before merging, need to investigate whether https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/b66e1d4cd08ac520157780a010047c2cd6fc6d97/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewDefiningMethodProposal.java#L77-L78 can also be moved as currently we have a parameter `addOverride` being passed around that isn't actually used.