### PR TITLE
Prevent rebuild triggered by type hierarchy restoration

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HistoryAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HistoryAction.java
@@ -86,6 +86,18 @@ public class HistoryAction extends Action {
 	 * @since 3.7
 	 */
 	static String getElementLabel(IJavaElement[] elements) {
+		return getElementLabel(elements, JavaElementLabels.ALL_DEFAULT | JavaElementLabels.ALL_POST_QUALIFIED | JavaElementLabels.P_COMPRESSED);
+	}
+
+	/**
+	 * Fetches the label for all the java elements.
+	 *
+	 * @param elements the java elements
+	 * @param flags flags for label generation
+	 * @return the label for all the java elements
+	 * @since 3.35
+	 */
+	static String getElementLabel(IJavaElement[] elements, long flags) {
 		switch (elements.length) {
 			case 0:
 				Assert.isTrue(false);
@@ -93,13 +105,13 @@ public class HistoryAction extends Action {
 
 			case 1:
 				return Messages.format(TypeHierarchyMessages.HistoryAction_inputElements_1,
-						new String[] { getShortLabel(elements[0]) });
+						new String[] { getShortLabel(elements[0], flags) });
 			case 2:
 				return Messages.format(TypeHierarchyMessages.HistoryAction_inputElements_2,
-						new String[] { getShortLabel(elements[0]), getShortLabel(elements[1]) });
+						new String[] { getShortLabel(elements[0], flags), getShortLabel(elements[1], flags) });
 			default:
 				return Messages.format(TypeHierarchyMessages.HistoryAction_inputElements_more,
-						new String[] { getShortLabel(elements[0]), getShortLabel(elements[1]), getShortLabel(elements[2]) });
+						new String[] { getShortLabel(elements[0], flags), getShortLabel(elements[1], flags), getShortLabel(elements[2], flags) });
 		}
 	}
 
@@ -111,7 +123,19 @@ public class HistoryAction extends Action {
 	 * @since 3.7
 	 */
 	static String getShortLabel(IJavaElement element) {
-		return JavaElementLabels.getElementLabel(element, JavaElementLabels.ALL_DEFAULT | JavaElementLabels.ALL_POST_QUALIFIED | JavaElementLabels.P_COMPRESSED);
+		return getShortLabel(element, JavaElementLabels.ALL_DEFAULT | JavaElementLabels.ALL_POST_QUALIFIED | JavaElementLabels.P_COMPRESSED);
+	}
+
+	/**
+	 * Fetches the short label for the java element.
+	 *
+	 * @param element the java element
+	 * @param flags flags for label generation
+	 * @return the short label for the java element
+	 * @since 3.35
+	 */
+	static String getShortLabel(IJavaElement element, long flags) {
+		return JavaElementLabels.getElementLabel(element, flags);
 	}
 
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/TypeHierarchyViewPart.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.eclipse.help.IContextProvider;
 
@@ -103,6 +104,7 @@ import org.eclipse.ui.part.ShowInContext;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.views.WorkbenchViewerSetup;
 
+import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IType;
@@ -116,6 +118,7 @@ import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.IContextMenuConstants;
 import org.eclipse.jdt.ui.ITypeHierarchyViewPart;
+import org.eclipse.jdt.ui.JavaElementLabels;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.actions.CCPActionGroup;
@@ -1643,7 +1646,7 @@ public class TypeHierarchyViewPart extends ViewPart implements ITypeHierarchyVie
 		int i= 0;
 		while (elementId != null) {
 			input= JavaCore.create(elementId);
-			if (input == null || !input.exists()) {
+			if (input == null) {
 				inputList= null;
 				break;
 			}
@@ -1654,16 +1657,24 @@ public class TypeHierarchyViewPart extends ViewPart implements ITypeHierarchyVie
 			doRestoreState(memento, input);
 		} else {
 			final IJavaElement[] hierarchyInput= inputList.toArray(new IJavaElement[inputList.size()]);
-
 			synchronized (this) {
-				String label= Messages.format(TypeHierarchyMessages.TypeHierarchyViewPart_restoreinput, HistoryAction.getElementLabel(hierarchyInput));
+				long flags = JavaElementLabels.M_APP_TYPE_PARAMETERS| JavaElementLabels.M_PARAMETER_TYPES | JavaElementLabels.ALL_POST_QUALIFIED | JavaElementLabels.ALL_POST_QUALIFIED | JavaElementLabels.P_COMPRESSED;
+				String label= Messages.format(TypeHierarchyMessages.TypeHierarchyViewPart_restoreinput, HistoryAction.getElementLabel(hierarchyInput, flags));
 				fNoHierarchyShownLabel.setText(label);
 
 				fRestoreStateJob= new Job(label) {
 					@Override
 					protected IStatus run(IProgressMonitor monitor) {
 						try {
-							doRestoreInBackground(memento, hierarchyInput, monitor);
+							Job.getJobManager().join(ClasspathContainerInitializer.class, monitor);
+							IJavaElement[] exsistingHierarchyInput = Stream.of(hierarchyInput).filter(IJavaElement::exists).toArray(length -> new IJavaElement[length]);
+							if(exsistingHierarchyInput.length == 0) {
+								PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+									doRestoreState(memento, new IJavaElement[0]);
+								});
+							} else {
+								doRestoreInBackground(memento, exsistingHierarchyInput, monitor);
+							}
 						} catch (JavaModelException e) {
 							return e.getStatus();
 						} catch (OperationCanceledException e) {
@@ -1671,6 +1682,8 @@ public class TypeHierarchyViewPart extends ViewPart implements ITypeHierarchyVie
 								showEmptyViewer();
 							}
 							return Status.CANCEL_STATUS;
+						} catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
 						}
 						return Status.OK_STATUS;
 					}


### PR DESCRIPTION
Prevent rebuild triggered by type hierarchy restoration.

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2305
