### PR TITLE
Make '*' injection in "Open Type" dialog more restrictive #2505

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
@@ -446,16 +446,20 @@ public class FilteredTypesSelectionDialog extends FilteredItemsSelectionDialog i
 		String text= super.getPatternText();
 		fTypeItemsComparator.setOriginalPattern(text);
 		StringBuilder builder= new StringBuilder();
-		boolean lastCharIsUpperCase= true;
+		boolean canAddAnyStringNext= true;
 		for (int i= 0; i < text.length(); ++i) {
 			char ch= text.charAt(i);
-			if (!lastCharIsUpperCase && Character.isUpperCase(ch)) {
+			if (canAddAnyStringNext && Character.isUpperCase(ch)) {
 				builder.append('*');
 			}
 			builder.append(ch);
-			lastCharIsUpperCase= Character.isUpperCase(ch);
+			canAddAnyStringNext= canAddAnyStringNext(ch);
 		}
 		return builder.toString();
+	}
+
+	private boolean canAddAnyStringNext(char c) {
+		return !Character.isUpperCase(c) && c != '.' && c != '*';
 	}
 
 	/**


### PR DESCRIPTION
## What it does

This adapts the modification of the pattern text, that was introduced with 02958ce874164f2a61fcfba52e975988f3704e89 to only add '*' between two camel-case words. Otherwise the search might return wrong or unexpected results when e.g. searching for fully-qualified types.

## How to test

1) Search for "java.lang.String". The Java class should be the first match, as opposed to e.g. "java.lang.AbstractStringBuilder", which is suggested when searching for "java.lang.*String".

2) Search for "ComAct", which should return the same results as "Com*Act". More specifically, it should also include types such as the "ComboBoxActionPropertyChangeListener", which was previously excluded because the "Box" was not part of the search query.

Closes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2505

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
