### PR TITLE
Fix inline of method reference when functional interface is void method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -29,6 +29,7 @@
 package org.eclipse.jdt.internal.corext.refactoring.code;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,6 +50,7 @@ import org.eclipse.ltk.core.refactoring.RefactoringStatusEntry;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.NamingConventions;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
@@ -101,6 +103,7 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 
 import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.core.manipulation.dom.ASTResolving;
 import org.eclipse.jdt.internal.core.manipulation.dom.NecessaryParenthesesChecker;
 import org.eclipse.jdt.internal.corext.CorextCore;
 import org.eclipse.jdt.internal.corext.codemanipulation.ContextSensitiveImportRewriteContext;
@@ -765,6 +768,28 @@ public class CallInliner {
 				ITypeBinding functionMethodType= functionClassMethods[0].getReturnType();
 				if (functionMethodType != null && (!functionMethodType.isPrimitive() || !functionMethodType.getName().equals("void"))) { //$NON-NLS-1$
 					builder.append("return "); //$NON-NLS-1$
+				} else {
+					// we have a method that returns something but the functional interface is
+					// void so we will copy over the contents in case they modify something external
+					// and instead of a return statement, we will make an unused assignment at the end
+					builder.append("@SuppressWarnings(\"unused\") "); //$NON-NLS-1$
+					builder.append(binding.getReturnType().getName() + " "); //$NON-NLS-1$
+					Statement body= ASTNodes.getFirstAncestorOrNull(methodRef, Statement.class);
+					if (body != null) {
+						List<String> excludedNames= Arrays.asList(ASTResolving.getUsedVariableNames(body));
+						final List<String> sourceNames= new ArrayList<>();
+						ASTVisitor visitor= new ASTVisitor() {
+							@Override
+							public boolean visit(SimpleName node) {
+								sourceNames.add(node.getFullyQualifiedName());
+								return false;
+							}
+						};
+						fSourceProvider.getDeclaration().accept(visitor);
+						sourceNames.addAll(excludedNames);
+						String[] varNames= StubUtility.getVariableNameSuggestions(NamingConventions.VK_LOCAL, fImportRewrite.getCompilationUnit().getJavaProject(), functionMethodType, null, sourceNames);
+						builder.append(varNames[0] + " = "); //$NON-NLS-1$
+					}
 				}
 			}
 			builder.append(statements[statements.length - 1]);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2314_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2314_1.java
@@ -1,0 +1,15 @@
+package bugs_in;
+
+public class Test_issue_2314_1 {
+    @FunctionalInterface
+    interface VoidFunction {
+        void call();
+    }
+    static class Condition1 {
+    	public static int /*]*/method/*[*/() { return 42; }
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = Condition1::method;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2314_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2314_2.java
@@ -1,0 +1,15 @@
+package bugs_in;
+
+public class Test_issue_2314_2 {
+    @FunctionalInterface
+    interface VoidFunction {
+        void call();
+    }
+    static class Condition1 {
+    	public static int /*]*/method/*[*/() { String x = "abc"; return x.length(); }
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = Condition1::method;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2314_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2314_1.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_2314_1 {
+    @FunctionalInterface
+    interface VoidFunction {
+        void call();
+    }
+    static class Condition1 {
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = () -> {@SuppressWarnings("unused") int x = 42;};
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2314_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2314_2.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_2314_2 {
+    @FunctionalInterface
+    interface VoidFunction {
+        void call();
+    }
+    static class Condition1 {
+    }
+
+    public static void main(String[] args) {
+        VoidFunction v = () -> {String x = "abc"; @SuppressWarnings("unused") int x1 = x.length();};
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -533,6 +533,16 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void test_issue_2314_1() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_2314_2() throws Exception {
+		performBugTest();
+	}
+
+	@Test
 	public void test_issue_2356_1() throws Exception {
 		performBugTest();
 	}


### PR DESCRIPTION
- modify CallInliner.replaceCall() logic to handle the case where the method being inlined has a return value but it has been referenced in a lambda method reference where the functional interface method is void
- in this case modify the return statement expression to be an assignment to an unused variable
- add new tests to InlineMethodTests
- fixes #2314

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
