### PR TITLE
Illegal ASTNode positions should not throw

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
@@ -752,11 +752,13 @@ public class CoreJavadocAccessImpl implements IJavadocAccess {
 				int childStart= child.getStartPosition();
 				if (previousEnd > childStart) {
 					// should never happen, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=304826
-					Exception exception= new Exception("Illegal ASTNode positions: previousEnd=" + previousEnd //$NON-NLS-1$
-							+ ", childStart=" + childStart //$NON-NLS-1$
-							+ ", element=" + fElement.getHandleIdentifier() //$NON-NLS-1$
-							+ ", Javadoc:\n" + fSource); //$NON-NLS-1$
-					JavaManipulationPlugin.log(exception);
+					if ((child.getFlags() & ASTNode.MALFORMED) == 0) {
+						Exception exception= new Exception("Illegal ASTNode positions: previousEnd=" + previousEnd //$NON-NLS-1$
+								+ ", childStart=" + childStart //$NON-NLS-1$
+								+ ", element=" + fElement.getHandleIdentifier() //$NON-NLS-1$
+								+ ", Javadoc:\n" + fSource); //$NON-NLS-1$
+						JavaManipulationPlugin.log(exception);
+					}
 				} else if (previousEnd != childStart) {
 					// Need to preserve whitespace before a node that's not
 					// directly following the previous node (e.g. on a new line)


### PR DESCRIPTION
Illegal ASTNode positions should not throw java.lang.Exception

Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2457

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
```
/// <table>
///   <tr>
///     <th>[top][#topProp}</th>
///   </tr>
/// </table>
public class Table {}
```
Hovering over the Table class will throw an exception

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
