### PR TITLE
Ignore JUnit version parsing problems when trying to determine JUnit 5/6 version

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.junit.JUnitCore;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IClassFile;
@@ -175,9 +176,14 @@ public class CoreTestSearchEngine {
 					String filename= type.getPath().lastSegment();
 					if ((filename.startsWith(junitBundlePrefix + "_") || filename.startsWith(junitBundlePrefix + "-")) && filename.endsWith(JAR_EXTENSION)) { //$NON-NLS-1$ //$NON-NLS-2$
 						String versionString = filename.substring(junitBundlePrefix.length() + 1, filename.length() - JAR_EXTENSION.length());
-						Version version = new Version(versionString);
-						if (version.getMajor() != junitMajorVersion) {
-							return false;
+						try {
+							Version version = Version.parseVersion(versionString);
+							if (version.getMajor() != junitMajorVersion) {
+								return false;
+							}
+						} catch (IllegalArgumentException e) {
+							// Some JUnit distributions use different naming, ignore those. See: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2665
+							JUnitCorePlugin.log(Status.error("Failed to parse determine JUnit version: " + filename, e)); //$NON-NLS-1$
 						}
 					}
 					// @Testable/@Suite annotations are not accessible if the JUnit classpath container is set to JUnit 3 or JUnit 4


### PR DESCRIPTION
Fixes: #2665

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
