### PR TITLE
Properly upper bound all dependencies in the junit runtimes

### DIFF
--- a/org.eclipse.jdt.junit4.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit4.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit4.runtime;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit4.runner;x-internal:=true
 Require-Bundle: org.junit;bundle-version="[4.13.0,5.0.0)",

--- a/org.eclipse.jdt.junit4.runtime/pom.xml
+++ b/org.eclipse.jdt.junit4.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit4.runtime</artifactId>
-  <version>1.3.100-SNAPSHOT</version>
+  <version>1.3.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit5.runtime;singleton:=true
-Bundle-Version: 1.1.400.qualifier
+Bundle-Version: 1.1.500.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit5.runner;x-internal:=true
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.jdt.junit5.runtime/pom.xml
+++ b/org.eclipse.jdt.junit5.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit5.runtime</artifactId>
-  <version>1.1.400-SNAPSHOT</version>
+  <version>1.1.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>


### PR DESCRIPTION
- With junit 6 in the target platform, the lack of upper bounds can and does cause wiring problems.
- Update the lower bounds and set the upper bound to exclude major version increments.