### PR TITLE
Wait for deferred PDE classpath initializer before initial reconcile

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaReconciler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaReconciler.java
@@ -23,6 +23,7 @@ import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.core.resources.IMarker;
@@ -49,6 +50,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.spelling.SpellingService;
 
+import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IElementChangedListener;
@@ -394,6 +396,11 @@ public class JavaReconciler extends MonoReconciler {
 	 */
 	@Override
 	protected void initialProcess() {
+		try {
+			Job.getJobManager().join(ClasspathContainerInitializer.class, null);
+		} catch (OperationCanceledException | InterruptedException e) {
+			// Ignore
+		}
 		synchronized (fMutex) {
 			super.initialProcess();
 		}


### PR DESCRIPTION
- This avoids the display the transient error annotations that are the result of PDE's deferring classpath initialization to a background job.

See https://github.com/eclipse-pde/eclipse.pde/pull/1888 for related details.

---

I acknowledge that there may well exist better solutions and I am willing to help review such alternative solutions in the future. 

My hope is that we can make this low-risk comprise change for m2 so that I can fully test tomorrows SDK build in real-life scenarios tomorrow, before the final m2 build, where I currently always see error annotation in open editors on startup; ones that do not go away, although I do believe that the "do not go away problem" has been solved.  So the remaining problem (transient annotation  that this PR addresses is definitely far less nasty.

In any case, of course I respect the decisions of the project committers whatever those decisions may be.  We're one big team and have the same goals in mind, i.e., high quality software.