### PR TITLE
Fix ExtractMethodInputPage preview text to reflect accessor settings

### DIFF
--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/code/ExtractMethodInputPage.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/code/ExtractMethodInputPage.java
@@ -178,24 +178,26 @@ public class ExtractMethodInputPage extends UserInputWizardPage {
 		}
 
 		Button finalButton= new Button(accessModifiersGroup, SWT.CHECK);
-		finalButton.setSelection(fSettings.getBoolean(MAKE_FINAL));
-		finalButton.setText(RefactoringMessages.ExtractMethodInputPage_final);
 		finalButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent event) {
 				setFinal(((Button)event.widget).getSelection());
 			}
 		});
+		finalButton.setSelection(fSettings.getBoolean(MAKE_FINAL));
+		setFinal(fSettings.getBoolean(MAKE_FINAL));
+		finalButton.setText(RefactoringMessages.ExtractMethodInputPage_final);
 
 		Button synchronizedButton= new Button(accessModifiersGroup, SWT.CHECK);
-		synchronizedButton.setSelection(fSettings.getBoolean(MAKE_SYNCHRONIZED));
-		synchronizedButton.setText(RefactoringMessages.ExtractMethodInputPage_synchronized);
 		synchronizedButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent event) {
 				setSynchronized(((Button)event.widget).getSelection());
 			}
 		});
+		synchronizedButton.setSelection(fSettings.getBoolean(MAKE_SYNCHRONIZED));
+		setSynchronized(fSettings.getBoolean(MAKE_SYNCHRONIZED));
+		synchronizedButton.setText(RefactoringMessages.ExtractMethodInputPage_synchronized);
 
 		updateAccessModifiers();
 		layouter.perform(label, accessModifiersGroup, 1);


### PR DESCRIPTION
- fix opening ExtractMethodInputPage not showing the final or synchronized access modifier setting in the preview
- fixes #2444

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
