### PR TITLE
Ensure asterisk added between sequential upper case letters

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
@@ -444,16 +444,25 @@ public class FilteredTypesSelectionDialog extends FilteredItemsSelectionDialog i
 	@Override
 	protected String getPatternText() {
 		String text= super.getPatternText();
-		fTypeItemsComparator.setOriginalPattern(text);
 		StringBuilder builder= new StringBuilder();
 		boolean canAddAnyStringNext= false;
+		boolean allUpperCase= true;
 		for (int i= 0; i < text.length(); ++i) {
 			char ch= text.charAt(i);
-			if (canAddAnyStringNext && Character.isUpperCase(ch)) {
+			boolean upperCase= Character.isUpperCase(ch);
+			allUpperCase &= upperCase;
+			if (canAddAnyStringNext && upperCase) {
 				builder.append('*');
 			}
 			builder.append(ch);
 			canAddAnyStringNext= canAddAnyStringNext(ch);
+		}
+		fTypeItemsComparator.setOriginalPattern(text);
+		// Default search is Camel Case but if there are any * or ? chars,
+		// it is a pattern search that is not case sensitive so if we are
+		// all caps (e.g. OOME or NPE), just pass the string along directly
+		if (allUpperCase) {
+			return text;
 		}
 		return builder.toString();
 	}


### PR DESCRIPTION
- modify FilteredTypesSelectionDialog.getPatternText() to ensure that asterisks are added between sequential upper-case letters
- fixes #2583

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
