### PR TITLE
Fix listener for folding preferences

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1192,10 +1192,10 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			handleProjectionDisabled();
 			fProjectionListener.dispose();
 			fProjectionListener= null;
-			fEditor= null;
 			for (IPreferenceStore store : FoldingPreferencePage.getAllFoldingPreferenceStores(fEditor)) {
 				store.removePropertyChangeListener(fPropertyChangeListener);
 			}
+			fEditor= null;
 		}
 	}
 


### PR DESCRIPTION
## What it does
Lets an editor being closed correctly unsubscribe as a listener of preference stores

## How to test
- Open a Java File
- Close it

**Expected result**
The `for`-loop should have some `store`s to iterate over.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
