### PR TITLE
Fix move method to recognize method references that are being used

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail19/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail19/in/A.java
@@ -1,0 +1,16 @@
+package p1;
+
+public class A {
+	B b;
+
+	public void method() {
+		new ArrayList<Integer>().stream().filter(this::isPositive).collect(Collectors.toList());
+	}
+
+	private boolean isPositive(Integer number) {
+		return number != null && number > 0;
+	}
+}
+class B {
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -845,6 +845,12 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 		failHelper1(new String[] { "p1.A" }, "p1.A", 6, 17, 6, 18, FIELD, "b", true, true);
 	}
 
+	// Issue 2577
+	@Test
+	public void testFail19() throws Exception {
+		failHelper1(new String[] { "p1.A" }, "p1.A", 6, 17, 6, 23, FIELD, "b", true, true);
+	}
+
 	// Cannot move static method
 	@Test
 	public void testFail2() throws Exception {


### PR DESCRIPTION
- add new logic to MemberVisibilityAdjustor to set a set of members to check visibility for
- add new logic to MoveInstanceMethodProcessor to find method references in the method being moved and create a list of members to register with the MemberVisibilityAdjustor
- add a new test to MoveInstanceMethodTests
- fixes #2577

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
