### PR TITLE
Allow highlighting instructions in ClassFileEditor

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -34,6 +34,7 @@ import org.eclipse.jdt.ui.tests.callhierarchy.CallHierarchyContentProviderTest;
 import org.eclipse.jdt.ui.tests.core.CoreTestSuite;
 import org.eclipse.jdt.ui.tests.core.CoreTests;
 import org.eclipse.jdt.ui.tests.dialogs.FilteredTypesSelectionDialogTests;
+import org.eclipse.jdt.ui.tests.editor.ClassFileEditorTests;
 import org.eclipse.jdt.ui.tests.editor.ClassFileInputTests;
 import org.eclipse.jdt.ui.tests.editor.MarkdownTypingTest;
 import org.eclipse.jdt.ui.tests.hover.JavadocHoverTests;
@@ -92,6 +93,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 	MarkdownCommentTests.class,
 	SmokeViewsTest.class,
 	ClassFileInputTests.class,
+	ClassFileEditorTests.class,
 	FilteredTypesSelectionDialogTests.class,
 	MarkdownTypingTest.class
 })

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/ClassFileEditorTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/ClassFileEditorTests.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2026, Daniel Schmid and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Daniel Schmid - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.editor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.custom.StyledTextContent;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.javaeditor.ClassFileEditor;
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
+import org.eclipse.jdt.internal.ui.util.CoreUtility;
+
+public class ClassFileEditorTests {
+	private static final String TYPE_NAME= "HelloWorld";
+
+	private IJavaProject javaProject;
+	private boolean wasAutoBuilding;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		javaProject = setUpProject();
+
+		wasAutoBuilding = CoreUtility.setAutoBuilding(false);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		JavaPlugin.getActivePage().closeAllEditors(false);
+		if (javaProject != null) {
+			JavaProjectHelper.delete(javaProject);
+		}
+		CoreUtility.setAutoBuilding(wasAutoBuilding);
+	}
+
+	private IJavaProject setUpProject() throws Exception {
+		javaProject= JavaProjectHelper.createJavaProject(ClassFileEditorTests.class.getSimpleName(), "bin");
+		JavaProjectHelper.addSourceContainer(javaProject, "src");
+		JavaProjectHelper.addRTJar(javaProject);
+		return javaProject;
+	}
+
+	@Test
+	void testHighlightRange() throws CoreException {
+		createHelloWorldClass();
+		ClassFileEditor classEditor= createClassFileEditor(TYPE_NAME);
+		classEditor.highlightInstruction("main", "([Ljava/lang/String;)V", 5);
+		assertEquals("    5  invokevirtual java.io.PrintStream.println(java.lang.String) : void [24]", getSingleHighlightedRange(classEditor));
+	}
+
+	@Test
+	void testHighlightInConstructor() throws CoreException {
+		createHelloWorldClass();
+		ClassFileEditor classEditor= createClassFileEditor(TYPE_NAME);
+		classEditor.highlightInstruction(TYPE_NAME, "()V", 1);
+		assertEquals("    1  invokespecial java.lang.Object() [8]", getSingleHighlightedRange(classEditor));
+	}
+
+	@Test
+	void testChangeHighlightRange() throws CoreException {
+		createHelloWorldClass();
+		ClassFileEditor classEditor= createClassFileEditor(TYPE_NAME);
+		classEditor.highlightInstruction("main", "([Ljava/lang/String;)V", 5);
+		classEditor.highlightInstruction("main", "([Ljava/lang/String;)V", 0);
+		assertEquals("    0  getstatic java.lang.System.out : java.io.PrintStream [16]", getSingleHighlightedRange(classEditor));
+	}
+
+	@Test
+	void testUnhighlight() throws CoreException {
+		createHelloWorldClass();
+		ClassFileEditor classEditor= createClassFileEditor(TYPE_NAME);
+		classEditor.highlightInstruction("main", "([Ljava/lang/String;)V", 5);
+		StyledText noSourceTextWidget= classEditor.getNoSourceTextWidget();
+		assertEquals(1, noSourceTextWidget.getStyleRanges().length);
+		classEditor.unhighlight();
+		assertEquals(0, noSourceTextWidget.getStyleRanges().length);
+	}
+
+	@Test
+	void testHighlightNonexistentCodeIndex() throws CoreException {
+		createHelloWorldClass();
+		ClassFileEditor classEditor= createClassFileEditor(TYPE_NAME);
+		classEditor.highlightInstruction("main", "([Ljava/lang/String;)V", 100);
+		StyledText noSourceTextWidget= classEditor.getNoSourceTextWidget();
+		assertEquals(0, noSourceTextWidget.getStyleRanges().length);
+	}
+
+	@Test
+	void testHighlightNonexistentMethod() throws CoreException {
+		createHelloWorldClass();
+		ClassFileEditor classEditor= createClassFileEditor(TYPE_NAME);
+		classEditor.highlightInstruction("main", "a", 5);
+		assertEquals(0, classEditor.getNoSourceTextWidget().getStyleRanges().length);
+	}
+
+	@Test
+	void testHighlightMultipleCompilationUnits() throws CoreException {
+		createClassFromSource("A.java", """
+				public class A {
+					void a() {
+						System.out.println("a");
+					}
+				}
+				class B {
+					void b() {
+						System.out.println("b");
+					}
+				}
+				""");
+		ClassFileEditor classEditor= createClassFileEditor("A");
+		classEditor.highlightInstruction("a", "()V", 3);
+		assertEquals("    3  ldc <String \"a\"> [21]", getSingleHighlightedRange(classEditor));
+
+		classEditor= createClassFileEditor("B");
+		classEditor.highlightInstruction("b", "()V", 3);
+		assertEquals("    3  ldc <String \"b\"> [21]", getSingleHighlightedRange(classEditor));
+
+	}
+
+	private String getSingleHighlightedRange(ClassFileEditor classEditor) {
+		StyledText noSourceTextWidget= classEditor.getNoSourceTextWidget();
+		StyleRange[] ranges= noSourceTextWidget.getStyleRanges();
+		assertEquals(1, ranges.length);
+		StyledTextContent content= noSourceTextWidget.getContent();
+		StyleRange range= ranges[0];
+		return content.getTextRange(range.start, range.length);
+	}
+
+	private void createHelloWorldClass() throws CoreException {
+		createClassFromSource(TYPE_NAME + ".java", """
+			public class HelloWorld {
+				public static void main(String[] args) {
+					System.out.println("Hello World");
+				}
+			}
+		""");
+	}
+
+	private void createClassFromSource(String fileName, String content) throws CoreException {
+		IPackageFragment fragment= javaProject.findPackageFragment(javaProject.getProject().getFullPath().append("src"));
+		fragment.createCompilationUnit(fileName, content, true, new NullProgressMonitor());
+		javaProject.getProject().build(IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+		javaProject.getProject().getFile("src/" + fileName).delete(true,new NullProgressMonitor());
+	}
+
+	private ClassFileEditor createClassFileEditor(String typeName) throws CoreException {
+		ClassFileEditor editor= (ClassFileEditor) EditorUtility.openInEditor(javaProject.getProject().getFile("bin/" + typeName + ".class"));
+		assertFalse(editor.isEditable());
+		return editor;
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/IUIConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/IUIConstants.java
@@ -30,4 +30,7 @@ public interface IUIConstants {
 
 	String DIALOGSTORE_TYPECOMMENT_DEPRECATED= JavaUI.ID_PLUGIN + ".typecomment.deprecated";	 //$NON-NLS-1$
 
+	// The preference is defined in the org.eclipse.debug.ui plugin.xml file
+	String INSTRUCTION_POINTER_COLOR_PREFERENCE_KEY= "currentIPColor"; //$NON-NLS-1$
+
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,11 +16,20 @@ package org.eclipse.jdt.internal.ui.javaeditor;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.osgi.util.NLS;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StackLayout;
+import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.custom.StyledTextContent;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
@@ -54,6 +63,7 @@ import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 
 import org.eclipse.jface.text.IWidgetTokenKeeper;
+import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.source.IOverviewRuler;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.IVerticalRuler;
@@ -104,6 +114,7 @@ import org.eclipse.jdt.ui.actions.IJavaEditorActionDefinitionIds;
 import org.eclipse.jdt.ui.actions.RefactorActionGroup;
 import org.eclipse.jdt.ui.wizards.BuildPathDialogAccess;
 
+import org.eclipse.jdt.internal.ui.IUIConstants;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaUIStatus;
 import org.eclipse.jdt.internal.ui.actions.CompositeActionGroup;
@@ -488,6 +499,8 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 				JavaPlugin.log(ex);
 			}
 			styledText.setText(content == null ? "" : content); //$NON-NLS-1$
+			unhighlight();
+			methodsToInstructionRegions = null;
 		}
 	}
 
@@ -557,6 +570,9 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 		}
 	}
 
+	private record MethodIdentifier(String name, String signature) {}
+	private record LineRegion(int startLine, int endLine) {}
+
 	private StackLayout fStackLayout;
 	private Composite fParent;
 
@@ -585,7 +601,10 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 	 * @since 3.3
 	 */
 	private StyledText fNoSourceTextWidget;
+	private StyleRange currentSelection;
 	private volatile boolean disposed;
+	private Color instructionPointerColor = new Color(0, 255, 0);
+	private Map<MethodIdentifier, LineRegion> methodsToInstructionRegions;
 
 	/**
 	 * Default constructor.
@@ -736,6 +755,7 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 	@Override
 	public void init(IEditorSite site, IEditorInput input) throws PartInitException {
 		JavaCore.runReadOnly(() -> super.init(site, input));
+		initInstructionPointerColor();
 	}
 	/*
 	 * @see AbstractTextEditor#doSetInput(IEditorInput)
@@ -964,6 +984,115 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 		}
 	}
 
+	/**
+	 * Clears the highlighting created by {@link #highlightInstruction(String, String, long)}
+	 */
+	public void unhighlight() {
+		if (disposed || fNoSourceTextWidget == null || fNoSourceTextWidget.isDisposed()) {
+			return;
+		}
+		if (currentSelection != null) {
+			fNoSourceTextWidget.replaceStyleRanges(currentSelection.start, currentSelection.length, new StyleRange[0]);
+			currentSelection= null;
+		}
+	}
+
+	/**
+	 * Highlights a specific bytecode instruction in the disassembly.
+	 *
+	 * This is used by JDT.debug to highlight the current instruction pointer.
+	 * @param methodName the name of the method containing the highlighting.
+	 * @param signature The bytecode signature of the method, e.g. ()V for void methods with no parameters
+	 * @param codeIndex the "code index" identifying the bytcode instruction to highlight
+	 */
+	public void highlightInstruction(String methodName, String signature, long codeIndex) {
+		if (disposed || fNoSourceTextWidget == null || fNoSourceTextWidget.isDisposed()) {
+			return;
+		}
+		unhighlight();
+		StyledTextContent content= fNoSourceTextWidget.getContent();
+
+		LineRegion methodBounds= getMethodsToInstructionRegionCache().get(new MethodIdentifier(methodName, signature));
+		if (methodBounds == null) {
+			return;
+		}
+		Region instructionPosition= findInstruction(methodBounds, content, codeIndex);
+		if (instructionPosition == null) {
+			return;
+		}
+		currentSelection= new StyleRange(instructionPosition.getOffset(), instructionPosition.getLength(), fNoSourceTextWidget.getForeground(), instructionPointerColor);
+		fNoSourceTextWidget.setStyleRange(currentSelection);
+
+		// move cursor to ensure scrolling
+		fNoSourceTextWidget.setSelection(instructionPosition.getOffset());
+	}
+
+	private Map<MethodIdentifier, LineRegion> getMethodsToInstructionRegionCache() {
+		return methodsToInstructionRegions = Objects.requireNonNullElseGet(methodsToInstructionRegions, this::createCache);
+	}
+
+	private Map<MethodIdentifier, LineRegion> createCache() {
+		String message = NLS.bind(org.eclipse.jdt.internal.core.util.Messages.classfileformat_methoddescriptor, "\\d+", "(.+)");  //$NON-NLS-1$//$NON-NLS-2$
+		Pattern methodDescriptorPattern = Pattern.compile("^\\s+" + message + "$"); //$NON-NLS-1$ //$NON-NLS-2$
+		StyledTextContent content= fNoSourceTextWidget.getContent();
+		Map<MethodIdentifier, LineRegion> cache = new HashMap<>();
+		for(int currentLine = 0; currentLine < content.getLineCount(); currentLine++) {
+			String line= content.getLine(currentLine);
+			Matcher descriptorMatcher= methodDescriptorPattern.matcher(line);
+			if (descriptorMatcher.matches()) {
+				String methodSignature = descriptorMatcher.group(1);
+				for(; currentLine < content.getLineCount(); currentLine++) {
+					// skip lines with leading slashes
+					line = content.getLine(currentLine);
+					if (!line.trim().startsWith("//")) { //$NON-NLS-1$
+						break;
+					}
+				}
+
+				int methodNameEnd = line.indexOf('(');
+				int methodNameStart = line.lastIndexOf(' ', methodNameEnd);
+				if (methodNameStart != -1) {
+					String methodName= line.substring(methodNameStart + 1, methodNameEnd);
+					int indentation = getIndentation(line);
+					int startLine = ++currentLine;
+					for(; currentLine < content.getLineCount() && getIndentation(content.getLine(currentLine)) > indentation; currentLine++) {
+						// find end of method
+					}
+					int endLine = currentLine;
+					cache.put(new MethodIdentifier(methodName, methodSignature), new LineRegion(startLine, endLine));
+				}
+			}
+		}
+		return cache;
+	}
+
+	private int getIndentation(String line) {
+		return line.length() - line.stripLeading().length();
+	}
+
+	private Region findInstruction(LineRegion methodBounds, StyledTextContent content, long codeIndex) {
+		for(int currentLine = methodBounds.startLine(); currentLine < methodBounds.endLine(); currentLine++) {
+			String line= content.getLine(currentLine);
+			if (line.trim().startsWith(codeIndex + " ")) { //$NON-NLS-1$
+				return new Region(content.getOffsetAtLine(currentLine), line.length());
+			}
+		}
+		return null;
+	}
+
+	private void initInstructionPointerColor() {
+		String color= getPreferenceStore().getString(IUIConstants.INSTRUCTION_POINTER_COLOR_PREFERENCE_KEY);
+		String[] splitColor = color.split(","); //$NON-NLS-1$
+		if (splitColor.length != 3) {
+			return;
+		}
+		try {
+			instructionPointerColor = new Color(Integer.parseInt(splitColor[0]), Integer.parseInt(splitColor[1]), Integer.parseInt(splitColor[2]));
+		} catch (NumberFormatException e) {
+			// use default color
+		}
+	}
+
 	/*
 	 * @see ClassFileDocumentProvider.InputChangeListener#inputChanged(IClassFileEditorInput)
 	 */
@@ -1031,5 +1160,12 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 		if (fSourceAttachmentForm != null && !fSourceAttachmentForm.isDisposed()) {
 			fSourceAttachmentForm.setFocus();
 		}
+	}
+
+	/*
+	 * Used for testing.
+	 */
+	public StyledText getNoSourceTextWidget() {
+		return fNoSourceTextWidget;
 	}
 }


### PR DESCRIPTION
## What it does

This PR allows selecting/highlighting instructions in the class file editor using:
- method name
- method signature
- code index (position in the method which is displayed at the beginning of a class file)

This is used to view the current instruction pointer when debugging class files without attached sources (the debugging part is implemented in https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/831.

<img width="2160" height="1440" alt="image" src="https://github.com/user-attachments/assets/1b7c98b1-34f8-417f-8495-0ca112bf8fb1" />
<img width="2160" height="1440" alt="image" src="https://github.com/user-attachments/assets/38b942c4-c387-4d8d-be33-525f03c1e4a1" />

video:

[Screencast_20260402_144851.webm](https://github.com/user-attachments/assets/bab13353-315d-4818-93f8-05d8247097b1)



Ideally, this would be done without needing to "parse"/search through the disassembly text but I don't think there is a good way to do that

## How to test
See https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/831

## Author checklist

- [x] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
