### PR TITLE
Tweak record constructor proposal to add component initialization

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/CodeCompletionTest16.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/CodeCompletionTest16.java
@@ -335,5 +335,7 @@ public class CodeCompletionTest16 extends AbstractCompletionTest {
 
 		String proposalString= doc.get();
 		assertTrue(proposalString.contains("public FooBar(String foo, String bar) {"), "proper constructor not found");
+		assertTrue(proposalString.contains("this.foo = foo;"), "first component not initialized");
+		assertTrue(proposalString.contains("this.bar = bar;"), "second component not initialized");
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/MethodDeclarationCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/MethodDeclarationCompletionProposal.java
@@ -29,11 +29,14 @@ import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.TextUtilities;
 
 import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.core.manipulation.CodeGeneration;
 
 import org.eclipse.jdt.internal.core.manipulation.util.Strings;
@@ -174,7 +177,7 @@ public class MethodDeclarationCompletionProposal extends JavaTypeCompletionPropo
 			buf.append(lineDelim);
 		} else {
 			buf.append("("); //$NON-NLS-1$
-			if (fType.isRecord()) {
+			if (fType.isRecord() && fReturnTypeSig == null) {
 				IField[] components= fType.getRecordComponents();
 				String separator= ""; //$NON-NLS-1$
 				for (IField component : components) {
@@ -185,6 +188,19 @@ public class MethodDeclarationCompletionProposal extends JavaTypeCompletionPropo
 			}
 			buf.append(") {"); //$NON-NLS-1$
 			buf.append(lineDelim);
+			if (fType.isRecord() && fReturnTypeSig == null) {
+				IJavaProject javaProject= impRewrite.getCompilationUnit().getJavaProject();
+				StringBuilder sb= new StringBuilder();
+				if (JavaCore.INSERT.equals(javaProject.getOption(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_BEFORE_ASSIGNMENT_OPERATOR, true)))
+					sb.append(' ');
+				sb.append('=');
+				if (JavaCore.INSERT.equals(javaProject.getOption(DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_AFTER_ASSIGNMENT_OPERATOR, true)))
+					sb.append(' ');
+				IField[] components= fType.getRecordComponents();
+				for (IField component : components) {
+					buf.append("\tthis." + component.getElementName() + sb.toString() + component.getElementName() + ";" + lineDelim); //$NON-NLS-1$ //$NON-NLS-2$
+				}
+			}
 
 			String body= CodeGeneration.getMethodBodyContent(fType.getCompilationUnit(), declTypeName, fMethodName, fReturnTypeSig == null, "", lineDelim); //$NON-NLS-1$
 			if (body != null) {


### PR DESCRIPTION
- fix MethodDeclarationCompletionProposal.updateReplacementString() to check for a record constructor and if true, add setting of the components with parameter variables
- modify CodeCompletionTest16.testRecordConstructor test

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Tweaks the add record constructor logic to initialize the components.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
