### PR TITLE
Improve fix for COMPILER_PB_MEMBER_OF_DEPRECATED_TYPE

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/Java50CleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/Java50CleanUp.java
@@ -106,8 +106,10 @@ public class Java50CleanUp extends AbstractMultiFix {
 			}
 		}
 
-		if (isEnabled(CleanUpConstants.ADD_MISSING_ANNOTATIONS) && isEnabled(CleanUpConstants.ADD_MISSING_ANNOTATIONS_DEPRECATED))
+		if (isEnabled(CleanUpConstants.ADD_MISSING_ANNOTATIONS) && isEnabled(CleanUpConstants.ADD_MISSING_ANNOTATIONS_DEPRECATED)) {
 			result.put(JavaCore.COMPILER_PB_MISSING_DEPRECATED_ANNOTATION, JavaCore.WARNING);
+			result.put(JavaCore.COMPILER_PB_MEMBER_OF_DEPRECATED_TYPE, JavaCore.WARNING);
+		}
 
 		if (isEnabled(CleanUpConstants.VARIABLE_DECLARATION_USE_TYPE_ARGUMENTS_FOR_RAW_TYPE_REFERENCES))
 			result.put(JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE, JavaCore.WARNING);


### PR DESCRIPTION
Fix invocation as multi fix from the problem hover:
+ the new problem must be enabled when creating the refactoring ast

Amend https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2587
