### PR TITLE
Remove unnecessary unrestricted requirements of junit-jupiter-api bundle

### DIFF
--- a/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
@@ -37,8 +37,7 @@ Require-Bundle:
  org.eclipse.test.performance,
  org.eclipse.jdt.core.manipulation,
  org.eclipse.core.expressions,
- org.eclipse.core.tests.harness,
- junit-jupiter-api
+ org.eclipse.core.tests.harness
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",

--- a/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests.refactoring/META-INF/MANIFEST.MF
@@ -40,8 +40,7 @@ Require-Bundle:
  org.eclipse.ui.ide,
  org.eclipse.ui.workbench.texteditor,
  org.junit;bundle-version="[4.0.0,5.0.0)",
- org.eclipse.core.tests.harness,
- junit-jupiter-api
+ org.eclipse.core.tests.harness
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir
 Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",

--- a/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.tests/META-INF/MANIFEST.MF
@@ -73,8 +73,7 @@ Require-Bundle:
  org.eclipse.jdt.astview,
  org.eclipse.compare.core,
  org.eclipse.compare,
- org.eclipse.core.tests.harness,
- junit-jupiter-api
+ org.eclipse.core.tests.harness
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Eclipse-BundleShape: dir
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Required bundles, just like imported-packages, especially for JUnit-5 should have version ranges with suitable upper-bounds to not accidentally require JUnit-6.
But the corresponding package-imports already cover all usages, so these requirements can just be removed.

Part of
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3430

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
