### PR TITLE
Refactor PatternCleanUp to jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PatternCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/PatternCleanUpCore.java
@@ -60,7 +60,7 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.ScopeAnalyzer;
 import org.eclipse.jdt.internal.corext.dom.VarDefinitionsUsesVisitor;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFix;
+import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperationWithSourceRange;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
@@ -75,7 +75,7 @@ import org.eclipse.jdt.ui.text.java.IProblemLocation;
  * It uses <code>split()</code>, <code>replaceFirst()</code>, <code>replaceAll()</code> and <code>matches()</code> methods on a <code>java.util.regex.Pattern</code> object.
  * It only changes code inside one method.
  */
-public class PatternCleanUp extends AbstractMultiFix {
+public class PatternCleanUpCore extends AbstractMultiFix {
 	private static final String STRING_CLASS_NAME= String.class.getCanonicalName();
 
 	private static final String SPLIT_METHOD= "split"; //$NON-NLS-1$
@@ -85,11 +85,11 @@ public class PatternCleanUp extends AbstractMultiFix {
 	private static final String MATCHES_METHOD= "matches"; //$NON-NLS-1$
 	private static final String COMPILE_METHOD= "compile"; //$NON-NLS-1$
 
-	public PatternCleanUp() {
+	public PatternCleanUpCore() {
 		this(Collections.emptyMap());
 	}
 
-	public PatternCleanUp(Map<String, String> options) {
+	public PatternCleanUpCore(Map<String, String> options) {
 		super(options);
 	}
 
@@ -275,7 +275,7 @@ public class PatternCleanUp extends AbstractMultiFix {
 			return null;
 		}
 
-		return new CompilationUnitRewriteOperationsFix(MultiFixMessages.PatternCleanup_description, unit,
+		return new CompilationUnitRewriteOperationsFixCore(MultiFixMessages.PatternCleanup_description, unit,
 				rewriteOperations.toArray(new CompilationUnitRewriteOperationWithSourceRange[0]));
 	}
 

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7253,7 +7253,7 @@
             runAfter="org.eclipse.jdt.ui.cleanup.primitive_serialization">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.PatternCleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.PatternCleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.precompile_regex"
             runAfter="org.eclipse.jdt.ui.cleanup.primitive_rather_than_wrapper">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/PerformanceTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/PerformanceTabPage.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.internal.ui.fix.BooleanLiteralCleanUp;
 import org.eclipse.jdt.internal.ui.fix.BreakLoopCleanUp;
 import org.eclipse.jdt.internal.ui.fix.LazyLogicalCleanUp;
 import org.eclipse.jdt.internal.ui.fix.NoStringCreationCleanUpCore;
-import org.eclipse.jdt.internal.ui.fix.PatternCleanUp;
+import org.eclipse.jdt.internal.ui.fix.PatternCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PlainReplacementCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PrimitiveComparisonCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PrimitiveParsingCleanUp;
@@ -56,7 +56,7 @@ public final class PerformanceTabPage extends AbstractCleanUpTabPage {
 				new PrimitiveParsingCleanUp(values),
 				new PrimitiveSerializationCleanUp(values),
 				new PrimitiveRatherThanWrapperCleanUpCore(values),
-				new PatternCleanUp(values),
+				new PatternCleanUpCore(values),
 				new StringBufferToStringBuilderCleanUpCore(values),
 				new NoStringCreationCleanUpCore(values),
 				new BooleanLiteralCleanUp(values)


### PR DESCRIPTION
- refactor PatternCleanUp to PatternCleanUpCore in jdt.core.manipulation
- change references

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See commit.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run regular JDT tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
