### PR TITLE
Highlight deprecation of canonical record constructor

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightings.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightings.java
@@ -1244,7 +1244,7 @@ public class SemanticHighlightings {
 						else
 							return declaringClass.getSuperclass().isDeprecated();
 					}
-					return declaringClass.isDeprecated() && methodBinding.isDefaultConstructor();
+					return declaringClass.isDeprecated() && (methodBinding.isDefaultConstructor() || methodBinding.isCanonicalConstructor());
 				} else if (binding instanceof IVariableBinding) {
 					IVariableBinding variableBinding= (IVariableBinding) binding;
 					ITypeBinding declaringClass= variableBinding.getDeclaringClass();


### PR DESCRIPTION
Fixes additional observation in https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2578

