### PR TITLE
Fix unused member cleanups to request a fresh AST

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnusedCodeCleanUpCore.java
@@ -56,7 +56,7 @@ public class UnusedCodeCleanUpCore extends AbstractMultiFix {
 	public CleanUpRequirements getRequirements() {
 		boolean requireAST= requireAST();
 		Map<String, String> requiredOptions= requireAST ? getRequiredOptions() : null;
-		return new CleanUpRequirements(requireAST, false, false, requiredOptions);
+		return new CleanUpRequirements(requireAST, true, false, requiredOptions);
 	}
 
 	private boolean requireAST() {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -6579,6 +6579,57 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testDeprecatedCleanup3() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/722
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
+		String sample1= """
+			package test;
+			public class E {
+
+				private int foo1() {
+					return 4;
+				}
+
+				/**
+				 * @deprecated use {@link #foo1()} instead
+				 * @return
+				 */
+				@Deprecated
+				private int foo2() {
+					return foo1();
+				}
+
+				public int foo3() {
+					return foo2();
+				}
+
+			}
+			"""; //
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", sample1, false, null);
+
+		enable(CleanUpConstants.REPLACE_DEPRECATED_CALLS);
+		enable(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_MEMBERS);
+		enable(CleanUpConstants.REMOVE_UNUSED_CODE_PRIVATE_METHODS);
+
+		String expected= """
+			package test;
+			public class E {
+
+				private int foo1() {
+					return 4;
+				}
+
+				public int foo3() {
+					return foo1();
+				}
+
+			}
+			""";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] {cu}, new String[] {expected},
+				new HashSet<>(Arrays.asList(FixMessages.InlineDeprecatedMethod_msg)));
+	}
+
+	@Test
 	public void testDeprecatedFieldCleanup1() throws Exception {
 		IPackageFragment pack2= fSourceFolder.createPackageFragment("test2", false, null);
 		String sample2= """


### PR DESCRIPTION
- fix UnusedCodeCleanUpCore.getRequirements() to specify a fresh AST is needed before running
- add new test to CleanUpTest1d8
- fixes #2368

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
