### PR TITLE
React to new info warnings from ecj

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CleanUpContextCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CleanUpContextCore.java
@@ -42,6 +42,7 @@ public class CleanUpContextCore {
 	 *            previous clean ups only if {@link CleanUpRequirementsCore#requiresFreshAST()} returns
 	 *            <code>true</code>.
 	 */
+	@Deprecated
 	public CleanUpContextCore(ICompilationUnit unit, CompilationUnit ast) {
 		Assert.isLegal(unit != null);
 		fUnit= unit;
@@ -53,6 +54,7 @@ public class CleanUpContextCore {
 	 *
 	 * @return the compilation unit to clean up
 	 */
+	@Deprecated
 	public ICompilationUnit getCompilationUnit() {
 		return fUnit;
 	}
@@ -69,6 +71,7 @@ public class CleanUpContextCore {
 	 *
 	 * @return an AST or <code>null</code> if none required
 	 */
+	@Deprecated
 	public CompilationUnit getAST() {
 		return fAst;
 	}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CleanUpOptionsCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CleanUpOptionsCore.java
@@ -39,11 +39,13 @@ public class CleanUpOptionsCore {
 	/**
 	 * True value
 	 */
+	@Deprecated
 	public static final String TRUE= "true"; //$NON-NLS-1$
 
 	/**
 	 * False value
 	 */
+	@Deprecated
 	public static final String FALSE= "false"; //$NON-NLS-1$
 
 	/**
@@ -52,6 +54,7 @@ public class CleanUpOptionsCore {
 	 * @param options map that maps clean ups keys (<code>String</code>) to a non-<code>null</code>
 	 *            string value
 	 */
+	@Deprecated
 	public CleanUpOptionsCore(Map<String, String> options) {
 		fOptions= options;
 	}
@@ -59,6 +62,7 @@ public class CleanUpOptionsCore {
 	/**
 	 * Creates a new instance.
 	 */
+	@Deprecated
 	public CleanUpOptionsCore() {
 		fOptions= new Hashtable<>();
 	}
@@ -71,6 +75,7 @@ public class CleanUpOptionsCore {
 	 * @throws IllegalArgumentException if the key is <code>null</code>
 	 * @see CleanUpConstants
 	 */
+	@Deprecated
 	public boolean isEnabled(String key) {
 		Assert.isLegal(key != null);
 		Object value= fOptions.get(key);
@@ -84,6 +89,7 @@ public class CleanUpOptionsCore {
 	 * @return the value associated with the key
 	 * @throws IllegalArgumentException if the key is null or unknown
 	 */
+	@Deprecated
 	public String getValue(String key) {
 		Assert.isLegal(key != null);
 		String value= fOptions.get(key);
@@ -100,6 +106,7 @@ public class CleanUpOptionsCore {
 	 * @see CleanUpOptionsCore#TRUE
 	 * @see CleanUpOptionsCore#FALSE
 	 */
+	@Deprecated
 	public void setOption(String key, String value) {
 		Assert.isLegal(key != null);
 		Assert.isLegal(value != null);
@@ -111,6 +118,7 @@ public class CleanUpOptionsCore {
 	 *
 	 * @return an unmodifiable set of all keys
 	 */
+	@Deprecated
 	public Set<String> getKeys() {
 		return Collections.unmodifiableSet(fOptions.keySet());
 	}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CleanUpRequirementsCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CleanUpRequirementsCore.java
@@ -30,12 +30,16 @@ import org.eclipse.jdt.core.JavaCore;
 @Deprecated(forRemoval=true, since="2024-06")
 final public class CleanUpRequirementsCore {
 
+	@Deprecated
 	protected final boolean fRequiresAST;
 
+	@Deprecated
 	protected final Map<String, String> fCompilerOptions;
 
+	@Deprecated
 	protected final boolean fRequiresFreshAST;
 
+	@Deprecated
 	protected final boolean fRequiresChangedRegions;
 
 
@@ -47,6 +51,7 @@ final public class CleanUpRequirementsCore {
 	 * @param requiresChangedRegions <code>true</code> if changed regions are required
 	 * @param compilerOptions map of compiler options or <code>null</code> if no requirements
 	 */
+	@Deprecated
 	public CleanUpRequirementsCore(boolean requiresAST, boolean requiresFreshAST, boolean requiresChangedRegions, Map<String, String> compilerOptions) {
 		Assert.isLegal(!requiresFreshAST || requiresAST, "Must not request fresh AST if no AST is required"); //$NON-NLS-1$
 		Assert.isLegal(compilerOptions == null || requiresAST, "Must not provide options if no AST is required"); //$NON-NLS-1$
@@ -69,6 +74,7 @@ final public class CleanUpRequirementsCore {
 	 *
 	 * @return <code>true</code> if the CleanUpContext context must provide an AST
 	 */
+	@Deprecated
 	public boolean requiresAST() {
 		return fRequiresAST;
 	}
@@ -79,6 +85,7 @@ final public class CleanUpRequirementsCore {
 	 *
 	 * @return <code>true</code> if the caller needs an up to date AST
 	 */
+	@Deprecated
 	public boolean requiresFreshAST() {
 		return fRequiresFreshAST;
 	}
@@ -89,6 +96,7 @@ final public class CleanUpRequirementsCore {
 	 * @return the compiler options map or <code>null</code> if none
 	 * @see JavaCore
 	 */
+	@Deprecated
 	public Map<String, String> getCompilerOptions() {
 		return fCompilerOptions;
 	}
@@ -108,6 +116,7 @@ final public class CleanUpRequirementsCore {
 	 * @return <code>true</code> if the CleanUpContext context must provide changed
 	 *         regions
 	 */
+	@Deprecated
 	public boolean requiresChangedRegions() {
 		return fRequiresChangedRegions;
 	}

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/ICleanUpFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/ICleanUpFixCore.java
@@ -38,6 +38,7 @@ public interface ICleanUpFixCore {
 	 * @return a compilation unit change change which should not be empty
 	 * @throws CoreException if something went wrong while calculating the change
 	 */
+	@Deprecated
 	CompilationUnitChange createChange(IProgressMonitor progressMonitor) throws CoreException;
 
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/changes/CompilationUnitChange.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/changes/CompilationUnitChange.java
@@ -37,6 +37,7 @@ public class CompilationUnitChange extends org.eclipse.jdt.core.refactoring.Comp
 	 * @param name the change's name, mainly used to render the change in the UI
 	 * @param cunit the compilation unit this change works on
 	 */
+	@Deprecated
 	public CompilationUnitChange(String name, ICompilationUnit cunit) {
 		super(name, cunit);
 	}
@@ -45,6 +46,7 @@ public class CompilationUnitChange extends org.eclipse.jdt.core.refactoring.Comp
 	 * @param change the change
 	 * @since 3.6
 	 */
+	@Deprecated
 	public CompilationUnitChange(org.eclipse.jdt.core.refactoring.CompilationUnitChange change) {
 		super(change.getName(), change.getCompilationUnit());
 		setDescriptor(change.getDescriptor());

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/core/refactoring/descriptors/RenameLocalVariableDescriptor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/core/refactoring/descriptors/RenameLocalVariableDescriptor.java
@@ -68,6 +68,7 @@ public final class RenameLocalVariableDescriptor extends JavaRefactoringDescript
 		super(IJavaRefactorings.RENAME_LOCAL_VARIABLE);
 	}
 
+	@Deprecated
 	@Override
 	protected void populateArgumentMap() {
 		super.populateArgumentMap();
@@ -83,6 +84,7 @@ public final class RenameLocalVariableDescriptor extends JavaRefactoringDescript
 	 * @param unit
 	 *            the compilation unit to set
 	 */
+	@Deprecated
 	public void setCompilationUnit(final ICompilationUnit unit) {
 		Assert.isNotNull(unit);
 		fUnit= unit;
@@ -94,6 +96,7 @@ public final class RenameLocalVariableDescriptor extends JavaRefactoringDescript
 	 * @param name
 	 *            the non-empty new name to set
 	 */
+	@Deprecated
 	public void setNewName(final String name) {
 		Assert.isNotNull(name);
 		Assert.isLegal(!"".equals(name), "Name must not be empty"); //$NON-NLS-1$//$NON-NLS-2$
@@ -107,6 +110,7 @@ public final class RenameLocalVariableDescriptor extends JavaRefactoringDescript
 	 * @param selection
 	 *            the selection to set
 	 */
+	@Deprecated
 	public void setSelection(final ISourceRange selection) {
 		Assert.isNotNull(selection);
 		fSelection= selection;
@@ -122,10 +126,12 @@ public final class RenameLocalVariableDescriptor extends JavaRefactoringDescript
 	 *            <code>true</code> to update references, <code>false</code>
 	 *            otherwise
 	 */
+	@Deprecated
 	public void setUpdateReferences(final boolean update) {
 		fReferences= update;
 	}
 
+	@Deprecated
 	@Override
 	public RefactoringStatus validateDescriptor() {
 		RefactoringStatus status= super.validateDescriptor();

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/core/refactoring/descriptors/RenameResourceDescriptor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/core/refactoring/descriptors/RenameResourceDescriptor.java
@@ -61,6 +61,7 @@ public final class RenameResourceDescriptor extends JavaRefactoringDescriptor {
 	/**
 	 * Creates a new refactoring descriptor.
 	 */
+	@Deprecated
 	public RenameResourceDescriptor() {
 		super(IJavaRefactorings.RENAME_RESOURCE);
 	}
@@ -88,12 +89,14 @@ public final class RenameResourceDescriptor extends JavaRefactoringDescriptor {
 	 *
 	 * @since 1.2
 	 */
+	@Deprecated
 	public RenameResourceDescriptor(String project, String description, String comment, Map<String, String> arguments, int flags) {
 		super(IJavaRefactorings.RENAME_RESOURCE, project, description, comment, arguments, flags);
 		fResourcePath= JavaRefactoringDescriptorUtil.getResourcePath(arguments, ATTRIBUTE_INPUT, project);
 		fName= JavaRefactoringDescriptorUtil.getString(arguments, ATTRIBUTE_NAME);
 	}
 
+	@Deprecated
 	@Override
 	protected void populateArgumentMap() {
 		super.populateArgumentMap();
@@ -107,6 +110,7 @@ public final class RenameResourceDescriptor extends JavaRefactoringDescriptor {
 	 * @param name
 	 *            the non-empty new name to set
 	 */
+	@Deprecated
 	public void setNewName(final String name) {
 		Assert.isNotNull(name);
 		Assert.isLegal(!"".equals(name), "Name must not be empty"); //$NON-NLS-1$//$NON-NLS-2$
@@ -121,6 +125,7 @@ public final class RenameResourceDescriptor extends JavaRefactoringDescriptor {
 	 *
 	 * @since 1.2
 	 */
+	@Deprecated
 	public String getNewName() {
 		return fName;
 	}
@@ -141,6 +146,7 @@ public final class RenameResourceDescriptor extends JavaRefactoringDescriptor {
 	 *
 	 * @see #getProject()
 	 */
+	@Deprecated
 	@Override
 	public void setProject(final String project) {
 		super.setProject(project);
@@ -156,6 +162,7 @@ public final class RenameResourceDescriptor extends JavaRefactoringDescriptor {
 	 * @param resource
 	 *            the resource to be renamed
 	 */
+	@Deprecated
 	public void setResource(final IResource resource) {
 		Assert.isNotNull(resource);
 		fResourcePath= resource.getFullPath();
@@ -170,10 +177,12 @@ public final class RenameResourceDescriptor extends JavaRefactoringDescriptor {
 	 *
 	 * @since 1.2
 	 */
+	@Deprecated
 	public IPath getResourcePath() {
 		return fResourcePath;
 	}
 
+	@Deprecated
 	@Override
 	public RefactoringStatus validateDescriptor() {
 		RefactoringStatus status= super.validateDescriptor();

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/core/refactoring/descriptors/RenameResourceRefactoringContribution.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/core/refactoring/descriptors/RenameResourceRefactoringContribution.java
@@ -37,6 +37,7 @@ import org.eclipse.jdt.core.refactoring.descriptors.RenameResourceDescriptor;
 @Deprecated
 public final class RenameResourceRefactoringContribution extends JavaRefactoringContribution {
 
+	@Deprecated
 	@Override
 	public Refactoring createRefactoring(JavaRefactoringDescriptor javaDescriptor, RefactoringStatus status) throws CoreException {
 		if (javaDescriptor instanceof RenameResourceDescriptor) {
@@ -58,11 +59,13 @@ public final class RenameResourceRefactoringContribution extends JavaRefactoring
 		return null;
 	}
 
+	@Deprecated
 	@Override
 	public RefactoringDescriptor createDescriptor() {
 		return new RenameResourceDescriptor();
 	}
 
+	@Deprecated
 	@Override
 	public RefactoringDescriptor createDescriptor(String id, String project, String description, String comment, Map<String, String> arguments, int flags) {
 		return new RenameResourceDescriptor(project, description, comment, arguments, flags);

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
@@ -144,10 +144,7 @@ public final class JUnitModel {
 		}
 	}
 
-	/**
-	 * @deprecated to prevent deprecation warnings
-	 */
-	@Deprecated
+	@SuppressWarnings("deprecation")
 	private static final class LegacyTestRunSessionListener implements ITestRunSessionListener {
 		private TestRunSession fActiveTestRunSession;
 		private ITestSessionListener fTestSessionListener;

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/ITestRunListener.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/ITestRunListener.java
@@ -35,6 +35,7 @@ public interface ITestRunListener {
  	 *
      * @see #testFailed(int, String, String, String)
  	 */
+	@Deprecated
  	int STATUS_OK= ITestRunListener2.STATUS_OK;
  	/**
 	 * Status constant indicating that a test had an error an unanticipated
@@ -42,6 +43,7 @@ public interface ITestRunListener {
  	 *
 	 * @see #testFailed(int, String, String, String)
  	 */
+	@Deprecated
  	int STATUS_ERROR= ITestRunListener2.STATUS_ERROR;
  	/**
 	 * Status constant indicating that a test failed an assertion
@@ -49,24 +51,28 @@ public interface ITestRunListener {
  	 *
  	 * @see #testFailed(int, String, String, String)
 	 */
+	@Deprecated
  	int STATUS_FAILURE= ITestRunListener2.STATUS_FAILURE;
  	/**
  	 * A test run has started.
  	 *
  	 * @param testCount the number of individual tests that will be run
  	 */
+	@Deprecated
 	void testRunStarted(int testCount);
 	/**
  	 * A test run has ended.
 	 *
 	 * @param elapsedTime the total elapsed time of the test run
 	 */
+	@Deprecated
 	void testRunEnded(long elapsedTime);
 	/**
 	 * A test run has been stopped prematurely.
 	 *
  	 * @param elapsedTime the time elapsed before the test run was stopped
 	 */
+	@Deprecated
 	void testRunStopped(long elapsedTime);
 	/**
 	 * An individual test has started.
@@ -74,6 +80,7 @@ public interface ITestRunListener {
 	 * @param testId a unique Id identifying the test
 	 * @param testName the name of the test that started
 	 */
+	@Deprecated
 	void testStarted(String testId, String testName);
 	/**
 	 * An individual test has ended.
@@ -81,6 +88,7 @@ public interface ITestRunListener {
 	 * @param testId a unique Id identifying the test
 	 * @param testName the name of the test that ended
 	 */
+	@Deprecated
 	void testEnded(String testId, String testName);
 	/**
 	 * An individual test has failed with a stack trace.
@@ -92,11 +100,13 @@ public interface ITestRunListener {
  	 * @param testName the name of the test that failed
 	 * @param trace the stack trace
 	 */
+	@Deprecated
 	void testFailed(int status, String testId, String testName, String trace);
 
 	/**
 	 * The VM instance performing the tests has terminated.
 	 */
+	@Deprecated
 	void testRunTerminated();
 
 	/**
@@ -111,6 +121,7 @@ public interface ITestRunListener {
 	 * @param trace the stack trace in the case of abnormal termination,
 	 * or the empty string if none
 	 */
+	@Deprecated
 	void testReran(String testId, String testClass, String testName, int status, String trace);
 }
 

--- a/org.eclipse.jdt.junit/internal compatibility/org/eclipse/jdt/internal/junit/launcher/TestSelectionDialog.java
+++ b/org.eclipse.jdt.junit/internal compatibility/org/eclipse/jdt/internal/junit/launcher/TestSelectionDialog.java
@@ -64,6 +64,7 @@ public class TestSelectionDialog extends TwoPaneElementSelector {
 
 	}
 
+	@Deprecated
 	public TestSelectionDialog(Shell shell, IType[] types) {
 		super(shell, new JavaElementLabelProvider(JavaElementLabelProvider.SHOW_BASICS | JavaElementLabelProvider.SHOW_OVERLAY_ICONS),
 				new PackageRenderer());
@@ -73,6 +74,7 @@ public class TestSelectionDialog extends TwoPaneElementSelector {
 	/**
 	 * @see org.eclipse.jface.window.Window#configureShell(Shell)
 	 */
+	@Deprecated
 	@Override
 	protected void configureShell(Shell newShell) {
 		super.configureShell(newShell);
@@ -82,6 +84,7 @@ public class TestSelectionDialog extends TwoPaneElementSelector {
 	/*
 	 * @see Window#open()
 	 */
+	@Deprecated
 	@Override
 	public int open() {
 		setElements(fTypes);

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/DebuggingPerformanceTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/DebuggingPerformanceTestSuite.java
@@ -24,10 +24,12 @@ import junit.framework.TestSuite;
 @Deprecated
 public class DebuggingPerformanceTestSuite extends TestSuite {
 
+	@Deprecated
 	public static Test suite() {
 		return new PerformanceTestSetup(new DebuggingPerformanceTestSuite());
 	}
 
+	@Deprecated
 	public DebuggingPerformanceTestSuite() {
 		addTest(TextTypingInvocationCountTest.suite());
 		addTest(JavaTypingInvocationCountTest.suite());

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/JavaTypingInvocationCountTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/JavaTypingInvocationCountTest.java
@@ -49,13 +49,16 @@ public class JavaTypingInvocationCountTest extends TypingInvocationCountTest {
 
 	private static final Class<TypingInvocationCountTest> THIS= TypingInvocationCountTest.class;
 
+	@Deprecated
 	public JavaTypingInvocationCountTest() {
 		super();
 	}
+	@Deprecated
 	public JavaTypingInvocationCountTest(String name) {
 		super(name);
 	}
 
+	@Deprecated
 	public static Test suite() {
 		TestSuite suite= new TestSuite(THIS.getName());
 		suite.addTest(new JavaTypingInvocationCountTest("test00"));

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/OpenJavaEditorInvocationCountTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/OpenJavaEditorInvocationCountTest.java
@@ -38,6 +38,7 @@ public class OpenJavaEditorInvocationCountTest extends OpenEditorTest {
 
 	private static final String FILE= PerformanceTestSetup.TEXT_LAYOUT;
 
+	@Deprecated
 	public static Test suite() {
 		return new PerformanceTestSetup(new TestSuite(THIS));
 	}
@@ -45,12 +46,14 @@ public class OpenJavaEditorInvocationCountTest extends OpenEditorTest {
 	/*
 	 * @see junit.framework.TestCase#tearDown()
 	 */
+	@Deprecated
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
 		EditorTestHelper.closeAllEditors();
 	}
 
+	@Deprecated
 	public void test() throws Exception {
 		InvocationCountPerformanceMeter performanceMeter= createInvocationCountPerformanceMeter(new Method[] {
 			PresentationReconciler.class.getDeclaredMethod("createPresentation", IRegion.class, IDocument.class),

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/QuickDiffInvocationCountTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/QuickDiffInvocationCountTest.java
@@ -48,6 +48,7 @@ public class QuickDiffInvocationCountTest extends TextPerformanceTestCase {
 
 	private AbstractTextEditor fEditor;
 
+	@Deprecated
 	public static Test suite() {
 		return new PerformanceTestSetup(new TestSuite(THIS));
 	}
@@ -55,6 +56,7 @@ public class QuickDiffInvocationCountTest extends TextPerformanceTestCase {
 	/*
 	 * @see junit.framework.TestCase#setUp()
 	 */
+	@Deprecated
 	@Override
 	protected void setUp() throws Exception {
 		super.setUp();
@@ -86,6 +88,7 @@ public class QuickDiffInvocationCountTest extends TextPerformanceTestCase {
 	 *
 	 * @throws Exception in case of problems
 	 */
+	@Deprecated
 	public void test() throws Exception {
 		PerformanceMeter performanceMeter= createInvocationCountPerformanceMeter(QuickDiffRangeDifference.class.getConstructors());
 		performanceMeter.start();
@@ -100,6 +103,7 @@ public class QuickDiffInvocationCountTest extends TextPerformanceTestCase {
 	/*
 	 * @see junit.framework.TestCase#tearDown()
 	 */
+	@Deprecated
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/ScrollAnnotatedJavaEditorInvocationCountTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/ScrollAnnotatedJavaEditorInvocationCountTest.java
@@ -37,14 +37,17 @@ public class ScrollAnnotatedJavaEditorInvocationCountTest extends AbstractScroll
 
 	private static final Class<ScrollAnnotatedJavaEditorInvocationCountTest> THIS= ScrollAnnotatedJavaEditorInvocationCountTest.class;
 
+	@Deprecated
 	public static Test suite() {
 		return new PerformanceTestSetup(new TestSuite(THIS));
 	}
 
+	@Deprecated
 	public static Test setUpTest(Test someTest) {
 		return new PerformanceTestSetup(someTest);
 	}
 
+	@Deprecated
 	@Override
 	protected void setUp(AbstractTextEditor editor) throws Exception {
 		editor.showChangeInformation(false); // don't need to test quick diff...
@@ -55,6 +58,7 @@ public class ScrollAnnotatedJavaEditorInvocationCountTest extends AbstractScroll
 	 * Measure the number of invocations of {@link org.eclipse.jface.text.source.AnnotationPainter#paintControl(PaintEvent)}
 	 * while scrolling page wise with error annotations in the Java editor.
 	 */
+	@Deprecated
 	public void testPageWise() throws Exception {
 		measure(PAGE_WISE, createInvocationCountPerformanceMeter(), 0, 1);
 	}
@@ -63,6 +67,7 @@ public class ScrollAnnotatedJavaEditorInvocationCountTest extends AbstractScroll
 	 * Measure the number of invocations of {@link org.eclipse.jface.text.source.AnnotationPainter#paintControl(PaintEvent)}
 	 * while scrolling line wise with error annotations in the Java editor.
 	 */
+	@Deprecated
 	public void testLineWise() throws Exception {
 		measure(LINE_WISE, createInvocationCountPerformanceMeter(), 0, 1);
 	}
@@ -72,6 +77,7 @@ public class ScrollAnnotatedJavaEditorInvocationCountTest extends AbstractScroll
 	 * while scrolling and selecting line wise with error annotations in the
 	 * Java editor.
 	 */
+	@Deprecated
 	public void testLineWiseSelect() throws Exception {
 		measure(LINE_WISE_SELECT, createInvocationCountPerformanceMeter(), 0, 1);
 	}
@@ -81,6 +87,7 @@ public class ScrollAnnotatedJavaEditorInvocationCountTest extends AbstractScroll
 	 * while scrolling line wise without moving the caret with error
 	 * annotations in the Java editor.
 	 */
+	@Deprecated
 	public void testLineWiseNoCaretMove() throws Exception {
 		measure(LINE_WISE_NO_CARET_MOVE, createInvocationCountPerformanceMeter(), 0, 1);
 	}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/TextTypingInvocationCountTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/performance/TextTypingInvocationCountTest.java
@@ -49,13 +49,16 @@ public class TextTypingInvocationCountTest extends TypingInvocationCountTest {
 
 	private static final Class<TypingInvocationCountTest> THIS= TypingInvocationCountTest.class;
 
+	@Deprecated
 	public TextTypingInvocationCountTest() {
 		super();
 	}
+	@Deprecated
 	public TextTypingInvocationCountTest(String name) {
 		super(name);
 	}
 
+	@Deprecated
 	public static Test suite() {
 		TestSuite suite= new TestSuite(THIS.getName());
 		suite.addTest(new TextTypingInvocationCountTest("test00"));

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d4ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d4ProjectTestSetup.java
@@ -29,11 +29,13 @@ import org.eclipse.jdt.core.IJavaProject;
 @Deprecated
 public class Java1d4ProjectTestSetup extends ProjectTestSetup {
 
+	@Deprecated
 	public Java1d4ProjectTestSetup() {
 		// Here we load Java 1.5 classes because JavaProjectHelper.RT_STUBS_14 does not exist
 		super("TestSetupProject1d4", JavaProjectHelper.RT_STUBS_15);
 	}
 
+	@Deprecated
 	@Override
 	protected IJavaProject createAndInitializeProject() throws CoreException {
 		IJavaProject javaProject= super.createAndInitializeProject();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d5ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d5ProjectTestSetup.java
@@ -29,10 +29,12 @@ import org.eclipse.jdt.core.IJavaProject;
 @Deprecated
 public class Java1d5ProjectTestSetup extends ProjectTestSetup {
 
+	@Deprecated
 	public Java1d5ProjectTestSetup() {
 		super("TestSetupProject1d5", JavaProjectHelper.RT_STUBS_15);
 	}
 
+	@Deprecated
 	@Override
 	protected IJavaProject createAndInitializeProject() throws CoreException {
 		IJavaProject javaProject= super.createAndInitializeProject();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d6ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d6ProjectTestSetup.java
@@ -29,10 +29,12 @@ import org.eclipse.jdt.core.IJavaProject;
 @Deprecated
 public class Java1d6ProjectTestSetup extends ProjectTestSetup {
 
+	@Deprecated
 	public Java1d6ProjectTestSetup() {
 		super("TestSetupProject1d6", JavaProjectHelper.RT_STUBS_16);
 	}
 
+	@Deprecated
 	@Override
 	protected IJavaProject createAndInitializeProject() throws CoreException {
 		IJavaProject javaProject= super.createAndInitializeProject();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d7ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java1d7ProjectTestSetup.java
@@ -26,10 +26,12 @@ import org.eclipse.jdt.core.IJavaProject;
 @Deprecated
 public class Java1d7ProjectTestSetup extends ProjectTestSetup {
 
+	@Deprecated
 	public Java1d7ProjectTestSetup() {
 		super("TestSetupProject1d7", JavaProjectHelper.RT_STUBS_17);
 	}
 
+	@Deprecated
 	@Override
 	protected IJavaProject createAndInitializeProject() throws CoreException {
 		IJavaProject javaProject= super.createAndInitializeProject();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/ui/internal/compatibility/InternalsNotRemovedTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/ui/internal/compatibility/InternalsNotRemovedTest.java
@@ -19,10 +19,9 @@ import org.eclipse.text.tests.Accessor;
 /**
  * Ensures that internal code which is used by a product doesn't get removed.
  *
- * @deprecated to hide deprecation warnings
  * @since 3.6
  */
-@Deprecated
+@SuppressWarnings("deprecation")
 public class InternalsNotRemovedTest {
 
 	static final String[] INTERNAL_FIELDS= new String[] {

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/TemplateSet.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/TemplateSet.java
@@ -74,6 +74,7 @@ public class TemplateSet {
 	private static final int TEMPLATE_IO_EXCEPTION= 10005;
 	private ContextTypeRegistry fRegistry;
 
+	@Deprecated
 	public TemplateSet(String templateTag, ContextTypeRegistry registry) {
 		fTemplateTag= templateTag;
 		fRegistry= registry;
@@ -87,6 +88,7 @@ public class TemplateSet {
 	 * @throws CoreException if reading fails
 	 * @see #addFromStream(InputStream, boolean)
 	 */
+	@Deprecated
 	public void addFromFile(File file, boolean allowDuplicates) throws CoreException {
 		try (InputStream stream= new FileInputStream(file)) {
 			addFromStream(stream, allowDuplicates);
@@ -95,6 +97,7 @@ public class TemplateSet {
 		}
 	}
 
+	@Deprecated
 	public String getTemplateTag() {
 		return fTemplateTag;
 	}
@@ -107,6 +110,7 @@ public class TemplateSet {
 	 * @param allowDuplicates <code>true</code> if duplicates are allowed
 	 * @throws CoreException if reading fails
 	 */
+	@Deprecated
 	public void addFromStream(InputStream stream, boolean allowDuplicates) throws CoreException {
 		try {
 			DocumentBuilderFactory factory= XmlProcessorFactoryJdtUi.createDocumentBuilderFactoryWithErrorOnDOCTYPE();
@@ -162,6 +166,7 @@ public class TemplateSet {
 		}
 	}
 
+	@Deprecated
 	protected String validateTemplate(Template template) {
 		TemplateContextType type= fRegistry.getContextType(template.getContextTypeId());
 		if (type == null) {
@@ -190,6 +195,7 @@ public class TemplateSet {
 	 * @throws CoreException in case the save operation fails
 	 * @see #saveToStream(OutputStream)
 	 */
+	@Deprecated
 	public void saveToFile(File file) throws CoreException {
 		try (OutputStream stream= new FileOutputStream(file)) {
 			saveToStream(stream);
@@ -204,6 +210,7 @@ public class TemplateSet {
 	 * @param stream the stream
 	 * @throws CoreException in case the save operation fails
 	 */
+	@Deprecated
 	public void saveToStream(OutputStream stream) throws CoreException {
 		try {
 			DocumentBuilderFactory factory= XmlProcessorFactoryJdtUi.createDocumentBuilderFactoryWithErrorOnDOCTYPE();
@@ -272,6 +279,7 @@ public class TemplateSet {
 	 *
 	 * @param template the template to add to the set
 	 */
+	@Deprecated
 	public void add(Template template) {
 		if (exists(template))
 			return; // ignore duplicate
@@ -288,6 +296,7 @@ public class TemplateSet {
 	 *
 	 * @param template the template to remove from the set
 	 */
+	@Deprecated
 	public void remove(Template template) {
 		fTemplates.remove(template);
 	}
@@ -295,6 +304,7 @@ public class TemplateSet {
 	/**
 	 * Empties the set.
 	 */
+	@Deprecated
 	public void clear() {
 		fTemplates.clear();
 	}
@@ -304,6 +314,7 @@ public class TemplateSet {
 	 *
 	 * @return all templates
 	 */
+	@Deprecated
 	public Template[] getTemplates() {
 		return fTemplates.toArray(new Template[fTemplates.size()]);
 	}
@@ -314,6 +325,7 @@ public class TemplateSet {
 	 * @param name the template name
 	 * @return the templates with the given name
 	 */
+	@Deprecated
 	public Template[] getTemplates(String name) {
 		ArrayList<Template> res= new ArrayList<>();
 		for (Template curr : fTemplates) {
@@ -330,6 +342,7 @@ public class TemplateSet {
 	 * @param name the template name
 	 * @return the first template with the given name
 	 */
+	@Deprecated
 	public Template getFirstTemplate(String name) {
 		for (Template curr : fTemplates) {
 			if (curr.getName().equals(name)) {

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/Templates.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/Templates.java
@@ -48,6 +48,7 @@ public class Templates extends org.eclipse.jdt.internal.corext.template.java.Tem
 		return fgTemplates;
 	}
 
+	@Deprecated
 	public Templates() {
 		super("template", JavaPlugin.getDefault().getTemplateContextRegistry()); //$NON-NLS-1$
 		create();
@@ -74,6 +75,7 @@ public class Templates extends org.eclipse.jdt.internal.corext.template.java.Tem
 	 *
 	 * @throws CoreException in case the reset operation fails
 	 */
+	@Deprecated
 	public void reset() throws CoreException {
 	}
 
@@ -82,6 +84,7 @@ public class Templates extends org.eclipse.jdt.internal.corext.template.java.Tem
 	 *
 	 * @throws CoreException in case the restore operation fails
 	 */
+	@Deprecated
 	public void restoreDefaults() throws CoreException {
 	}
 
@@ -90,6 +93,7 @@ public class Templates extends org.eclipse.jdt.internal.corext.template.java.Tem
 	 *
 	 * @throws CoreException in case the save operation fails
 	 */
+	@Deprecated
 	public void save() throws CoreException {
 	}
 

--- a/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/corext/SourceRange.java
+++ b/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/corext/SourceRange.java
@@ -31,15 +31,18 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
 	private final int fOffset;
 	private final int fLength;
 
+	@Deprecated
 	public SourceRange(int offset, int length){
 		fLength= length;
 		fOffset= offset;
 	}
 
+	@Deprecated
 	public SourceRange(ASTNode node) {
 		this(node.getStartPosition(), node.getLength());
 	}
 
+	@Deprecated
 	public SourceRange(IProblem problem) {
 		this(problem.getSourceStart(), problem.getSourceEnd() - problem.getSourceStart() + 1);
 	}
@@ -47,6 +50,7 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
 	/*
 	 * @see ISourceRange#getLength()
 	 */
+	@Deprecated
 	@Override
 	public int getLength() {
 		return fLength;
@@ -55,15 +59,18 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
 	/*
 	 * @see ISourceRange#getOffset()
 	 */
+	@Deprecated
 	@Override
 	public int getOffset() {
 		return fOffset;
 	}
 
+	@Deprecated
 	public int getEndExclusive() {
 		return getOffset() + getLength();
 	}
 
+	@Deprecated
 	public int getEndInclusive() {
 		return getEndExclusive() - 1;
 	}
@@ -71,6 +78,7 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
 	/*non java doc
 	 * for debugging only
 	 */
+	@Deprecated
 	@Override
 	public String toString(){
 		return "<offset: " + fOffset +" length: " + fLength + "/>"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -82,6 +90,7 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
 	 * @param ranges the ranges to sort
 	 * @return the sorted ranges, which are identical to the parameter ranges
 	 */
+	@Deprecated
 	public static ISourceRange[] reverseSortByOffset(ISourceRange[] ranges){
 		Arrays.sort(ranges, Comparator.comparing(ISourceRange::getOffset).reversed());
 		return ranges;
@@ -90,6 +99,7 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
     /*
      * @see Object#equals(Object)
      */
+	@Deprecated
     @Override
 	public boolean equals(Object obj) {
     	if (! (obj instanceof ISourceRange))
@@ -100,15 +110,18 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
     /*
      * @see Object#hashCode()
      */
+	@Deprecated
     @Override
 	public int hashCode() {
         return fLength ^ fOffset;
     }
 
+	@Deprecated
     public boolean covers(ASTNode node) {
     	return covers(new SourceRange(node));
     }
 
+	@Deprecated
     public boolean covers(SourceRange range) {
     	return    getOffset() <= range.getOffset()
     	       	&& getEndInclusive() >= range.getEndInclusive();
@@ -121,6 +134,7 @@ public class SourceRange implements ISourceRange { // see https://bugs.eclipse.o
      * @param range a source range, can be <code>null</code>
      * @return <code>true</code> iff range is not null and range.getOffset() is not -1
      */
+	@Deprecated
     public static boolean isAvailable(ISourceRange range) {
     		return range != null && range.getOffset() != -1;
     }

--- a/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/corext/util/TypeNameMatchCollector.java
+++ b/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/corext/util/TypeNameMatchCollector.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.core.search.TypeNameMatch;
  */
 @Deprecated
 public class TypeNameMatchCollector extends org.eclipse.jdt.core.manipulation.TypeNameMatchCollector {
+	@Deprecated
 	public TypeNameMatchCollector(Collection<TypeNameMatch> collection) {
 		super(collection);
 	}

--- a/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/ui/util/PixelConverter.java
+++ b/org.eclipse.jdt.ui/internal compatibility/org/eclipse/jdt/internal/ui/util/PixelConverter.java
@@ -30,10 +30,12 @@ public class PixelConverter {
 
 	private final FontMetrics fFontMetrics;
 
+	@Deprecated
 	public PixelConverter(Control control) {
 		this(control.getFont());
 	}
 
+	@Deprecated
 	public PixelConverter(Font font) {
 		GC gc = new GC(font.getDevice());
 		gc.setFont(font);
@@ -44,6 +46,7 @@ public class PixelConverter {
 	/*
 	 * see org.eclipse.jface.dialogs.DialogPage#convertHeightInCharsToPixels(int)
 	 */
+	@Deprecated
 	public int convertHeightInCharsToPixels(int chars) {
 		return Dialog.convertHeightInCharsToPixels(fFontMetrics, chars);
 	}
@@ -51,6 +54,7 @@ public class PixelConverter {
 	/*
 	 * see org.eclipse.jface.dialogs.DialogPage#convertHorizontalDLUsToPixels(int)
 	 */
+	@Deprecated
 	public int convertHorizontalDLUsToPixels(int dlus) {
 		return Dialog.convertHorizontalDLUsToPixels(fFontMetrics, dlus);
 	}
@@ -58,6 +62,7 @@ public class PixelConverter {
 	/*
 	 * see org.eclipse.jface.dialogs.DialogPage#convertVerticalDLUsToPixels(int)
 	 */
+	@Deprecated
 	public int convertVerticalDLUsToPixels(int dlus) {
 		return Dialog.convertVerticalDLUsToPixels(fFontMetrics, dlus);
 	}
@@ -65,6 +70,7 @@ public class PixelConverter {
 	/*
 	 * see org.eclipse.jface.dialogs.DialogPage#convertWidthInCharsToPixels(int)
 	 */
+	@Deprecated
 	public int convertWidthInCharsToPixels(int chars) {
 		return Dialog.convertWidthInCharsToPixels(fFontMetrics, chars);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ConfigureContainerAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/ConfigureContainerAction.java
@@ -53,6 +53,7 @@ public class ConfigureContainerAction implements IObjectActionDelegate {
 	/*
 	 * @see IObjectActionDelegate#setActivePart(IAction, IWorkbenchPart)
 	 */
+	@Deprecated
 	@Override
 	public void setActivePart(IAction action, IWorkbenchPart targetPart) {
 		fPart= targetPart;
@@ -61,6 +62,7 @@ public class ConfigureContainerAction implements IObjectActionDelegate {
 	/*
 	 * @see IActionDelegate#run(IAction)
 	 */
+	@Deprecated
 	@Override
 	public void run(IAction action) {
 		if (fCurrentSelection instanceof IStructuredSelection) {
@@ -112,6 +114,7 @@ public class ConfigureContainerAction implements IObjectActionDelegate {
 		}
 	}
 
+	@Deprecated
 	protected static int indexInClasspath(IClasspathEntry[] entries, IClasspathEntry entry) {
 		for (int i= 0; i < entries.length; i++) {
 			if (entries[i] == entry) {
@@ -124,6 +127,7 @@ public class ConfigureContainerAction implements IObjectActionDelegate {
 	/*
 	 * @see IActionDelegate#selectionChanged(IAction, ISelection)
 	 */
+	@Deprecated
 	@Override
 	public void selectionChanged(IAction action, ISelection selection) {
 		fCurrentSelection= selection;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/PackageViewerWrapper.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/PackageViewerWrapper.java
@@ -56,12 +56,14 @@ class PackageViewerWrapper extends StructuredViewer {
 	private ListenerList<ISelectionChangedListener> fSelectionChangedListenerList;
 	private ListenerList<ISelectionChangedListener> fPostSelectionChangedListenerList;
 
+	@Deprecated
 	public PackageViewerWrapper() {
 		fListenerList= new ListenerList<>(ListenerList.IDENTITY);
 		fPostSelectionChangedListenerList= new ListenerList<>(ListenerList.IDENTITY);
 		fSelectionChangedListenerList= new ListenerList<>(ListenerList.IDENTITY);
 	}
 
+	@Deprecated
 	public void setViewer(StructuredViewer viewer) {
 		Assert.isNotNull(viewer);
 
@@ -74,6 +76,7 @@ class PackageViewerWrapper extends StructuredViewer {
 		transferListeners();
 	}
 
+	@Deprecated
 	StructuredViewer getViewer(){
 		return fViewer;
 	}
@@ -114,6 +117,7 @@ class PackageViewerWrapper extends StructuredViewer {
 		}
 	}
 
+	@Deprecated
 	@Override
 	public void setSelection(ISelection selection, boolean reveal) {
 		if (selection instanceof IStructuredSelection) {
@@ -142,60 +146,70 @@ class PackageViewerWrapper extends StructuredViewer {
 			fViewer.setSelection(selection, reveal);
 	}
 
+	@Deprecated
 	@Override
 	public void addPostSelectionChangedListener(ISelectionChangedListener listener) {
 		fPostSelectionChangedListenerList.add(listener);
 		fViewer.addPostSelectionChangedListener(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void addSelectionChangedListener(ISelectionChangedListener listener) {
 		fSelectionChangedListenerList.add(listener);
 		fViewer.addSelectionChangedListener(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void addDoubleClickListener(IDoubleClickListener listener) {
 		fViewer.addDoubleClickListener(listener);
 		fListenerList.add(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void addOpenListener(IOpenListener listener) {
 		fViewer.addOpenListener(listener);
 		fListenerList.add(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void addHelpListener(HelpListener listener) {
 		fViewer.addHelpListener(listener);
 		fListenerList.add(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
 		fViewer.removeSelectionChangedListener(listener);
 		fSelectionChangedListenerList.remove(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void removePostSelectionChangedListener(ISelectionChangedListener listener) {
 		fViewer.removePostSelectionChangedListener(listener);
 		fPostSelectionChangedListenerList.remove(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void removeHelpListener(HelpListener listener) {
 		fListenerList.remove(listener);
 		fViewer.removeHelpListener(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void removeDoubleClickListener(IDoubleClickListener listener) {
 		fViewer.removeDoubleClickListener(listener);
 		fListenerList.remove(listener);
 	}
 
+	@Deprecated
 	@Override
 	public void removeOpenListener(IOpenListener listener) {
 		fViewer.removeOpenListener(listener);
@@ -203,226 +217,271 @@ class PackageViewerWrapper extends StructuredViewer {
 	}
 
 	// --------- simply delegate to wrapped viewer ---------
+	@Deprecated
 	@Override
 	public Control getControl() {
 		return fViewer.getControl();
 	}
 
+	@Deprecated
 	@Override
 	public void addFilter(ViewerFilter filter) {
 		fViewer.addFilter(filter);
 	}
 
+	@Deprecated
 	@Override
 	public void setFilters(ViewerFilter... filters) {
 		fViewer.setFilters(filters);
 	}
 
+	@Deprecated
 	@Override
 	public ViewerFilter[] getFilters() {
 		return fViewer.getFilters();
 	}
 
+	@Deprecated
 	@Override
 	public void refresh() {
 		fViewer.refresh();
 	}
 
+	@Deprecated
 	@Override
 	public void removeFilter(ViewerFilter filter) {
 		fViewer.removeFilter(filter);
 	}
 
+	@Deprecated
 	@Override
 	public ISelection getSelection() {
 		return fViewer.getSelection();
 	}
 
+	@Deprecated
 	@Override
 	public void refresh(boolean updateLabels) {
 		fViewer.refresh(updateLabels);
 	}
 
+	@Deprecated
 	@Override
 	public void refresh(Object element, boolean updateLabels) {
 		fViewer.refresh(element, updateLabels);
 	}
 
+	@Deprecated
 	@Override
 	public void refresh(Object element) {
 		fViewer.refresh(element);
 	}
 
+	@Deprecated
 	@Override
 	public void resetFilters() {
 		fViewer.resetFilters();
 	}
 
+	@Deprecated
 	@Override
 	public void reveal(Object element) {
 		fViewer.reveal(element);
 	}
 
+	@Deprecated
 	@Override
 	public void setContentProvider(IContentProvider contentProvider) {
 		fViewer.setContentProvider(contentProvider);
 	}
 
+	@Deprecated
 	@Override
 	public void setSorter(ViewerSorter sorter) {
 		fViewer.setSorter(sorter);
 	}
 
+	@Deprecated
 	@Override
 	public void setComparator(ViewerComparator comparator) {
 		fViewer.setComparator(comparator);
 	}
 
+	@Deprecated
 	@Override
 	public void setUseHashlookup(boolean enable) {
 		fViewer.setUseHashlookup(enable);
 	}
 
+	@Deprecated
 	@Override
 	public Widget testFindItem(Object element) {
 		return fViewer.testFindItem(element);
 	}
 
+	@Deprecated
 	@Override
 	public void update(Object element, String[] properties) {
 		fViewer.update(element, properties);
 	}
 
+	@Deprecated
 	@Override
 	public void update(Object[] elements, String[] properties) {
 		fViewer.update(elements, properties);
 	}
 
+	@Deprecated
 	@Override
 	public IContentProvider getContentProvider() {
 		return fViewer.getContentProvider();
 	}
 
+	@Deprecated
 	@Override
 	public Object getInput() {
 		return fViewer.getInput();
 	}
 
+	@Deprecated
 	@Override
 	public IBaseLabelProvider getLabelProvider() {
 		return fViewer.getLabelProvider();
 	}
 
+	@Deprecated
 	@Override
 	public void setLabelProvider(IBaseLabelProvider labelProvider) {
 		fViewer.setLabelProvider(labelProvider);
 	}
 
+	@Deprecated
 	@Override
 	public Object getData(String key) {
 		return fViewer.getData(key);
 	}
 
+	@Deprecated
 	@Override
 	public Item scrollDown(int x, int y) {
 		return fViewer.scrollDown(x, y);
 	}
 
+	@Deprecated
 	@Override
 	public Item scrollUp(int x, int y) {
 		return fViewer.scrollUp(x, y);
 	}
 
+	@Deprecated
 	@Override
 	public void setData(String key, Object value) {
 		fViewer.setData(key, value);
 	}
 
+	@Deprecated
 	@Override
 	public void setSelection(ISelection selection) {
 		fViewer.setSelection(selection);
 	}
 
+	@Deprecated
 	@Override
 	public boolean equals(Object obj) {
 		return fViewer.equals(obj);
 	}
 
+	@Deprecated
 	@Override
 	public int hashCode() {
 		return fViewer.hashCode();
 	}
 
+	@Deprecated
 	@Override
 	public String toString() {
 		return fViewer.toString();
 	}
 
+	@Deprecated
 	public void setViewerInput(Object input){
 		fViewer.setInput(input);
 	}
 
 	// need to provide implementation for abstract methods
+	@Deprecated
 	@Override
 	protected Widget doFindInputItem(Object element) {
 		return ((IPackagesViewViewer) fViewer).doFindInputItem(element);
 	}
 
+	@Deprecated
 	@Override
 	protected Widget doFindItem(Object element) {
 		return ((IPackagesViewViewer)fViewer).doFindItem(element);
 	}
 
+	@Deprecated
 	@Override
 	protected void doUpdateItem(Widget item, Object element, boolean fullMap) {
 		((IPackagesViewViewer)fViewer).doUpdateItem(item, element, fullMap);
 	}
 
+	@Deprecated
 	@Override
 	protected List getSelectionFromWidget() {
 		return ((IPackagesViewViewer)fViewer).getSelectionFromWidget();
 	}
 
+	@Deprecated
 	@Override
 	protected void internalRefresh(Object element) {
 		((IPackagesViewViewer)fViewer).internalRefresh(element);
 	}
 
+	@Deprecated
 	@Override
 	protected void setSelectionToWidget(List l, boolean reveal) {
 		((IPackagesViewViewer) fViewer).setSelectionToWidget(l, reveal);
 	}
 
+	@Deprecated
 	@Override
 	public ViewerComparator getComparator() {
 		return fViewer.getComparator();
 	}
 
+	@Deprecated
 	@Override
 	public IElementComparer getComparer() {
 		return fViewer.getComparer();
 	}
 
+	@Deprecated
 	@Override
 	public ViewerSorter getSorter() {
 		return fViewer.getSorter();
 	}
 
+	@Deprecated
 	@Override
 	public void setComparer(IElementComparer comparer) {
 		fViewer.setComparer(comparer);
 	}
 
+	@Deprecated
 	@Override
 	public void addDragSupport(int operations, Transfer[] transferTypes, DragSourceListener listener) {
 		fViewer.addDragSupport(operations, transferTypes, listener);
 	}
 
+	@Deprecated
 	@Override
 	public void addDropSupport(int operations, Transfer[] transferTypes, DropTargetListener listener) {
 		fViewer.addDropSupport(operations, transferTypes, listener);
 	}
 
+	@Deprecated
 	@Override
 	public Widget[] testFindItems(Object element) {
 		return fViewer.testFindItems(element);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CustomBufferFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CustomBufferFactory.java
@@ -33,6 +33,7 @@ public class CustomBufferFactory implements IBufferFactory {
 	/*
 	 * @see org.eclipse.jdt.core.IBufferFactory#createBuffer(org.eclipse.jdt.core.IOpenable)
 	 */
+	@Deprecated
 	@Override
 	public IBuffer createBuffer(IOpenable owner) {
 		if (owner instanceof ICompilationUnit) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/IReconcilingParticipant.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/IReconcilingParticipant.java
@@ -27,5 +27,6 @@ public interface IReconcilingParticipant {
 	/**
 	 * Called after reconciling has been finished.
 	 */
+	@Deprecated
 	void reconciled();
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/CodeGeneration.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/CodeGeneration.java
@@ -43,6 +43,7 @@ public class CodeGeneration {
 	 * for a new class type body.
 	 * @since 3.2
 	 */
+	@Deprecated
 	public static final String CLASS_BODY_TEMPLATE_ID= org.eclipse.jdt.core.manipulation.CodeGeneration.CLASS_BODY_TEMPLATE_ID;
 
 	/**
@@ -50,6 +51,7 @@ public class CodeGeneration {
 	 * for a new interface type body.
 	 * @since 3.2
 	 */
+	@Deprecated
 	public static final String INTERFACE_BODY_TEMPLATE_ID= org.eclipse.jdt.core.manipulation.CodeGeneration.INTERFACE_BODY_TEMPLATE_ID;
 
 	/**
@@ -57,6 +59,7 @@ public class CodeGeneration {
 	 * for a new enum type body.
 	 * @since 3.2
 	 */
+	@Deprecated
 	public static final String ENUM_BODY_TEMPLATE_ID= org.eclipse.jdt.core.manipulation.CodeGeneration.ENUM_BODY_TEMPLATE_ID;
 
 	/**
@@ -64,6 +67,7 @@ public class CodeGeneration {
 	 * for a new annotation type body.
 	 * @since 3.2
 	 */
+	@Deprecated
 	public static final String ANNOTATION_BODY_TEMPLATE_ID= org.eclipse.jdt.core.manipulation.CodeGeneration.ANNOTATION_BODY_TEMPLATE_ID;
 
 	private CodeGeneration() {
@@ -79,6 +83,7 @@ public class CodeGeneration {
 	 * @return Returns the new content or <code>null</code> if the template is undefined or empty.
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 */
+	@Deprecated
 	public static String getCompilationUnitContent(ICompilationUnit cu, String typeComment, String typeContent, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getCompilationUnitContent(cu, typeComment, typeContent, lineDelimiter);
 	}
@@ -96,6 +101,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.1
 	 */
+	@Deprecated
 	public static String getCompilationUnitContent(ICompilationUnit cu, String fileComment, String typeComment, String typeContent, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getCompilationUnitContent(cu, fileComment, typeComment, typeContent, lineDelimiter);
 	}
@@ -108,6 +114,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.1
 	 */
+	@Deprecated
 	public static String getFileComment(ICompilationUnit cu, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getFileComment(cu, lineDelimiter);
 	}
@@ -121,6 +128,7 @@ public class CodeGeneration {
 	 * @return Returns the new content or <code>null</code> if the code template is undefined or empty. The returned content is unformatted and is not indented.
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 */
+	@Deprecated
 	public static String getTypeComment(ICompilationUnit cu, String typeQualifiedName, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getTypeComment(cu, typeQualifiedName, lineDelimiter);
 	}
@@ -136,6 +144,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.1
 	 */
+	@Deprecated
 	public static String getTypeComment(ICompilationUnit cu, String typeQualifiedName, String[] typeParameterNames, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getTypeComment(cu, typeQualifiedName, typeParameterNames, lineDelimiter);
 	}
@@ -151,6 +160,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.2
 	 */
+	@Deprecated
 	public static String getTypeBody(String typeKind, ICompilationUnit cu, String typeName, String lineDelim) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getTypeBody(typeKind, cu, typeName, lineDelim);
 	}
@@ -165,6 +175,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.0
 	 */
+	@Deprecated
 	public static String getFieldComment(ICompilationUnit cu, String typeName, String fieldName, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getFieldComment(cu, typeName, fieldName, lineDelimiter);
 	}
@@ -185,6 +196,7 @@ public class CodeGeneration {
 	 * code template is empty. The returned content is unformatted and not indented (formatting required).
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 */
+	@Deprecated
 	public static String getMethodComment(ICompilationUnit cu, String declaringTypeName, MethodDeclaration decl, IMethodBinding overridden, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getMethodComment(cu, declaringTypeName, decl, overridden, lineDelimiter);
 	}
@@ -211,6 +223,7 @@ public class CodeGeneration {
 	 * the comment code template is empty. The returned content is unformatted and not indented (formatting required).
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 */
+	@Deprecated
 	public static String getMethodComment(ICompilationUnit cu, String declaringTypeName, String methodName, String[] paramNames, String[] excTypeSig, String retTypeSig, IMethod overridden, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getMethodComment(cu, declaringTypeName, methodName, paramNames, excTypeSig, retTypeSig, overridden, lineDelimiter);
 	}
@@ -239,6 +252,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.1
 	 */
+	@Deprecated
 	public static String getMethodComment(ICompilationUnit cu, String declaringTypeName, String methodName, String[] paramNames, String[] excTypeSig, String retTypeSig, String[] typeParameterNames, IMethod overridden, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getMethodComment(cu, declaringTypeName, methodName, paramNames, excTypeSig, retTypeSig, typeParameterNames, overridden, lineDelimiter);
 	}
@@ -256,6 +270,7 @@ public class CodeGeneration {
 	 * the comment code template is empty. The returned string is unformatted and and has no indent (formatting required).
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 */
+	@Deprecated
 	public static String getMethodComment(IMethod method, IMethod overridden, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getMethodComment(method, overridden, lineDelimiter);
 	}
@@ -285,6 +300,7 @@ public class CodeGeneration {
 	 * @since 3.2
 	 */
 
+	@Deprecated
 	public static String getMethodComment(ICompilationUnit cu, String declaringTypeName, MethodDeclaration decl, boolean isDeprecated, String overriddenMethodName, String overriddenMethodDeclaringTypeName, String[] overriddenMethodParameterTypeNames, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getMethodComment(cu, declaringTypeName, decl, isDeprecated, overriddenMethodName, overriddenMethodDeclaringTypeName, overriddenMethodParameterTypeNames, lineDelimiter);
 	}
@@ -305,6 +321,7 @@ public class CodeGeneration {
 	 * the comment code template is empty. The returned string is unformatted and and has no indent (formatting required).
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 */
+	@Deprecated
 	public static String getMethodBodyContent(ICompilationUnit cu, String declaringTypeName, String methodName, boolean isConstructor, String bodyStatement, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getMethodBodyContent(cu, declaringTypeName, methodName, isConstructor, bodyStatement, lineDelimiter);
 	}
@@ -325,6 +342,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.0
 	 */
+	@Deprecated
 	public static String getGetterMethodBodyContent(ICompilationUnit cu, String declaringTypeName, String methodName, String fieldName, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getGetterMethodBodyContent(cu, declaringTypeName, methodName, fieldName, lineDelimiter);
 	}
@@ -346,6 +364,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.0
 	 */
+	@Deprecated
 	public static String getSetterMethodBodyContent(ICompilationUnit cu, String declaringTypeName, String methodName, String fieldName, String paramName, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getSetterMethodBodyContent(cu, declaringTypeName, methodName, fieldName, paramName, lineDelimiter);
 	}
@@ -368,6 +387,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.0
 	 */
+	@Deprecated
 	public static String getGetterComment(ICompilationUnit cu, String declaringTypeName, String methodName, String fieldName, String fieldType, String bareFieldName, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getGetterComment(cu, declaringTypeName, methodName, fieldName, fieldType, bareFieldName, lineDelimiter);
 	}
@@ -391,6 +411,7 @@ public class CodeGeneration {
 	 * @throws CoreException Thrown when the evaluation of the code template fails.
 	 * @since 3.0
 	 */
+	@Deprecated
 	public static String getSetterComment(ICompilationUnit cu, String declaringTypeName, String methodName, String fieldName, String fieldType, String paramName, String bareFieldName, String lineDelimiter) throws CoreException {
 		return org.eclipse.jdt.core.manipulation.CodeGeneration.getSetterComment(cu, declaringTypeName, methodName, fieldName, fieldType, paramName, bareFieldName, lineDelimiter);
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/JavaElementContentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/JavaElementContentProvider.java
@@ -53,16 +53,20 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 public class JavaElementContentProvider extends StandardJavaElementContentProvider implements IElementChangedListener {
 
 	/** The tree viewer */
+	@Deprecated
 	protected TreeViewer fViewer;
 	/** The input object */
+	@Deprecated
 	protected Object fInput;
 
+	@Deprecated
 	@Override
 	public void dispose() {
 		super.dispose();
 		JavaCore.removeElementChangedListener(this);
 	}
 
+	@Deprecated
 	@Override
 	public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
 		super.inputChanged(viewer, oldInput, newInput);
@@ -77,6 +81,7 @@ public class JavaElementContentProvider extends StandardJavaElementContentProvid
 	/**
 	 * Creates a new content provider for Java elements.
 	 */
+	@Deprecated
 	public JavaElementContentProvider() {
 	}
 
@@ -91,10 +96,12 @@ public class JavaElementContentProvider extends StandardJavaElementContentProvid
 	 *
 	 * @since 2.0
 	 */
+	@Deprecated
 	public JavaElementContentProvider(boolean provideMembers, boolean provideWorkingCopy) {
 		super(provideMembers, provideWorkingCopy);
 	}
 
+	@Deprecated
 	@Override
 	public void elementChanged(final ElementChangedEvent event) {
 		try {
@@ -113,6 +120,7 @@ public class JavaElementContentProvider extends StandardJavaElementContentProvid
 	 *
 	 * @throws JavaModelException if an error occurs while processing the delta
 	 */
+	@Deprecated
 	protected void processDelta(IJavaElementDelta delta) throws JavaModelException {
 		int kind= delta.getKind();
 		int flags= delta.getFlags();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/JavaElementSorter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/JavaElementSorter.java
@@ -38,6 +38,7 @@ public class JavaElementSorter extends ViewerSorter {
 	/**
 	 * Constructor.
 	 */
+	@Deprecated
 	public JavaElementSorter() {
 		super(null); // delay initialization of collator
 		fComparator= new JavaElementComparator();
@@ -59,6 +60,7 @@ public class JavaElementSorter extends ViewerSorter {
 	/*
 	 * @see ViewerSorter#category
 	 */
+	@Deprecated
 	@Override
 	public int category(Object element) {
 		return fComparator.category(element);
@@ -67,6 +69,7 @@ public class JavaElementSorter extends ViewerSorter {
 	/*
 	 * @see ViewerSorter#compare
 	 */
+	@Deprecated
 	@Override
 	public int compare(Viewer viewer, Object e1, Object e2) {
 		return fComparator.compare(viewer, e1, e2);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/SharedASTProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/SharedASTProvider.java
@@ -62,6 +62,7 @@ public final class SharedASTProvider {
 	/**
 	 * Wait flag class.
 	 */
+	@Deprecated
 	public static final class WAIT_FLAG {
 
 		private String fName;
@@ -73,6 +74,7 @@ public final class SharedASTProvider {
 		/*
 		 * @see java.lang.Object#toString()
 		 */
+		@Deprecated
 		@Override
 		public String toString() {
 			return fName;
@@ -87,6 +89,7 @@ public final class SharedASTProvider {
 	 * AST is not for the given Java element.
 	 * </p>
 	 */
+	@Deprecated
 	public static final WAIT_FLAG WAIT_YES= new WAIT_FLAG("wait yes"); //$NON-NLS-1$
 
 	/**
@@ -96,6 +99,7 @@ public final class SharedASTProvider {
 	 * No AST will be created by the AST provider.
 	 * </p>
 	 */
+	@Deprecated
 	public static final WAIT_FLAG WAIT_ACTIVE_ONLY= new WAIT_FLAG("wait active only"); //$NON-NLS-1$
 
 	/**
@@ -105,6 +109,7 @@ public final class SharedASTProvider {
 	 * No AST will be created by the AST provider.
 	 * </p>
 	 */
+	@Deprecated
 	public static final WAIT_FLAG WAIT_NO= new WAIT_FLAG("don't wait"); //$NON-NLS-1$
 
 
@@ -129,6 +134,7 @@ public final class SharedASTProvider {
 	 *         <li><code>null</code> will be returned if the operation gets canceled.</li>
 	 *         </ul>
 	 */
+	@Deprecated
 	public static CompilationUnit getAST(ITypeRoot element, WAIT_FLAG waitFlag, IProgressMonitor progressMonitor) {
 		CoreASTProvider.WAIT_FLAG finalWaitFlag = null;
 		if (waitFlag == WAIT_ACTIVE_ONLY) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/FindStringsToExternalizeAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/FindStringsToExternalizeAction.java
@@ -101,12 +101,14 @@ public class FindStringsToExternalizeAction extends SelectionDispatchAction {
 	 *
 	 * @param site the site providing context information for this action
 	 */
+	@Deprecated
 	public FindStringsToExternalizeAction(IWorkbenchSite site) {
 		super(site);
 		setText(ActionMessages.FindStringsToExternalizeAction_label);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this, IJavaHelpContextIds.FIND_STRINGS_TO_EXTERNALIZE_ACTION);
 	}
 
+	@Deprecated
 	@Override
 	public void selectionChanged(IStructuredSelection selection) {
 		try {
@@ -141,6 +143,7 @@ public class FindStringsToExternalizeAction extends SelectionDispatchAction {
 		return true;
 	}
 
+	@Deprecated
 	@Override
 	public void run(final IStructuredSelection selection) {
 		try {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/OpenExternalJavadocAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/OpenExternalJavadocAction.java
@@ -46,6 +46,7 @@ public class OpenExternalJavadocAction extends OpenAttachedJavadocAction {
 	 *
 	 * @param site the site providing additional context information for this action
 	 */
+	@Deprecated
 	public OpenExternalJavadocAction(IWorkbenchSite site) {
 		super(site);
 		setText(ActionMessages.OpenExternalJavadocAction_label);
@@ -78,6 +79,7 @@ public class OpenExternalJavadocAction extends OpenAttachedJavadocAction {
 	 * @param editor the Java editor
 	 * @noreference This constructor is not intended to be referenced by clients.
 	 */
+	@Deprecated
 	public OpenExternalJavadocAction(JavaEditor editor) {
 		super(editor);
 		setText(ActionMessages.OpenExternalJavadocAction_label);
@@ -89,6 +91,7 @@ public class OpenExternalJavadocAction extends OpenAttachedJavadocAction {
 	 * No Javadoc since the method isn't meant to be public but is
 	 * since the beginning
 	 */
+	@Deprecated
 	@Override
 	public void run(IJavaElement element) {
 		super.run(element);
@@ -97,6 +100,7 @@ public class OpenExternalJavadocAction extends OpenAttachedJavadocAction {
 	/*
 	 * @see org.eclipse.jdt.ui.actions.OpenAttachedJavadocAction#forceExternalBrowser()
 	 */
+	@Deprecated
 	@Override
 	boolean forceExternalBrowser() {
 		return true;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ShowActionGroup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ShowActionGroup.java
@@ -56,6 +56,7 @@ public class ShowActionGroup extends ActionGroup {
 	 *
 	 * @param page the page that owns this action group
 	 */
+	@Deprecated
 	public ShowActionGroup(Page page) {
 		this(page.getSite());
 	}
@@ -67,6 +68,7 @@ public class ShowActionGroup extends ActionGroup {
 	 *
 	 * @param part the view part that owns this action group
 	 */
+	@Deprecated
 	public ShowActionGroup(IViewPart part) {
 		this(part.getSite());
 		fIsPackageExplorer= part instanceof PackageExplorerPart;
@@ -78,6 +80,7 @@ public class ShowActionGroup extends ActionGroup {
 	 *
 	 * @noreference This constructor is not intended to be referenced by clients.
 	 */
+	@Deprecated
 	public ShowActionGroup(JavaEditor part) {
 		fShowInPackagesViewAction= new ShowInPackageViewAction(part);
 		fShowInPackagesViewAction.setActionDefinitionId(IJavaEditorActionDefinitionIds.SHOW_IN_PACKAGE_VIEW);
@@ -103,12 +106,14 @@ public class ShowActionGroup extends ActionGroup {
 		}
 	}
 
+	@Deprecated
 	@Override
 	public void fillActionBars(IActionBars actionBar) {
 		super.fillActionBars(actionBar);
 		setGlobalActionHandlers(actionBar);
 	}
 
+	@Deprecated
 	@Override
 	public void fillContextMenu(IMenuManager menu) {
 		super.fillContextMenu(menu);
@@ -120,6 +125,7 @@ public class ShowActionGroup extends ActionGroup {
 	/*
 	 * @see ActionGroup#dispose()
 	 */
+	@Deprecated
 	@Override
 	public void dispose() {
 		ISelectionProvider provider= fSite.getSelectionProvider();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ShowInPackageViewAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/actions/ShowInPackageViewAction.java
@@ -57,6 +57,7 @@ public class ShowInPackageViewAction extends SelectionDispatchAction {
 	 *
 	 * @param site the site providing context information for this action
 	 */
+	@Deprecated
 	public ShowInPackageViewAction(IWorkbenchSite site) {
 		super(site);
 		setText(ActionMessages.ShowInPackageViewAction_label);
@@ -71,16 +72,19 @@ public class ShowInPackageViewAction extends SelectionDispatchAction {
 	 *
 	 * @noreference This constructor is not intended to be referenced by clients.
 	 */
+	@Deprecated
 	public ShowInPackageViewAction(JavaEditor editor) {
 		this(editor.getEditorSite());
 		fEditor= editor;
 		setEnabled(SelectionConverter.canOperateOn(fEditor));
 	}
 
+	@Deprecated
 	@Override
 	public void selectionChanged(ITextSelection selection) {
 	}
 
+	@Deprecated
 	@Override
 	public void selectionChanged(IStructuredSelection selection) {
 		setEnabled(checkEnabled(selection));
@@ -92,6 +96,7 @@ public class ShowInPackageViewAction extends SelectionDispatchAction {
 		return selection.getFirstElement() instanceof IJavaElement;
 	}
 
+	@Deprecated
 	@Override
 	public void run(ITextSelection selection) {
 		try {
@@ -105,6 +110,7 @@ public class ShowInPackageViewAction extends SelectionDispatchAction {
 		}
 	}
 
+	@Deprecated
 	@Override
 	public void run(IStructuredSelection selection) {
 		if (!checkEnabled(selection))
@@ -117,6 +123,7 @@ public class ShowInPackageViewAction extends SelectionDispatchAction {
 	 *
 	 * @param element the element to reveal
 	 */
+	@Deprecated
 	public void run(IJavaElement element) {
 		if (element == null)
 			return;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter.java
@@ -76,6 +76,7 @@ public class JarWriter {
 	 * 								This can also be used to return information
 	 * 								in the status object.
 	 */
+	@Deprecated
 	public JarWriter(JarPackageData jarPackage, Shell parent) throws CoreException {
 		Assert.isNotNull(jarPackage, "The JAR specification is null"); //$NON-NLS-1$
 		fJarPackage= jarPackage;
@@ -104,6 +105,7 @@ public class JarWriter {
 	 * 								This can also be used to return information
 	 * 								in the status object.
 	 */
+	@Deprecated
 	public void close() throws CoreException {
 		if (fJarOutputStream != null)
 			try {
@@ -123,6 +125,7 @@ public class JarWriter {
 	 * 								This can also be used to return information
 	 * 								in the status object.
 	 */
+	@Deprecated
 	public void write(IFile resource, IPath destinationPath) throws CoreException {
 		try (ByteArrayOutputStream output= new ByteArrayOutputStream();
 				BufferedInputStream contentStream= new BufferedInputStream(resource.getContents(false))) {
@@ -163,6 +166,7 @@ public class JarWriter {
 	 * @param	lastModified	a long which represents the last modification date
      * @throws	IOException		if an I/O error has occurred
 	 */
+	@Deprecated
 	protected void write(IPath path, byte[] contents, long lastModified) throws IOException {
 		JarEntry newEntry= new JarEntry(path.toString().replace(File.separatorChar, '/'));
 		if (fJarPackage.isCompressed())
@@ -240,6 +244,7 @@ public class JarWriter {
 	 * 			or <code>null</code> if no dialog should be presented
 	 * @return	<code>true</code> if it is OK to create the JAR
 	 */
+	@Deprecated
 	protected boolean canCreateJar(Shell parent) {
 		File file= fJarPackage.getAbsoluteJarLocation().toFile();
 		if (file.exists()) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter2.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarWriter2.java
@@ -77,6 +77,7 @@ public class JarWriter2 {
 	 * 							This can also be used to return information
 	 * 							in the status object.
 	 */
+	@Deprecated
 	public JarWriter2(JarPackageData jarPackage, Shell parent) throws CoreException {
 		Assert.isNotNull(jarPackage, "The JAR specification is null"); //$NON-NLS-1$
 		fJarPackage= jarPackage;
@@ -105,6 +106,7 @@ public class JarWriter2 {
 	 * 								This can also be used to return information
 	 * 								in the status object.
 	 */
+	@Deprecated
 	public void close() throws CoreException {
 		if (fJarOutputStream != null)
 			try {
@@ -124,6 +126,7 @@ public class JarWriter2 {
 	 * 								This can also be used to return information
 	 * 								in the status object.
 	 */
+	@Deprecated
 	public void write(IFile resource, IPath destinationPath) throws CoreException {
 		try {
 			IPath fileLocation= resource.getLocation();
@@ -156,6 +159,7 @@ public class JarWriter2 {
      * @throws	IOException			if an I/O error has occurred
 	 * @throws	CoreException 		if the resource can-t be accessed
 	 */
+	@Deprecated
 	protected void addFile(IFile resource, IPath path, File correspondingFile) throws IOException, CoreException {
 		JarEntry newEntry= new JarEntry(path.toString().replace(File.separatorChar, '/'));
 		byte[] readBuffer= new byte[4096];
@@ -220,6 +224,7 @@ public class JarWriter2 {
 	 *  						or <code>null</code> if it doesn't exist
 	 * @throws IOException if an I/O error has occurred
 	 */
+	@Deprecated
 	protected void addDirectories(IPath destinationPath, File correspondingFile) throws IOException {
 		String path= destinationPath.toString().replace(File.separatorChar, '/');
 		int lastSlash= path.lastIndexOf('/');
@@ -259,6 +264,7 @@ public class JarWriter2 {
 	 * 			or <code>null</code> if no dialog should be presented
 	 * @return	<code>true</code> if it is OK to create the JAR
 	 */
+	@Deprecated
 	protected boolean canCreateJar(Shell parent) {
 		File file= fJarPackage.getAbsoluteJarLocation().toFile();
 		if (file.exists()) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIds.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/refactoring/IRefactoringProcessorIds.java
@@ -53,6 +53,7 @@ public interface IRefactoringProcessorIds {
 	 *   <li>participants registered for renaming <code>IProject</code>.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String RENAME_JAVA_PROJECT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_JAVA_PROJECT_PROCESSOR;
 
 	/**
@@ -65,6 +66,7 @@ public interface IRefactoringProcessorIds {
 	 *   <li>participants registered for renaming <code>IFolder</code>.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String RENAME_SOURCE_FOLDER_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_SOURCE_FOLDER_PROCESSOR;
 
 	/**
@@ -91,6 +93,7 @@ public interface IRefactoringProcessorIds {
 	 * {@link IJavaElementMapper} and {@link IResourceMapper}, which can be
 	 * retrieved from the processor using the getAdapter() method.</p>
 	 */
+	@Deprecated
 	String RENAME_PACKAGE_FRAGMENT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_PACKAGE_FRAGMENT_PROCESSOR;
 
 	/**
@@ -105,6 +108,7 @@ public interface IRefactoringProcessorIds {
 	 *       compilation unit contains a top level type.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String RENAME_COMPILATION_UNIT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_COMPILATION_UNIT_PROCESSOR;
 
 	/**
@@ -132,6 +136,7 @@ public interface IRefactoringProcessorIds {
 	 * through the interfaces {@link IJavaElementMapper} and {@link IResourceMapper}, which can be retrieved from the
 	 * processor using the getAdapter() method.</p>
 	 */
+	@Deprecated
 	String RENAME_TYPE_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_TYPE_PROCESSOR;
 
 	/**
@@ -146,6 +151,7 @@ public interface IRefactoringProcessorIds {
 	 *       For those derived methods participants will be loaded as well.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String RENAME_METHOD_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_METHOD_PROCESSOR;
 
 	/**
@@ -159,6 +165,7 @@ public interface IRefactoringProcessorIds {
 	 *       corresponding setter and getter methods are renamed as well.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String RENAME_FIELD_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_FIELD_PROCESSOR;
 
 	/**
@@ -171,6 +178,7 @@ public interface IRefactoringProcessorIds {
 	 * </ul>
 	 * @since 3.24
 	 */
+	@Deprecated
 	String RENAME_MODULE_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_MODULE_PROCESSOR;
 
 	/**
@@ -183,6 +191,7 @@ public interface IRefactoringProcessorIds {
 	 * </ul>
 	 * @since 3.1
 	 */
+	@Deprecated
 	String RENAME_ENUM_CONSTANT_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_ENUM_CONSTANT_PROCESSOR;
 
 	/**
@@ -194,6 +203,7 @@ public interface IRefactoringProcessorIds {
 	 *   <li>participants registered for renaming <code>IResource</code>.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String RENAME_RESOURCE_PROCESSOR= IRefactoringProcessorIdsCore.RENAME_RESOURCE_PROCESSOR;
 
 	/**
@@ -217,6 +227,7 @@ public interface IRefactoringProcessorIds {
 	 *   <li><code>IResource</code>: participants registered for moving resources.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String MOVE_PROCESSOR= IRefactoringProcessorIdsCore.MOVE_PROCESSOR;
 
 	/**
@@ -227,6 +238,7 @@ public interface IRefactoringProcessorIds {
 	 * static Java element that gets moved. No support is available to participate
 	 * in non static member moves.
 	 */
+	@Deprecated
 	String MOVE_STATIC_MEMBERS_PROCESSOR= IRefactoringProcessorIdsCore.MOVE_STATIC_MEMBERS_PROCESSOR;
 
 	/**
@@ -254,6 +266,7 @@ public interface IRefactoringProcessorIds {
 	 *   <li><code>IResource</code>: participants registered for deleting resources.</li>
 	 * </ul>
 	 */
+	@Deprecated
 	String DELETE_PROCESSOR= IRefactoringProcessorIdsCore.DELETE_PROCESSOR;
 
 	/**
@@ -284,5 +297,6 @@ public interface IRefactoringProcessorIds {
 	 * @see org.eclipse.core.resources.mapping.ResourceMapping
 	 * @since 3.3
 	 */
+	@Deprecated
 	String COPY_PROCESSOR= IRefactoringProcessorIdsCore.COPY_PROCESSOR;
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/IJavadocCompletionProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/java/IJavadocCompletionProcessor.java
@@ -36,6 +36,7 @@ public interface IJavadocCompletionProcessor {
 	 * Specifies that only proposals should be returned that match
 	 * the case of the prefix in the code (value: <code>1</code>).
 	 */
+	@Deprecated
 	int RESTRICT_TO_MATCHING_CASE= 1;
 
 
@@ -50,6 +51,7 @@ public interface IJavadocCompletionProcessor {
 	 * @return	an array of context information objects or <code>null</code>
 	 * 				if no context could be found
 	 */
+	@Deprecated
 	IContextInformation[] computeContextInformation(ICompilationUnit cu, int offset);
 
 
@@ -67,6 +69,7 @@ public interface IJavadocCompletionProcessor {
 	 * @return an array of completion proposals or <code>null</code> if
 	 *				no proposals could be found
      */
+	@Deprecated
 	IJavaCompletionProposal[] computeCompletionProposals(ICompilationUnit cu, int offset, int length, int flags);
 
 
@@ -76,5 +79,6 @@ public interface IJavadocCompletionProcessor {
 	 *
 	 * @return an error message or <code>null</code> if no error occurred
 	 */
+	@Deprecated
 	String getErrorMessage();
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewJavaProjectWizardPage.java
@@ -86,6 +86,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 * @param root the workspace root
 	 * @param mainpage the main page of the wizard
 	 */
+	@Deprecated
 	public NewJavaProjectWizardPage(IWorkspaceRoot root, WizardNewProjectCreationPage mainpage) {
 		super(PAGE_NAME);
 
@@ -106,6 +107,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
      * @see org.eclipse.jface.dialogs.DialogPage#dispose()
      * @since 3.3
      */
+	@Deprecated
     @Override
 	public void dispose() {
     	try {
@@ -134,6 +136,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @param path the folder to be taken as the default output path
 	 */
+	@Deprecated
 	public void setDefaultOutputFolder(IPath path) {
 		fOutputLocation= path;
 		setProjectModified();
@@ -157,6 +160,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 * @param appendDefaultJRE <code>true</code> a variable entry for the
 	 *  default JRE (specified in the preferences) will be added to the classpath.
 	 */
+	@Deprecated
 	public void setDefaultClassPath(IClasspathEntry[] entries, boolean appendDefaultJRE) {
 		if (entries != null && appendDefaultJRE) {
 			IClasspathEntry[] jreEntry= NewJavaProjectPreferencePage.getDefaultJRELibrary();
@@ -175,6 +179,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @since 2.0
 	 */
+	@Deprecated
 	public void setProjectModified() {
 		fProjectModified= true;
 	}
@@ -186,6 +191,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @return the project handle
 	 */
+	@Deprecated
 	protected IProject getProjectHandle() {
 		Assert.isNotNull(fMainPage);
 		return fMainPage.getProjectHandle();
@@ -198,6 +204,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @return the project location path
 	 */
+	@Deprecated
 	protected IPath getLocationPath() {
 		Assert.isNotNull(fMainPage);
 		return fMainPage.getLocationPath();
@@ -210,10 +217,12 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 * @return the Java project handle
 	 * @see #getProjectHandle()
 	 */
+	@Deprecated
 	public IJavaProject getNewJavaProject() {
 		return JavaCore.create(getProjectHandle());
 	}
 
+	@Deprecated
 	@Override
 	public void createControl(Composite parent) {
 		Composite composite= new Composite(parent, SWT.NONE);
@@ -235,6 +244,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @since 2.0
 	 */
+	@Deprecated
 	protected void initBuildPaths() {
 		fBuildPathsBlock.init(getNewJavaProject(), fOutputLocation, fClasspathEntries);
 	}
@@ -247,6 +257,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 * @param visible if <code>true</code> the page becomes visible; otherwise
 	 * it becomes invisible
 	 */
+	@Deprecated
 	@Override
 	public void setVisible(boolean visible) {
 		super.setVisible(visible);
@@ -274,6 +285,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @since 2.0
 	 */
+	@Deprecated
 	public IPath getOutputLocation() {
 		return fBuildPathsBlock.getOutputLocation();
 	}
@@ -286,6 +298,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @since 2.0
 	 */
+	@Deprecated
 	public IClasspathEntry[] getRawClassPath() {
 		return fBuildPathsBlock.getRawClassPath();
 	}
@@ -301,6 +314,7 @@ public class NewJavaProjectWizardPage extends NewElementWizardPage {
 	 *
 	 * @return the runnable
 	 */
+	@Deprecated
 	public IRunnableWithProgress getRunnable() {
 		return monitor -> {
 			if (monitor == null) {


### PR DESCRIPTION
Add `@Deprecated` to members of truly deprecated classes
+ most classes have a replacement for a long time already
+ PackageViewerWrapper sticks out as it is still in use / not replaced

Replace `@Deprecated` with `@SuppressWarnings` where that was the intention

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4568
Changes created using https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2587