### PR TITLE
Fix UnwrapNewArrayOperation to keep NLS comments for all arguments

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnwrapNewArrayOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/UnwrapNewArrayOperation.java
@@ -64,10 +64,12 @@ public class UnwrapNewArrayOperation extends CompilationUnitRewriteOperation {
 
 		boolean tagged= false;
 		try {
-			for (int i= 0; i < expressionsInArray.size(); ++i) {
-				Expression operand= expressionsInArray.get(i);
-				int lineNo= root.getLineNumber(operand.getStartPosition());
-				for (NLSLine nlsLine : NLSScanner.scan(cu)) {
+			NLSLine[] nlsLines= NLSScanner.scan(cu);
+			ASTNode topNode= ASTNodes.getFirstAncestorOrNull(node, MethodInvocation.class, SuperMethodInvocation.class, ClassInstanceCreation.class);
+			int startLine= root.getLineNumber(topNode.getStartPosition());
+			int endLine= root.getLineNumber(topNode.getStartPosition() + topNode.getLength());
+			for (int lineNo= startLine; lineNo <= endLine; ++lineNo) {
+				for (NLSLine nlsLine : nlsLines) {
 					if (nlsLine.getLineNumber() == lineNo - 1) {
 						for (NLSElement element : nlsLine.getElements()) {
 							if (element.hasTag()) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -4688,4 +4688,36 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
 	}
 
+	@Test
+	public void testUnnecessaryArrayIssue2515_NLS() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class TestNLSUnnecessaryArray {
+				private void func(String a, Object ...list) {
+				}
+				public void foo() {
+					func("a", new Object[] {this, this}); //$NON-NLS-1$
+				}
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("A.java", sample, false, null);
+
+		enable(CleanUpConstants.REMOVE_UNNECESSARY_ARRAY_CREATION);
+
+		String expected= """
+			package test1;
+
+			public class TestNLSUnnecessaryArray {
+				private void func(String a, Object ...list) {
+				}
+				public void foo() {
+					func("a", this, this); //$NON-NLS-1$
+				}
+			}
+			""";
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected }, null);
+	}
 }


### PR DESCRIPTION
- modify UnwrapNewArrayOperation.rewriteAST() to not only check the array items, but also all arguments for the top-level node
- add new test to CleanUpTest
- fixes #2515

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
