### PR TITLE
Ensure test file working copies are discarded in JDT UI tests

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -19,6 +19,9 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,16 +61,25 @@ public class JavadocHoverTests extends CoreTests {
 
 	private IJavaProject fJProject1;
 
+	private List<ICompilationUnit> workingCopies;
+
 	@Before
 	public void setUp() throws Exception {
 		fJProject1= pts.getProject();
 		JavaProjectHelper.addSourceContainer(fJProject1, "src");
 		assertNotNull(JavaProjectHelper.addRTJar_16(fJProject1, false));
+		workingCopies = new ArrayList<>();
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		JavaProjectHelper.clear(fJProject1, pts.getDefaultClasspath());
+		try {
+			for (ICompilationUnit workingCopy : workingCopies) {
+				workingCopy.discardWorkingCopy();
+			}
+		} finally {
+			JavaProjectHelper.clear(fJProject1, pts.getDefaultClasspath());
+		}
 	}
 
 	protected ICompilationUnit getWorkingCopy(String path, String source, WorkingCopyOwner owner) throws JavaModelException {
@@ -78,6 +90,7 @@ public class JavadocHoverTests extends CoreTests {
 			workingCopy.becomeWorkingCopy(null/*no progress monitor*/);
 		workingCopy.getBuffer().setContents(source);
 		workingCopy.makeConsistent(null/*no progress monitor*/);
+		workingCopies.add(workingCopy);
 		return workingCopy;
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
@@ -74,15 +76,24 @@ public class MarkdownCommentTests extends CoreTests {
 	static final char JEM_COMPILATIONUNIT= '{';
 	static final char JEM_TYPE= LINK_BRACKET_REPLACEMENT; // replacement for '['
 
+	private List<ICompilationUnit> workingCopies;
+
 	@Before
 	public void setUp() throws Exception {
 		fJProject1= pts.getProject();
 		JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		workingCopies = new ArrayList<>();
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		JavaProjectHelper.clear(fJProject1, pts.getDefaultClasspath());
+		try {
+			for (ICompilationUnit workingCopy : workingCopies) {
+				workingCopy.discardWorkingCopy();
+			}
+		} finally {
+			JavaProjectHelper.clear(fJProject1, pts.getDefaultClasspath());
+		}
 	}
 
 	protected ICompilationUnit getWorkingCopy(String path, String source, WorkingCopyOwner owner) throws JavaModelException {
@@ -93,6 +104,7 @@ public class MarkdownCommentTests extends CoreTests {
 			workingCopy.becomeWorkingCopy(null/*no progress monitor*/);
 		workingCopy.getBuffer().setContents(source);
 		workingCopy.makeConsistent(null/*no progress monitor*/);
+		workingCopies.add(workingCopy);
 		return workingCopy;
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AbstractAnnotateAssistTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AbstractAnnotateAssistTests.java
@@ -118,7 +118,9 @@ public abstract class AbstractAnnotateAssistTests extends QuickFixTest {
 			if (proposals==null) {
 				IClassFile classFile= ((IClassFileEditorInput) javaEditor.getEditorInput()).getClassFile();
 				ICompilationUnit cu= classFile.getWorkingCopy((WorkingCopyOwner) null, null);
-				Assert.assertNotNull("cu=" + cu + " source=" + classFile.getSource(), proposals);
+				String cuString = cu.toString();
+				cu.discardWorkingCopy();
+				Assert.assertNotNull("cu=" + cuString + " source=" + classFile.getSource(), proposals);
 			}
 			List<ICompletionProposal> list= Arrays.asList(proposals);
 			return list;


### PR DESCRIPTION
This change prevents working copy leaks in MarkdownCommentTests. Such leaks can call fails in subsequent tests.

Fixes: #2423

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
