### PR TITLE
Protect access to AbstractSpellDictionary.fHashBuckets to avoid CME

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/AbstractSpellDictionary.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/AbstractSpellDictionary.java
@@ -185,7 +185,7 @@ public abstract class AbstractSpellDictionary implements ISpellDictionary {
 
 			hash= hash2;
 
-			ArrayList<byte[]> candidateList= null;
+			ArrayList<byte[]> candidateList;
 			synchronized(fHashBuckets) {
 				final Object candidates= getCandidates(hash);
 				if (candidates == null)
@@ -257,7 +257,7 @@ public abstract class AbstractSpellDictionary implements ISpellDictionary {
 		int minimum= Integer.MAX_VALUE;
 
 		StringBuilder buffer= new StringBuilder(BUFFER_CAPACITY);
-		ArrayList<byte[]> candidateList= null;
+		ArrayList<byte[]> candidateList;
 		synchronized(fHashBuckets) {
 			final Object candidates= getCandidates(fHashProvider.getHash(word));
 			if (candidates == null)


### PR DESCRIPTION
- use synchronized blocks when accessing fHashBuckets Map in in non-synchronized methods
- fixes #2373

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Prevents occasional CME.  See issue.


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
No known test.  Only happens sporadically.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
