### PR TITLE
sort folding regions to avoid confusing different custom regions (prevent random collapsing/expanding of custom folding regions when editing a file)

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
@@ -691,10 +691,13 @@ public class CustomFoldingRegionTest {
 				// region outer
 
 				public class Test {
+					// region middle
+
 					// region inner
 					void someMethod() {
 						// content
 					}
+					// endregion
 					// endregion
 				}
 
@@ -707,24 +710,19 @@ public class CustomFoldingRegionTest {
 
 			List<IRegion> initialRegions= FoldingTestUtils.extractRegions(model);
 
-			assertEquals(3, initialRegions.size());
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 2, 12);//outer
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 5, 9);//inner
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 6, 7);//someMethod
+			assertEquals(4, initialRegions.size());
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 2, 15);//outer
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 5, 12);//middle
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 7, 11);//inner
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 8, 9);//someMethod
 
-			List<Position> positions= new ArrayList<>();
-			Iterator<Annotation> it= model.getAnnotationIterator();
-			while (it.hasNext()) {
-				Annotation a= it.next();
-				if (a instanceof ProjectionAnnotation) {
-					Position p= model.getPosition(a);
-					positions.add(p);
-				}
-			}
+			// get the mutable Positions which are in the same order as the extracted regions (copies)
+			List<Position> positions= getFoldingPositionsFromModel(model);
 			assertEquals(initialRegions.size(), positions.size());
 
 			String additionalText= "more ";
 			editor.getViewer().getDocument().replace(code.indexOf("content"), 0, additionalText);
+			cu.reconcile(ICompilationUnit.NO_AST, false, null, null);
 
 			for(int i= 0; i < positions.size(); i++) {
 				assertEquals(initialRegions.get(i).getOffset(), positions.get(i).getOffset());
@@ -733,6 +731,19 @@ public class CustomFoldingRegionTest {
 		} finally {
 			editor.close(false);
 		}
+	}
+
+	private List<Position> getFoldingPositionsFromModel(ProjectionAnnotationModel model) {
+		List<Position> positions = new ArrayList<>();
+		Iterator<Annotation> it= model.getAnnotationIterator();
+		while (it.hasNext()) {
+			Annotation a= it.next();
+			if (a instanceof ProjectionAnnotation) {
+				Position p= model.getPosition(a);
+				positions.add(p);
+			}
+		}
+		return positions;
 	}
 
 	private List<IRegion> getProjectionRangesOfFile(String str) throws Exception {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1320,13 +1320,14 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		List<JavaProjectionAnnotation> updates= new ArrayList<>();
 
 		computeFoldingStructure(ctx);
-		Map<JavaProjectionAnnotation, Position> newStructure= ctx.fMap;
 		Map<IJavaElement, List<Tuple>> oldStructure= computeCurrentStructure(ctx);
 
-		Iterator<JavaProjectionAnnotation> e= newStructure.keySet().iterator();
-		while (e.hasNext()) {
-			JavaProjectionAnnotation newAnnotation= e.next();
-			Position newPosition= newStructure.get(newAnnotation);
+		List<Map.Entry<JavaProjectionAnnotation, Position>> newStructureList = new ArrayList<>(ctx.fMap.entrySet());
+		Collections.sort(newStructureList, Comparator.comparingInt(e -> e.getValue().offset));
+
+		for(Map.Entry<JavaProjectionAnnotation, Position> newStructureEntry : newStructureList) {
+			JavaProjectionAnnotation newAnnotation= newStructureEntry.getKey();
+			Position newPosition= newStructureEntry.getValue();
 
 			IJavaElement element= newAnnotation.getElement();
 			/*


### PR DESCRIPTION
## What it does

(This is the technical description of why and how, for a quick introduction of what this fixes, view "How to test")

If extended folding is enabled, custom folding regions (if enabled) are not necessarily created in the order they are located in the file (because the file is processed sequentially and the regions can be created only once a `// endregion` (or similar) comment has been found).

To keep collapsed folding collapsed and expanded regions expanded, the folding logic [tries to match the old folding regions with the new ones](https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/6ae4ee7f4f9cb880f70c42e392865ee04b656a66/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java#L1349-L1369). For this, it uses a combination of information about which `IJavaElement`s are associated to the folding regions, whether the folding regions correspond to comments or not and (if it is still ambiguous) the order of folding regions.

If two custom folding regions are associated with the same `IJavaElement`, it can incorrectly associate them hence it will collapse a previously expanded region when editing a file (or vice-versa) because they are in the wrong order.

This PR fixes that issue for custom folding regions by sorting them by their offset. The existing (old) folding regions are already sorted [here](https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/6ae4ee7f4f9cb880f70c42e392865ee04b656a66/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java#L2302). Sorting folding regions (once more) shouldn't be much an issue when it comes to performance because Java uses TimSort which is pretty optimized in general and O(n) if it's already sorted (and to confirm this, I checked with VisualVM and didn't see the sorting show up when profiling - neither with nor without extended folding, see below).

This is very similar to #2410 and this PR would actually fix the reproducer from #2410 but there are cases where both changes are necessary.

For example, this PR fixes the issue in "How to test"

On the other hand, it's also possible to construct a case where this PR isn't sufficient and #2410 is still necessary. For example, consider the following class:
```java
public class SomeClass {
    void a(){
         // ...
    }

    void b(){
         // ...
    }
}
```

If
- extended folding is active
- `a()` is collapsed while `b()` isn't
- the `a()` method is removed

then `b()` shouldn't be collapsed. This is an example where #2410 is still necessary.

#2410 enabled the use of `IJavaElement`s (which are also used for the "old" Java folding) with extended folding for properly detecting the `IJavaElement`s. On the other hand, this PR improves the situation for multiple custom folding regions associated to the same `IJavaElement`.

### is there anything left

Even with both of these fixes, there are some possibilities where folding regions are confused. This may happen if custom folding regions are added or removed.

For example, imagine the following class:
```java
public class Hello1234 {
	// region abc
	
	// endregion abc
	
	// region def
	
	// endregion def
	
	// region gih
	
	// endregion gih
}
```
If the `def` region is collapsed and the `abc` region is removed (e.g. by deleting the `// region abc` line), all custom regions get expanded.

## How to test
- Enable extended folding
- Create the following class:
```java
public class SimpleNestedFolding {
	// region outer

	//region inner

	// endregion

	//endregion
}
```
- Collapse the inner regions
- Edit the file
- observe the outer region being collapsed

I have also done some checks with VisualVM. I created a file with 12k inner classes (or technically I reused it) and edited it while profiling `org.eclipse.jdt.ui.text.folding.**` with VisualVM.

With extended folding, I got the following results:
<img width="931" height="1043" alt="image" src="https://github.com/user-attachments/assets/9c0e057f-8555-410b-8791-4af230fc18f2" />

And these are my results with the "old" folding:
<img width="945" height="958" alt="image" src="https://github.com/user-attachments/assets/59346560-bb1a-443a-8012-80f379e42f0a" />

As you can see, the sorting isn't relevant for performance here, it doesn't even appear in the profiling output (it's part of the "Self time" in `update()`).


## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
