### PR TITLE
Improve Quick Fix Hover to not hide Javadoc Hover

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaHoverMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaHoverMessages.java
@@ -31,6 +31,7 @@ public final class JavaHoverMessages extends NLS {
 	public static String AbstractAnnotationHover_message_singleQuickFix;
 	public static String AbstractAnnotationHover_message_multipleQuickFix;
 	public static String AbstractAnnotationHover_multifix_variable_description;
+	public static String JavaTextHover_Javadoc_Proposal;
 
 	public static String JavadocHover_back;
 	public static String JavadocHover_back_toElement_toolTip;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaHoverMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavaHoverMessages.properties
@@ -17,6 +17,7 @@ AbstractAnnotationHover_message_singleQuickFix= 1 quick fix available:
 AbstractAnnotationHover_message_multipleQuickFix= {0} quick fixes available:
 AbstractAnnotationHover_multifix_variable_description=Fix {0} problems of same category in file
 JavaTextHover_createTextHover= Could not create Java text hover
+JavaTextHover_Javadoc_Proposal= Show Javadoc
 
 NoBreakpointAnnotation_addBreakpoint= Add a breakpoint
 


### PR DESCRIPTION
Quick Fix Hover blocks the Java Doc Hover for the Java Element. It makes it difficult to choose right quick fix without knowing about the Java Element. So we create a Java Doc Hover when user hovers on Quick Fix Hover.

see https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2673
