### PR TITLE
Improve logic for search pattern modification in "Open Type" dialog

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/dialogs/FilteredTypesSelectionDialogTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/dialogs/FilteredTypesSelectionDialogTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Patrick Ziegler others.
+ * Copyright (c) 2025 Patrick Ziegler and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -103,7 +103,10 @@ public class FilteredTypesSelectionDialogTests {
 		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2505
 		"java.lang.String, java.lang.String",
 		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2538
-		"OOME, java.lang.OutOfMemoryError"
+		"OOME, java.lang.OutOfMemoryError",
+		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2583
+		"OOfME, java.lang.OutOfMemoryError",
+		"OOMemE, java.lang.OutOfMemoryError"
 	})
 	public void testWithSearchString(String pattern, String expectedType) {
 		dialog.setInitialPattern(pattern);


### PR DESCRIPTION
With this change, we allow wildcards between upper-case characters if the search pattern is a mix between upper- and lower-case characters.

Reason for this change is that the matcher switches to a "match by words" mode, if the pattern contains at least one wildcard. Unlike the "camel-case mode", a wildcard must then be added between all upper-cases characters, in order to not treat them as single-letter words.

Example:
- "OOME" -> "OOME", matches "OutOfMemoryError" (camel-case matcher)
- "OutOME" -> "Out\*O\*M\*E\*", matches "OutOfMemoryError" (word matcher)

Closes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2583

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
