### PR TITLE
Fix add final for fields cleanup for generic class and lambda

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
@@ -300,7 +300,7 @@ public class VariableDeclarationFixCore extends CompilationUnitRewriteOperations
 								@Override
 								public boolean visit(SimpleName name) {
 									IBinding nameBinding= name.resolveBinding();
-									if (nameBinding == null || (nameBinding instanceof IVariableBinding varBinding && varBinding.isEqualTo(binding))) {
+									if (nameBinding == null || (nameBinding instanceof IVariableBinding varBinding && varBinding.getVariableDeclaration().isEqualTo(binding))) {
 										throw new SearchException();
 									}
 									return false;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -28047,6 +28047,52 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testAddFinalIssue2492() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
+		String sample= """
+			package test;
+			public class E<R> {
+				interface K {
+					void run();
+				}
+				private R key;
+
+				private K k = () -> {
+					System.out.println(key);
+				};
+
+				public FinalIssue(R key) {
+					this.key= key;
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL);
+		enable(CleanUpConstants.VARIABLE_DECLARATIONS_USE_FINAL_PRIVATE_FIELDS);
+
+		String expected= """
+				package test;
+				public class E<R> {
+					interface K {
+						void run();
+					}
+					private R key;
+
+					private final K k = () -> {
+						System.out.println(key);
+					};
+
+					public FinalIssue(R key) {
+						this.key= key;
+					}
+				}
+				""";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] {cu1}, new String[] {expected}, null);
+	}
+
+	@Test
 	public void testAddFinalBug129807() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test", false, null);
 		String sample= """


### PR DESCRIPTION
- fix VariableDeclarationFixCore.fieldCanBeFinal() method to add call to IVariableBinding.getVariableDeclaration() in lambda visitor because reference to the field in lambda will be ParameterizedFieldBinding and will not be equal to original generic field binding
- add new test to CleanUpTest
- fixes #2492

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
