### PR TITLE
Ignore org.eclipse.jface.text bundle loading

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
@@ -104,7 +104,7 @@ public class PluginsNotLoadedTest {
 			"org.eclipse.jdt.ui.examples.projects",
 			"org.eclipse.jdt.ui.tests.refactoring",
 			"org.eclipse.jface.databinding",
-			"org.eclipse.jface.text",
+//			"org.eclipse.jface.text", https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2503
 			"org.eclipse.jface.text.tests",
 			"org.eclipse.ltk.core.refactoring.tests",
 			"org.eclipse.ltk.ui.refactoring.tests",


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.ui/pull/3157 / https://github.com/eclipse-platform/eclipse.platform.ui/commit/3f57e264cee6ea4f06fddeba602ef7190586e31d is is always loaded if AsyncCompletionProposalPopup class is used.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2503
