### PR TITLE
Fix multiple inline causing local variable name collisions

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/CodeScopeBuilder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/CodeScopeBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -59,6 +59,9 @@ public class CodeScopeBuilder extends ASTVisitor {
 			if (fNames == null)
 				fNames= new ArrayList<>(2);
 			fNames.add(name);
+		}
+		public Scope getParent() {
+			return fParent;
 		}
 		public Scope findScope(int start, int length) {
 			if (fStart <= start && start + length <= fStart + fLength) {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2376.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_2376.java
@@ -1,0 +1,25 @@
+package bugs_in;
+
+public class Test_issue_2376 {
+
+	@FunctionalInterface
+	public interface I {
+		int run();
+	}
+
+	public int /*]*/method()/*[*/ {
+		String x = "abc";
+		return x.length();
+	}
+
+	public void foo2(int k) {
+		int a = method();
+		if (k == 0) {
+			method();
+		}
+		I blah= this::method;
+		I blah2= this::method;
+		int b = method();
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2376.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_2376.java
@@ -1,0 +1,23 @@
+package bugs_in;
+
+public class Test_issue_2376 {
+
+	@FunctionalInterface
+	public interface I {
+		int run();
+	}
+
+	public void foo2(int k) {
+		String x = "abc";
+		int a = x.length();
+		if (k == 0) {
+			String x1 = "abc";
+			x1.length();
+		}
+		I blah= () -> {String x1 = "abc"; return x1.length();};
+		I blah2= () -> {String x1 = "abc"; return x1.length();};
+		String x1 = "abc";
+		int b = x1.length();
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -552,6 +552,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_2376() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- add new getParent() method to CodeScopeBuilder.Scope
- modify SourceProvider.makeNamesUnique() method to look in parent scopes in addition to current scope for collisions and to only store new names created in the scope if we are not targetting a method reference which will add braces automatically
- in the case where makeNamesUnique() doesn't find the names, store them anyway so the next inlining of the method in the same scope will do the rename
- add new test to InlineMethodTests
- fixes #2376

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
