### PR TITLE
Fix regression on very fast test execution

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
@@ -329,16 +329,6 @@ public class RemoteTestRunnerClient {
 		if (fServerSocket != null  && ! fServerSocket.isClosed() && fSocket == null) {
 			shutDown(); // will throw a SocketException in Threads that wait in ServerSocket#accept()
 		}
-
-		if (stopped || !ended) {
-			// JUnit 3 and 4 RemoteTestRunnerClient properly handle notifying stopped/terminated
-			String testKind= testRunnerKind.getId();
-			if (TestKindRegistry.JUNIT3_TEST_KIND_ID.equals(testKind)
-					|| TestKindRegistry.JUNIT4_TEST_KIND_ID.equals(testKind)) {
-				return;
-			}
-			notifyTestRunStopped(0);
-		}
 	}
 
 	private synchronized void shutDown() {
@@ -369,6 +359,15 @@ public class RemoteTestRunnerClient {
 				fServerSocket= null;
 			}
 		} catch(IOException e) {
+		}
+		if (stopped || !ended) {
+			// JUnit 3 and 4 RemoteTestRunnerClient properly handle notifying stopped/terminated
+			String testKind= testRunnerKind.getId();
+			if (TestKindRegistry.JUNIT3_TEST_KIND_ID.equals(testKind)
+					|| TestKindRegistry.JUNIT4_TEST_KIND_ID.equals(testKind)) {
+				return;
+			}
+			notifyTestRunStopped(0);
 		}
 	}
 


### PR DESCRIPTION
After the fix for #2696 I've observed (on Windows) regression in the JUnit view: if the test was terminated (regularly) very fast, the test results would be sometimes not shown at all, and JUnit view would show "Stopped" status.

I see (at least on Windows) that test launch termination is reported almost immediately, *before* any test process output is processed by ServerConnection.

The correct place to evaluate "stopped or not" condition would be after the output processing is finished, so moved the new block of code from #2696 to the ServerConnection.shutDown().

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2696