### PR TITLE
Fix inconsistent project settings regarding java version

### DIFF
--- a/org.eclipse.jdt.junit.runtime/.classpath
+++ b/org.eclipse.jdt.junit.runtime/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.runtime
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.runtime;singleton:=true
-Bundle-Version: 3.7.700.qualifier
+Bundle-Version: 3.8.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 
@@ -20,4 +20,4 @@ Export-Package:
    org.eclipse.jdt.junit5.runtime,
    org.eclipse.jdt.ui.tests"
 Require-Bundle: org.junit;bundle-version="3.8.2"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.jdt.junit.runtime/build.properties
+++ b/org.eclipse.jdt.junit.runtime/build.properties
@@ -22,3 +22,4 @@ bin.includes = about.html,\
 src.includes = about.html
 jars.extra.classpath = compatibility.jar
 jre.compilation.profile = JavaSE-1.8
+pom.model.property.tycho.useJDK=SYSTEM

--- a/org.eclipse.jdt.junit.runtime/pom.xml
+++ b/org.eclipse.jdt.junit.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit.runtime</artifactId>
-  <version>3.7.700-SNAPSHOT</version>
+  <version>3.8.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit4.runtime/.classpath
+++ b/org.eclipse.jdt.junit4.runtime/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.eclipse.jdt.junit4.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit4.runtime/META-INF/MANIFEST.MF
@@ -4,9 +4,9 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit4.runtime;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit4.runner;x-internal:=true
 Require-Bundle: org.junit;bundle-version="[4.13.0,5.0.0)",
  org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.jdt.junit4.runtime/build.properties
+++ b/org.eclipse.jdt.junit4.runtime/build.properties
@@ -20,3 +20,4 @@ bin.includes = about.html,\
                .,\
                META-INF/
 jre.compilation.profile = JavaSE-1.8
+pom.model.property.tycho.useJDK=SYSTEM

--- a/org.eclipse.jdt.junit4.runtime/pom.xml
+++ b/org.eclipse.jdt.junit4.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit4.runtime</artifactId>
-  <version>1.3.200-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit5.runtime/.classpath
+++ b/org.eclipse.jdt.junit5.runtime/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>

--- a/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit5.runtime;singleton:=true
-Bundle-Version: 1.1.500.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit5.runner;x-internal:=true
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",
@@ -23,4 +23,4 @@ Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",
  junit-platform-suite-engine;bundle-version="[1.14.0,2.0.0)",
  org.apiguardian.api;bundle-version="[1.1.2,2.0.0)",
  org.junit;bundle-version="[4.12.0,5.0.0)"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/org.eclipse.jdt.junit5.runtime/build.properties
+++ b/org.eclipse.jdt.junit5.runtime/build.properties
@@ -20,3 +20,4 @@ bin.includes = about.html,\
                .,\
                META-INF/
 jre.compilation.profile = JavaSE-1.8
+pom.model.property.tycho.useJDK=SYSTEM

--- a/org.eclipse.jdt.junit5.runtime/pom.xml
+++ b/org.eclipse.jdt.junit5.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit5.runtime</artifactId>
-  <version>1.1.500-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>


### PR DESCRIPTION
The org.eclipse.jdt.junit.runtime currently declares a BREE with Java-11 and therefore also gets this as a JRE11 on the classpath, but in the build.properties it declares jre.compilation.profile = JavaSE-1.8 and should actually work to run tests on older JREs as well. Furthermore it has previously declared source/compliance/target level of 1.8 already so it actually was targeted at 1.8

To prevent confusion in an OSGi environment (where it will only resolve for Java 11+) this now fixes the manifest and classpath to align with that as well.

This is a regression from 8fc47ee24e6af110bc194b291586674df7378ac5 where it was claimed to bum the bundle to java 11 but it was not and likely should not unless we support java 1.8 in JDT.

FYI @trancexpress @iloveeclipse 