### PR TITLE
Revert "Wait for deferred PDE classpath initializer before initial reconcile"

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaReconciler.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaReconciler.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.widgets.Shell;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.ICoreRunnable;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.core.resources.IMarker;
@@ -50,7 +49,6 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.eclipse.ui.texteditor.spelling.SpellingService;
 
-import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IElementChangedListener;
@@ -396,11 +394,6 @@ public class JavaReconciler extends MonoReconciler {
 	 */
 	@Override
 	protected void initialProcess() {
-		try {
-			Job.getJobManager().join(ClasspathContainerInitializer.class, null);
-		} catch (OperationCanceledException | InterruptedException e) {
-			// Ignore
-		}
 		synchronized (fMutex) {
 			super.initialProcess();
 		}


### PR DESCRIPTION
This reverts commit 1f01b4197f57f636144e5a5059b9af06f14d79e5.

The code in PDE that used ClasspathContainerInitializer.class family is gone, so this code is meaningless now and only increases code complexity.

See https://github.com/eclipse-pde/eclipse.pde/pull/1898

