### PR TITLE
Do not throw exception for saving the non-project wide nullness setting

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ProblemSeveritiesConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ProblemSeveritiesConfigurationBlock.java
@@ -631,6 +631,9 @@ public class ProblemSeveritiesConfigurationBlock extends OptionsConfigurationBlo
 		}
 		private AnnotationTarget getAnnotationKind(String name) {
 			try {
+				if (fProject == null) {
+					return AnnotationTarget.NONE;
+				}
 				IType annotationType= JavaCore.create(fProject).findType(name);
 				if (annotationType != null && annotationType.exists()) {
 					for (IAnnotation metaAnn : annotationType.getAnnotations()) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
This patch fixes the following problem:

1. Open Preferences -> Java -> Compiler -> Errors/Warnings 
2. "Enable annotation-based null analysis"
3. Click on the 'Use default annotations for null specifications (*Configure*)
4. Try to modify the annotation names
5. Click on Ok
6. Dialog stays, a following exception is logged:
`

java.lang.NullPointerException: Cannot invoke "org.eclipse.jdt.core.IJavaProject.findType(String)" because the return value of "org.eclipse.jdt.core.JavaCore.create(org.eclipse.core.resources.IProject)" is null
	at org.eclipse.jdt.internal.ui.preferences.ProblemSeveritiesConfigurationBlock$NullAnnotationsConfigurationDialog.getAnnotationKind(ProblemSeveritiesConfigurationBlock.java:634)
	at org.eclipse.jdt.internal.ui.preferences.ProblemSeveritiesConfigurationBlock$NullAnnotationsConfigurationDialog.detectedAnnotationTargets(ProblemSeveritiesConfigurationBlock.java:621)
	at org.eclipse.jdt.internal.ui.preferences.ProblemSeveritiesConfigurationBlock$NullAnnotationsConfigurationDialog.buttonPressed(ProblemSeveritiesConfigurationBlock.java:574)
	at org.eclipse.jface.dialogs.Dialog.lambda$0(Dialog.java:615)
	at org.eclipse.swt.events.SelectionListener$1.widgetSelected(SelectionListener.java:83)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:286)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:91)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:5884)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1656)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:5099)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4540)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:824)
	at org.eclipse.jface.window.Window.open(Window.java:804)
	at org.eclipse.jdt.internal.ui.preferences.ProblemSeveritiesConfigurationBlock.openNullAnnotationsConfigurationDialog(ProblemSeveritiesConfigurationBlock.java:1520)
	at org.eclipse.jdt.internal.ui.preferences.ProblemSeveritiesConfigurationBlock$2.widgetSelected(ProblemSeveritiesConfigurationBlock.java:1489)
	at org.eclipse.jdt.internal.ui.preferences.OptionsConfigurationBlock$2.widgetSelected(OptionsConfigurationBlock.java:559)
	at org.eclipse.swt.widgets.TypedListener.handleEvent(TypedListener.java:286)
`

## How to test

Following the reproduction steps

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
