### PR TITLE
Match also junit-platform-commons-* file name when detecting a JUnit 6 launch type

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -60,8 +60,8 @@ import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
  */
 public class CoreTestSearchEngine {
 
-	private static final String JUNIT_PLATFORM_SUITE_API_PREFIX= BuildPathSupport.JUNIT_PLATFORM_SUITE_API + "_"; //$NON-NLS-1$
-	private static final String JUNIT_PLATFORM_COMMONS_PREFIX= BuildPathSupport.JUNIT_PLATFORM_COMMONS + "_"; //$NON-NLS-1$
+	private static final String JUNIT_PLATFORM_SUITE_API_PREFIX= BuildPathSupport.JUNIT_PLATFORM_SUITE_API;
+	private static final String JUNIT_PLATFORM_COMMONS_PREFIX= BuildPathSupport.JUNIT_PLATFORM_COMMONS;
 	private static final String JAR_EXTENSION= ".jar"; //$NON-NLS-1$
 
 	public static boolean isTestOrTestSuite(IType declaringType) throws CoreException {
@@ -173,8 +173,8 @@ public class CoreTestSearchEngine {
 				if (type != null) {
 					// check if we have the right JUnit JUpiter version
 					String filename= type.getPath().lastSegment();
-					if (filename.startsWith(junitBundlePrefix) && filename.endsWith(JAR_EXTENSION)) {
-						String versionString = filename.substring(junitBundlePrefix.length(), filename.length() - JAR_EXTENSION.length());
+					if ((filename.startsWith(junitBundlePrefix + "_") || filename.startsWith(junitBundlePrefix + "-")) && filename.endsWith(JAR_EXTENSION)) { //$NON-NLS-1$ //$NON-NLS-2$
+						String versionString = filename.substring(junitBundlePrefix.length() + 1, filename.length() - JAR_EXTENSION.length());
 						Version version = new Version(versionString);
 						if (version.getMajor() != junitMajorVersion) {
 							return false;


### PR DESCRIPTION
Fixes: #2625

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
