### PR TITLE
If there is no source show the raw class file content

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileDocumentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileDocumentProvider.java
@@ -209,13 +209,22 @@ public class ClassFileDocumentProvider extends FileDocumentProvider {
 	protected boolean setDocumentContent(IDocument document, IEditorInput editorInput, String encoding) throws CoreException {
 		if (editorInput instanceof IClassFileEditorInput) {
 			IClassFile classFile= ((IClassFileEditorInput) editorInput).getClassFile();
-			String source= classFile.getSource();
+			String source= getSourceIfPresent(classFile);
 			if (source == null)
 				source= ""; //$NON-NLS-1$
 			document.set(source);
 			return true;
 		}
 		return super.setDocumentContent(document, editorInput, encoding);
+	}
+
+	private String getSourceIfPresent(IClassFile classFile) {
+		try {
+			return classFile.getSource();
+		} catch (JavaModelException e) {
+			//Assume no source...
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently if ClassFileEditor is opened for a classfile that is not on the classpath it fails with an error "The class file is not on the classpath" even though it could just display the raw class.

This now adjust the ClassFileEditor in a way to be more lenient and allows to display class files that are not on the classfile at least with the default raw view.

FYI @iloveeclipse 