### PR TITLE
Fix record constructor completion to add necessary parameters

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/MethodDeclarationCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/MethodDeclarationCompletionProposal.java
@@ -173,7 +173,17 @@ public class MethodDeclarationCompletionProposal extends JavaTypeCompletionPropo
 			buf.append("();"); //$NON-NLS-1$
 			buf.append(lineDelim);
 		} else {
-			buf.append("() {"); //$NON-NLS-1$
+			buf.append("("); //$NON-NLS-1$
+			if (fType.isRecord()) {
+				IField[] components= fType.getRecordComponents();
+				String separator= ""; //$NON-NLS-1$
+				for (IField component : components) {
+					buf.append(separator + Signature.toString(component.getTypeSignature()));
+					buf.append(" " + component.getElementName()); //$NON-NLS-1$
+					separator= ", "; //$NON-NLS-1$
+				}
+			}
+			buf.append(") {"); //$NON-NLS-1$
 			buf.append(lineDelim);
 
 			String body= CodeGeneration.getMethodBodyContent(fType.getCompilationUnit(), declTypeName, fMethodName, fReturnTypeSig == null, "", lineDelim); //$NON-NLS-1$


### PR DESCRIPTION
- modify MethodDeclarationCompletionProposal to add components to a generated constructor in a record
- add new test to CodeCompletionTests16
- for #2501

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
