### PR TITLE
preserve contextual information with enhanced folding

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
@@ -45,6 +45,12 @@ public final class FoldingTestUtils {
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
 		ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
 
+		List<IRegion> regions= extractRegions(model);
+		editor.close(false);
+		return regions;
+	}
+
+	public static List<IRegion> extractRegions(ProjectionAnnotationModel model) {
 		List<IRegion> regions= new ArrayList<>();
 		Iterator<Annotation> it= model.getAnnotationIterator();
 		while (it.hasNext()) {


### PR DESCRIPTION
## What it does
Currently, the "enhanced folding" does not add information like the Java element the folding regions are associated with to them. Because of this, it is possible that Eclipse confuses/swaps two folding regions when editing the file which resets their expanded/collapsed state (because it considers them moved or doesn't find the folding regions any more).

The information of which element a folding region is associated to is used [in `update()` to correlate "old" folding regions with "new" folding regions](https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/master/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java#L1317).

With #2302 (that's how I noticed it), the issue solved by this PR causes can also cause parts outside of the visible region to become visible hence this PR is a precondition to make #2302 work properly.

## How to test

- Enable "Enhanced Folding" and "Custom Folding regions" (with the default region markers) in Preferences > Java Editor > Folding
- Create the following class:
```java
public class TestClass {

	// region

	void test() {

	}

	//endregion

}
```
- Collapse the `test` method
- Edit the file by adding a line break somewhere (or perform a similar edit)
- Without this PR, the whole `//region` folding region is collapsed. With it, the `test()` method stays collapsed and the region stays expanded.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

## Other notes

If wanted, I can make the integration test more extensive like this:
```java
	@Test
	public void testFoldingUpdateWithMultipleCustomRegionsDoesNotSwitchRegions() throws Exception {
		String code= """
				package org.example.test;

				// region outer

				public class Test {
					// region middle
					void someMethod() {
						boolean b = true;
						// region inner
						if (b) {
							// content
						}
						// endregion
						for(;;) {
							// something else
						}
					}
					// endregion
				}

				// endregion outer
				""";
		ICompilationUnit cu= fPackageFragment.createCompilationUnit("Test.java", code, true, null);
		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
		try {
			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);

			List<IRegion> initialRegions= FoldingTestUtils.extractRegions(model);

			assertEquals(6, initialRegions.size());
			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 2, 20);//outer
			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 5, 17);//middle
			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 6, 15);//someMethod
			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 8, 12);//inner
			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 9, 10);//if
			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 13, 14);//for

			List<Position> positions= new ArrayList<>();
			Iterator<Annotation> it= model.getAnnotationIterator();
			while (it.hasNext()) {
				Annotation a= it.next();
				if (a instanceof ProjectionAnnotation) {
					Position p= model.getPosition(a);
					positions.add(p);
				}
			}
			assertEquals(initialRegions.size(), positions.size());

			String additionalText= "more ";
			int indexToReplace= code.indexOf("content");
			editor.getViewer().getDocument().replace(indexToReplace, 0, additionalText);

			for(int i= 0; i < positions.size() - 1; i++) {
				if (initialRegions.get(i).getOffset() > indexToReplace) {
					assertEquals(initialRegions.get(i).getOffset() + additionalText.length(), positions.get(i).getOffset());
					assertEquals(initialRegions.get(i).getLength(), positions.get(i).getLength());
				}else {
					assertEquals(initialRegions.get(i).getOffset(), positions.get(i).getOffset());
					assertEquals(initialRegions.get(i).getLength() + additionalText.length(), positions.get(i).getLength());
				}
			}
		} finally {
			editor.close(false);
		}
	}
```

The test failures also exist with https://github.com/eclipse-jdt/eclipse.jdt.ui/runs/47384564584 (current `master`) so I think this is unrelated to my PR.