### PR TITLE
Removed unnecessary @SuppressWarnings("deprecation") from jdt.ui

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpConfigurationBlock.java
@@ -55,7 +55,6 @@ import org.eclipse.jdt.internal.ui.wizards.dialogfields.SelectionButtonDialogFie
 /**
  * The clean up configuration block for the clean up preference page.
  */
-@SuppressWarnings("deprecation") // java.util.Observable since 9;
 public class CleanUpConfigurationBlock extends ProfileConfigurationBlock {
 
 	private static final String CLEANUP_PAGE_SETTINGS_KEY= "cleanup_page"; //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CleanUpTabPage.java
@@ -113,7 +113,6 @@ public abstract class CleanUpTabPage extends ModifyDialogTabPage implements ICle
 		fInitialValues= Map.copyOf(fValues);
 	}
 
-	@SuppressWarnings("deprecation") // java.util.Observer
 	protected void registerPreference(final CheckboxPreference preference) {
 		if (fCheckboxes.add(preference)) {
 			fCount++;
@@ -161,7 +160,6 @@ public abstract class CleanUpTabPage extends ModifyDialogTabPage implements ICle
 
 	/* Register a preference that is an option for a cleanup. Checking it does not change the number of clean ups.
 	 */
-	@SuppressWarnings("deprecation") // java.util.Observer
 	protected void registerOptionPreference(final CheckboxPreference main, final CheckboxPreference... options) {
 		registerPreference(main);
 		fCheckboxes.addAll(Arrays.asList(options));
@@ -190,7 +188,6 @@ public abstract class CleanUpTabPage extends ModifyDialogTabPage implements ICle
 	 * @param subSlaves indirect slaves, i.e. a slave is a master of its subSlave).
 	 * 		First index into array is the subSlave's master's index. subSlaves can also be <code>null</code>.
 	 */
-	@SuppressWarnings("deprecation") // java.util.Observer
 	protected void registerSlavePreference(final CheckboxPreference master, final CheckboxPreference[] slaves, final CheckboxPreference[][] subSlaves) {
 		internalRegisterSlavePreference(master, slaves);
 
@@ -241,7 +238,6 @@ public abstract class CleanUpTabPage extends ModifyDialogTabPage implements ICle
 		}
 	}
 
-	@SuppressWarnings("deprecation") // java.util.Observer
 	private void internalRegisterSlavePreference(final CheckboxPreference master, final ButtonPreference[] slaves) {
 		fCheckboxes.addAll(Arrays.asList(slaves));
     	master.addObserver( (o, arg) -> {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CodeFormatingTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/CodeFormatingTabPage.java
@@ -35,7 +35,6 @@ import org.eclipse.jdt.internal.ui.fix.ImportsCleanUp;
 import org.eclipse.jdt.internal.ui.fix.SortMembersCleanUp;
 import org.eclipse.jdt.internal.ui.preferences.formatter.JavaPreview;
 
-@SuppressWarnings("deprecation") // java.util.Observable since 9;
 public final class CodeFormatingTabPage extends AbstractCleanUpTabPage {
 
 	public static final String ID= "org.eclipse.jdt.ui.cleanup.tabpage.code_formatting"; //$NON-NLS-1$


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4553
