### PR TITLE
Fix Pull Up refactoring to not allow annotation target unless source is

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1611,6 +1611,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String PullUpRefactoring_Type_declared_in_class;
 
+	public static String PullUpRefactoring_target_is_annotation;
+
 	public static String PullUpRefactoring_type_not_accessible;
 
 	public static String PullUpRefactoring_Type_variable_not_available;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -648,6 +648,7 @@ PullUPRefactoring_no_all_binary=Pull up is not available on this type. All super
 PullUPRefactoring_not_java_lang_object=Pull up is not available on this type. Type has no super types.
 PullUpRefactoring_final_fields=Moving final fields will result in compilation errors if they are not initialized on creation or in constructors
 PullUpRefactoring_checking_referenced_elements=Checking referenced elements...
+PullUpRefactoring_target_is_annotation=The target type: ''{0}'' is an annotation but the source type is not.
 PullUpRefactoring_type_not_accessible=Type ''{0}'' referenced in one of the moved elements is not accessible from type ''{1}''
 PullUpRefactoring_field_not_accessible=Field ''{0}'' referenced in one of the moved elements is not accessible from type ''{1}''
 PullUpRefactoring_method_not_accessible=Method ''{0}'' referenced in one of the moved elements is not accessible from type ''{1}''

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PullUpRefactoringProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/structure/PullUpRefactoringProcessor.java
@@ -1185,7 +1185,7 @@ public class PullUpRefactoringProcessor extends HierarchyProcessor {
 	@Override
 	public RefactoringStatus checkFinalConditions(final IProgressMonitor monitor, final CheckConditionsContext context) throws CoreException, OperationCanceledException {
 		try {
-			SubMonitor subMonitor= SubMonitor.convert(monitor, RefactoringCoreMessages.PullUpRefactoring_checking, 15);
+			SubMonitor subMonitor= SubMonitor.convert(monitor, RefactoringCoreMessages.PullUpRefactoring_checking, 16);
 			clearCaches();
 
 			final RefactoringStatus result= new RefactoringStatus();
@@ -1204,6 +1204,7 @@ public class PullUpRefactoringProcessor extends HierarchyProcessor {
 			result.merge(checkIfSkippingOverElements(subMonitor.newChild(1)));
 			result.merge(checkIfOverridingSuperClass(subMonitor.newChild(1)));
 			result.merge(checkIfHidingMethod(subMonitor.newChild(1)));
+			result.merge(checkIfTargetIsAnnotation());
 			if (monitor.isCanceled())
 				throw new OperationCanceledException();
 			if (!JdtFlags.isAbstract(getDestinationType()) && getAbstractMethods().length > 0)
@@ -1222,6 +1223,17 @@ public class PullUpRefactoringProcessor extends HierarchyProcessor {
 		} finally {
 			monitor.done();
 		}
+	}
+
+	private RefactoringStatus checkIfTargetIsAnnotation() throws JavaModelException {
+		if (fDestinationType.isAnnotation()) {
+			if (!fCachedDeclaringType.isAnnotation()) {
+				final String msg= Messages.format(RefactoringCoreMessages.PullUpRefactoring_target_is_annotation, new Object[] { fDestinationType.getElementName() });
+				final RefactoringStatusContext context= JavaStatusContext.create(fDestinationType);
+				return RefactoringStatus.createErrorStatus(msg, context);
+			}
+		}
+		return null;
 	}
 
 	private RefactoringStatus checkIfHidingMethod(SubMonitor newChild) throws JavaModelException {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail39/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PullUp/testFail39/in/A.java
@@ -1,0 +1,20 @@
+package p;
+
+import java.lang.annotation.Annotation;
+
+@interface A {
+	String value() default "default";
+}
+class B implements A {
+    public void m() {
+        System.out.println("public method");
+    }
+    @Override
+    public String value() {
+        return "";
+    }
+    @Override
+    public Class<? extends Annotation> annotationType() {
+        return null;
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PullUpTests.java
@@ -1944,6 +1944,12 @@ public class PullUpTests extends GenericRefactoringTest {
 	public void testFail38() throws Exception {
 		helper2(new String[] { "m" }, new String[][] { new String[0] }, true, false, 0);
 	}
+
+	@Test
+	public void testFail39() throws Exception {
+		helper2(new String[] { "m" }, new String[][] { new String[0] }, true, false, 0);
+	}
+
 	//----------------------------------------------------------
 	@Test
 	public void testField0() throws Exception {


### PR DESCRIPTION
- modify PullUpRefactoringProcessor to add a check if moving to an annotation class but the source class is not also an annotation
- add new test to PullUpTests
- fixes #2312

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
