### PR TITLE
Enable Javadoc settings when Markdown formatting switched on

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterModifyDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/formatter/FormatterModifyDialog.java
@@ -1624,10 +1624,11 @@ public class FormatterModifyDialog extends ModifyDialog {
 				});
 
 		Preference<?> javadocMaster= section.findChildPreference(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_JAVADOC_COMMENT);
+		Preference<?> markdownMaster= section.findChildPreference(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_MARKDOWN_COMMENT);
 		Preference<?> blockMaster= section.findChildPreference(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_BLOCK_COMMENT);
 		Preference<?> headerMaster= section.findChildPreference(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_HEADER);
 
-		Predicate<String> javadocChecker= v -> DefaultCodeFormatterConstants.TRUE.equals(javadocMaster.getValue()) || DefaultCodeFormatterConstants.TRUE.equals(headerMaster.getValue());
+		Predicate<String> javadocChecker= v -> DefaultCodeFormatterConstants.TRUE.equals(javadocMaster.getValue()) ||  DefaultCodeFormatterConstants.TRUE.equals(markdownMaster.getValue()) || DefaultCodeFormatterConstants.TRUE.equals(headerMaster.getValue());
 		Predicate<String> blockChecker= v -> DefaultCodeFormatterConstants.TRUE.equals(blockMaster.getValue()) || DefaultCodeFormatterConstants.TRUE.equals(headerMaster.getValue());
 
 		List<PreferenceTreeNode<?>> mainItems= section.getChildren();
@@ -1636,6 +1637,7 @@ public class FormatterModifyDialog extends ModifyDialog {
 		Section javadocSection= sectionFinder.apply("-javadocs"); //$NON-NLS-1$
 		for (PreferenceTreeNode<?> pref : javadocSection.getChildren()) {
 			javadocMaster.addDependant(pref, javadocChecker);
+			markdownMaster.addDependant(pref, javadocChecker);
 			headerMaster.addDependant(pref, javadocChecker);
 		}
 		Section blockSection= sectionFinder.apply("-blockcomments"); //$NON-NLS-1$


### PR DESCRIPTION
The Javadoc formatting section was incorrectly disabled when "Enable Classic Javadoc formatting" was unchecked, even if Markdown Javadoc formatting was enabled. Now it remains active when either option is selected.


https://github.com/user-attachments/assets/07af4410-2a7b-4217-8fe6-d456ca57fe82



Fixes : https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2630

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
