### PR TITLE
Do not execute Tests in sibling packages with common prefix

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
@@ -663,9 +664,16 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 	private void addAllSubPackageFragments(IPackageFragment pkgFragment, Set<String> pkgNames) throws JavaModelException {
 		String elementName= getPackageName(pkgFragment.getElementName());
 		IPackageFragmentRoot pkgFragmentRoot= (IPackageFragmentRoot) pkgFragment.getParent();
+		Pattern packagePattern = Pattern.compile(elementName.replace(".", "\\.") + "(?:$|\\..*)"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		for (IJavaElement child : pkgFragmentRoot.getChildren()) {
-			if (child instanceof IPackageFragment && getPackageName(((IPackageFragment) child).getElementName()).startsWith(elementName) && ((IPackageFragment) child).hasChildren()) {
-				pkgNames.add(getPackageName(((IPackageFragment) child).getElementName()));
+			if (!(child instanceof IPackageFragment childFragment)) {
+				continue;
+			}
+
+			final String childPackageName = getPackageName(childFragment.getElementName());
+
+			if (childFragment.hasChildren() && packagePattern.matcher(childPackageName).matches()) {
+				pkgNames.add(childPackageName);
 			}
 		}
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/AdvancedJUnitLaunchConfigurationDelegateTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/AdvancedJUnitLaunchConfigurationDelegateTest.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Platform;
 
 import org.eclipse.debug.core.ILaunch;
@@ -35,6 +36,7 @@ import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.Launch;
 
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -173,7 +175,59 @@ public class AdvancedJUnitLaunchConfigurationDelegateTest {
 		assertThat(fileLines).contains(lineForFirstTest).size().isEqualTo(1);
 	}
 
+	@Test
+	public void runTestsInSourceFolderPackagesWithCommonPrefix() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-TestProject-PackagesCommonPrefix";
+		fJavaProject= JavaProjectHelper.createJavaProject(projectName, "bin");
+		IPackageFragmentRoot root= JavaProjectHelper.addSourceContainer(fJavaProject, "src");
+		IPackageFragment firstPackage= root.createPackageFragment("a", true, new NullProgressMonitor());
+		IPackageFragment nestedPackage= root.createPackageFragment("a.nested", true, new NullProgressMonitor());
+		IPackageFragment secondPackage= root.createPackageFragment("ab", true, new NullProgressMonitor());
+
+		firstPackage.createCompilationUnit("FirstTest.java", """
+				package a;
+				class FirstTest {
+					@org.junit.jupiter.api.Test
+					void myTest() {
+					}
+				}
+				""", true, new NullProgressMonitor());
+
+		nestedPackage.createCompilationUnit("NestedTest.java", """
+				package a.nested;
+				class NestedTest {
+					@org.junit.jupiter.api.Test
+					void myTest() {
+					}
+				}
+				""", true, new NullProgressMonitor());
+
+		secondPackage.createCompilationUnit("UnrelatedTest.java", """
+				package ab;
+				class UnrelatedTest {
+					@org.junit.jupiter.api.Test
+					void myTest() {
+					}
+				}
+				""", true, new NullProgressMonitor());
+
+		List<String> fileLines= showCommandAndExtractContentOfPackageNameFile(projectName, fJavaProject, firstPackage);
+
+		assertThat(fileLines) //
+				.containsExactly("a", "a.nested");
+	}
+
 	private List<String> showCommandLineAndExtractContentOfTestNameFile(String projectName, IJavaProject javaProject, IPackageFragmentRoot testSrc1)
+			throws CoreException, JavaModelException, IOException {
+		return showCommandLineAndExtractContentOfFileArgument(projectName, javaProject, testSrc1, "-testNameFile");
+	}
+
+	private List<String> showCommandAndExtractContentOfPackageNameFile(String projectName, IJavaProject javaProject, IPackageFragment testPackage)
+			throws CoreException, JavaModelException, IOException {
+		return showCommandLineAndExtractContentOfFileArgument(projectName, javaProject, testPackage, "-packageNameFile");
+	}
+
+	private List<String> showCommandLineAndExtractContentOfFileArgument(String projectName, IJavaProject javaProject, IJavaElement testElement, String searchString)
 			throws CoreException, JavaModelException, IOException {
 		JavaProjectHelper.addRTJar18(javaProject);
 		IClasspathEntry cpe= JavaCore.newContainerEntry(JUnitCore.JUNIT5_CONTAINER_PATH);
@@ -184,16 +238,15 @@ public class AdvancedJUnitLaunchConfigurationDelegateTest {
 		configuration.setProjectName(projectName);
 		String testRunnerKind= TestKindRegistry.JUNIT5_TEST_KIND_ID;
 		configuration.setTestRunnerKind(testRunnerKind);
-		String containerHandle= testSrc1.getHandleIdentifier();
+		String containerHandle= testElement.getHandleIdentifier();
 		configuration.setContainerHandle(containerHandle);
 		String mode= ILaunchManager.DEBUG_MODE;
 		ILaunch launch= new Launch(configuration, mode, null);
-		IProgressMonitor progressMonitor= null;
+		IProgressMonitor progressMonitor= new NullProgressMonitor();
 		String showCommandLine= delegate.showCommandLine(configuration, mode, launch, progressMonitor);
-		String firstSearchStr= "-testNameFile";
-		int indexTestNameFile= showCommandLine.indexOf(firstSearchStr);
-		assertThat(indexTestNameFile).overridingErrorMessage("-testNameFile argument not found").isGreaterThan(-1);
-		String filePath= extractPathForArgumentFile(showCommandLine, firstSearchStr, indexTestNameFile);
+		int indexSearchString= showCommandLine.indexOf(searchString);
+		assertThat(indexSearchString).overridingErrorMessage("%s argument not found", searchString).isGreaterThan(-1);
+		String filePath= extractPathForArgumentFile(showCommandLine, searchString, indexSearchString);
 		List<String> fileLines= Files.readAllLines(Paths.get(filePath));
 		return fileLines;
 	}


### PR DESCRIPTION
## What it does
Proposed Fix for #2563 
Tests from sibling packages are no longer considered for Test Execution when launching JUnit Tests on a Java package.

## How to test
Create the following package structure:
<img width="284" height="225" alt="grafik" src="https://github.com/user-attachments/assets/83251f67-162e-40b0-8be2-f7217b07928b" />
Right Click on the `com.example.a` package and select "Run As > JUnit Test".
Only the `com.example.a.nested.MyNestedTest`, `com.example.a.MyOtherTest` and `com.example.a.MyTest` Tests are launched. No Tests from the `com.example.ab` package are launched

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
