### PR TITLE
Adjust highlighting of deprecation

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightings.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightings.java
@@ -1237,14 +1237,14 @@ public class SemanticHighlightings {
 					ITypeBinding declaringClass= methodBinding.getDeclaringClass();
 					if (declaringClass == null)
 						return false;
-					if (declaringClass.isAnonymous()) {
+					if (declaringClass.isAnonymous() && methodBinding.isConstructor()) {
 						ITypeBinding[] interfaces= declaringClass.getInterfaces();
 						if (interfaces.length > 0)
 							return interfaces[0].isDeprecated();
 						else
 							return declaringClass.getSuperclass().isDeprecated();
 					}
-					return declaringClass.isDeprecated() && !(token.getNode().getParent() instanceof MethodDeclaration);
+					return declaringClass.isDeprecated() && methodBinding.isDefaultConstructor();
 				} else if (binding instanceof IVariableBinding) {
 					IVariableBinding variableBinding= (IVariableBinding) binding;
 					ITypeBinding declaringClass= variableBinding.getDeclaringClass();


### PR DESCRIPTION
After https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4564 deprecation no longer propagates from a type to its members.

Still highlight as deprecated constructors of anonymous classes and default constructors.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4553#issuecomment-3448344936
