### PR TITLE
New Class dialog: fix cropped Interfaces field on mixed-DPI monitors

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
@@ -1177,7 +1177,7 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 		});
 		GridData gd= (GridData) fSuperInterfacesDialogField.getListControl(null).getLayoutData();
 		if (fTypeKind == CLASS_TYPE) {
-			gd.heightHint= convertHeightInCharsToPixels(3);
+			gd.heightHint= convertHeightInCharsToPixels(4);
 		} else {
 			gd.heightHint= convertHeightInCharsToPixels(6);
 		}


### PR DESCRIPTION
### What it does

The Interfaces field in the New Class dialog was clipped when moving dialog between monitors with different scaling factors (100–300% DPI). This was caused by GridData.heightHint being set to convertHeightInCharsToPixels(3), which can resolve too small after a DPI switch and result in the text field and its adjacent button being cut off.

This change increases the height hint from 3 to 4 character rows when fTypeKind == CLASS_TYPE, ensuring the control renders correctly across all tested DPI scales.

## How to test

- Run the runtime workspace with following arguments
  ```
  -Dswt.autoScale=quarter
  -Dswt.autoScale.updateOnRuntime=true
  ```
- Primary monitor at 100% zoom, secondary monitor at 200% zoom (scaling)
- Start Eclipse from the file explorer on the 200% monitor.
- Open the "New >>Class" dialog.
- Move the dialog to the 100% monitor.

### Results
<img width="1237" height="1643" alt="image" src="https://github.com/user-attachments/assets/e1bda0e6-4be1-402a-bad0-0e05560973c4" />


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
