### PR TITLE
Revert "More refactoring of LocalCorrectionsSubProcessor methods (#26…

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -45,6 +45,7 @@ import org.eclipse.ui.part.FileEditorInput;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
@@ -76,7 +77,10 @@ import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.ParenthesizedExpression;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.ProvidesDirective;
 import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
@@ -84,6 +88,7 @@ import org.eclipse.jdt.core.dom.Statement;
 import org.eclipse.jdt.core.dom.StructuralPropertyDescriptor;
 import org.eclipse.jdt.core.dom.SwitchCase;
 import org.eclipse.jdt.core.dom.SwitchStatement;
+import org.eclipse.jdt.core.dom.ThrowStatement;
 import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
@@ -109,6 +114,7 @@ import org.eclipse.jdt.internal.corext.fix.IProposableFix;
 import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
 import org.eclipse.jdt.internal.corext.refactoring.structure.ASTNodeSearchUtil;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.refactoring.util.TightSourceRangeComputer;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.JavaElementImageDescriptor;
@@ -144,8 +150,6 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.CreateVariableRefer
 import org.eclipse.jdt.internal.ui.text.correction.proposals.CreateVariableReferenceProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposalCore;
-import org.eclipse.jdt.internal.ui.text.correction.proposals.GenerateForLoopAssistProposal;
-import org.eclipse.jdt.internal.ui.text.correction.proposals.GenerateForLoopAssistProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.LinkedCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.LinkedCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.LinkedNamesAssistProposal;
@@ -159,7 +163,6 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.NewLocalVariableCor
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewMethodCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewMethodCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewProviderMethodDeclaration;
-import org.eclipse.jdt.internal.ui.text.correction.proposals.NewProviderMethodDeclarationCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewVariableCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewVariableCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.RefactoringCorrectionProposal;
@@ -588,7 +591,77 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 	}
 
 	public static void getUnusedObjectAllocationProposals(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
-		new LocalCorrectionsSubProcessor().getUnusedObjectAllocationProposalsBase(context, problem, proposals);
+		CompilationUnit root= context.getASTRoot();
+		AST ast= root.getAST();
+		ASTNode selectedNode= problem.getCoveringNode(root);
+		if (selectedNode == null) {
+			return;
+		}
+
+		ASTNode parent= selectedNode.getParent();
+
+		if (parent instanceof ExpressionStatement) {
+			ExpressionStatement expressionStatement= (ExpressionStatement) parent;
+			Expression expr= expressionStatement.getExpression();
+			ITypeBinding exprType= expr.resolveTypeBinding();
+
+			if (exprType != null && Bindings.isSuperType(ast.resolveWellKnownType("java.lang.Throwable"), exprType)) { //$NON-NLS-1$
+				ASTRewrite rewrite= ASTRewrite.create(ast);
+				TightSourceRangeComputer sourceRangeComputer= new TightSourceRangeComputer();
+				rewrite.setTargetSourceRangeComputer(sourceRangeComputer);
+
+				ThrowStatement throwStatement= ast.newThrowStatement();
+				throwStatement.setExpression((Expression) rewrite.createMoveTarget(expr));
+				sourceRangeComputer.addTightSourceNode(expressionStatement);
+				rewrite.replace(expressionStatement, throwStatement, null);
+
+				String label= CorrectionMessages.LocalCorrectionsSubProcessor_throw_allocated_description;
+				Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
+				LinkedCorrectionProposal proposal= new LinkedCorrectionProposal(label, context.getCompilationUnit(), rewrite, IProposalRelevance.THROW_ALLOCATED_OBJECT, image);
+				proposal.setEndPosition(rewrite.track(throwStatement));
+				proposals.add(proposal);
+			}
+
+			MethodDeclaration method= ASTResolving.findParentMethodDeclaration(selectedNode);
+			if (method != null && !method.isConstructor()) {
+				ASTRewrite rewrite= ASTRewrite.create(ast);
+				TightSourceRangeComputer sourceRangeComputer= new TightSourceRangeComputer();
+				rewrite.setTargetSourceRangeComputer(sourceRangeComputer);
+
+				ReturnStatement returnStatement= ast.newReturnStatement();
+				returnStatement.setExpression((Expression) rewrite.createMoveTarget(expr));
+				sourceRangeComputer.addTightSourceNode(expressionStatement);
+				rewrite.replace(expressionStatement, returnStatement, null);
+
+				String label= CorrectionMessages.LocalCorrectionsSubProcessor_return_allocated_description;
+				Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
+				int relevance;
+				ITypeBinding returnTypeBinding= method.getReturnType2().resolveBinding();
+				if (returnTypeBinding != null && exprType != null && exprType.isAssignmentCompatible(returnTypeBinding)) {
+					relevance= IProposalRelevance.RETURN_ALLOCATED_OBJECT_MATCH;
+				} else if (method.getReturnType2() instanceof PrimitiveType
+						&& ((PrimitiveType) method.getReturnType2()).getPrimitiveTypeCode() == PrimitiveType.VOID) {
+					relevance= IProposalRelevance.RETURN_ALLOCATED_OBJECT_VOID;
+				} else {
+					relevance= IProposalRelevance.RETURN_ALLOCATED_OBJECT;
+				}
+				LinkedCorrectionProposal proposal= new LinkedCorrectionProposal(label, context.getCompilationUnit(), rewrite, relevance, image);
+				proposal.setEndPosition(rewrite.track(returnStatement));
+				proposals.add(proposal);
+			}
+
+			{
+				ASTRewrite rewrite= ASTRewrite.create(ast);
+				rewrite.remove(parent, null);
+
+				String label= CorrectionMessages.LocalCorrectionsSubProcessor_remove_allocated_description;
+				Image image= ISharedImages.get().getImage(ISharedImages.IMG_TOOL_DELETE);
+				ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, context.getCompilationUnit(), rewrite, IProposalRelevance.REMOVE_UNUSED_ALLOCATED_OBJECT, image);
+				proposals.add(proposal);
+			}
+
+		}
+		getAssignToVariableProposals(context, selectedNode, null, proposals);
 	}
 
 	public static boolean getAssignToVariableProposals(IInvocationContext context, ASTNode node, IProblemLocation[] locations, Collection<ICommandAccess> resultingCollections) {
@@ -907,12 +980,8 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 	public static void getGenerateForLoopProposals(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
 		ASTNode coveringNode= problem.getCoveringNode(context.getASTRoot());
 		if (coveringNode != null) {
-			getGenerateForLoopProposals(context, coveringNode, null, proposals);
+			QuickAssistProcessor.getGenerateForLoopProposals(context, coveringNode, null, proposals);
 		}
-	}
-
-	public static boolean getGenerateForLoopProposals(IInvocationContext context, ASTNode coveringNode, IProblemLocation[] problems, Collection<ICommandAccess> proposals) {
-		return new LocalCorrectionsSubProcessor().getGenerateForLoopProposalsBase(context, coveringNode, problems, proposals);
 	}
 
 	public static void getTryWithResourceProposals(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
@@ -932,7 +1001,26 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 	}
 
 	public static void addServiceProviderProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) throws CoreException {
-		new LocalCorrectionsSubProcessor().getServiceProviderProposal(context, problem, proposals);
+		ASTNode node= problem.getCoveredNode(context.getASTRoot());
+		if (!(node instanceof Name) || !(node.getParent() instanceof ProvidesDirective)) {
+			return;
+		}
+
+		Name name= (Name) node;
+		ProvidesDirective prov= (ProvidesDirective) name.getParent();
+		ITypeBinding targetBinding= name.resolveTypeBinding();
+		ITypeBinding serviceBinding= prov.getName().resolveTypeBinding();
+		if (targetBinding != null && serviceBinding != null) {
+			ICompilationUnit targetCU= ASTResolving.findCompilationUnitForBinding(context.getCompilationUnit(), context.getASTRoot(), targetBinding);
+
+			IJavaProject proj= context.getCompilationUnit().getJavaProject();
+			IType type= proj.findType(serviceBinding.getQualifiedName());
+			Image image= JavaPluginImages.get(JavaPluginImages.IMG_MISC_PUBLIC);
+			proposals.add(new NewProviderMethodDeclaration(
+					Messages.format(CorrectionMessages.LocalCorrectionsSubProcessor_add_provider_method_description, type.getElementName()),
+					targetCU, context.getASTRoot(), targetBinding,
+					IProposalRelevance.CREATE_METHOD, image, type));
+		}
 	}
 
 	public static void addServiceProviderConstructorProposals(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) throws CoreException {
@@ -953,7 +1041,7 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 		Image image= JavaPluginImages.get(JavaPluginImages.IMG_OBJS_EXCEPTION);
 		switch (uid) {
 			case INITIALIZE_VARIABLE, RETURN_ALLOCATED_OBJECT, ADD_MISSING_CASE,
-				CREATE_DEFAULT, ADD_PERMITTED_TYPES, CORRECTION_CHANGE_ID -> {
+				CREATE_DEFAULT, ADD_PERMITTED_TYPES -> {
 				image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
 			}
 			case ADD_OVERRIDE -> {
@@ -1020,7 +1108,7 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 	protected ICommandAccess astRewriteCorrectionProposalToT(ASTRewriteCorrectionProposalCore core, int uid) {
 		Image image= ISharedImages.get().getImage(ISharedImages.IMG_TOOL_DELETE);
 		switch (uid) {
-			case REMOVE_REDUNDANT_SUPERINTERFACE, REMOVE_PROPOSAL, DELETE_ID -> {
+			case REMOVE_REDUNDANT_SUPERINTERFACE, REMOVE_PROPOSAL -> {
 				image= ISharedImages.get().getImage(ISharedImages.IMG_TOOL_DELETE);
 			}
 			case INVALID_OPERATOR -> {
@@ -1108,21 +1196,5 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 			}
 		}
 		return new ModifierChangeCorrectionProposal(core, image);
-	}
-
-	@Override
-	protected ICommandAccess newProviderMethodDeclarationProposalToT(NewProviderMethodDeclarationCore core, int uid) {
-		Image image= JavaPluginImages.get(JavaPluginImages.IMG_MISC_PUBLIC);
-		switch (uid) {
-			case MISC_PUBLIC_ID -> {
-				image= JavaPluginImages.get(JavaPluginImages.IMG_MISC_PUBLIC);
-			}
-		}
-		return new NewProviderMethodDeclaration(core, image);
-	}
-
-	@Override
-	protected ICommandAccess generateForLoopAssistProposalToT(GenerateForLoopAssistProposalCore core) {
-		return new GenerateForLoopAssistProposal(core);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/GenerateForLoopAssistProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/GenerateForLoopAssistProposal.java
@@ -50,14 +50,4 @@ public class GenerateForLoopAssistProposal extends LinkedCorrectionProposal {
 		super("", cu, null, IProposalRelevance.GENERATE_FOR_LOOP, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE), //$NON-NLS-1$
 				new GenerateForLoopAssistProposalCore(cu, currentStatement, loopTypeToGenerate));
 	}
-
-	/**
-	 * Creates an instance of a {@link GenerateForLoopAssistProposal}.
-	 *
-	 * @param core the instance of GenerateForLoopAssistProposalCore
-	 */
-	public GenerateForLoopAssistProposal(GenerateForLoopAssistProposalCore core) {
-		super("", core.getCompilationUnit(), null, IProposalRelevance.GENERATE_FOR_LOOP, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE), //$NON-NLS-1$
-				core);
-	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewProviderMethodDeclaration.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewProviderMethodDeclaration.java
@@ -55,11 +55,6 @@ public class NewProviderMethodDeclaration extends AbstractMethodCorrectionPropos
 		this.fReturnType= returnType;
 	}
 
-	public NewProviderMethodDeclaration(NewProviderMethodDeclarationCore core, Image image) {
-		super(core.getName(), core.getCompilationUnit(), core.getRelevance(), image, core);
-		this.fReturnType= core.getReturnType();
-	}
-
 	@Override
 	protected void performChange(IEditorPart part, IDocument document) throws CoreException {
 		// Should this really be done in the UI api call and not in the core API call?

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewProviderMethodDeclarationCore.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/NewProviderMethodDeclarationCore.java
@@ -32,10 +32,6 @@ public class NewProviderMethodDeclarationCore extends AbstractMethodCorrectionPr
 		return false;
 	}
 
-	public IType getReturnType() {
-		return this.fReturnType;
-	}
-
 	@Override
 	protected void addNewModifiers(ASTRewrite rewrite, ASTNode targetTypeDecl, List<IExtendedModifier> modifiers) {
 		modifiers.addAll(rewrite.getAST().newModifiers(Modifier.PUBLIC | Modifier.STATIC));


### PR DESCRIPTION
…42)"

This reverts commit 0460f877d653cb0c0060194590e894a729777a6f.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Reverts patch that was meant for M3 but was too late and can wait until 4.39 M1.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Regular testing.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
