### PR TITLE
Fix add import module clean-up to not omit parameterized types

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ModuleImportsCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ModuleImportsCleanUpCore.java
@@ -194,6 +194,9 @@ public class ModuleImportsCleanUpCore extends AbstractCleanUp {
 							node.getParent().getNodeType() != ASTNode.NAME_QUALIFIED_TYPE) {
 						IBinding binding= node.resolveBinding();
 						if (binding instanceof ITypeBinding typeBinding) {
+							if (typeBinding.isParameterizedType()) {
+								typeBinding= typeBinding.getTypeDeclaration();
+							}
 							if (findTypeInModules(typeBinding) == ModuleTypeStatus.NOT_FOUND) {
 								IPackageBinding pkgBinding= typeBinding.getPackage();
 								if (pkgBinding != null

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest25.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest25.java
@@ -463,4 +463,72 @@ public class CleanUpTest25 extends CleanUpTestCase {
 		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
 	}
 
+	@Test
+	public void testAddModuleCleanUp6() throws Exception {
+		IPackageFragment defaultPkg= fSourceFolder.createPackageFragment("", false, null);
+		String moduleInfo= """
+				module module1 {
+					requires java.base;
+				}
+				""";
+		defaultPkg.createCompilationUnit("module-info.java", moduleInfo, false, null);
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			// header comment
+			import java.math.BigInteger;
+			import java.util.List;
+			import java.util.ArrayList;
+			import java.util.Map;
+			// header comment 2
+			import static java.lang.Math.*; // comment
+
+			public class E {
+
+				List<String> list;
+				ArrayList<String> list2;
+				Map<String, String> map;
+				BigInteger b;
+
+				public void foo() {
+					sqrt(1.0);
+					abs(6.4);
+					pow(2,2);
+				}
+
+			}
+			""";
+		ICompilationUnit cu1= pack1.createCompilationUnit("E.java", sample, false, null);
+
+		enable(CleanUpConstants.USE_MODULE_IMPORTS);
+
+		sample= """
+			package test1;
+
+			// header comment 2
+			import static java.lang.Math.*; // comment
+
+			import module java.base;
+
+			public class E {
+
+				List<String> list;
+				ArrayList<String> list2;
+				Map<String, String> map;
+				BigInteger b;
+
+				public void foo() {
+					sqrt(1.0);
+					abs(6.4);
+					pow(2,2);
+				}
+
+			}
+			""";
+		String expected1= sample;
+
+		assertRefactoringResultAsExpected(new ICompilationUnit[] { cu1 }, new String[] { expected1 }, null);
+	}
+
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
