### PR TITLE
Do not convert to switch expression when there are no changes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchExpressionsFixCore.java
@@ -103,6 +103,7 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 			final List<SwitchCase> returnList= new ArrayList<>();
 			boolean defaultFound= false;
 			boolean useSwitchStatement= false;
+			boolean isSwitchLabeledRule= false;
 			List<Statement> currentBlock= null;
 			SwitchCase currentCase= null;
 			Map<SwitchCase, List<Statement>> caseMap= new LinkedHashMap<>();
@@ -110,6 +111,9 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 				Statement statement= iter.next();
 				if (statement instanceof SwitchCase) {
 					SwitchCase switchCase= (SwitchCase)statement;
+					if (switchCase.isSwitchLabeledRule()) {
+						isSwitchLabeledRule= true;
+					}
 					if (switchCase.isDefault()) {
 						defaultFound= true;
 					}
@@ -301,8 +305,8 @@ public class SwitchExpressionsFixCore extends CompilationUnitRewriteOperationsFi
 					break;
 				}
 			}
-			if (forceOldStyle && !createReturnStatement && assignmentBinding == null) {
-				return null;
+			if ((forceOldStyle || isSwitchLabeledRule) && !createReturnStatement && assignmentBinding == null) {
+				return null; // nothing to change
 			}
 			return new SwitchExpressionsFixOperation(switchStatement, caseMap, createReturnStatement, commonAssignmentName,
 					assignmentBinding, forceOldStyle, useSwitchStatement);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
@@ -721,7 +721,7 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 	}
 
 	@Test
-	public void testNoConvertToSwitchExpression5() throws Exception {
+	public void testNoConvertToSwitchExpression3() throws Exception {
 		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
 		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
 		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
@@ -763,7 +763,42 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
 		assertProposalDoesNotExist(proposals, FixMessages.SwitchExpressionsFix_convert_to_switch_expression);
-
 	}
+
+	@Test
+	public void testNoConvertToSwitchExpression4() throws Exception { // https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2728
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+			    public void f(int i) {
+				    int j;
+			        switch (i) {
+				        case 0 -> j = 3;
+				        default -> throw new AssertionError();
+			        }
+			    }
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("switch");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 0);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+		assertProposalDoesNotExist(proposals, FixMessages.SwitchExpressionsFix_convert_to_switch_expression);
+	}
+
 }
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest14.java
@@ -1320,6 +1320,30 @@ public class CleanUpTest14 extends CleanUpTestCase {
 	}
 
 	@Test
+	public void testDoNotConvertToSwitchExpressionIssue2728() throws Exception {
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String sample= """
+			package test1;
+
+			public class E1 {
+			    public void f(int i) {
+				    int j;
+			        switch (i) {
+				        case 0 -> j = 3;
+				        default -> throw new AssertionError();
+			        }
+			    }
+			}
+			"""; //
+
+		ICompilationUnit cu1= pack1.createCompilationUnit("E1.java", sample, false, null);
+
+		enable(CleanUpConstants.CONTROL_STATEMENTS_CONVERT_TO_SWITCH_EXPRESSIONS);
+
+		assertRefactoringHasNoChange(new ICompilationUnit[] { cu1 });
+	}
+
+	@Test
 	public void testDoNotRemoveParenthesesIssue2451_1() throws Exception {
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
 		String sample= """


### PR DESCRIPTION
- modify SwitchExpressionsFixCore to recognize when the switch statement already uses new case labels and will have no changes
- add new tests to CleanUpTest14 and AssistQuickFixTest14
- fixes #2728

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
