### PR TITLE
Do not remove lone empty commented return statement in a lambda

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionAndMethodRefFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/LambdaExpressionAndMethodRefFixCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2025 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -105,7 +105,19 @@ public class LambdaExpressionAndMethodRefFixCore extends CompilationUnitRewriteO
 
 				if (returnStatement != null) {
 					bodyExpression= returnStatement.getExpression();
-					actionType= ActionType.REMOVE_RETURN;
+					if (bodyExpression == null) {
+						// do not remove empty returns if they are the only statement in the lambda
+						// and they are commented
+						CompilationUnit cu= (CompilationUnit)visited.getRoot();
+						if (cu.getExtendedStartPosition(returnStatement) < returnStatement.getStartPosition() ||
+								cu.getExtendedLength(returnStatement) > returnStatement.getLength()) {
+							actionType= ActionType.DO_NOTHING;
+						} else {
+							actionType= ActionType.REMOVE_RETURN;
+						}
+					} else {
+						actionType= ActionType.REMOVE_RETURN;
+					}
 				}
 			} else if (visited.getBody() instanceof Expression) {
 				bodyExpression= (Expression) visited.getBody();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -17080,6 +17080,18 @@ public class CleanUpTest extends CleanUpTestCase {
 			            return;
 			        }
 			    }
+
+				private interface I1 {
+					void run(int i);
+				}
+
+				public void doNotRemoveCommentLambdaReturn() {
+					I1 i1= i -> {
+						return; // do nothing
+					};
+					i1.run(3);
+				}
+
 			}
 			""";
 		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d8.java
@@ -1812,6 +1812,12 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 						return;
 					};
 				}
+
+				public static void useInterfaceX2() {
+					X x = i -> {
+						return; // do nothing
+					};
+				}
 			}
 			""";
 
@@ -1926,6 +1932,12 @@ public class CleanUpTest1d8 extends CleanUpTestCase {
 				public static void useInterfaceX() {
 					X x = i -> {
 			        };
+				}
+
+				public static void useInterfaceX2() {
+					X x = i -> {
+						return; // do nothing
+					};
 				}
 			}
 			""";

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/UselessReturnCleanUp.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 Fabrice TIERCELIN and others.
+ * Copyright (c) 2020, 2025 Fabrice TIERCELIN and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -124,6 +124,14 @@ public class UselessReturnCleanUp extends AbstractMultiFix {
 				@Override
 				public boolean visit(final ReturnStatement node) {
 					if (result && node.getExpression() == null && isLastStatement(node)) {
+						// do not remove a single return statement in a lambda body if it has a commmeht
+						if (node.getParent().getLocationInParent() == LambdaExpression.BODY_PROPERTY) {
+							if (ASTNodes.getPreviousStatement(node) == null &&
+									(unit.getExtendedStartPosition(node) < node.getStartPosition() ||
+											unit.getExtendedLength(node) > node.getLength())) {
+								return true;
+							}
+						}
 						rewriteOperations.add(new UselessReturnOperation(node, startNode));
 
 						result= false;


### PR DESCRIPTION
- change LambdaExpressionAndMethodRefFixCore to not remove a return statement that is empty, commented, and is the only statement for the lambda
- similar logic change to UselessReturnCleanUp
- add new test scenarios to CleanUpTest1d8 and CleanUpTes
- fixes #2477

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
