### PR TITLE
Remove junit-platform-suite-commons from JUnit 6 classpath container

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
@@ -409,10 +409,6 @@ public class BuildPathSupport {
 			JUNIT_PLATFORM_SUITE_ENGINE, new VersionRange("[6.0.0,7.0.0)"), null, "junit-platform-suite-engine_6.*.jar", "junit-platform-suite-engine.source", "", //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
 			JUnitPreferencesConstants.JUNIT_PLATFORM_SUITE_ENGINE_JAVADOC);
 
-	public static final JUnitPluginDescription JUNIT6_PLATFORM_SUITE_COMMONS_PLUGIN= new JUnitPluginDescription(
-			JUNIT_PLATFORM_SUITE_COMMONS, new VersionRange("[6.0.0,7.0.0)"), null, "junit-platform-suite-commons_6.*.jar", "junit-platform-suite-commons.source", "", //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
-			JUnitPreferencesConstants.JUNIT_PLATFORM_SUITE_COMMONS_JAVADOC);
-
 	public static final JUnitPluginDescription JUNIT4_AS_3_PLUGIN= new JUnitPluginDescription(
 			JUNIT4_PLUGIN.bundleId, JUNIT4_PLUGIN.versionRange, JUNIT4_PLUGIN.bundleRoot, JUNIT4_PLUGIN.binaryImportedRoot,
 			JUNIT4_PLUGIN.sourceBundleId, JUNIT4_PLUGIN.repositorySource, JUNIT3_PLUGIN.javadocPreferenceKey) {
@@ -634,13 +630,6 @@ public class BuildPathSupport {
 	 */
 	public static IClasspathEntry getJUnit6PlatformSuiteEngineLibraryEntry() {
 		return JUNIT6_PLATFORM_SUITE_ENGINE_PLUGIN.getLibraryEntry();
-	}
-
-	/**
-	 * @return the org.junit.platform.suite.commons JUnit 6 library, or <code>null</code> if not available
-	 */
-	public static IClasspathEntry getJUnit6PlatformSuiteCommonsLibraryEntry() {
-		return JUNIT6_PLATFORM_SUITE_COMMONS_PLUGIN.getLibraryEntry();
 	}
 
 	private BuildPathSupport() {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/JUnitContainerInitializer.java
@@ -161,7 +161,6 @@ public class JUnitContainerInitializer extends ClasspathContainerInitializer {
 			entriesList.add(BuildPathSupport.getJUnit6PlatformLauncherLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnit6PlatformSuiteApiLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnit6PlatformSuiteEngineLibraryEntry());
-			entriesList.add(BuildPathSupport.getJUnit6PlatformSuiteCommonsLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnitOpentest4jLibraryEntry());
 			entriesList.add(BuildPathSupport.getJUnitApiGuardianLibraryEntry());
 			entriesList.add(BuildPathSupport.getHamcrestLibraryEntry());


### PR DESCRIPTION
`junit-platform-suite-commons` is a part of `junit-platform-suite` as per the JUnit 6 change log: https://github.com/junit-team/junit-framework/wiki/Upgrading-to-JUnit-6.0#removed-modules

Fixes: #2604

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
