### PR TITLE
Refactor UnimplementedCodeCleanUp to jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnimplementedCodeCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/UnimplementedCodeCleanUpCore.java
@@ -27,28 +27,28 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.manipulation.JavaManipulation;
 
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContext;
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
+import org.eclipse.jdt.internal.corext.codemanipulation.CodeGenerationSettingsConstants;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.UnimplementedCodeFixCore;
 
-import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.cleanup.CleanUpRequirements;
 import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 
-import org.eclipse.jdt.internal.ui.JavaPlugin;
-
-public class UnimplementedCodeCleanUp extends AbstractMultiFix {
+public class UnimplementedCodeCleanUpCore extends AbstractMultiFix {
 
 	public static final String MAKE_TYPE_ABSTRACT= "cleanup.make_type_abstract_if_missing_method"; //$NON-NLS-1$
 
-	public UnimplementedCodeCleanUp() {
+	public UnimplementedCodeCleanUpCore() {
 		super();
 	}
 
-	public UnimplementedCodeCleanUp(Map<String, String> settings) {
+	public UnimplementedCodeCleanUpCore(Map<String, String> settings) {
 		super(settings);
 	}
 
@@ -73,7 +73,7 @@ public class UnimplementedCodeCleanUp extends AbstractMultiFix {
 			bld.append("public class Face implements IFace {\n"); //$NON-NLS-1$
 		}
 		if (isEnabled(CleanUpConstants.ADD_MISSING_METHODES)) {
-			boolean createComments= Boolean.parseBoolean(PreferenceConstants.getPreference(PreferenceConstants.CODEGEN_ADD_COMMENTS, null));
+			boolean createComments= Boolean.parseBoolean(JavaManipulation.getPreference(CodeGenerationSettingsConstants.CODEGEN_ADD_COMMENTS, null));
 			if (createComments)
 				bld.append(indent(getOverridingMethodComment(), "    ")); //$NON-NLS-1$
 
@@ -170,7 +170,7 @@ public class UnimplementedCodeCleanUp extends AbstractMultiFix {
 	}
 
 	private static Template getCodeTemplate(String id) {
-		return JavaPlugin.getDefault().getCodeTemplateStore().findTemplateById(id);
+		return JavaManipulation.getCodeTemplateStore().findTemplateById(id);
 	}
 
 	private String evaluateTemplate(Template template, CodeTemplateContext context) {
@@ -178,7 +178,7 @@ public class UnimplementedCodeCleanUp extends AbstractMultiFix {
 		try {
 			buffer= context.evaluate(template);
 		} catch (BadLocationException | TemplateException e) {
-			JavaPlugin.log(e);
+			JavaManipulationPlugin.log(e);
 			return ""; //$NON-NLS-1$
 		}
 		if (buffer == null)

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -78,7 +78,7 @@ import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 import org.eclipse.jdt.internal.ui.fix.PlainReplacementCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PrimitiveRatherThanWrapperCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.RedundantModifiersCleanUp;
-import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp;
+import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUpCore;
 import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation;
 
 public class CleanUpTest extends CleanUpTestCase {
@@ -30313,7 +30313,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			""";
 		ICompilationUnit cu2= pack1.createCompilationUnit("E02.java", sample, false, null);
 
-		enable(UnimplementedCodeCleanUp.MAKE_TYPE_ABSTRACT);
+		enable(UnimplementedCodeCleanUpCore.MAKE_TYPE_ABSTRACT);
 
 		sample= """
 			package test;

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpConstantsOptions.java
@@ -22,7 +22,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
-import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp;
+import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUpCore;
 
 public class CleanUpConstantsOptions extends CleanUpConstants {
 	private static void setEclipseDefaultSettings(CleanUpOptions options) {
@@ -147,7 +147,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(ADD_MISSING_NLS_TAGS, CleanUpOptions.FALSE);
 
 		options.setOption(ADD_MISSING_METHODES, CleanUpOptions.FALSE);
-		options.setOption(UnimplementedCodeCleanUp.MAKE_TYPE_ABSTRACT, CleanUpOptions.FALSE);
+		options.setOption(UnimplementedCodeCleanUpCore.MAKE_TYPE_ABSTRACT, CleanUpOptions.FALSE);
 
 		//Code Organizing
 		options.setOption(FORMAT_SOURCE_CODE, CleanUpOptions.FALSE);
@@ -337,7 +337,7 @@ public class CleanUpConstantsOptions extends CleanUpConstants {
 		options.setOption(ADD_MISSING_NLS_TAGS, CleanUpOptions.FALSE);
 
 		options.setOption(ADD_MISSING_METHODES, CleanUpOptions.FALSE);
-		options.setOption(UnimplementedCodeCleanUp.MAKE_TYPE_ABSTRACT, CleanUpOptions.FALSE);
+		options.setOption(UnimplementedCodeCleanUpCore.MAKE_TYPE_ABSTRACT, CleanUpOptions.FALSE);
 
 		//Code Organizing
 		options.setOption(FORMAT_SOURCE_CODE, CleanUpOptions.FALSE);

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7343,7 +7343,7 @@
             runAfter="org.eclipse.jdt.ui.cleanup.unlooped_while">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.unimplemented_code"
             runAfter="org.eclipse.jdt.ui.cleanup.strings">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/MissingCodeTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/MissingCodeTabPage.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
 import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
 import org.eclipse.jdt.internal.ui.fix.PotentialProgrammingProblemsCleanUpCore;
-import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp;
+import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUpCore;
 
 public final class MissingCodeTabPage extends AbstractCleanUpTabPage {
 
@@ -35,7 +35,7 @@ public final class MissingCodeTabPage extends AbstractCleanUpTabPage {
 
 	@Override
 	protected AbstractCleanUp[] createPreviewCleanUps(Map<String, String> values) {
-		return new AbstractCleanUp[] { new Java50CleanUp(values), new PotentialProgrammingProblemsCleanUpCore(values), new UnimplementedCodeCleanUp(values) };
+		return new AbstractCleanUp[] { new Java50CleanUp(values), new PotentialProgrammingProblemsCleanUpCore(values), new UnimplementedCodeCleanUpCore(values) };
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -120,7 +120,6 @@ import org.eclipse.jdt.internal.corext.fix.CodeStyleFixCore;
 import org.eclipse.jdt.internal.corext.fix.IProposableFix;
 import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
 import org.eclipse.jdt.internal.corext.fix.RenameUnusedVariableFixCore;
-import org.eclipse.jdt.internal.corext.fix.UnimplementedCodeFixCore;
 import org.eclipse.jdt.internal.corext.fix.UnusedCodeFixCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.ASTNodeSearchUtil;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
@@ -133,7 +132,6 @@ import org.eclipse.jdt.ui.actions.GenerateHashCodeEqualsAction;
 import org.eclipse.jdt.ui.actions.IJavaEditorActionDefinitionIds;
 import org.eclipse.jdt.ui.actions.InferTypeArgumentsAction;
 import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
-import org.eclipse.jdt.ui.cleanup.ICleanUp;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposal;
@@ -146,7 +144,6 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 import org.eclipse.jdt.internal.ui.fix.CodeStyleCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
-import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUp;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
 import org.eclipse.jdt.internal.ui.refactoring.nls.ExternalizeWizard;
@@ -274,27 +271,7 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 	}
 
 	public static void addUnimplementedMethodsProposals(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
-		IProposableFix addMethodFix= UnimplementedCodeFixCore.createAddUnimplementedMethodsFix(context.getASTRoot(), problem);
-		if (addMethodFix != null) {
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-
-			Map<String, String> settings= new Hashtable<>();
-			settings.put(CleanUpConstants.ADD_MISSING_METHODES, CleanUpOptions.TRUE);
-			ICleanUp cleanUp= new UnimplementedCodeCleanUp(settings);
-
-			proposals.add(new FixCorrectionProposal(addMethodFix, cleanUp, IProposalRelevance.ADD_UNIMPLEMENTED_METHODS, image, context));
-		}
-
-		IProposableFix makeAbstractFix= UnimplementedCodeFixCore.createMakeTypeAbstractFix(context.getASTRoot(), problem);
-		if (makeAbstractFix != null) {
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-
-			Map<String, String> settings= new Hashtable<>();
-			settings.put(UnimplementedCodeCleanUp.MAKE_TYPE_ABSTRACT, CleanUpOptions.TRUE);
-			ICleanUp cleanUp= new UnimplementedCodeCleanUp(settings);
-
-			proposals.add(new FixCorrectionProposal(makeAbstractFix, cleanUp, IProposalRelevance.MAKE_TYPE_ABSTRACT, image, context));
-		}
+		new LocalCorrectionsSubProcessor().getUnimplementedMethodsProposals(context, problem, proposals);
 	}
 
 	public static void addUninitializedLocalVariableProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
@@ -1314,7 +1291,8 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
 		switch (uid) {
 			case STATIC_INDIRECT_ACCESS, STATIC_NON_STATIC_ACCESS_USING_TYPE,
-				STATIC_INSTANCE_ACCESS, REMOVE_UNNECESSARY_CAST, UNQUALIFIED_FIELD_ACCESS -> {
+				STATIC_INSTANCE_ACCESS, REMOVE_UNNECESSARY_CAST, UNQUALIFIED_FIELD_ACCESS,
+				ADD_UNIMPLEMENTED_METHODS -> {
 				image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
 			}
 			case UNUSED_CODE, REMOVE_REDUNDANT_TYPE_ARGS, REMOVE_UNNECESSARY_NLS -> {


### PR DESCRIPTION
- refactor to UnimplementedCodeCleanUpCore
- modify references appropriately
- add new LocalCorrectionsBaseSubProcessor.getUnimplementedMethodsProposals() to be used by LocalCorrectionsSubProcessor

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See commit.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run regular testing.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
