### PR TITLE
Add logic to avoid invalid post-fix suggestions

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/PostfixCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/PostfixCompletionProposalComputer.java
@@ -46,10 +46,12 @@ import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StringLiteral;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.manipulation.SharedASTProviderCore;
 
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
 import org.eclipse.jdt.internal.corext.template.java.JavaPostfixContextType;
 
@@ -258,9 +260,14 @@ public class PostfixCompletionProposalComputer extends AbstractTemplateCompletio
 			});
 
 			completionNode= bestNode[0];
-			ASTNode completionNodeParent= findBestMatchingParentNode(completionNode);
-			postfixCompletionTemplateEngine.setASTNodes(completionNode, completionNodeParent);
-			postfixCompletionTemplateEngine.setContext(context);
+			Statement s= completionNode instanceof Statement stmt ? stmt : ASTNodes.getFirstAncestorOrNull(completionNode, Statement.class);
+			if (s != null && s.getStartPosition() < invOffset && s.getStartPosition() + s.getLength() >= invOffset) {
+				ASTNode completionNodeParent= findBestMatchingParentNode(completionNode);
+				postfixCompletionTemplateEngine.setASTNodes(completionNode, completionNodeParent);
+				postfixCompletionTemplateEngine.setContext(context);
+			} else {
+				postfixCompletionTemplateEngine.reset();
+			}
 		}
 	}
 


### PR DESCRIPTION
- add logic to PostfixCompletionProposalComputer to clear proposals if the selected node and it's entire statement precedes the invocation point for the completion
- works around https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1016 and https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4530

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See first issue mentioned.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See first issue mentioned.  Should not offer a proposal while the 2nd issue mentioned above is not fixed.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
