### PR TITLE
Show progress when pre-calculating the AST during save #2414

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.java
@@ -27,6 +27,8 @@ public final class FixMessages extends NLS {
 	}
 
 	public static String CleanUpPostSaveListener_name;
+	public static String CleanUpPostSaveListener_CalculatingChanges_taskName;
+	public static String CleanUpPostSaveListener_CreatingAST_taskName;
 	public static String CleanUpPostSaveListener_SaveAction_ChangeName;
 	public static String CleanUpPostSaveListener_SlowCleanUpDialog_link;
 	public static String CleanUpPostSaveListener_SlowCleanUpDialog_title;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.properties
@@ -116,6 +116,8 @@ PrimitiveComparisonFix_convert_compareTo_to_primitive_comparison=Convert compare
 PrimitiveRatherThanWrapperFix_description=Primitive type rather then wrapper class
 
 CleanUpPostSaveListener_name=Code Clean Up
+CleanUpPostSaveListener_CalculatingChanges_taskName=Calculating changes for save actions...
+CleanUpPostSaveListener_CreatingAST_taskName=Calculating AST for save actions...
 CleanUpPostSaveListener_SaveAction_ChangeName=Save Actions
 CleanUpPostSaveListener_SlowCleanUpDialog_link=If this happens again we recommend to disable the corresponding save actions on the <a>'Save Actions'</a> preference page.
 CleanUpPostSaveListener_SlowCleanUpDialog_title=Slow Save Actions

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
@@ -13,12 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.fix;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -39,6 +41,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -60,6 +63,7 @@ import org.eclipse.text.edits.UndoEdit;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.window.Window;
 
 import org.eclipse.jface.text.BadLocationException;
@@ -71,7 +75,9 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.Region;
 
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PreferencesUtil;
+import org.eclipse.ui.progress.IProgressService;
 
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.CompositeChange;
@@ -362,7 +368,15 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
 
     				CompilationUnit ast= null;
     				if (requiresAST(cleanUps)) {
-    					ast= createAst(unit, options, Progress.subMonitor(monitor, 10));
+    					AtomicReference<CompilationUnit> ref = new AtomicReference<>();
+    					runUsingProgressService(m -> {
+    						m.beginTask(FixMessages.CleanUpPostSaveListener_CreatingAST_taskName, IProgressMonitor.UNKNOWN);
+    						ref.set(createAst(unit, options, m));
+    					});
+    					ast= ref.get();
+    					if (ast == null) {
+    						return;
+    					}
     				}
 
     				CleanUpContext context;
@@ -373,7 +387,21 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
     				}
 
     				ArrayList<ICleanUp> undoneCleanUps= new ArrayList<>();
-					CleanUpChange change= CleanUpRefactoring.calculateChange(context, cleanUps, undoneCleanUps, slowCleanUps);
+
+					AtomicReference<CleanUpChange> ref= new AtomicReference<>();
+					ICleanUp[] cleanUpsCopy = new ICleanUp[cleanUps.length];
+					System.arraycopy(cleanUps, 0, cleanUpsCopy, 0, cleanUps.length);
+
+					runUsingProgressService(m -> {
+						m.beginTask(FixMessages.CleanUpPostSaveListener_CalculatingChanges_taskName, IProgressMonitor.UNKNOWN);
+						try {
+							ref.set(CleanUpRefactoring.calculateChange(context, cleanUpsCopy, undoneCleanUps, slowCleanUps));
+						} catch (CoreException e) {
+							// "e" will be unpacked and rethrown
+							throw new InvocationTargetException(e);
+						}
+					});
+					CleanUpChange change= ref.get();
 
     				RefactoringStatus postCondition= new RefactoringStatus();
 					for (ICleanUp cleanUp : cleanUps) {
@@ -568,6 +596,29 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
 		}
 
 		return false;
+	}
+
+	private static void runUsingProgressService(IRunnableWithProgress runnable) throws CoreException {
+		try {
+			IProgressService progressService= PlatformUI.getWorkbench().getProgressService();
+			progressService.run(true, false, runnable);
+		} catch (InvocationTargetException e) {
+			if (e.getCause() instanceof OperationCanceledException) {
+				return;
+			}
+			if (e.getCause() instanceof RuntimeException rte) {
+				throw rte;
+			}
+			if (e.getCause() instanceof CoreException ce) {
+				throw ce;
+			}
+			// Other kind of exceptions are simply logged
+			JavaPlugin.log(e);
+		} catch (InterruptedException e) {
+			// This currently doesn't happen since canceling the monitor does not throw an OperationCanceledException.
+			// ... but better safe than sorry, so log it.
+			JavaPlugin.log(e);
+		}
 	}
 
 	private CompilationUnit createAst(ICompilationUnit unit, Map<String, String> cleanUpOptions, IProgressMonitor monitor) {


### PR DESCRIPTION
## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2414

Show a progress dialog (after a delay) if the precalculation of the AST during a _save_ takes too long.

## ~Requires~ May be tested together with
- [x] https://github.com/eclipse-platform/eclipse.platform.ui/pull/3147
- [ ] https://github.com/eclipse-platform/eclipse.platform.ui/pull/4203

The aforementioned PRs must **not** necessarily be merged before this one, but it would be nice to have them since they would avoid the "flickering" of the progress dialog showing up and immediately disappearing when the calculations of the AST and/or the cleanup changes take just a few milliseconds. 

## How to test
- Activate a _save action_ that requires an AST, _e.g._ "Organize imports"
- Open a big class and make a modification
- Save

**Expected outcome**
If the AST takes a while to calculate then you should see a (non-cancelable) progress dialog with a moving progress bar (`IProgressMonitor.UNKNOWN`).

<img width="522" height="208" alt="image" src="https://github.com/user-attachments/assets/8ec746e2-4da0-431c-aae2-67809e280dea" />

---

Also, if calculating the changes takes a while, you should see another (non-cancelable) progress dialog with a moving progress bar (`IProgressMonitor.UNKNOWN`).

<img width="519" height="204" alt="image" src="https://github.com/user-attachments/assets/2ac44b3c-22a8-4f96-ba91-01de4c88b8c6" />

---

**A small hack to help testing**

You can simulate these long-running operations from the issue...

<img width="865" height="146" alt="image" src="https://github.com/user-attachments/assets/5566295b-291d-45e4-a43c-6240197cbeac" />

... by adding a delay like this one...

```java
for (int i=0; i<5;i++) {
	try {
		Thread.sleep(1000);
	} catch (InterruptedException e) {
		e.printStackTrace();
	}
}
```

...to `org.eclipse.jdt.internal.corext.fix.CleanUpPostSaveListener.createAst(ICompilationUnit, Map<String, String>, IProgressMonitor)` (1) and another delay in `org.eclipse.jdt.core.dom.ASTParser.createAST(IProgressMonitor)` (2). Technically, the delay in the `ASTParser` should be enough to simulate both scenarios, but since the call to `SharedASTProviderCore.getAST(...);` inside `CleanUpPostSaveListener.createAst(...)` passes `SharedASTProviderCore.WAIT_NO` as parameter, it is really unlikely that the call will reach as deep as `ASTParser::createAST`.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
