### PR TITLE
Fix split package signing for o.e.jdt.junit versus o.e.jdt.junit.core

### DIFF
--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.17.200.qualifier
+Bundle-Version: 3.17.300.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3190

```
The package 'org.eclipse.jdt.junit.launcher 0.0.0' is jar-signed differently by the containing IUs
org.eclipse.jdt.junit 3.17.200.v20250616-1826
  {CN=Eclipse.org Foundation, Inc., O=Eclipse.org Foundation, Inc., L=Ottawa, ST=Ontario, from=2024-07-22, to=2025-07-21}
    {CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O=DigiCert, Inc., from=2021-04-29, to=2036-04-28}
      {CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, from=2013-08-01, to=2038-01-15}
org.eclipse.jdt.junit.core 3.14.0.v20251024-0945
  {CN=Eclipse.org Foundation, Inc., O=Eclipse.org Foundation, Inc., L=Ottawa, ST=Ontario, from=2025-07-17, to=2026-07-16}
    {CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O=DigiCert, Inc., from=2021-04-29, to=2036-04-28}
      {CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, from=2013-08-01, to=2038-01-15}
```