### PR TITLE
Fix add delegate methods for records

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/DelegateEntryComparator.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/DelegateEntryComparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2018 IBM Corporation and others.
+ * Copyright (c) 2009, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -45,6 +45,7 @@ import org.eclipse.jdt.internal.corext.codemanipulation.AddDelegateMethodsOperat
  */
 public class DelegateEntryComparator implements Comparator<DelegateEntry> {
 
+	@SuppressWarnings("null")
 	@Override
 	public int compare(DelegateEntry firstEntry, DelegateEntry secondEntry) {
 		IVariableBinding firstVariable= firstEntry.field;
@@ -54,10 +55,10 @@ public class DelegateEntryComparator implements Comparator<DelegateEntry> {
 			try {
 				IMethod firstMethod= (IMethod)firstEntry.delegateMethod.getJavaElement();
 				IMethod secondMethod= (IMethod)secondEntry.delegateMethod.getJavaElement();
-				ISourceRange firstSourceRange= firstMethod.getSourceRange();
-				ISourceRange secondSourceRange= secondMethod.getSourceRange();
+				ISourceRange firstSourceRange= firstMethod != null ? firstMethod.getSourceRange() : null;
+				ISourceRange secondSourceRange= secondMethod != null ? secondMethod.getSourceRange() : null;
 				if (!SourceRange.isAvailable(firstSourceRange) || !SourceRange.isAvailable(secondSourceRange)) {
-					return firstMethod.getElementName().compareTo(secondMethod.getElementName());
+					return firstEntry.delegateMethod.getName().compareTo(secondEntry.delegateMethod.getName());
 				} else {
 					return firstSourceRange.getOffset() - secondSourceRange.getOffset();
 				}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateDelegateMethodsTest16.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateDelegateMethodsTest16.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.core.source;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+
+import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.corext.codemanipulation.AddDelegateMethodsOperation;
+import org.eclipse.jdt.internal.corext.codemanipulation.AddDelegateMethodsOperation.DelegateEntry;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ASTNodeSearchUtil;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+
+import org.eclipse.jdt.ui.tests.core.rules.Java16ProjectTestSetup;
+
+/**
+ * Tests generation of delegate methods
+ */
+public class GenerateDelegateMethodsTest16 extends SourceTestCase16 {
+	@Rule
+	public Java16ProjectTestSetup pts= new Java16ProjectTestSetup(false);
+
+	@Before
+	public void before() {
+		String str= """
+				/* (non-Javadoc)
+				 * ${see_to_target}
+				 */""";
+		StubUtility.setCodeTemplate(CodeTemplateContextType.DELEGATECOMMENT_ID, str, null);
+	}
+
+
+	public void runOperation(IType type, IField[] fields, String[] methodNames, IJavaElement insertBefore, boolean createComments) throws CoreException {
+
+		assertEquals(fields.length, methodNames.length);
+
+		RefactoringASTParser parser= new RefactoringASTParser(IASTSharedValues.SHARED_AST_LEVEL);
+		CompilationUnit unit= parser.parse(type.getCompilationUnit(), true);
+
+
+		DelegateEntry[] entries= new DelegateEntry[fields.length];
+
+		for (int i= 0; i < fields.length; i++) {
+
+			IField field= fields[i];
+			// Fields
+			VariableDeclarationFragment frag= ASTNodeSearchUtil.getFieldDeclarationFragmentNode(field, unit);
+			IVariableBinding b= frag.resolveBinding();
+			ITypeBinding typeBinding= b.getType();
+			IMethodBinding[] methodBindings= typeBinding.getDeclaredMethods();
+			IMethodBinding methodBinding= null;
+
+			for (int j= 0; j < methodBindings.length; ++j) {
+				if (methodBindings[j].getName().equals(methodNames[i])) {
+					methodBinding= methodBindings[j];
+					break;
+				}
+			}
+
+			entries[i]= new DelegateEntry(methodBinding, b);
+		}
+
+		fSettings.createComments= createComments;
+
+		AddDelegateMethodsOperation op= new AddDelegateMethodsOperation(unit, entries, insertBefore, fSettings, true, true);
+
+		op.run(new NullProgressMonitor());
+		JavaModelUtil.reconcile(type.getCompilationUnit());
+	}
+
+	// ------------- Actual tests
+
+
+	/**
+	 * Test delegate generation for record component methods
+	 */
+	@Test
+	public void test13() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2362
+
+		ICompilationUnit a= fPackageP.createCompilationUnit("A.java", "package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"	private Y y;\r\n" +
+				"\r\n" +
+				"	public record Y(String a, Integer b) {\r\n" +
+				"		public Integer b() {\r\n" +
+				"			return b;\r\n" +
+				"		}\r\n" +
+				"	}\r\n" +
+				"}\r\n" +
+				"", true, null);
+
+		IType type= a.getType("A");
+		type.resolveType("Y");
+		IField someField= a.getType("A").getField("y");
+
+		runOperation(type, new IField[] { someField, someField }, new String[] { "a", "b" }, null, true);
+
+		compareSource("package p;\r\n" +
+				"\r\n" +
+				"public class A {\r\n" +
+				"	private Y y;\r\n" +
+				"\r\n" +
+				"	public record Y(String a, Integer b) {\r\n" +
+				"		public Integer b() {\r\n" +
+				"			return b;\r\n" +
+				"		}\r\n" +
+				"	}\r\n" +
+				"\r\n" +
+				"	/* (non-Javadoc)\r\n" +
+				"	 * @see p.A.Y#a()\r\n" +
+				"	 */\r\n" +
+				"	public String a() {\r\n" +
+				"		return y.a();\r\n" +
+				"	}\r\n" +
+				"\r\n" +
+				"	/* (non-Javadoc)\r\n" +
+				"	 * @see p.A.Y#b()\r\n" +
+				"	 */\r\n" +
+				"	public Integer b() {\r\n" +
+				"		return y.b();\r\n" +
+				"	}\r\n" +
+				"}\r\n" +
+				"", a.getSource());
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -27,6 +27,7 @@ AddUnimplementedMethodsTest.class,
 GenerateGettersSettersTest.class,
 GenerateGettersSettersTest16.class,
 GenerateDelegateMethodsTest.class,
+GenerateDelegateMethodsTest16.class,
 AddUnimplementedConstructorsTest.class,
 GenerateConstructorUsingFieldsTest.class,
 GenerateHashCodeEqualsTest.class,


### PR DESCRIPTION
- avoid an NPE when sorting delegates as record component accessors are not part of the model by adding checks in DelegateEntryComparator
- add new GenerateDelegateMethodsTest16
- add new test to SourceActionTests
- fixes #2362

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
