### PR TITLE
Fix handling of enum switch expression when warn despite default enabled

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsBaseSubProcessor.java
@@ -1310,8 +1310,8 @@ public abstract class LocalCorrectionsBaseSubProcessor<T> {
 					ThrowStatement newThrowStatement= getThrowForUnsupportedCase(expression, ast, astRewrite);
 					listRewrite.insertAt(newThrowStatement, defaultIndex, null);
 					proposal.addLinkedPosition(astRewrite.track(newThrowStatement), true, enumConstName);
+					defaultIndex++;
 				}
-				defaultIndex++;
 				if (!hasDefault) {
 					if (ASTHelper.isSwitchExpressionNodeSupportedInAST(ast)) {
 						if (statements.size() > 0) {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsBaseSubProcessor.java
@@ -1208,7 +1208,7 @@ public abstract class LocalCorrectionsBaseSubProcessor<T> {
 			if (missingEnumCases.size() == 0 && hasDefault)
 				return;
 
-			createMissingCaseProposalsBase(context, parent, missingEnumCases, proposals);
+			createMissingCaseProposalsBase(context, parent, problem, missingEnumCases, proposals);
 		}
 	}
 
@@ -1249,7 +1249,7 @@ public abstract class LocalCorrectionsBaseSubProcessor<T> {
 	}
 
 	@SuppressWarnings("deprecation")
-	public void createMissingCaseProposalsBase(IInvocationContext context, ASTNode parent, ArrayList<String> enumConstNames, Collection<T> proposals) {
+	public void createMissingCaseProposalsBase(IInvocationContext context, ASTNode parent, IProblemLocation problem, ArrayList<String> enumConstNames, Collection<T> proposals) {
 		List<Statement> statements;
 		Expression expression;
 		if (parent instanceof SwitchStatement) {
@@ -1304,6 +1304,13 @@ public abstract class LocalCorrectionsBaseSubProcessor<T> {
 					newSwitchCase.setExpression(newName);
 				}
 				listRewrite.insertAt(newSwitchCase, defaultIndex, null);
+				defaultIndex++;
+				if (problem != null && problem.getProblemId() == IProblem.SwitchExpressionMissingEnumConstantCaseDespiteDefault) {
+					newSwitchCase.setSwitchLabeledRule(true);
+					ThrowStatement newThrowStatement= getThrowForUnsupportedCase(expression, ast, astRewrite);
+					listRewrite.insertAt(newThrowStatement, defaultIndex, null);
+					proposal.addLinkedPosition(astRewrite.track(newThrowStatement), true, enumConstName);
+				}
 				defaultIndex++;
 				if (!hasDefault) {
 					if (ASTHelper.isSwitchExpressionNodeSupportedInAST(ast)) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest14.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.ui.tests.quickfix;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,6 +25,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
 import org.eclipse.jdt.ui.tests.core.rules.Java14ProjectTestSetup;
@@ -646,4 +648,62 @@ public class QuickFixTest14 extends QuickFixTest {
 
 		assertEqualStringsIgnoreOrder(new String[] { preview }, new String[] { expected });
 	}
+
+	@Test
+	public void testIncompleteSwitchDespiteSwitch() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		Map<String, String> options= fJProject1.getOptions(false);
+		options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.WARNING);
+		options.put(JavaCore.COMPILER_PB_MISSING_ENUM_CASE_DESPITE_DEFAULT, JavaCore.ENABLED);
+		fJProject1.setOptions(options);
+
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class TestSwitchEnum {
+				enum E { F, G, H }
+				static int testEnumExhaustive(E eParm) {
+					return switch(eParm) {
+						case F -> 0;
+						case G -> 1;
+						default -> -1;
+					};
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("TestSwitchEnum.java", str1, false, null);
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
+		assertNumberOfProposals(proposals, 3);
+		assertCorrectLabels(proposals);
+
+		String expected= """
+			package test;
+			public class TestSwitchEnum {
+				enum E { F, G, H }
+				static int testEnumExhaustive(E eParm) {
+					return switch(eParm) {
+						case F -> 0;
+						case G -> 1;
+						case H -> throw new UnsupportedOperationException("Unimplemented case: " + eParm);
+						default -> -1;
+					};
+				}
+			}
+			""";
+
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/QuickFixTest14.java
@@ -651,7 +651,7 @@ public class QuickFixTest14 extends QuickFixTest {
 
 	@Test
 	public void testIncompleteSwitchDespiteSwitch() throws Exception {
-		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1= projectSetup.getProject();
 		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
 		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
 		Map<String, String> options= fJProject1.getOptions(false);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -1157,7 +1157,7 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 	}
 
 	public static void createMissingCaseProposals(IInvocationContext context, ASTNode parent, ArrayList<String> enumConstNames, Collection<ICommandAccess> proposals) {
-		new LocalCorrectionsSubProcessor().createMissingCaseProposalsBase(context, parent, enumConstNames, proposals);
+		new LocalCorrectionsSubProcessor().createMissingCaseProposalsBase(context, parent, null, enumConstNames, proposals);
 	}
 
 	public static void removeDefaultCaseProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickFixProcessor.java
@@ -318,6 +318,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.PreviewFeatureNotSupported:
 			case IProblem.SwitchExpressionsYieldMissingEnumConstantCase:
 			case IProblem.SwitchExpressionsYieldMissingDefaultCase:
+			case IProblem.SwitchExpressionMissingEnumConstantCaseDespiteDefault:
 			case IProblem.PreviewFeaturesNotAllowed:
 			case IProblem.UninitializedBlankFinalField:
 			case IProblem.FeatureNotSupported:
@@ -812,6 +813,7 @@ public class QuickFixProcessor implements IQuickFixProcessor {
 			case IProblem.MissingEnumConstantCase:
 			case IProblem.MissingEnumDefaultCase:
 			case IProblem.SwitchExpressionsYieldMissingEnumConstantCase:
+			case IProblem.SwitchExpressionMissingEnumConstantCaseDespiteDefault:
 				LocalCorrectionsSubProcessor.getMissingEnumConstantCaseProposals(context, problem, proposals);
 				break;
 			case IProblem.EnhancedSwitchMissingDefault:


### PR DESCRIPTION
- use new SwitchExpressionMissingEnumConstantCaseDespiteDefault problem id to determine if we have a switch expression with a default but missing enum constants in which case abide with the severity setting of missing enum constant rather than treat it as a syntax error
- modify LocalCorrections processor and QuickFixProcessor accordingly
- fixes #2434

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
