### PR TITLE
Fix possible error because writes is null

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/VariableDeclarationFixCore.java
@@ -401,7 +401,9 @@ public class VariableDeclarationFixCore extends CompilationUnitRewriteOperations
 		}
 
 		private boolean isWrittenInTypeConstructors(List<Name> writes, ITypeBinding declaringClass) {
-
+			if (writes == null) {
+				return false;
+			}
 			for (Name name : writes) {
 	            MethodDeclaration methodDeclaration= getWritingConstructor(name);
 	            if (methodDeclaration == null)


### PR DESCRIPTION
- add null check in isWrittenTypeConstructor() method in VariableDeclarationFixCore.VariableDeclarationFinder
- fixes #2661

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
