### PR TITLE
Fix simplify lambda for case where an empty return statement is used

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionAndMethodRefFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionAndMethodRefFixCore.java
@@ -393,7 +393,9 @@ public class LambdaExpressionAndMethodRefFixCore extends CompilationUnitRewriteO
 						copyOfLambdaExpression2.setParentheses(false);
 					}
 
-					copyOfLambdaExpression2.setBody(ASTNodeFactory.parenthesizeIfNeeded(ast, ASTNodes.createMoveTarget(rewrite, bodyExpression)));
+					if (bodyExpression != null) {
+						copyOfLambdaExpression2.setBody(ASTNodeFactory.parenthesizeIfNeeded(ast, ASTNodes.createMoveTarget(rewrite, bodyExpression)));
+					}
 					ASTNodes.replaceButKeepComment(rewrite, visited, copyOfLambdaExpression2, group);
 					break;
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -1802,6 +1802,16 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			    public static Function<Instant, java.sql.Date> useTypeReferenceQualifyingInheritedType() {
 			        return instant -> java.sql.Date.from(instant);
 			    }
+
+				private interface X {
+					void k(Integer i);
+				}
+
+				public static void useInterfaceX() {
+					X x = i -> {
+						return;
+					};
+				}
 			}
 			""";
 
@@ -1908,6 +1918,15 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 			    public static Function<Instant, java.sql.Date> useTypeReferenceQualifyingInheritedType() {
 			        return java.sql.Date::from;
 			    }
+
+				private interface X {
+					void k(Integer i);
+				}
+
+				public static void useInterfaceX() {
+					X x = i -> {
+			        };
+				}
 			}
 			""";
 


### PR DESCRIPTION
- fix LambdaExpressionAndMethodRefFixCore to recognize an empty return statement
- modify simplify lambda test in CleanUpTest1d8 to add new scenario
- fixes #2467

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
