### PR TITLE
Fix I-build compile error

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/InternalClassFileEditorInput.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/InternalClassFileEditorInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,6 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.javaeditor;
-
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +34,6 @@ import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
-
 
 /**
  * Class file considered as editor input.
@@ -104,7 +102,7 @@ public class InternalClassFileEditorInput implements IClassFileEditorInput, IPer
 			return ((IOrdinaryClassFile) fClassFile).getType().getFullyQualifiedName();
 		} else if (fClassFile instanceof IModularClassFile) {
 			try {
-				return ((IModularClassFile) fClassFile).getModule().getElementName();
+				return fClassFile.getModule().getElementName();
 			} catch (JavaModelException e) {
 				return e.getMessage();
 			}


### PR DESCRIPTION
Error visible in
https://ci.eclipse.org/releng/job/Builds/job/I-build-4.39/53/console :
```
09:24:41  [ERROR]
/home/jenkins/agent/workspace/Builds/I-build-4.39/cje-production/gitCache/eclipse.platform.releng.aggregator/eclipse.jdt.ui/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/InternalClassFileEditorInput.java:[107]
09:24:41  [ERROR] 	return ((IModularClassFile)
fClassFile).getModule().getElementName();
09:24:41  [ERROR] 	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
09:24:41  [ERROR] Unnecessary cast from IClassFile to IModularClassFile
09:24:41  [ERROR] -> [Help 1]
```

IClassFile inherits getModule method from ITypeRoot so this renders the purpose of IModularClassfile unclear/useless.
