### PR TITLE
Fix types dialog when pattern contains only uppercase letters #2538

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,6 +33,7 @@ import org.eclipse.jdt.ui.tests.buildpath.BuildpathTestSuite;
 import org.eclipse.jdt.ui.tests.callhierarchy.CallHierarchyContentProviderTest;
 import org.eclipse.jdt.ui.tests.core.CoreTestSuite;
 import org.eclipse.jdt.ui.tests.core.CoreTests;
+import org.eclipse.jdt.ui.tests.dialogs.FilteredTypesSelectionDialogTests;
 import org.eclipse.jdt.ui.tests.editor.ClassFileInputTests;
 import org.eclipse.jdt.ui.tests.hover.JavadocHoverTests;
 import org.eclipse.jdt.ui.tests.hover.MarkdownCommentTests;
@@ -89,7 +90,8 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 	JavadocHoverTests.class,
 	MarkdownCommentTests.class,
 	SmokeViewsTest.class,
-	ClassFileInputTests.class
+	ClassFileInputTests.class,
+	FilteredTypesSelectionDialogTests.class
 })
 public class AutomatedSuite {
 	@BeforeEach

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/dialogs/FilteredTypesSelectionDialogTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/dialogs/FilteredTypesSelectionDialogTests.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Patrick Ziegler others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Patrick Ziegler - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.dialogs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.testplugin.util.DisplayHelper;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Table;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.ui.dialogs.SelectionDialog;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+
+import org.eclipse.jdt.internal.core.search.JavaSearchTypeNameMatch;
+
+import org.eclipse.jdt.ui.JavaUI;
+
+import org.eclipse.jdt.internal.ui.dialogs.FilteredTypesSelectionDialog;
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
+
+/**
+ * Test case for the {@link FilteredTypesSelectionDialog} to make sure that the
+ * suggested types fit to the search string.
+ */
+public class FilteredTypesSelectionDialogTests {
+	private static IJavaProject testProject;
+	private static String CU_NAME = "Test.java";
+	private static String CU_CONTENT = """
+			package test;
+			public class Test {
+			}
+			""";
+
+	private FilteredTypesSelectionDialog dialog;
+	private SelectionDisplayHelper displayHelper;
+	private Shell shell;
+
+	@BeforeAll
+	public static void setUpAll() throws CoreException {
+		testProject = JavaProjectHelper.createJavaProject("TestProject", "bin");
+		JavaProjectHelper.addRTJar(testProject);
+
+		IPackageFragmentRoot packageRoot = JavaProjectHelper.addSourceContainer(testProject, "src");
+		IPackageFragment packageFragment = packageRoot.createPackageFragment("test", true, null);
+		ICompilationUnit cu = packageFragment.createCompilationUnit(CU_NAME, CU_CONTENT, true, null);
+		EditorUtility.openInSpecificEditor(cu, JavaUI.ID_CU_EDITOR, true);
+	}
+
+	@AfterAll
+	public static void tearDownAll() throws CoreException {
+		if (testProject != null) {
+			JavaProjectHelper.delete(testProject);
+		}
+	}
+
+	@BeforeEach
+	public void setUp() {
+		shell = new Shell();
+		dialog = new FilteredTypesSelectionDialog(shell, false, null, null, IJavaSearchConstants.TYPE);
+		dialog.setBlockOnOpen(false);
+		displayHelper = new SelectionDisplayHelper(dialog);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		shell.dispose();
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2387
+		"java.lang.AbstractBuilder, java.lang.AbstractStringBuilder",
+		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2505
+		"java.lang.String, java.lang.String",
+		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2538
+		"OOME, java.lang.OutOfMemoryError"
+	})
+	public void testWithSearchString(String pattern, String expectedType) {
+		dialog.setInitialPattern(pattern);
+		dialog.setTitle("Search for type");
+		dialog.open();
+		displayHelper.waitForCondition(Display.getCurrent(), 5000);
+
+		JavaSearchTypeNameMatch firstMatch = displayHelper.getFirstMatch();
+		assertEquals(expectedType, firstMatch.getFullyQualifiedName());
+	}
+
+	/**
+	 * Utility class that exposes the table of the selection dialog. When the
+	 * search string is updated, a job is notified that calculates the content
+	 * of the table.
+	 *
+	 * This helper waits until this job is done by checking whether the table
+	 * contains at least one element.
+	 *
+	 * Elements in this table are of type {@link JavaSearchTypeNameMatch}.
+	 */
+	private static class SelectionDisplayHelper extends DisplayHelper {
+		private final SelectionDialog dialog;
+		private Table table;
+
+		public SelectionDisplayHelper(SelectionDialog dialog) {
+			this.dialog = dialog;
+		}
+
+		@Override
+		protected boolean condition() {
+			// wait until search has finished
+			return getTable().getItemCount() != 0;
+		}
+
+		public JavaSearchTypeNameMatch getFirstMatch() {
+			return (JavaSearchTypeNameMatch) getTable().getItem(0).getData();
+		}
+
+		public Table getTable() {
+			if (table == null) {
+				table = findTable(dialog.getShell());
+			}
+			return table;
+		}
+
+		private static Table findTable(Control control) {
+			if (control instanceof Table table) {
+				return table;
+			}
+			if (control instanceof Composite composite) {
+				for (Control child : composite.getChildren()) {
+					Table table = findTable(child);
+					if (table != null) {
+						return table;
+					}
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
@@ -446,7 +446,7 @@ public class FilteredTypesSelectionDialog extends FilteredItemsSelectionDialog i
 		String text= super.getPatternText();
 		fTypeItemsComparator.setOriginalPattern(text);
 		StringBuilder builder= new StringBuilder();
-		boolean canAddAnyStringNext= true;
+		boolean canAddAnyStringNext= false;
 		for (int i= 0; i < text.length(); ++i) {
 			char ch= text.charAt(i);
 			if (canAddAnyStringNext && Character.isUpperCase(ch)) {


### PR DESCRIPTION
## What it does

This solves a regression where a search pattern, that only contains upper-case letters, wouldn't show any matches.

The bug was caused with 210f65acc02641c0e26a081aa88ca119c4c2b2ca, where a fix a different issue was fixed when searching for a type by its fully qualified name.

Cause of this issue is the inversion of the "canAddAnyStringNext" logic, which now requires this variable to be initialized with "false". Otherwise every search string would being with a "*", like "*OOM" for "OOM".

A test case has been added to cover the relevant cases and to make sure future changes don't introduce any regressions.

Closes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2538

<!-- Include relevant issues and describe how they are addressed. -->

## How to test
Use the "Open Type" dialog with the following search strings: `java.lang.String`, `java.lang.AbstractBuilder`, `OOME`.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
