### PR TITLE
Do not wait for AST when copying code in ClipboarOperationAction

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClipboardOperationAction.java
@@ -484,7 +484,11 @@ public final class ClipboardOperationAction extends TextEditorAction {
 
 
 	private ClipboardData getClipboardData(ITypeRoot inputElement, int offset, int length) {
-		CompilationUnit astRoot= SharedASTProviderCore.getAST(inputElement, SharedASTProviderCore.WAIT_ACTIVE_ONLY, null);
+		// Since this call happens in the UI thread, pass WAIT_NO as parameter
+		// so that the call can not reach the wait call that causes UI freezes.
+		// The cost of doing so is that the method could return null from time
+		// to time and therefore the imports may not be copied to the clipboard
+		CompilationUnit astRoot= SharedASTProviderCore.getAST(inputElement, SharedASTProviderCore.WAIT_NO, null);
 		if (astRoot == null) {
 			return null;
 		}


### PR DESCRIPTION
## What it does
Does not let the call to `SharedASTProviderCore.getAST(...)` in `ClipboarOperation` wait for the AST of the class. This keeps the call from landing in this line...

https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/3a6d9228ceaa45137f34283c663d8ab28ec18605/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CoreASTProvider.java#L176

... which is known to cause UI freezes when the call is done in the UI thread (which is the case here, #2028 ).

**TL;DR**
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2028 without causing the leak reported in #2403 (I triggered the tests locally by adding the **Extra VM Arguments** [mentioned here](https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2403#issuecomment-3146705909))

## How to test
Copy code from one class to the other (you may use the classes provided in https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2382#issue-3263253258).
If the AST was present at the moment of the copy operation then the imports will be present in the target class. If the AST was **not** ready at the time of the copy operation then the imports will **not** be copied in the target class.

**Disclaimer**
This PR aims to avoid the UI freeze and it does so at the cost of _maybe_ (just _maybe_) not copying the imports when copying code. This is a small tradeoff that I consider acceptable since UI freezes are IMO the absolute worst. I plan to come back to this complex issue (the "deadlock" that happens when waiting in the UI freeze) but for the moment, this PR does the absolute minimum change possible that gets rid of the UI freeze.

It would be nice to get it merged for the next release so (sorry for the spam but) I'll take the liberty of asking for your input directly @jjohnstn , @iloveeclipse and @laeubi .

## Author checklist

- [x] I have thoroughly tested my changes, but manually **and by triggering the `JavaLeakTest` locally**
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
