### PR TITLE
Also show the dialog "Slow Save Actions" the very first time a file is saved since the Workbench was started

### DIFF
--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
@@ -305,8 +305,6 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
 	private static final String WARNING_VALUE= "warning"; //$NON-NLS-1$
 	private static final String ERROR_VALUE= "error"; //$NON-NLS-1$
 	private static final String CHANGED_REGION_POSITION_CATEGORY= "changed_region_position_category"; //$NON-NLS-1$
-	private static boolean FIRST_CALL= false;
-	private static boolean FIRST_CALL_DONE= false;
 
 	@Override
 	public boolean needsChangedRegions(ICompilationUnit unit) throws CoreException {
@@ -333,18 +331,7 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
 			CompositeChange result= new CompositeChange(FixMessages.CleanUpPostSaveListener_SaveAction_ChangeName);
 			LinkedList<UndoEdit> undoEdits= new LinkedList<>();
 
-			if (FIRST_CALL && !FIRST_CALL_DONE) {
-				FIRST_CALL= false;
-				FIRST_CALL_DONE= true;
-			} else {
-				FIRST_CALL= true;
-			}
-			HashSet<ICleanUp> slowCleanUps;
-			if (FIRST_CALL_DONE) {
-				slowCleanUps= new HashSet<>();
-			} else {
-				slowCleanUps= null;
-			}
+			HashSet<ICleanUp> slowCleanUps= new HashSet<>();
 			IUndoManager manager= RefactoringCore.getUndoManager();
 
 			boolean success= false;
@@ -428,7 +415,7 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
     			manager.addUndo(result.getName(), undo);
 			}
 
-			if (slowCleanUps != null && slowCleanUps.size() > 0)
+			if (slowCleanUps.size() > 0)
 				showSlowCleanUpsWarning(slowCleanUps);
 		} finally {
 			monitor.done();


### PR DESCRIPTION
If some slow _save action_ is performed after saving the very first file since the user started the Workbench (Eclipse) the dialog that informs the user that a save action is slow should appear. Currently, this dialog only appears **after** the first batch of slow actions is finished.

## What it does
Offers the user to deactivate slow save actions even if this is the very first file being saved since the workspace was initiated.

## How to test
- Open/Restart Eclipse
- Go to a project where you have activated some _save actions_ (one that is very expensive and takes more than 2 seconds)
- Change the file and save

### A small hack to help testing
Add this delay into `org.eclipse.jdt.core.manipulation.OrganizeImportsOperation.createTextEdit(IProgressMonitor)` and use the _Organize Imports_ action to test:

```java
public TextEdit createTextEdit(IProgressMonitor m) throws CoreException, OperationCanceledException {
	SubMonitor subMonitor= SubMonitor.convert(m, Messages.format(JavaManipulationMessages.OrganizeImportsOperation_description, BasicElementLabels.getFileName(fCompilationUnit)), 9);
	fNumberOfImportsAdded= 0;
	fNumberOfImportsRemoved= 0;

	CompilationUnit astRoot= fASTRoot;
	if (astRoot == null) {
		astRoot= CoreASTProvider.getInstance().getAST(fCompilationUnit, CoreASTProvider.WAIT_YES, subMonitor.split(2));
	}

        // Add this delay
	int delayInSeconds =5;
	subMonitor.setWorkRemaining(7 + delayInSeconds);

	for (int i=delayInSeconds; i>0;i--) {
		System.out.println("Processing, " + i + " seconds left..."); //$NON-NLS-1$ //$NON-NLS-2$
		subMonitor.split(1);
		try {
			Thread.sleep(1_000);
		} catch (InterruptedException e) {
		}
	}
        // Leave the rest unchanged...
        // ...
}
      
```
**Expected behavior**
You should see the dialog that suggests to deactivate the slow save action:

<img width="656" height="282" alt="image" src="https://github.com/user-attachments/assets/b66f67fb-2e85-4c35-8b93-acef12f38ec2" />

**Current behavior (before this PR)**
This dialog will not show up the very first time you save a file in the workspace and a save action takes more 2 seconds.

## Author checklist

- [x] I have thoroughly tested my changes.
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
