### PR TITLE
Fix push down refactoring to check fields referenced via source class

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1657,6 +1657,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String PushDownRefactoring_referenced;
 
+	public static String PushDownRefactoring_referenced_field;
+
 	public static String PushDownRefactoring_type_not_accessible;
 
 	public static String QualifiedNameFinder_qualifiedNames_description;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -787,6 +787,7 @@ PushDownRefactoring_calculating_required=Calculating required members...
 PushDownRefactoring_category_description=Changes to push down members
 PushDownRefactoring_change_name=Push down
 PushDownRefactoring_referenced=Pushed down member ''{0}'' is referenced by ''{1}''
+PushDownRefactoring_referenced_field=Pushed down field ''{0}'' is referenced via declaring type in ''{1}''
 PushDownRefactoring_check_references=Checking referenced elements...
 PushDownRefactoring_type_not_accessible=Type ''{0}'' referenced in one of the pushed elements is not accessible from type ''{1}''
 PushDownRefactoring_field_not_accessible=Field ''{0}'' referenced in one of the pushed elements is not accessible from type ''{1}''

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/testFail17/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/testFail17/in/A.java
@@ -1,0 +1,10 @@
+package p;
+
+class A {
+	int f;
+}
+class B extends A {
+	void m() {
+		new A().f = 0;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/testFail18/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/PushDown/testFail18/in/A.java
@@ -1,0 +1,11 @@
+package p;
+
+class A {
+	int f;
+}
+class B extends A {
+	void m() {
+		A a = new A();
+		a.f = 5;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/PushDownTests.java
@@ -1304,6 +1304,44 @@ public class PushDownTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void testFail17() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2417
+		String[] selectedMethodNames= {};
+		String[][] selectedMethodSignatures= {};
+		String[] selectedFieldNames= {"f"};
+		String[] namesOfMethodsToPushDown= {};
+		String[][] signaturesOfMethodsToPushDown= {};
+		String[] namesOfFieldsToPushDown= selectedFieldNames;
+		String[] namesOfMethodsToDeclareAbstract= {};
+		String[][] signaturesOfMethodsToDeclareAbstract= {};
+
+		failInputHelper(selectedMethodNames, selectedMethodSignatures,
+				selectedFieldNames,
+				namesOfMethodsToPushDown, signaturesOfMethodsToPushDown,
+				namesOfFieldsToPushDown,
+				namesOfMethodsToDeclareAbstract, signaturesOfMethodsToDeclareAbstract,
+				RefactoringStatus.ERROR);
+	}
+
+	@Test
+	public void testFail18() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2417
+		String[] selectedMethodNames= {};
+		String[][] selectedMethodSignatures= {};
+		String[] selectedFieldNames= {"f"};
+		String[] namesOfMethodsToPushDown= {};
+		String[][] signaturesOfMethodsToPushDown= {};
+		String[] namesOfFieldsToPushDown= selectedFieldNames;
+		String[] namesOfMethodsToDeclareAbstract= {};
+		String[][] signaturesOfMethodsToDeclareAbstract= {};
+
+		failInputHelper(selectedMethodNames, selectedMethodSignatures,
+				selectedFieldNames,
+				namesOfMethodsToPushDown, signaturesOfMethodsToPushDown,
+				namesOfFieldsToPushDown,
+				namesOfMethodsToDeclareAbstract, signaturesOfMethodsToDeclareAbstract,
+				RefactoringStatus.ERROR);
+	}
+
+	@Test
 	public void testVisibility0() throws Exception {
 		String[] selectedMethodNames= {"foo"};
 		String[][] selectedMethodSignatures= {new String[0]};


### PR DESCRIPTION
- modify PushDownRefactoringProcessor.getReferencingElements() method to also check for fields that are referenced via an instance of the declaring class
- add new tests to PushDownTests
- fixes #2417

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
