### PR TITLE
Fix type filtering in CallHierarchy view

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallSearchResultCollector.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallSearchResultCollector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -75,15 +75,13 @@ class CallSearchResultCollector {
 	private boolean isIgnored(IMember enclosingElement) {
 		String fullyQualifiedName= getTypeOfElement(enclosingElement).getFullyQualifiedName();
 
-		if (CallHierarchyCore.getDefault().isShowAll()) {
-			return false;
-		}
 		IClasspathEntry classpathEntry= determineClassPathEntry(enclosingElement);
 
-		if (classpathEntry != null) {
+		if (!CallHierarchyCore.getDefault().isShowAll() && classpathEntry != null) {
 			boolean isTest= classpathEntry.isTest();
-			return CallHierarchyCore.getDefault().isHideTestCode() && isTest
-					|| CallHierarchyCore.getDefault().isShowTestCode() && !isTest;
+			if (CallHierarchyCore.getDefault().isHideTestCode() && isTest
+					|| CallHierarchyCore.getDefault().isShowTestCode() && !isTest)
+				return true;
 		}
 		return CallHierarchyCore.getDefault().isIgnored(fullyQualifiedName);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/CallHierarchyMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2010 IBM Corporation and others.
+# Copyright (c) 2000, 2025 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -68,7 +68,7 @@ FiltersDialog_ShowAllCode = Show All Code
 FiltersDialog_TestCodeOnly = Test Code only
 
 FiltersDialog_filter= Filter Calls
-FiltersDialog_filterOnNames= &Name filter patterns (matching names will be hidden):
+FiltersDialog_filterOnNames= Qualified type &name filter patterns (matching types will be hidden):
 FiltersDialog_filterOnNamesSubCaption= Patterns are separated by commas (* = any string, ? = any character)
 FiltersDialog_maxCallDepth= &Max call depth:
 FiltersDialog_messageMaxCallDepthInvalid= The max call depth must be in range [1..99]

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/FiltersDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/callhierarchy/FiltersDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -91,7 +91,7 @@ class FiltersDialog extends StatusDialog {
         fMaxCallDepth.addModifyListener(e -> validateInput());
 
         GridData gridData = new GridData();
-        gridData.widthHint = convertWidthInCharsToPixels(10);
+        gridData.widthHint = convertWidthInCharsToPixels(12);
         fMaxCallDepth.setLayoutData(gridData);
     }
 
@@ -130,6 +130,8 @@ class FiltersDialog extends StatusDialog {
 
 		GridData gridData= new GridData();
 		gridData.horizontalIndent= 0;
+		gridData.horizontalSpan= 1;
+		gridData.grabExcessHorizontalSpace= true;
 		fShowAll.setLayoutData(gridData);
 		fHideTest.setLayoutData(gridData);
 		fShowTest.setLayoutData(gridData);
@@ -205,7 +207,7 @@ class FiltersDialog extends StatusDialog {
 		fFilterOnNames.setSelection(CallHierarchy.getDefault().isFilterEnabled());
 
 		setSelection();
-		
+
 		updateEnabledState();
 	}
 


### PR DESCRIPTION
- fix CallSearchResultCollector.isIgnored() method to not return false just because show all code is selected
- also fix same method to not immediately return when user has selected tests only or hide tests and the test is false
- fix dialog message to denote that it is a qualified type name filter and not just a name filter (e.g. can't specify a method name)
- fixes #2396

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue and comment.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
