### PR TITLE
Fix SingleUsedFieldCleanUp to remove volatile modifier if field moved

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/SingleUsedFieldCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/SingleUsedFieldCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Fabrice TIERCELIN and others.
+ * Copyright (c) 2021, 2025 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -429,7 +429,7 @@ public class SingleUsedFieldCleanUp extends AbstractMultiFix {
 			for (IExtendedModifier iExtendedModifier : modifiers) {
 				Modifier modifier= (Modifier) iExtendedModifier;
 
-				if (!modifier.isPrivate() && !modifier.isStatic() && !modifier.isTransient()) {
+				if (!modifier.isPrivate() && !modifier.isStatic() && !modifier.isTransient() && !modifier.isVolatile()) {
 					newModifiers.add((Modifier) rewrite.createCopyTarget(modifier));
 				}
 			}


### PR DESCRIPTION
- add new test to CleanUpTest
- fixes #2369

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
