### PR TITLE
React to 3 new warnings after compiler bugfix 

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarPackageData.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/jarpackager/JarPackageData.java
@@ -883,6 +883,7 @@ public class JarPackageData {
 	 *
 	 * @deprecated Use {@link #createJarWriter3(Shell)} instead
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(forRemoval= true, since= "2024-12")
 	public JarWriter2 createJarWriter(Shell parent) throws CoreException {
 		return new JarWriter2(this, parent);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaTextTools.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/JavaTextTools.java
@@ -317,7 +317,8 @@ public class JavaTextTools {
 	 * @return the partition managing position categories or <code>null</code> if there is none
 	 * @deprecated As of 3.0, replaced by {@link org.eclipse.jface.text.TextUtilities#computePartitionManagingCategories(IDocument)}
 	 */
-	@Deprecated
+	@SuppressWarnings("removal")
+	@Deprecated(forRemoval= true, since="2025-12")
 	public String[] getPartitionManagingPositionCategories() {
 		return new String[] { org.eclipse.jface.text.rules.DefaultPartitioner.CONTENT_TYPES_CATEGORY };
 	}


### PR DESCRIPTION
Three new warnings were first reported in https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2626#issuecomment-3511295570 whereas in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4607#issuecomment-3514206792 I explained why this is not a compiler bug but the intended effect of bugfix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4579

The change inserts two new `@SuppressWarnings("removal")` .

Additionally the case of `JavaTextTools.getPartitionManagingPositionCategories()` demonstrates a benefit of the newly reported warning: that method was ordinarily deprecated but uses class `DefaultPartitioner`, which is deprecated for removal. In my understanding this actually requires that "forRemoval" propagates, as to alert clients of this method that it will likely be removed, too, as soon as the referenced class is removed.

@iloveeclipse do you agree to propagating forRemoval in this way? Should it say "since" as of the next release, or reflect the since class of `DefaultPartitioner` (2025-03 see https://github.com/eclipse-platform/eclipse.platform.ui/pull/2735).