### PR TITLE
Don't log InterruptedExceptions in CompletionProposalComputerDescriptor

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/CompletionProposalComputerDescriptor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/CompletionProposalComputerDescriptor.java
@@ -368,10 +368,14 @@ final class CompletionProposalComputerDescriptor {
 		} catch (CoreException x) {
 			status= createExceptionStatus(x);
 		} catch (RuntimeException x) {
-			// log error and keep going with other providers
-			String title= (context instanceof JavaContentAssistInvocationContext ctx) && (ctx.getCompilationUnit() instanceof ICompilationUnit cu) ? cu.getElementName() : null;
-			SelectionUtil.logException("computing completion proposal", x, title, context.getDocument(), context.getInvocationOffset()); //$NON-NLS-1$
-			status= createExceptionStatus(x);
+			//No need to log an exception if the user canceled the operation
+			if (!(x.getCause() instanceof InterruptedException)) {
+				// log error and keep going with other providers
+				String title= (context instanceof JavaContentAssistInvocationContext ctx) && (ctx.getCompilationUnit() instanceof ICompilationUnit cu) ? cu.getElementName() : null;
+				SelectionUtil.logException("computing completion proposal", x, title, context.getDocument(), context.getInvocationOffset()); //$NON-NLS-1$
+				status= createExceptionStatus(x);
+			}
+
 			return Collections.emptyList();
 		} finally {
 			monitor.done();


### PR DESCRIPTION
## What it does
Avoid logging a `RuntimeException` that wraps an `InterruptedException`. These are thrown way down in the `Parser` if the user cancels (clicks outside of) the completion proposal popup.

## Requires
- https://github.com/eclipse-platform/eclipse.platform.ui/pull/3157
- https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4302

## How to test
Once this PR and the requires PRs are merged, it can be tested as specified in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4302
