### PR TITLE
Move the relocation code from the factory to the ClassFileEditor

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.ui.tests.buildpath.BuildpathTestSuite;
 import org.eclipse.jdt.ui.tests.callhierarchy.CallHierarchyContentProviderTest;
 import org.eclipse.jdt.ui.tests.core.CoreTestSuite;
 import org.eclipse.jdt.ui.tests.core.CoreTests;
+import org.eclipse.jdt.ui.tests.editor.ClassFileInputTests;
 import org.eclipse.jdt.ui.tests.hover.JavadocHoverTests;
 import org.eclipse.jdt.ui.tests.hover.MarkdownCommentTests;
 import org.eclipse.jdt.ui.tests.hover.PackageJavadocTests;
@@ -87,7 +88,8 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 	PackageJavadocTests.class,
 	JavadocHoverTests.class,
 	MarkdownCommentTests.class,
-	SmokeViewsTest.class
+	SmokeViewsTest.class,
+	ClassFileInputTests.class
 })
 public class AutomatedSuite {
 	@BeforeEach

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/ClassFileInputTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/ClassFileInputTests.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2025, Andrey Loskutov (loskutov@gmx.de) and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.editor;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+
+import org.eclipse.ui.IPersistableElement;
+import org.eclipse.ui.XMLMemento;
+import org.eclipse.ui.internal.IWorkbenchConstants;
+
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.internal.ui.javaeditor.ClassFileEditorInputFactory;
+import org.eclipse.jdt.internal.ui.javaeditor.HandleEditorInput;
+import org.eclipse.jdt.internal.ui.javaeditor.InternalClassFileEditorInput;
+
+public class ClassFileInputTests {
+
+	@SuppressWarnings("restriction")
+	private static final String TAG_FACTORY_ID= IWorkbenchConstants.TAG_FACTORY_ID;
+	private static final String TYPE_NAME= "HelloWorld";
+
+	private String fileName;
+	private String className;
+	private IJavaProject javaProject ;
+
+	private ClassFileEditorInputFactory factory;
+
+	@Before
+	public void setUp() throws Exception {
+		factory = new ClassFileEditorInputFactory();
+		fileName= TYPE_NAME + ".java";
+		className= TYPE_NAME + ".class";
+		javaProject = setUpProject();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (javaProject != null) {
+			JavaProjectHelper.delete(javaProject);
+		}
+	}
+
+	private IJavaProject setUpProject() throws Exception {
+		javaProject= JavaProjectHelper.createJavaProject(ClassFileInputTests.class.getSimpleName(), "bin");
+		JavaProjectHelper.addSourceContainer(javaProject, "src");
+		IPackageFragment fragment= javaProject.findPackageFragment(javaProject.getProject().getFullPath().append("src"));
+		String content= """
+			public class HelloWorld {
+			}
+		""";
+		fragment.createCompilationUnit(fileName, content, true, new NullProgressMonitor());
+		javaProject.getProject().build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+		return javaProject;
+	}
+
+	@Test
+	public void testClassFileInputPersistence() throws Exception {
+		IProject project= javaProject.getProject();
+		IFile file= project.getFile("bin/" + className);
+		IClassFile classFile= JavaCore.createClassFileFrom(file);
+		InternalClassFileEditorInput input= new InternalClassFileEditorInput(classFile);
+		XMLMemento memento = createMemento(input.getFactoryId(), input);
+
+		HandleEditorInput handle= (HandleEditorInput) factory.createElement(memento);
+		assertEquals(input.getName(), handle.getName());
+		assertEquals(input.getClassFile().getHandleIdentifier(), handle.getHandleIdentifier());
+		assertEquals(input.getClassFile(), handle.getElement());
+		assertNotNull(handle.getToolTipText());
+		assertNotNull(handle.getImageDescriptor());
+
+		XMLMemento mementoFromHandle =createMemento(handle.getFactoryId(), handle);
+		assertEquals(memento.toString(), mementoFromHandle.toString());
+
+		HandleEditorInput handle2= (HandleEditorInput) factory.createElement(mementoFromHandle);
+		assertEquals(handle, handle2);
+		assertEquals(handle.hashCode(), handle2.hashCode());
+
+		mementoFromHandle =createMemento(handle.getFactoryId(), handle.getPersistable());
+		assertEquals(memento.toString(), mementoFromHandle.toString());
+	}
+
+	static XMLMemento createMemento(String factoryId, IPersistableElement elt) {
+		XMLMemento memento = XMLMemento.createWriteRoot("dummy");
+		memento.putString(TAG_FACTORY_ID, factoryId);
+		elt.saveState(memento);
+		return memento;
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditorInputFactory.java
@@ -20,12 +20,6 @@ import org.eclipse.ui.IElementFactory;
 import org.eclipse.ui.IMemento;
 
 import org.eclipse.jdt.core.IClassFile;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IOrdinaryClassFile;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
 
 /**
  * The factory which is capable of recreating class file editor
@@ -35,45 +29,24 @@ public class ClassFileEditorInputFactory implements IElementFactory {
 
 	public final static String ID=  "org.eclipse.jdt.ui.ClassFileEditorInputFactory"; //$NON-NLS-1$
 	public final static String KEY= "org.eclipse.jdt.ui.ClassFileIdentifier"; //$NON-NLS-1$
+	public final static String KEY_NAME= KEY + ".name"; //$NON-NLS-1$
 
 	public ClassFileEditorInputFactory() {
 	}
 
-	/*
-	 * @see org.eclipse.ui.IElementFactory#createElement(org.eclipse.ui.IMemento)
-	 */
 	@Override
 	public IAdaptable createElement(IMemento memento) {
 		String identifier= memento.getString(KEY);
 		if (identifier == null) {
 			return null;
 		}
-		IJavaElement element= JavaCore.create(identifier);
-		try {
-			if (!element.exists() && element instanceof IOrdinaryClassFile) {
-				/*
-				 * Let's try to find the class file,
-				 * see https://bugs.eclipse.org/bugs/show_bug.cgi?id=83221
-				 */
-				IOrdinaryClassFile cf= (IOrdinaryClassFile)element;
-				IType type= cf.getType();
-				IJavaProject project= element.getJavaProject();
-				if (project != null) {
-					type= project.findType(type.getFullyQualifiedName());
-					if (type == null)
-						return null;
-					element= type.getParent();
-				}
-			}
-			return EditorUtility.getEditorInput(element);
-		} catch (JavaModelException x) {
-			// Don't report but simply return null
-			return null;
-		}
+		String name= memento.getString(KEY_NAME);
+		return new HandleEditorInput(identifier, name == null? "" : name); //$NON-NLS-1$
 	}
 
 	public static void saveState(IMemento memento, InternalClassFileEditorInput input) {
 		IClassFile c= input.getClassFile();
 		memento.putString(KEY, c.getHandleIdentifier());
+		memento.putString(KEY_NAME, input.getName());
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/HandleEditorInput.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/HandleEditorInput.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.javaeditor;
 
+import java.util.Objects;
+
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Status;
@@ -95,4 +97,24 @@ public class HandleEditorInput implements IEditorInput, IPersistableElement {
 		return ClassFileEditorInputFactory.ID;
 	}
 
+	public String getHandleIdentifier() {
+		return handleIdentifier;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(handleIdentifier, name);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof HandleEditorInput)) {
+			return false;
+		}
+		HandleEditorInput other= (HandleEditorInput) obj;
+		return Objects.equals(handleIdentifier, other.handleIdentifier) && Objects.equals(name, other.name);
+	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/HandleEditorInput.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/HandleEditorInput.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Status;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IMemento;
+import org.eclipse.ui.IPersistableElement;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.internal.ui.JavaPluginImages;
+
+/**
+ * An {@link IEditorInput} that carries a JDT handle that can be transformed into an JavaElement
+ *
+ * @see ClassFileEditorInputFactory#createElement(IMemento)
+ * @see ClassFileEditor#transformEditorInput(IEditorInput)
+ */
+public class HandleEditorInput implements IEditorInput, IPersistableElement {
+
+	private final String handleIdentifier;
+	private final String name;
+
+	public HandleEditorInput(String handleIdentifier, String name) {
+		Assert.isNotNull(handleIdentifier);
+		Assert.isNotNull(name);
+		this.handleIdentifier= handleIdentifier;
+		this.name= name;
+	}
+
+	public IJavaElement getElement() throws CoreException {
+		IJavaElement element= JavaCore.create(handleIdentifier);
+		if (element == null) {
+			throw new CoreException(Status.error("Unable to restore Java element from: " + handleIdentifier)); //$NON-NLS-1$
+		}
+		return element;
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+	@Override
+	public boolean exists() {
+		return false;
+	}
+
+	@Override
+	public ImageDescriptor getImageDescriptor() {
+		return JavaPluginImages.DESC_OBJS_CFILE;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public IPersistableElement getPersistable() {
+		return this;
+	}
+
+	@Override
+	public String getToolTipText() {
+		return name;
+	}
+
+	@Override
+	public void saveState(IMemento memento) {
+		memento.putString(ClassFileEditorInputFactory.KEY, handleIdentifier);
+		memento.putString(ClassFileEditorInputFactory.KEY_NAME, name);
+	}
+
+	@Override
+	public String getFactoryId() {
+		return ClassFileEditorInputFactory.ID;
+	}
+
+}


### PR DESCRIPTION
Currently the ClassFileEditorInputFactory performs some action to relocate ordinary class files into proper types of the project.

This has some problems:

- recovery should ideally be very fast because this code is called very early even before the UI is visible
- as it is not supported to return `null` error handling is not reliable possible any error will be swallowed and results in a generic error message that is hard to understand by the user and hard to track down because there is no stacktrace to the original code

This now do the following:

- create a new carrier input `HandleEditorInput` that is just a wrapper around a string and except for the case the memento itself is invalid we can always return a non-null value
- the existing `ClassFileEditor#transformEditorInput` method is enhanced to contain the code previously at the factory

This has the advantage that now we can throw `CoreEceptions` in case anything goes wrong. Also the code is now part of the editor itself so any advanced handling (e.g. delayed loading in a Job, other cases of transformation needed) can now be handled not only in the editor but with full access to the editor instance itself.

@iloveeclipse this does not change any behavior (by intention), it only moves the code from the factory to the editor, so whatever changes one want to make to the editor in the future it is now completely possible in the the editor and shows a stacktrace where the problem occurs (so no swallow of exceptions):

## Before

Without this only the generic error part is shown without a usable stacktrace pointing to the location where the problem occurs, restarting Eclipse again and the Editor is lost entirely.

<img width="803" height="173" alt="grafik" src="https://github.com/user-attachments/assets/7dd58b69-9ccb-47f9-a694-0868f6b8e7fa" />

## After

It now shows still an error but now with a usable stacktrace, after a restart it retains the editor

<img width="1074" height="899" alt="grafik" src="https://github.com/user-attachments/assets/1eb63d35-293f-4312-a20c-27bfe4226775" />

