### PR TITLE
Do not return null editor input from the ClassFileEditorInputFactory

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ExceptionalEditorInput.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ExceptionalEditorInput.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+
+import org.eclipse.ui.IPersistableElement;
+
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.JavaModelException;
+
+/**
+ * An editor input that is returned in case of an {@link JavaModelException} is thrown while trying to gather the actual input
+ */
+class ExceptionalEditorInput implements IClassFileEditorInput {
+
+
+	private String fIdentifier;
+	private Exception fException;
+	private IPersistableElement fElement;
+
+	public ExceptionalEditorInput(String identifier, IPersistableElement element, Exception modelException) {
+		fIdentifier= identifier;
+		fElement= element;
+		fException= modelException;
+	}
+
+	@Override
+	public boolean exists() {
+		return false;
+	}
+
+	@Override
+	public ImageDescriptor getImageDescriptor() {
+		return ImageDescriptor.getMissingImageDescriptor();
+	}
+
+	@Override
+	public String getName() {
+		return fIdentifier;
+	}
+
+	@Override
+	public IPersistableElement getPersistable() {
+		return fElement;
+	}
+
+	@Override
+	public String getToolTipText() {
+		return String.format("Error while gathering input for %s: %s", fIdentifier, fException); //$NON-NLS-1$
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter == IPersistableElement.class) {
+			return adapter.cast(getPersistable());
+		}
+		return null;
+	}
+
+	@Override
+	public IClassFile getClassFile() {
+		if (fException instanceof RuntimeException rte) {
+			throw rte;
+		}
+		throw new RuntimeException(getToolTipText(), fException);
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OrdinaryClassFileEditorInput.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/OrdinaryClassFileEditorInput.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import org.eclipse.jdt.core.IOrdinaryClassFile;
+
+public class OrdinaryClassFileEditorInput extends InternalClassFileEditorInput {
+
+	public OrdinaryClassFileEditorInput(IOrdinaryClassFile classFile) {
+		super(classFile);
+	}
+
+	@Override
+	public IOrdinaryClassFile getClassFile() {
+		return (IOrdinaryClassFile) super.getClassFile();
+	}
+
+}


### PR DESCRIPTION
Currently `ClassFileEditorInputFactory` return null in some cases when restoring an editor input from an `IMemento`. While this is legal in general for `IElementFactory` it is not very useful for factories that restore editor inputs because this will fail to instantiate the editor with a nasty exception without any way for the editor to handle or the user to understand the underlying problem.

This now changes two things:

1) In case of an error, a special `ExceptionalEditorInput` is created, that when later used to gather its underlying data will rethrow the original exception so we get a useful message about the cause.
2) In case of an element not found by the project an `InternalClassFileEditorInput` is returned as we actually have the class data already there.