### PR TITLE
Allow specifying final and synchronized for extract method refactorin

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_in/A_test203a.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_in/A_test203a.java
@@ -1,0 +1,11 @@
+package destination_in;
+
+public class A_test203 {
+	@interface C {
+		interface B {
+			default void foo() {
+				int i= /*[*/0;/*]*/				
+			}
+		}
+	}		
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_in/A_test203b.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_in/A_test203b.java
@@ -1,0 +1,11 @@
+package destination_in;
+
+public class A_test203 {
+	@interface C {
+		interface B {
+			default void foo() {
+				int i= /*[*/0;/*]*/				
+			}
+		}
+	}		
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_in/A_test203c.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_in/A_test203c.java
@@ -1,0 +1,11 @@
+package destination_in;
+
+public class A_test203 {
+	@interface C {
+		interface B {
+			default void foo() {
+				int i= /*[*/0;/*]*/				
+			}
+		}
+	}		
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_out/A_test203a.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_out/A_test203a.java
@@ -1,0 +1,15 @@
+package destination_in;
+
+public class A_test203 {
+	@interface C {
+		interface B {
+			default void foo() {
+				int i= /*[*/extracted();/*]*/				
+			}
+		}
+	}
+
+	protected static final int extracted() {
+		return 0;
+	}		
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_out/A_test203b.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_out/A_test203b.java
@@ -1,0 +1,15 @@
+package destination_in;
+
+public class A_test203 {
+	@interface C {
+		interface B {
+			default void foo() {
+				int i= /*[*/extracted();/*]*/				
+			}
+		}
+	}
+
+	protected static synchronized int extracted() {
+		return 0;
+	}		
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_out/A_test203c.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/destination18_out/A_test203c.java
@@ -1,0 +1,15 @@
+package destination_in;
+
+public class A_test203 {
+	@interface C {
+		interface B {
+			default void foo() {
+				int i= /*[*/extracted();/*]*/				
+			}
+		}
+	}
+
+	protected static final synchronized int extracted() {
+		return 0;
+	}		
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_in/A_test108.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_in/A_test108.java
@@ -1,0 +1,9 @@
+package staticMethods_in;
+
+interface A_test107 {
+	class B {
+		{
+			/*[*/int i= 0;/*]*/
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_in/A_test109.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_in/A_test109.java
@@ -1,0 +1,9 @@
+package staticMethods_in;
+
+interface A_test107 {
+	class B {
+		{
+			/*[*/int i= 0;/*]*/
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_out/A_test108.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_out/A_test108.java
@@ -1,0 +1,13 @@
+package staticMethods_in;
+
+interface A_test107 {
+	class B {
+		{
+			extracted();
+		}
+	}
+
+	static void extracted() {
+		/*[*/int i= 0;/*]*/
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_out/A_test109.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractMethodWorkSpace/ExtractMethodTests/staticMethods18_out/A_test109.java
@@ -1,0 +1,13 @@
+package staticMethods_in;
+
+interface A_test107 {
+	class B {
+		{
+			extracted();
+		}
+	}
+
+	static void extracted() {
+		/*[*/int i= 0;/*]*/
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests.java
@@ -92,11 +92,18 @@ public class ExtractMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	protected void performTest(IPackageFragment packageFragment, String id, TestMode mode, String outputFolder, String[] newNames, int[] newOrder, int destination, int visibility) throws Exception {
+		performTest(packageFragment, id, mode, outputFolder, newNames, newOrder, destination, visibility, false, false);
+	}
+
+	protected void performTest(IPackageFragment packageFragment, String id, TestMode mode, String outputFolder, String[] newNames, int[] newOrder, int destination, int visibility,
+			boolean makeFinal, boolean makeSynchronized) throws Exception {
 		ICompilationUnit unit= createCU(packageFragment, id);
 		int[] selection= getSelection();
 		ExtractMethodRefactoring refactoring= new ExtractMethodRefactoring(unit, selection[0], selection[1]);
 		refactoring.setMethodName("extracted");
 		refactoring.setVisibility(visibility);
+		refactoring.setFinal(makeFinal);
+		refactoring.setSynchronized(makeSynchronized);
 		TestModelProvider.clearDelta();
 		RefactoringStatus status= refactoring.checkInitialConditions(new NullProgressMonitor());
 		switch (mode) {

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests1d8.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractMethodTests1d8.java
@@ -40,12 +40,24 @@ public class ExtractMethodTests1d8 extends ExtractMethodTests {
 		performTest(fgTestSetup1d8.getDefaultMethodsPackage(), "A", COMPARE_WITH_OUTPUT, "defaultMethods18_out", null, null, destination, visibility);
 	}
 
+	protected void defaultMethodsTest(int destination, int visibility, boolean makeFinal, boolean makeSynchronized) throws Exception {
+		performTest(fgTestSetup1d8.getDefaultMethodsPackage(), "A", COMPARE_WITH_OUTPUT, "defaultMethods18_out", null, null, destination, visibility, makeFinal, makeSynchronized);
+	}
+
 	protected void staticMethodsTest(int destination, int visibility) throws Exception {
 		performTest(fgTestSetup1d8.getStaticMethodsPackage(), "A", COMPARE_WITH_OUTPUT, "staticMethods18_out", null, null, destination, visibility);
 	}
 
+	protected void staticMethodsTest(int destination, int visibility, boolean makeFinal, boolean makeSynchronized) throws Exception {
+		performTest(fgTestSetup1d8.getStaticMethodsPackage(), "A", COMPARE_WITH_OUTPUT, "staticMethods18_out", null, null, destination, visibility, makeFinal, makeSynchronized);
+	}
+
 	protected void destinationTest(int destination, int visibility) throws Exception {
 		performTest(fgTestSetup1d8.getDestinationPackage(), "A", COMPARE_WITH_OUTPUT, "destination18_out", null, null, destination, visibility);
+	}
+
+	protected void destinationTest(int destination, int visibility, boolean makeFinal, boolean makeSynchronized) throws Exception {
+		performTest(fgTestSetup1d8.getDestinationPackage(), "A", COMPARE_WITH_OUTPUT, "destination18_out", null, null, destination, visibility, makeFinal, makeSynchronized);
 	}
 
 	protected void lambdaExpressionTest(int destination, int visibility) throws Exception {
@@ -151,6 +163,18 @@ public class ExtractMethodTests1d8 extends ExtractMethodTests {
 		staticMethodsTest(1, Modifier.PUBLIC);
 	}
 
+	@Override
+	@Test
+	public void test108() throws Exception {
+		staticMethodsTest(1, Modifier.PUBLIC, true, false);
+	}
+
+	@Override
+	@Test
+	public void test109() throws Exception {
+		staticMethodsTest(1, Modifier.PUBLIC, false, true);
+	}
+
 	//====================================================================================
 	// Testing Destination Types
 	//====================================================================================
@@ -171,6 +195,21 @@ public class ExtractMethodTests1d8 extends ExtractMethodTests {
 	@Test
 	public void test203() throws Exception {
 		destinationTest(1, Modifier.PROTECTED);
+	}
+
+	@Test
+	public void test203a() throws Exception {
+		destinationTest(1, Modifier.PROTECTED, true, false);
+	}
+
+	@Test
+	public void test203b() throws Exception {
+		destinationTest(1, Modifier.PROTECTED, false, true);
+	}
+
+	@Test
+	public void test203c() throws Exception {
+		destinationTest(1, Modifier.PROTECTED, true, true);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/RefactoringMessages.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/RefactoringMessages.java
@@ -270,6 +270,8 @@ public final class RefactoringMessages extends NLS {
 
 	public static String ExtractMethodInputPage_duplicates_single;
 
+	public static String ExtractMethodInputPage_final;
+
 	public static String ExtractMethodInputPage_generateJavadocComment;
 
 	public static String ExtractMethodInputPage_label_text;
@@ -283,6 +285,8 @@ public final class RefactoringMessages extends NLS {
 	public static String ExtractMethodInputPage_public;
 
 	public static String ExtractMethodInputPage_signature_preview;
+
+	public static String ExtractMethodInputPage_synchronized;
 
 	public static String ExtractMethodInputPage_throwRuntimeExceptions;
 

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/refactoringui.properties
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/refactoringui.properties
@@ -61,7 +61,9 @@ RefactoringExecutionHelper_cannot_execute=The operation cannot be performed due 
 
 ExtractMethodWizard_extract_method=Extract Method
 
-ExtractMethodInputPage_access_Modifiers=&Access modifier:
+ExtractMethodInputPage_access_Modifiers=&Access modifier
+ExtractMethodInputPage_final=final
+ExtractMethodInputPage_synchronized=synchronized
 ExtractMethodInputPage_public=public
 ExtractMethodInputPage_default=package
 ExtractMethodInputPage_protected=protected


### PR DESCRIPTION
- modify ExtractMethodRefactoring to add support for final and synchronized specification
- modify ExtractMethodInputPage to add final and synchronized to access modifiers and make it a group
- add new tests to ExtractMethodTests1d8
- fixes #2330

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
