### PR TITLE
Fix incorrect rendering of h1 - h6 tags in Javadoc and hover

### DIFF
--- a/org.eclipse.jdt.ui/JavadocHoverStyleSheet.css
+++ b/org.eclipse.jdt.ui/JavadocHoverStyleSheet.css
@@ -1,15 +1,22 @@
 /* Font definitions */
 html         { font-family: sans-serif; font-size: 9pt; font-style: normal; font-weight: normal; }
-body, h1, h2, h3, h4, h5, h6, p, table, td, caption, th, ul, ol, dl, li, dd, dt { font-size: 1em; }
+body, p, table, td, caption, th, ul, ol, dl, li, dd, dt { font-size: 1em; }
 pre          { font-family: monospace; }
+h1           { font-size: 1.8em; }	
+h2           { font-size: 1.2em; }
+h3           { font-size: 1.1em; }
+h4			 { font-size: 1em;	 }
+h5			 { font-size: 0.9em; }
+h6			 { font-size: 0.8em; }
 
 /* Margins */
 body	     { overflow: auto; margin-top: 0px; margin-bottom: 0.5em; margin-left: 0.3em; margin-right: 0px; }
-h1           { margin-top: 0.3em; margin-bottom: 0.04em; }	
-h2           { margin-top: 2em; margin-bottom: 0.25em; }
-h3           { margin-top: 1.7em; margin-bottom: 0.25em; }
-h4           { margin-top: 2em; margin-bottom: 0.3em; }
-h5           { margin-top: 0px; margin-bottom: 0px; }
+h1           { margin-top: 1.2em; margin-bottom: 0.5em; }	
+h2           { margin-top: 1.1em; margin-bottom: 0.4em; }
+h3           { margin-top: 1em; margin-bottom: 0.4em; 	}
+h4           { margin-top: 0.9em; margin-bottom: 0.5em; }
+h5           { margin-top: 0.8px; margin-bottom: 0.4px; }
+h6			 { margin-top: 0.7em; margin-bottom: 0.3em;	}
 p            { margin-top: 1em; margin-bottom: 1em; }
 pre          { margin-left: 0.6em; }
 ul	         { margin-top: 0px; margin-bottom: 1em; margin-left: 1em; padding-left: 1em; }
@@ -27,7 +34,6 @@ a:visited    { text-decoration: underline; }
 a.header:link    { text-decoration: none; color: InfoText }
 a.header:visited { text-decoration: none; color: InfoText }
 a.header:hover   { text-decoration: underline; color: activeHyperlinkColor; } /* get's replaced with actual color */
-h4           { font-style: italic; }
 strong	     { font-weight: bold; }
 em	         { font-style: italic; }
 var	         { font-style: italic; }

--- a/org.eclipse.jdt.ui/JavadocViewStyleSheet.css
+++ b/org.eclipse.jdt.ui/JavadocViewStyleSheet.css
@@ -1,18 +1,22 @@
 /* Font definitions */
 html         { font-family: sans-serif; font-size: 9pt; font-style: normal; font-weight: normal; }
-body, h4, h5, h6, p, table, td, caption, th, ul, ol, dl, li, dd, dt { font-size: 1em; }
+body, p, table, td, caption, th, ul, ol, dl, li, dd, dt { font-size: 1em; }
 pre          { font-family: monospace; }
 h1           { font-size: 1.8em; }	
 h2           { font-size: 1.2em; }
 h3           { font-size: 1.1em; }
+h4			 { font-size: 1em;	 }
+h5			 { font-size: 0.9em; }
+h6			 { font-size: 0.8em; }
 
 /* Margins */
 body	     { overflow: auto; margin-top: 5px; margin-bottom: 4px; margin-left: 8px; margin-right: 4px; }
-h1           { margin-top: 0.3em; margin-bottom: 0.04em; }	
-h2           { margin-top: 2em; margin-bottom: 0.25em; }
-h3           { margin-top: 1.7em; margin-bottom: 0.25em; }
-h4           { margin-top: 2em; margin-bottom: 0.3em; }
-h5           { margin-top: 0px; margin-bottom: 0px; }
+h1           { margin-top: 1.2em; margin-bottom: 0.5em; }	
+h2           { margin-top: 1.1em; margin-bottom: 0.4em; }
+h3           { margin-top: 1em; margin-bottom: 0.4em;	}
+h4           { margin-top: 0.9em; margin-bottom: 0.5em; }
+h5           { margin-top: 0.8px; margin-bottom: 0.4px; }
+h6			 { margin-top: 0.7em; margin-bottom: 0.3em; }
 p            { margin-top: 1em; margin-bottom: 1em; }
 pre          { margin-left: 0.6em; }
 ul	         { margin-top: 0px; margin-bottom: 1em; margin-left: 1em; padding-left: 1em; }
@@ -30,7 +34,6 @@ a:visited    { text-decoration: underline; }
 a.header:link    { text-decoration: none; color: InfoText }
 a.header:visited { text-decoration: none; color: InfoText }
 a.header:hover   { text-decoration: underline; color: activeHyperlinkColor; } /* get's replaced with actual color */
-h4           { font-style: italic; }
 strong	     { font-weight: bold; }
 em	         { font-style: italic; }
 var	         { font-style: italic; }


### PR DESCRIPTION
Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2629

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<img width="698" height="1298" alt="image" src="https://github.com/user-attachments/assets/a9f2f6e1-7a0a-4f57-a039-f88f3e0e6db7" />

Improve Javadoc and hover rendering for HTML heading tags

## How to test
**Ensure correct handling of the following scenarios**
1. Javadoc hover does not render heading tags properly. The `<h1> to <h6>` elements are shown as plain text or incorrectly formatted in the hover popup.
2. `<h4>` content appears in italics even though no <i> or <em> tags are used. This behavior is seen both in the source Javadoc view and in the hover tooltip.
3. A missing newline after `<h4>`. There should be an additional blank line rendered after an `<h4>` heading for proper visual separation.
4. Inconsistent heading font sizes. The headings `<h4>`, `<h5>`, and `<h6>` currently render with the same font size; they should follow a decreasing size hierarchy consistent with HTML standards.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
