### PR TITLE
Add additional null check to generated equals() method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -829,13 +829,13 @@ public final class GenerateHashCodeEqualsOperation implements IWorkspaceRunnable
 		body.statements().add(
 				createReturningIfStatement(fAst.newThisExpression(), fAst.newSimpleName(VARIABLE_NAME_EQUALS_PARAM), Operator.EQUALS, true));
 
-		if (needsNoSuperCall(fType, METHODNAME_EQUALS, new ITypeBinding[] {fAst.resolveWellKnownType(JAVA_LANG_OBJECT)})) {
-			if (!fUseInstanceOf) {
-				// if (obj == null) return false;
-				body.statements().add(
-						createReturningIfStatement(fAst.newSimpleName(VARIABLE_NAME_EQUALS_PARAM), fAst.newNullLiteral(), Operator.EQUALS, false));
-			}
-		} else {
+		if (!fUseInstanceOf) {
+			// if (obj == null) return false;
+			body.statements().add(
+					createReturningIfStatement(fAst.newSimpleName(VARIABLE_NAME_EQUALS_PARAM), fAst.newNullLiteral(), Operator.EQUALS, false));
+		}
+
+		if (!needsNoSuperCall(fType, METHODNAME_EQUALS, new ITypeBinding[] {fAst.resolveWellKnownType(JAVA_LANG_OBJECT)})) {
 			// if (!super.equals(obj)) return false;
 			SuperMethodInvocation superEqualsCall= fAst.newSuperMethodInvocation();
 			superEqualsCall.setName(fAst.newSimpleName(METHODNAME_EQUALS));

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateHashCodeEqualsTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateHashCodeEqualsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1886,6 +1886,8 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 				"	public boolean equals(Object obj) {\r\n" +
 				"		if (this == obj)\r\n" +
 				"			return true;\r\n" +
+				"		if (obj == null)\r\n" +
+				"			return false;\r\n" +
 				"		if (!super.equals(obj))\r\n" +
 				"			return false;\r\n" +
 				"		if (getClass() != obj.getClass())\r\n" +
@@ -1954,6 +1956,8 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 				"	public boolean equals(Object obj) {\r\n" +
 				"		if (this == obj)\r\n" +
 				"			return true;\r\n" +
+				"		if (obj == null)\r\n" +
+				"			return false;\r\n" +
 				"		if (!super.equals(obj))\r\n" +
 				"			return false;\r\n" +
 				"		if (getClass() != obj.getClass())\r\n" +
@@ -2051,6 +2055,8 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 				"	public boolean equals(Object obj) {\r\n" +
 				"		if (this == obj)\r\n" +
 				"			return true;\r\n" +
+				"		if (obj == null)\r\n" +
+				"			return false;\r\n" +
 				"		if (!super.equals(obj))\r\n" +
 				"			return false;\r\n" +
 				"		if (getClass() != obj.getClass())\r\n" +
@@ -2336,6 +2342,8 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 						public boolean equals(Object obj) {
 							if (this == obj)
 								return true;
+							if (obj == null)
+								return false;
 							if (!super.equals(obj))
 								return false;
 							if (getClass() != obj.getClass())


### PR DESCRIPTION
- prevent null check warnings for generated equals() method that uses super.equals() to test the input object
- fixes #2683

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or modified tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
