### PR TITLE
Break the loop in getStickyLines() if same AST node was found

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaStickyLinesProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaStickyLinesProvider.java
@@ -298,6 +298,9 @@ public class JavaStickyLinesProvider implements IStickyLinesProvider {
 								Modifier modifier= (Modifier)node;
 								startIndentation+= modifier.getLength();
 								node= getASTNode(cu, mapWidgetToLineNumber(sourceViewer, textWidgetLineNumber+1), line);
+								if(node == modifier) {
+									node= node.getParent();
+								}
 							} else {
 								node= node.getParent();
 							}


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2540