### PR TITLE
Show progress when organizing imports during save

### DIFF
--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ImportsFix.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ImportsFix.java
@@ -13,10 +13,21 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.fix;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Status;
 
 import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.TextEdit;
+
+import org.eclipse.jface.operation.IRunnableWithProgress;
+
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.progress.IWorkbenchSiteProgressService;
 
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 
@@ -26,13 +37,13 @@ import org.eclipse.jdt.core.manipulation.OrganizeImportsOperation;
 import org.eclipse.jdt.core.manipulation.OrganizeImportsOperation.IChooseImportQuery;
 import org.eclipse.jdt.core.search.TypeNameMatch;
 
+import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettings;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 
 import org.eclipse.jdt.internal.ui.actions.ActionMessages;
-import org.eclipse.jdt.internal.core.manipulation.util.BasicElementLabels;
 
 public class ImportsFix extends TextEditFix {
 
@@ -48,7 +59,13 @@ public class ImportsFix extends TextEditFix {
 
 		final ICompilationUnit unit= (ICompilationUnit)cu.getJavaElement();
 		OrganizeImportsOperation op= new OrganizeImportsOperation(unit, cu, settings.importIgnoreLowercase, false, false, query);
-		final TextEdit edit= op.createTextEdit(null);
+
+		TextEdit edit= runUsingProgressService(op);
+		if (edit == null) {
+			// This one doesn't show any progress and it may block the UI
+			edit= op.createTextEdit(null);
+		}
+
 		if (hasAmbiguity[0]) {
 			status.addInfo(Messages.format(ActionMessages.OrganizeImportsAction_multi_error_unresolvable, getLocationString(cu)));
 		}
@@ -63,6 +80,44 @@ public class ImportsFix extends TextEditFix {
 
 		return new ImportsFix(edit, unit, FixMessages.ImportsFix_OrganizeImports_Description);
     }
+
+	private static TextEdit runUsingProgressService(OrganizeImportsOperation op) throws CoreException {
+
+		final AtomicReference<TextEdit> edit= new AtomicReference<>();
+		IWorkbenchSiteProgressService progressService= null;
+		try {
+			progressService= PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart().getSite().getAdapter(IWorkbenchSiteProgressService.class);
+		} catch (NullPointerException npe) {
+			// Either this has been called from a non-UI thread or something is still missing (workbench window / active page / part / site)
+			return null;
+		}
+
+		try {
+			progressService.run(true, true, new IRunnableWithProgress() {
+				@Override
+				public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
+					try {
+						edit.set(op.createTextEdit(monitor));
+					} catch (OperationCanceledException | CoreException e) {
+						throw new InvocationTargetException(e);
+					}
+				}
+			});
+		} catch (InvocationTargetException e) {
+			// CoreExceptions and OperationCanceledExceptions are re-thrown
+			if (e.getCause() instanceof CoreException ce)
+				throw ce;
+			if (e.getCause() instanceof OperationCanceledException ce)
+				throw ce;
+
+			// Other kind of exceptions are packed into a CoreException
+			throw new CoreException(Status.error(e.getCause().getMessage(), e.getCause()));
+		} catch (InterruptedException e) {
+			throw new OperationCanceledException();
+		}
+
+		return edit.get();
+	}
 
 	private static String getLocationString(final CompilationUnit cu) {
 		return BasicElementLabels.getPathLabel(cu.getJavaElement().getPath(), false);


### PR DESCRIPTION
## What it does
Show a progress indicator when performing the save action _Organize Imports_

If organizing the imports takes long enough, this dialog will appear

<img width="520" height="199" alt="image" src="https://github.com/user-attachments/assets/526c4e19-e7ef-4125-8fc0-aeed2d99e71b" />

## How to test
- Activate the save action "Organize imports"
- Add an unnecessary import to a class
- Save the class

### A small hack to help testing
Add this busy wait in the method `org.eclipse.jdt.core.manipulation.OrganizeImportsOperation.createTextEdit(IProgressMonitor)`

```java
public TextEdit createTextEdit(IProgressMonitor m) throws CoreException, OperationCanceledException {
	SubMonitor subMonitor= SubMonitor.convert(m, Messages.format(JavaManipulationMessages.OrganizeImportsOperation_description, BasicElementLabels.getFileName(fCompilationUnit)), 9);
	fNumberOfImportsAdded= 0;
	fNumberOfImportsRemoved= 0;

	CompilationUnit astRoot= fASTRoot;
	if (astRoot == null) {
		astRoot= CoreASTProvider.getInstance().getAST(fCompilationUnit, CoreASTProvider.WAIT_YES, subMonitor.split(2));
	}

        // Add this delay
	int delayInSeconds =5;
	subMonitor.setWorkRemaining(7 + delayInSeconds);

	for (int i=delayInSeconds; i>0;i--) {
		System.out.println("Processing, " + i + " seconds left..."); //$NON-NLS-1$ //$NON-NLS-2$
		subMonitor.split(1);
		try {
			Thread.sleep(1_000);
		} catch (InterruptedException e) {
		}
	}
        // Leave the rest unchanged...
        // ...
}
      
```

## Author checklist

- [ ] I have thoroughly tested my changes. TODO: check on Windows too
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
