### PR TITLE
Do not return null from ClassFileEditorInputFactory when type not found

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
@@ -61,7 +61,7 @@ public class ClassFileEditorInputFactory implements IElementFactory {
 				if (project != null) {
 					type= project.findType(type.getFullyQualifiedName());
 					if (type == null)
-						return null;
+						return new InternalClassFileEditorInput(cf);
 					element= type.getParent();
 				}
 			}


### PR DESCRIPTION
Currently the ClassFileEditorInputFactory tries to update a stored element reference to a type in the project when it encounters an IOrdinaryClassFile. If that lookup fails (for whatever reason) it return null that results in a complete crash of the editor during restore as null is not a valid EditorInput.

## What it does

This now returns an InternalClassFileEditorInput instead to make it show the editor again after a restart.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2371

## How to test

See instructions here:

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2371#issue-3254760845

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)


@iloveeclipse please kindly review this as it is a long outstanding issue (seems to be introduced 19 years ago with fixing a NPE in [Bug 170552](https://bugs.eclipse.org/bugs/show_bug.cgi?id=170552))  it would be good to have it in M2.

FYI @merks 
