### PR TITLE
Fix CoreMarkdownAccessImpl to convert unicode characters

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreMarkdownAccessImpl.java
@@ -54,10 +54,13 @@ public class CoreMarkdownAccessImpl extends CoreJavadocAccessImpl {
 
 	@Override
 	protected String removeDocLineIntros(String textWithSlashes) {
+		// handle unicode
+		String content= textWithSlashes.replaceAll("\\\\u000[d,D]", "\r"); //$NON-NLS-1$ //$NON-NLS-2$
+		content= content.replaceAll("\\\\u000[a,A]", "\n"); //$NON-NLS-1$ //$NON-NLS-2$
 		String lineBreakGroup= "(\\r\\n?|\\n)"; //$NON-NLS-1$
 		String noBreakSpace= "[^\r\n&&\\s]"; //$NON-NLS-1$
 		// in the markdown case relevant leading whitespace is contained in TextElements, no need to preserve blanks *between* elements
-		return textWithSlashes.replaceAll(lineBreakGroup + noBreakSpace + "*///" + noBreakSpace + '*', "$1"); //$NON-NLS-1$ //$NON-NLS-2$
+		return content.replaceAll(lineBreakGroup + noBreakSpace + "*///" + noBreakSpace + '*', "$1"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -900,6 +900,30 @@ public class MarkdownCommentTests extends CoreTests {
 		assertHtmlContent(expectedContent, actualHtmlContent);
 	}
 	@Test
+	public void testGH1787() throws CoreException {
+		String source= """
+				package p;
+
+				public class E {
+				    /// Unicode in markdown \u000A///\u000D///\u000D\u000A///here
+				    public void m() {}
+				}
+
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/E.java", source, null);
+		assertNotNull("E.java", cu);
+
+		IType type= cu.getType("E");
+
+		IMethod method= type.getMethods()[0];
+		String actualHtmlContent= getHoverHtmlContent(cu, method);
+		assertHtmlContent("""
+				<p>Unicode in markdown</p>
+				<p>here</p>
+				""",
+				actualHtmlContent);
+	}
+	@Test
 	public void testFenceLenFour_1() throws CoreException {
 		String source= """
 				/// ````


### PR DESCRIPTION
- fix CoreMarkdownAccessImpl.removeDocLineIntros to replace all unicode line break characters to regular line break characters before performing the normal logic
- add new test to MarkdownCommentTests
- fixes #1787

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
