### PR TITLE
Sort Profile settings by key when exporting

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ProfileStore.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/ProfileStore.java
@@ -26,9 +26,10 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -291,11 +292,11 @@ public class ProfileStore {
 		element.setAttribute(XML_ATTRIBUTE_VERSION, Integer.toString(profile.getVersion()));
 		element.setAttribute(XML_ATTRIBUTE_PROFILE_KIND, profileVersioner.getProfileKind());
 
-		final Iterator<String> keyIter= profile.getSettings().keySet().iterator();
+		Map<String, String> sorted = new TreeMap<>(profile.getSettings());
 
-		while (keyIter.hasNext()) {
-			final String key= keyIter.next();
-			final String value= profile.getSettings().get(key);
+		for (Entry<String, String> entry : sorted.entrySet()) {
+			final String key= entry.getKey();
+			final String value= entry.getValue();
 			if (value != null) {
 				final Element setting= document.createElement(XML_NODE_SETTING);
 				setting.setAttribute(XML_ATTRIBUTE_ID, key);
@@ -305,6 +306,7 @@ public class ProfileStore {
 				JavaPlugin.logErrorMessage("ProfileStore: Profile does not contain value for key " + key); //$NON-NLS-1$
 			}
 		}
+
 		return element;
 	}
 


### PR DESCRIPTION
## What it does
When the exporting a profile, e.g. for cleanup or formatting, the order of the key/value pairs may be undefined, as they come from a HashMap. This change sorts the entries by key before creating the XML Profile Element.

## How to test
1. Edit default Cleanup Profile
2. Give it a different name
3. Export to XML file
4. The settings in the XML file should be sorted by key

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
