### PR TITLE
Show progress when calculating AST during copy (Ctrl + c) operation #2028

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.ResourceBundle;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.swt.SWTError;
 import org.eclipse.swt.custom.BusyIndicator;
@@ -43,6 +44,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
+import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.ISelection;
 
 import org.eclipse.jface.text.BadLocationException;
@@ -484,7 +486,11 @@ public final class ClipboardOperationAction extends TextEditorAction {
 
 
 	private ClipboardData getClipboardData(ITypeRoot inputElement, int offset, int length) {
-		CompilationUnit astRoot= SharedASTProviderCore.getAST(inputElement, SharedASTProviderCore.WAIT_ACTIVE_ONLY, null);
+		AtomicReference<CompilationUnit> ref = new AtomicReference<>();
+
+		runUsingProgressService(monitor -> ref.set(SharedASTProviderCore.getAST(inputElement, SharedASTProviderCore.WAIT_ACTIVE_ONLY, monitor)));
+
+		CompilationUnit astRoot= ref.get();
 		if (astRoot == null) {
 			return null;
 		}
@@ -551,6 +557,23 @@ public final class ClipboardOperationAction extends TextEditorAction {
 		String[] typeImports= namesToImport.toArray(new String[namesToImport.size()]);
 		String[] staticImports= staticsToImport.toArray(new String[staticsToImport.size()]);
 		return new ClipboardData(inputElement, typeImports, staticImports);
+	}
+
+	private static void runUsingProgressService(IRunnableWithProgress runnable) {
+		try {
+			PlatformUI.getWorkbench().getProgressService().run(true, true, runnable);
+		} catch (InvocationTargetException e) {
+			if (e instanceof InvocationTargetException ite && ite.getCause() instanceof RuntimeException rte)
+				// Something happened inside the call, re-throw
+				throw rte;
+
+			// Other kind of exceptions are simply logged
+			JavaPlugin.log(e);
+		} catch (InterruptedException e) {
+			// This currently doesn't happen since canceling the monitor does not throw an OperationCanceledException.
+			// ... but better safe than sorry, so log it.
+			JavaPlugin.log(e);
+		}
 	}
 
 	private void doPasteWithImportsOperation() {


### PR DESCRIPTION
## What it does
If the copy operation requires an AST, then the AST will be calculated by using forking to a non-UI thread and using a `ProgressMonitorDialog`. This gives the user a chance to cancel the operation while also showing the current progress.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2028

## How to test
Sadly I don't know of any clean way to recreate the UI freeze described in #2028 , but one could emulate the behavior with a small hack (see below).

Once the lengthy operation is reproducible (or emulated via the hack), do this:
- Create these 2 classes in 2 different files

```java
import java.io.InputStream;
import java.util.ArrayList;

class A {
	private void a() {
		ArrayList<InputStream> l; // Copy this line
	}
}
```

```java
import java.io.BufferedReader;
import java.util.List;

class B {
	private void b() {
		List<BufferedReader> l2;
		// paste it in this method
	}
	
}
```
- Select and copy (`Ctrl + c`) the line `ArrayList<InputStream> l;` inside `A`. You should see this dialog:

<img width="520" height="198" alt="image" src="https://github.com/user-attachments/assets/01579f5e-d312-43c7-9d54-319209b4134f" />


- Paste the line in the method `b` in class `B`

**Expected outcome**
If you did **not** cancel the progress when copying the line from `A` then `B` should compile since the imports where obtained and added to the clipboard contents

If you **did** cancel the operation then `B` should not compile since some imports are missing.

### Small hack to help testing
Add this to `org.eclipse.jdt.core.manipulation.CoreASTProvider.getAST(ITypeRoot, WAIT_FLAG, IProgressMonitor)`, which resembles (but it is **not** identical to) the newly added method `waitForLock`:

```java
public CompilationUnit getAST(final ITypeRoot input, WAIT_FLAG waitFlag, IProgressMonitor progressMonitor) {
	if (input == null || waitFlag == null)
		throw new IllegalArgumentException("input or wait flag are null"); //$NON-NLS-1$
	if (progressMonitor != null && progressMonitor.isCanceled())
		return null;

	// Add this
	if (getThreadName().equals("ModalContext")) { //$NON-NLS-1$
		synchronized (fWaitLock) {
			int timeoutInSeconds= 3;
			if (progressMonitor != null)
				progressMonitor.beginTask("Waiting for AST for: " + input.getElementName(), timeoutInSeconds); //$NON-NLS-1$
			for (int i= timeoutInSeconds; i > 0; i--) {
				if (progressMonitor != null && progressMonitor.isCanceled())
					return null; // imports will NOT be copied in the copy operation
				try {
					fWaitLock.wait(1_000);
				} catch (InterruptedException e) { }
				if (progressMonitor != null)
					progressMonitor.worked(1);
			}
		}
	}
	
	// Leave the rest unchanged...
}
```


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
