### PR TITLE
Fix ambiguous null arguments in Accessor.invoke calls

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaAutoIndentStrategyTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JavaAutoIndentStrategyTest.java
@@ -240,7 +240,7 @@ public class JavaAutoIndentStrategyTest implements ILogListener {
 	}
 
 	private void performSmartIndentAfterNewLine() {
-		fAccessor.invoke("clearCachedValues", null, null);
+		fAccessor.invoke("clearCachedValues", (Class<?>[]) null, (Object[]) null);
 		fAccessor.invoke("smartIndentAfterNewLine", new Class[] { IDocument.class, DocumentCommand.class }, new Object[] { fDocument, fDocumentCommand });
 		fCommandAccessor.invoke("execute", new Class[] { IDocument.class }, new Object[] { fDocument });
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/packageview/WorkingSetDropAdapterTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/packageview/WorkingSetDropAdapterTest.java
@@ -221,7 +221,7 @@ public class WorkingSetDropAdapterTest {
 	private void setWorkingSets(IWorkingSet[] workingSets) {
 		WorkingSetModel model= fPackageExplorer.getWorkingSetModel();
 		if (model == null) {
-			fPackageExplorerPartAccessor.invoke("createWorkingSetModel", null);
+			fPackageExplorerPartAccessor.invoke("createWorkingSetModel", (Object[]) null);
 			model= fPackageExplorer.getWorkingSetModel();
 		}
 		model.setActiveWorkingSets(workingSets);


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2517

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
