### PR TITLE
Fix control blocks clean-up to preserve else comments properly

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ControlStatementsFix.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ControlStatementsFix.java
@@ -239,7 +239,9 @@ public class ControlStatementsFix extends CompilationUnitRewriteOperationsFixCor
 				List<Comment> comments= cuRoot.getCommentList();
 				for (Comment comment : comments) {
 					int commentLine= cuRoot.getLineNumber(comment.getStartPosition());
-					if (commentLine == controlStatementLine && comment.getStartPosition() > startPosition &&
+					if ((commentLine == controlStatementLine ||
+							fBodyProperty == IfStatement.ELSE_STATEMENT_PROPERTY && commentLine >= controlStatementLine)
+							&& commentLine < bodyLine && comment.getStartPosition() > startPosition &&
 							comment.getStartPosition() < fBody.getStartPosition()) {
 						commentsToPreserve.add(comment);
 						String commentText= cuBuffer.getText(comment.getStartPosition(), comment.getLength());

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -4110,6 +4110,42 @@ public class CleanUpTest extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testCodeStyleIssue2494() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+			public class E1 {
+				public void foo(int a) {
+					if (a == 3) // is 3
+						System.out.println("3");
+					else // value is 2
+						System.out.println("2");
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_USE_BLOCKS);
+		enable(CleanUpConstants.CONTROL_STATEMENTS_USE_BLOCKS_ALWAYS);
+
+		sample= """
+			package test1;
+			public class E1 {
+				public void foo(int a) {
+					if (a == 3) { // is 3
+			        	System.out.println("3");
+			        } else { // value is 2
+			        	System.out.println("2");
+			        }
+				}
+			}
+			""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
+	@Test
 	public void testCodeStyle_StaticAccessThroughInstance_Bug307407() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """


### PR DESCRIPTION
- fix logic in ControlStatementsFix.AddBlockOperation.rewriteAST() to recognize that we have an else clause and that the start position will be on a previous line to the else comment
- add new test to CleanUpTest
- fixes #2494

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
