### PR TITLE
Limit initial quick type hierarchy view expansion #2549

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/typehierarchy/HierarchyInformationControl.java
@@ -134,6 +134,7 @@ public class HierarchyInformationControl extends AbstractInformationControl {
 		tree.setLayoutData(gd);
 
 		TreeViewer treeViewer= new TreeViewer(tree) {
+			private static final int EXPANSION_LIMIT = 10;
 			private Set<Object> visited;
 
 			@Override
@@ -153,7 +154,7 @@ public class HierarchyInformationControl extends AbstractInformationControl {
 			}
 
 			private boolean shouldExpand(Widget widget) {
-				if (widget == null) {
+				if (widget == null || visited.size() > EXPANSION_LIMIT) {
 					return false;
 				}
 				Object data= widget.getData();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
This PR fixes #2549.
When opening the quick type hierarchy view, there is no limit on the amount of items expanded initially, leading to possibly long loading times and ui freezes.
With this change, the amount of items in the tree expanded initially is limited to the `largeViewLimit` setting.

For an especially bad example in our code base (see #2549) this change reduces the waiting time for the view dramatically, while not impacting use cases with a more _reasonable_ amount of classes (less than the `largeViewLimit`):
<img width="2104" height="838" alt="image" src="https://github.com/user-attachments/assets/a115900a-c92a-4fed-be08-ebcf35539266" />


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Sadly I could not find a simple reproducer that does not contain our product code or is a big zip bundle of thousands of classes.
The issue occurs if there is a very large amount of classes in the type hierarchy view that do not get mitigated by the change from #1830.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
