### PR TITLE
Fix inline method for replacing method reference

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -768,9 +768,7 @@ public class CallInliner {
 				}
 			}
 			builder.append(statements[statements.length - 1]);
-			if (binding.getReturnType() != null && (!binding.getReturnType().isPrimitive() || !binding.getReturnType().getName().equals("void"))) { //$NON-NLS-1$
-				builder.append(";"); //$NON-NLS-1$
-			}
+			builder.append(";"); //$NON-NLS-1$
 			separator= lines.length == 1 ? "" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$
 			builder.append(separator + "}"); //$NON-NLS-1$
 			ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.LAMBDA_EXPRESSION);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -768,7 +768,7 @@ public class CallInliner {
 				}
 			}
 			builder.append(statements[statements.length - 1]);
-			if (binding.getReturnType() != null && (!binding.getReturnType().isPrimitive() || binding.getReturnType().getName() != "void")) { //$NON-NLS-1$
+			if (binding.getReturnType() != null && (!binding.getReturnType().isPrimitive() || !binding.getReturnType().getName().equals("void"))) { //$NON-NLS-1$
 				builder.append(";"); //$NON-NLS-1$
 			}
 			separator= lines.length == 1 ? "" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -728,11 +728,14 @@ public class CallInliner {
 			}
 		} else if (fTargetNode instanceof MethodReference methodRef) {
 			IMethodBinding binding= methodRef.resolveMethodBinding();
-			if (binding == null) {
+			ITypeBinding typeBinding= methodRef.resolveTypeBinding();
+			if (binding == null || typeBinding == null) {
 				status.addError(RefactoringCoreMessages.CallInliner_unexpected_model_exception,
 						JavaStatusContext.create(fCUnit, fInvocation));
 				return;
 			}
+			IMethodBinding[] functionClassMethods= typeBinding.getDeclaredMethods();
+
 			StringBuilder builder= new StringBuilder("("); //$NON-NLS-1$
 			String[] parmNames= binding.getParameterNames();
 			String separator= ""; //$NON-NLS-1$
@@ -747,10 +750,26 @@ public class CallInliner {
 			}
 			String[] lines= allblocks.split("\n"); //$NON-NLS-1$
 			separator= lines.length == 1 ? "" : "\n\t"; //$NON-NLS-1$ //$NON-NLS-2$
-			for (int i= 0; i < lines.length; ++i) {
+			for (int i= 0; i < lines.length - 1; ++i) {
 				builder.append(separator);
 				builder.append(lines[i]);
 				separator= "\n\t"; //$NON-NLS-1$
+			}
+			builder.append(separator);
+			String[] statements= lines[lines.length - 1].split(";"); //$NON-NLS-1$
+			for (int i= 0; i < statements.length - 1; ++i) {
+				builder.append(statements[i]);
+				builder.append("; "); //$NON-NLS-1$
+			}
+			if (binding.getReturnType() != null && (!binding.getReturnType().isPrimitive() || !binding.getReturnType().getName().equals("void"))) { //$NON-NLS-1$
+				ITypeBinding functionMethodType= functionClassMethods[0].getReturnType();
+				if (functionMethodType != null && (!functionMethodType.isPrimitive() || !functionMethodType.getName().equals("void"))) { //$NON-NLS-1$
+					builder.append("return "); //$NON-NLS-1$
+				}
+			}
+			builder.append(statements[statements.length - 1]);
+			if (binding.getReturnType() != null && (!binding.getReturnType().isPrimitive() || binding.getReturnType().getName() != "void")) { //$NON-NLS-1$
+				builder.append(";"); //$NON-NLS-1$
 			}
 			separator= lines.length == 1 ? "" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$
 			builder.append(separator + "}"); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2356_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2356_1.java
@@ -1,0 +1,15 @@
+package bugs_in;
+
+public class Test_issue_2356_1 {
+    @FunctionalInterface
+    interface VoidFunction {
+        int call();
+    }
+    static class Condition1 {
+    	public static int /*]*/method/*[*/() { return 42; }
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = Condition1::method;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2356_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2356_2.java
@@ -1,0 +1,15 @@
+package bugs_in;
+
+public class Test_issue_2356_2 {
+    @FunctionalInterface
+    interface VoidFunction {
+        int call();
+    }
+    static class Condition1 {
+    	public static int /*]*/method/*[*/() { String x = "abc"; return x.length(); }
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = Condition1::method;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2356_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2356_1.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_2356_1 {
+    @FunctionalInterface
+    interface VoidFunction {
+        int call();
+    }
+    static class Condition1 {
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = () -> {return 42;};
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2356_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2356_2.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_2356_2 {
+    @FunctionalInterface
+    interface VoidFunction {
+        int call();
+    }
+    static class Condition1 {
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = () -> {String x = "abc"; return x.length();};
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -532,6 +532,16 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_2356_1() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_2356_2() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- fix CallInliner.replaceCall() to fix the last statement of the last block when replacing a method reference so that it is written as a return statement
- add new tests to InlineMethodTests
- fixes #2356

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
