### PR TITLE
Stop using jface.text.tests DisplayHelper

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.testplugin.util.DisplayHelper;
 
 import org.eclipse.swt.custom.StyledText;
 
@@ -41,7 +42,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import org.eclipse.jface.text.codemining.ICodeMiningProvider;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
-import org.eclipse.jface.text.tests.util.DisplayHelper;
 
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbench;

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/AbstractCompletionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/AbstractCompletionTest.java
@@ -28,6 +28,7 @@ import org.junit.rules.TestName;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
+import org.eclipse.jdt.testplugin.util.DisplayHelper;
 import org.eclipse.jdt.text.tests.performance.EditorTestHelper;
 
 import org.eclipse.swt.custom.VerifyKeyListener;
@@ -56,7 +57,6 @@ import org.eclipse.jface.text.contentassist.ICompletionProposalExtension;
 import org.eclipse.jface.text.contentassist.ICompletionProposalExtension2;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.jface.text.tests.util.DisplayHelper;
 
 import org.eclipse.ui.texteditor.ITextEditor;
 


### PR DESCRIPTION
Use the JDT testplugin one.
JFace.text.tests one is to be removed.
