### PR TITLE
Fix unnecessary array cleanup to check for ambiguous varargs methods

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/ASTNodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3489,16 +3489,27 @@ public class ASTNodes {
 		ITypeBinding[] parameterTypes= testedMethod.getParameterTypes();
 
 		if (!binding.isEqualTo(testedMethod)
-				&& parameterTypesForConflictingMethod.length == parameterTypes.length
 				&& binding.getName().equals(testedMethod.getName())
+				&& !hasSameReturnAndParamTypes(binding, testedMethod)
 				&& (inSameClass || Modifier.isPublic(methodModifiers) || Modifier.isProtected(methodModifiers)
-						|| (inSamePackage && !Modifier.isPrivate(methodModifiers)))) {
+						|| (inSamePackage && !Modifier.isPrivate(methodModifiers)))
+				&& (parameterTypesForConflictingMethod.length == parameterTypes.length
+						|| parameterTypes.length < parameterTypesForConflictingMethod.length &&
+							testedMethod.isVarargs())) {
 			for (int i= 0; i < parameterTypesForConflictingMethod.length; i++) {
-				if (parameterTypesForConflictingMethod[i] == null || parameterTypes[i] == null) {
+				ITypeBinding parameterType=
+						(testedMethod.isVarargs() && i > parameterTypes.length - 1) ? parameterTypes[parameterTypes.length - 1].getComponentType() : parameterTypes[i];
+				if (parameterTypesForConflictingMethod[i] == null || parameterType == null) {
 					return true;
 				}
 
-				if (!parameterTypesForConflictingMethod[i].isAssignmentCompatible(parameterTypes[i])) {
+				if (!parameterTypesForConflictingMethod[i].isAssignmentCompatible(parameterType)) {
+					if (testedMethod.isVarargs() && i == parameterTypes.length - 1) {
+						parameterType= parameterTypes[i].getComponentType();
+						if (parameterTypesForConflictingMethod[i].isAssignmentCompatible(parameterType)) {
+							continue;
+						}
+					}
 					return false;
 				}
 			}
@@ -3506,6 +3517,22 @@ public class ASTNodes {
 			return true;
 		}
 
+		return false;
+	}
+
+	private static boolean hasSameReturnAndParamTypes(IMethodBinding binding, IMethodBinding testedMethod) {
+		if (binding.getReturnType().isEqualTo(testedMethod.getReturnType())) {
+			ITypeBinding[] bindingParamTypes= binding.getParameterTypes();
+			ITypeBinding[] testedMethodParamTypes= testedMethod.getParameterTypes();
+			if (bindingParamTypes.length == testedMethodParamTypes.length) {
+				for (int i= 0; i < bindingParamTypes.length; ++i) {
+					if (!bindingParamTypes[i].isEqualTo(testedMethodParamTypes[i])) {
+						return false;
+					}
+				}
+				return true;
+			}
+		}
 		return false;
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -4663,4 +4663,29 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
     }
 
+	@Test
+	public void testUnnecessaryArrayIssue2513_MethodConflict() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class A {
+			    public static void doNotChangeMethodDispatch() {
+			        bar("d", new Object[] {"e"});
+			    }
+
+			    public static void bar(Object... elements) {
+			    }
+
+			    public static void bar(Object element, Object ...elements) {
+			    }
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("A.java", sample, false, null);
+
+		enable(CleanUpConstants.REMOVE_UNNECESSARY_ARRAY_CREATION);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
+	}
+
 }


### PR DESCRIPTION
- modify ASTNodes.isMethodMatching() to recognize when looking at a varargs method that tests much be made against the component type of the last argument once the last argument index is reached and we aren't looking at an override of the original method
- add new test to CleanUpTest1d5
- fixes #2513

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
