### PR TITLE
Fix IllegalAccessError for AbstractMethodCorrectionProposalCore.

### DIFF
--- a/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/AbstractMethodCorrectionProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/proposals/org/eclipse/jdt/internal/ui/text/correction/proposals/AbstractMethodCorrectionProposalCore.java
@@ -66,14 +66,14 @@ public abstract class AbstractMethodCorrectionProposalCore extends LinkedCorrect
 		fSenderBinding= binding;
 	}
 
-	protected ASTNode getInvocationNode() {
+	public ASTNode getInvocationNode() {
 		return fNode;
 	}
 
 	/**
 	 * @return The binding of the type declaration (generic type)
 	 */
-	protected ITypeBinding getSenderBinding() {
+	public ITypeBinding getSenderBinding() {
 		return fSenderBinding;
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AdvancedQuickAssistTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AdvancedQuickAssistTest.java
@@ -6905,4 +6905,53 @@ public class AdvancedQuickAssistTest extends QuickFixTest {
 
 		assertProposalPreviewEquals(expected, CorrectionMessages.AssignToVariableAssistProposal_assignallparamstofields_description, proposals);
 	}
+
+	@Test
+	public void testCreateMethodInSuperType() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		StringBuffer str= new StringBuffer();
+		str.append("package test1;\n"
+				+ "public class Base {\n"
+				+ "    public void foo() {\n"
+				+ "    }\n"
+				+ "}");
+		pack1.createCompilationUnit("Base.java", str.toString(), false, null);
+
+		str = new StringBuffer();
+		str.append("package test1;\n"
+				+ "public class Common extends Base {\n"
+				+ "}");
+		pack1.createCompilationUnit("Common.java", str.toString(), false, null);
+
+		str = new StringBuffer();
+		str.append("package test1;\n"
+				+ "public class Extended extends Common {\n"
+				+ "    public void foo() {\n"
+				+ "    }\n"
+				+ "}");
+		ICompilationUnit cu= pack1.createCompilationUnit("Extended.java", str.toString(), false, null);
+
+		String selection= "foo()";
+		int offset= str.indexOf(selection);
+
+		AssistContext context= getCorrectionContext(cu, offset, 0);
+		assertNoErrors(context);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+
+		assertCorrectLabels(proposals);
+		assertNumberOfProposals(proposals, 1);
+
+		String[] expected= new String[9];
+		StringBuffer buf= new StringBuffer();
+		buf.append(
+			 "package test1;\n"
+				+ "public class Common extends Base {\n\n"
+				+ "    public void foo() {\n"
+				+ "        //TODO\n"
+				+ "        \n"
+				+ "    }\n"
+				+ "}");
+		expected[0]= buf.toString();
+		assertExpectedExistInProposals(proposals, expected);
+	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -142,6 +142,7 @@ import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.core.manipulation.util.Strings;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
+import org.eclipse.jdt.internal.corext.codemanipulation.StubUtility2Core;
 import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
@@ -2617,9 +2618,16 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		return true;
 	}
 
-
 	public static boolean getCreateInSuperClassProposals(IInvocationContext context, ASTNode node, Collection<ICommandAccess> resultingCollections) throws CoreException {
-		return getCreateInSuperClassProposals(context, node, resultingCollections, true);
+		if (!(node instanceof SimpleName) || !(node.getParent() instanceof MethodDeclaration)) {
+			return false;
+		}
+		MethodDeclaration decl= (MethodDeclaration) node.getParent();
+		if (decl.getName() != node || decl.resolveBinding() == null || Modifier.isPrivate(decl.getModifiers())) {
+			return false;
+		}
+		boolean addOverride = StubUtility2Core.findAnnotation("java.lang.Override", decl.modifiers()) == null; //$NON-NLS-1$
+		return getCreateInSuperClassProposals(context, node, resultingCollections, addOverride);
 	}
 
 	public static boolean getCreateInSuperClassProposals(IInvocationContext context, ASTNode node, Collection<ICommandAccess> resultingCollections, boolean addOverride) throws CoreException {


### PR DESCRIPTION
- See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1293 . :ghost: This appears to be the exact same issue. I was attempting to refactor some of this code, when I discovered this issue.
- `AbstractMethodCorrectionProposal` (jdt.ui) calls protected methods from `AbstractMethodCorrectionProposalCore` (jdt.core.manipulation), in the same package namespace (split package) and this is not caught as a compilation error
- 'Override' annotation should not be created where already present
- Make the library calls public and add a testcase, though the `IllegalAccessError` does not occur at all in the test run (with the methods set to `protected`)

To reproduce the issue :

**Base.java**
```
package org.example;

public class Base {
	public void foo() {
	}
}
```

**Common.java**
```
package org.example;

public class Common extends Base {
}
```

**Extended.java**
```
package org.example;

public class Extended extends Common {
	public void foo() {
	}
}
```

Now, activate quick-assist over `foo()` in `Extended.java` and select `Create 'foo'() in super type 'Common'`

```
!ENTRY org.eclipse.ui 4 0 2025-07-11 11:04:56.538
!MESSAGE Unhandled event loop exception
!STACK 0
java.lang.IllegalAccessError: class org.eclipse.jdt.internal.ui.text.correction.proposals.AbstractMethodCorrectionProposal tried to access method 'org.eclipse.jdt.core.dom.ASTNode org.eclipse.jdt.internal.ui.text.correction.proposals.AbstractMethodCorrectionProposalCore.getInvocationNode()' (org.eclipse.jdt.internal.ui.text.correction.proposals.AbstractMethodCorrectionProposal is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @3b083a9e; org.eclipse.jdt.internal.ui.text.correction.proposals.AbstractMethodCorrectionProposalCore is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @6a9c9a0c)
    at org.eclipse.jdt.internal.ui.text.correction.proposals.AbstractMethodCorrectionProposal.getInvocationNode(AbstractMethodCorrectionProposal.java:50)
    at org.eclipse.jdt.internal.ui.text.correction.proposals.NewDefiningMethodProposal.addOverrideAnnotation(NewDefiningMethodProposal.java:84)
    at org.eclipse.jdt.internal.ui.text.correction.proposals.NewDefiningMethodProposal.performChange(NewDefiningMethodProposal.java:78)
    at org.eclipse.jdt.ui.text.java.correction.CUCorrectionProposal.apply(CUCorrectionProposal.java:240)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.insertProposal(CompletionProposalPopup.java:1004)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.insertSelectedProposalWithMask(CompletionProposalPopup.java:951)
    at org.eclipse.jface.text.contentassist.CompletionProposalPopup.verifyKey(CompletionProposalPopup.java:1395)
    at org.eclipse.jface.text.contentassist.ContentAssistant$InternalListener.verifyKey(ContentAssistant.java:829)
```

