### PR TITLE
Fix Markdown comments indentation

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocAutoIndentStrategy.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocAutoIndentStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -105,7 +105,7 @@ public class JavaDocAutoIndentStrategy extends DefaultIndentLineAutoEditStrategy
 				if (d.getChar(firstNonWS) == '/') {
 					// Javadoc/markdown started on this line
 					if (d.getChar(firstNonWS+1) == '/') {
-						buf.append("///"); //$NON-NLS-1$
+						buf.append("/// "); //$NON-NLS-1$
 					} else {
 						buf.append(" * "); //$NON-NLS-1$
 					}


### PR DESCRIPTION
This commit adds an additional space after a markdown start tag

Before

https://github.com/user-attachments/assets/d2df0200-1a27-4996-97e8-0ffe7c807457


After

https://github.com/user-attachments/assets/5a5ab92f-4681-4f04-87a6-a74819841f80


Fixes : https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2500


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
