### PR TITLE
(simplified) Do not return null editor input from the ClassFileEditorInputFactory

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
@@ -50,20 +50,22 @@ public class ClassFileEditorInputFactory implements IElementFactory {
 		}
 		IJavaElement element= JavaCore.create(identifier);
 		try {
-			if (!element.exists() && element instanceof IOrdinaryClassFile) {
+			if (!element.exists() && element instanceof IOrdinaryClassFile cf) {
 				/*
 				 * Let's try to find the class file,
 				 * see https://bugs.eclipse.org/bugs/show_bug.cgi?id=83221
 				 */
-				IOrdinaryClassFile cf= (IOrdinaryClassFile)element;
 				IType type= cf.getType();
 				IJavaProject project= element.getJavaProject();
 				if (project != null) {
 					type= project.findType(type.getFullyQualifiedName());
-					if (type == null)
-						return null;
-					element= type.getParent();
+					if (type != null) {
+						return EditorUtility.getEditorInput(type.getParent());
+					}
 				}
+				//if not found on the project still return an input
+				//so it can be handled by the editor
+				return new InternalClassFileEditorInput(cf);
 			}
 			return EditorUtility.getEditorInput(element);
 		} catch (JavaModelException x) {


### PR DESCRIPTION
Currently ClassFileEditorInputFactory return null in cases when restoring an editor input from an IMemento and the class is not found on the (current) classpath of the project. This prevents the editor from showing up and results in a generic error message instead and prevents proper handling of the case in the editor.

This now in case of an element not found by the project an InternalClassFileEditorInput is returned as we actually have the class data there. The editor can then further handel the case much better.
