### PR TITLE
Refactor CreatePackageInfoWithDefaultNullnessProposal

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/proposals/CreatePackageInfoWithDefaultNullnessProposalCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/proposals/CreatePackageInfoWithDefaultNullnessProposalCore.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Till Brychcy and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Till Brychcy - initial API and implementation
+ *     Red Hat Ltd. - refactored to jdt.core.manipulation core class
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.text.correction.proposals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.core.resources.IResource;
+
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.RefactoringCore;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaModelMarker;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.manipulation.ChangeCorrectionProposalCore;
+import org.eclipse.jdt.core.manipulation.CodeGeneration;
+
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoringCore.MultiFixTarget;
+import org.eclipse.jdt.internal.corext.fix.NullAnnotationsFixCore;
+import org.eclipse.jdt.internal.corext.refactoring.changes.CreateCompilationUnitChange;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+
+import org.eclipse.jdt.internal.ui.text.correction.IProposalRelevance;
+
+public final class CreatePackageInfoWithDefaultNullnessProposalCore extends ChangeCorrectionProposalCore {
+	public static CreatePackageInfoWithDefaultNullnessProposalCore createFor(int problemId, String name, IPackageFragment pack) throws CoreException {
+		int relevance= IProposalRelevance.ADD_MISSING_NULLNESS_ANNOTATION;
+		String nonNullByDefaultAnnotationName= NullAnnotationsFixCore.getNonNullByDefaultAnnotationName(pack, false);
+
+		String lineDelimiter= StubUtility.getLineDelimiterUsed(pack.getJavaProject());
+		StringBuilder content= new StringBuilder();
+		String fileComment= getFileComment(JavaModelUtil.PACKAGE_INFO_JAVA, pack, lineDelimiter);
+		String typeComment= getTypeComment(JavaModelUtil.PACKAGE_INFO_JAVA, pack, lineDelimiter);
+		if (fileComment != null) {
+			content.append(fileComment);
+			content.append(lineDelimiter);
+		}
+
+		if (typeComment != null) {
+			content.append(typeComment);
+			content.append(lineDelimiter);
+		} else if (fileComment != null) {
+			// insert an empty file comment to avoid that the file comment becomes the type comment
+			content.append("/**"); //$NON-NLS-1$
+			content.append(lineDelimiter);
+			content.append(" *"); //$NON-NLS-1$
+			content.append(lineDelimiter);
+			content.append(" */"); //$NON-NLS-1$
+			content.append(lineDelimiter);
+		}
+
+		content.append("@"); //$NON-NLS-1$
+		content.append(nonNullByDefaultAnnotationName);
+		content.append(lineDelimiter);
+		content.append("package "); //$NON-NLS-1$
+		content.append(pack.getElementName());
+		content.append(";"); //$NON-NLS-1$
+		content.append(lineDelimiter);
+		String source= content.toString();
+
+		ICompilationUnit unit= pack.getCompilationUnit(JavaModelUtil.PACKAGE_INFO_JAVA);
+		Change change= new CreateCompilationUnitChange(unit, source, null);
+		CreatePackageInfoWithDefaultNullnessProposalCore proposal= new CreatePackageInfoWithDefaultNullnessProposalCore(problemId, name, change, relevance, unit);
+		return proposal;
+	}
+
+	private static String getFileComment(String fileName, IPackageFragment pack, String lineDelimiterUsed) throws CoreException {
+		ICompilationUnit cu= pack.getCompilationUnit(fileName);
+		return CodeGeneration.getFileComment(cu, lineDelimiterUsed);
+	}
+
+	private static String getTypeComment(String fileName, IPackageFragment pack, String lineDelimiterUsed) throws CoreException {
+		ICompilationUnit cu= pack.getCompilationUnit(fileName);
+		String typeName= fileName.substring(0, fileName.length() - JavaModelUtil.DEFAULT_CU_SUFFIX.length());
+		return CodeGeneration.getTypeComment(cu, typeName, lineDelimiterUsed);
+	}
+
+	public final int fProblemId;
+
+	public final ICompilationUnit fUnit;
+
+	public CreatePackageInfoWithDefaultNullnessProposalCore(int problemId, String name, Change change, int relevance, ICompilationUnit unit) {
+		super(name, change, relevance);
+		fProblemId= problemId;
+		fUnit= unit;
+	}
+
+	public void resolve(MultiFixTarget[] problems, IProgressMonitor monitor) throws CoreException {
+		/*
+		 * if there are multiple problems for different source folders with the same package and they are in the same project,
+		 * only create a package-info.java in one of them. prefer main sources to test sources, for now by sorting by folder
+		 * name (e.g. "/proj/src/main/java" < "/proj/src/test/java", "/proj/src" < "/proj/src-tests").
+		 *
+		 * similar, if they are in different projects and one is on the classpath of the other, create it in the
+		 * project that cannot see the other.
+		 */
+		HashMap<String, ArrayList<MultiFixTarget>> packageToTarget= new HashMap<>();
+		ArrayList<IPackageFragment> removeList= new ArrayList<>();
+		for (MultiFixTarget problem : problems) {
+			IPackageFragment packageFragment= (IPackageFragment) problem.getCompilationUnit().getParent();
+			ArrayList<MultiFixTarget> list= packageToTarget.get(packageFragment.getElementName());
+			if (list == null) {
+				list= new ArrayList<>();
+				list.add(problem);
+				packageToTarget.put(packageFragment.getElementName(), list);
+			} else {
+				IPackageFragmentRoot packageFragmentRoot= (IPackageFragmentRoot) packageFragment.getParent();
+				boolean needToAdd= true;
+				for (int i= 0; i < list.size(); i++) {
+					MultiFixTarget previous= list.get(i);
+					IPackageFragmentRoot previousPackageFragmentRoot= (IPackageFragmentRoot) previous.getCompilationUnit().getParent().getParent();
+					if (Objects.equals(packageFragmentRoot.getJavaProject(), previousPackageFragmentRoot.getJavaProject())) {
+						if (packageFragmentRoot.getResource().getProjectRelativePath().toString().compareTo(previousPackageFragmentRoot.getResource().getProjectRelativePath().toString()) < 0) {
+							list.remove(i);
+							i--;
+						} else {
+							needToAdd= false;
+						}
+					} else {
+						if (packageFragmentRoot.getJavaProject().isOnClasspath(previousPackageFragmentRoot.getJavaProject())) {
+							needToAdd= false;
+							removeList.add(packageFragment);
+						} else if (previousPackageFragmentRoot.getJavaProject().isOnClasspath(packageFragmentRoot.getJavaProject())) {
+							list.remove(i);
+							i--;
+							removeList.add((IPackageFragment) previous.getCompilationUnit().getParent());
+						}
+					}
+				}
+				if (needToAdd) {
+					list.add(problem);
+				}
+			}
+		}
+		CompositeChange compositeChange= new CompositeChange(this.getName());
+		for (Entry<String, ArrayList<MultiFixTarget>> entry : packageToTarget.entrySet()) {
+			ArrayList<MultiFixTarget> list= entry.getValue();
+			for (MultiFixTarget multiFixTarget : list) {
+				CreatePackageInfoWithDefaultNullnessProposalCore createPackageInfoProposal= createFor(this.fProblemId, this.getName(),
+						(IPackageFragment) multiFixTarget.getCompilationUnit().getParent());
+				compositeChange.add(createPackageInfoProposal.getChange());
+			}
+		}
+		PerformChangeOperation operation= new PerformChangeOperation(compositeChange);
+		operation.setUndoManager(RefactoringCore.getUndoManager(), compositeChange.getName());
+		operation.run(monitor);
+		// for package fragments on the removeList, a package-info.java has been created in another project on the classpath.
+		// in an incremental build, the markers are not deleted, so delete them here.
+		for (IPackageFragment packageFragment : removeList) {
+			packageFragment.getResource().deleteMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_ZERO);
+		}
+	}
+}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoringCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoringCore.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat Ltd - refactored parts to jdt.core.manipulation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.corext.fix;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+
+public class CleanUpRefactoringCore {
+
+	public static class CleanUpTarget {
+
+		private final ICompilationUnit fCompilationUnit;
+
+		public CleanUpTarget(ICompilationUnit unit) {
+			fCompilationUnit= unit;
+		}
+
+		public ICompilationUnit getCompilationUnit() {
+			return fCompilationUnit;
+		}
+	}
+
+	public static class MultiFixTarget extends CleanUpTarget {
+
+		private final IProblemLocation[] fProblems;
+
+		public MultiFixTarget(ICompilationUnit unit, IProblemLocation[] problems) {
+			super(unit);
+			fProblems= problems;
+		}
+
+		public IProblemLocation[] getProblems() {
+			return fProblems;
+		}
+	}
+
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/CorrectionMarkerResolutionGenerator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/CorrectionMarkerResolutionGenerator.java
@@ -222,7 +222,7 @@ public class CorrectionMarkerResolutionGenerator implements IMarkerResolutionGen
 						// if marker is on package-info.java, no need to create it (another quickfix offers just to add @NonNullByDefault)
 						continue;
 					}
-					if (createPackageInfoWithDefaultNullnessProposal.fProblemId == id)
+					if (createPackageInfoWithDefaultNullnessProposal.getProblemId() == id)
 						result.add(marker);
 				}
 				if (result.isEmpty())

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/NullAnnotationsCorrectionProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/NullAnnotationsCorrectionProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2025 GK Software AG and others.
+ * Copyright (c) 2011, 2026 GK Software AG and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,33 +12,27 @@
  *     Stephan Herrmann - [quick fix] Add quick fixes for null annotations - https://bugs.eclipse.org/337977
  *     IBM Corporation - bug fixes
  *     IBM Corporation - extend core processor
+ *     Red Hat Ltd. - refactor methods to NullAnnotationsCorrectionsProcessorCore
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.text.correction;
 
 import java.util.Collection;
-import java.util.Hashtable;
-import java.util.Map;
 
 import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.core.runtime.CoreException;
 
-import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.compiler.IProblem;
-import org.eclipse.jdt.core.dom.CompilationUnit;
 
-import org.eclipse.jdt.internal.corext.fix.NullAnnotationsFixCore;
 import org.eclipse.jdt.internal.corext.fix.NullAnnotationsRewriteOperations.ChangeKind;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
-import org.eclipse.jdt.internal.corext.util.Messages;
 
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ICommandAccess;
 
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
-import org.eclipse.jdt.internal.ui.fix.NullAnnotationsCleanUpCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.CreatePackageInfoWithDefaultNullnessProposal;
+import org.eclipse.jdt.internal.ui.text.correction.proposals.CreatePackageInfoWithDefaultNullnessProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ExtractToNullCheckedLocalProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ExtractToNullCheckedLocalProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposal;
@@ -67,20 +61,7 @@ public class NullAnnotationsCorrectionProcessor extends NullAnnotationsCorrectio
 	}
 
 	public static void addAddMissingDefaultNullnessProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) throws CoreException {
-		final CompilationUnit astRoot= context.getASTRoot();
-		if (JavaModelUtil.PACKAGE_INFO_JAVA.equals(astRoot.getJavaElement().getElementName())) {
-			NullAnnotationsFixCore fix= NullAnnotationsFixCore.createAddMissingDefaultNullnessAnnotationsFix(astRoot, problem);
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-			Map<String, String> options= new Hashtable<>();
-			FixCorrectionProposal proposal= new FixCorrectionProposal(fix, new NullAnnotationsCleanUpCore(options, problem.getProblemId()), IProposalRelevance.ADD_MISSING_NULLNESS_ANNOTATION, image,
-					context);
-			proposals.add(proposal);
-		} else {
-			final IPackageFragment pack= (IPackageFragment) astRoot.getJavaElement().getParent();
-			String nonNullByDefaultAnnotationname= NullAnnotationsFixCore.getNonNullByDefaultAnnotationName(pack, true);
-			String label= Messages.format(CorrectionMessages.NullAnnotationsCorrectionProcessor_create_packageInfo_with_defaultnullness, new String[] { nonNullByDefaultAnnotationname });
-			proposals.add(CreatePackageInfoWithDefaultNullnessProposal.createFor(problem.getProblemId(), label, pack));
-		}
+		new NullAnnotationsCorrectionProcessor().getAddMissingDefaultNullnessProposal(context, problem, proposals);
 	}
 
 	/**
@@ -114,5 +95,10 @@ public class NullAnnotationsCorrectionProcessor extends NullAnnotationsCorrectio
 	@Override
 	protected ICommandAccess extractToNullCheckedLocalProposalCoreToT(ExtractToNullCheckedLocalProposalCore core, int uid) {
 		return new ExtractToNullCheckedLocalProposal(core);
+	}
+
+	@Override
+	protected ICommandAccess createPackageInfoWithDefaultNullnessProposalCoreToT(CreatePackageInfoWithDefaultNullnessProposalCore core, int uid) {
+		return new CreatePackageInfoWithDefaultNullnessProposal(core);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/CreatePackageInfoWithDefaultNullnessProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/proposals/CreatePackageInfoWithDefaultNullnessProposal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Till Brychcy and others.
+ * Copyright (c) 2017, 2026 Till Brychcy and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,109 +10,60 @@
  *
  * Contributors:
  *     Till Brychcy - initial API and implementation
+ *     Red Hat Ltd - refactor parts to CreatePackageInfoWithNullnessProposalCore
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.text.correction.proposals;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map.Entry;
-import java.util.Objects;
+import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-
-import org.eclipse.core.resources.IResource;
 
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 
 import org.eclipse.ltk.core.refactoring.Change;
-import org.eclipse.ltk.core.refactoring.CompositeChange;
-import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
-import org.eclipse.ltk.core.refactoring.RefactoringCore;
 
 import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaModelMarker;
-import org.eclipse.jdt.core.IPackageFragment;
-import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring.MultiFixTarget;
-import org.eclipse.jdt.internal.core.manipulation.StubUtility;
-import org.eclipse.jdt.internal.corext.fix.NullAnnotationsFixCore;
-import org.eclipse.jdt.internal.corext.refactoring.changes.CreateCompilationUnitChange;
-import org.eclipse.jdt.internal.corext.util.InfoFilesUtil;
-import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoringCore;
 
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.text.java.correction.ChangeCorrectionProposal;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
-import org.eclipse.jdt.internal.ui.text.correction.IProposalRelevance;
 
 public final class CreatePackageInfoWithDefaultNullnessProposal extends ChangeCorrectionProposal {
-	public static CreatePackageInfoWithDefaultNullnessProposal createFor(int problemId, String name, IPackageFragment pack) throws CoreException {
-		int relevance= IProposalRelevance.ADD_MISSING_NULLNESS_ANNOTATION;
-		String nonNullByDefaultAnnotationName= NullAnnotationsFixCore.getNonNullByDefaultAnnotationName(pack, false);
 
-		String lineDelimiter= StubUtility.getLineDelimiterUsed(pack.getJavaProject());
-		StringBuilder content= new StringBuilder();
-		String fileComment= InfoFilesUtil.getFileComment(JavaModelUtil.PACKAGE_INFO_JAVA, pack, lineDelimiter);
-		String typeComment= InfoFilesUtil.getTypeComment(JavaModelUtil.PACKAGE_INFO_JAVA, pack, lineDelimiter);
-		if (fileComment != null) {
-			content.append(fileComment);
-			content.append(lineDelimiter);
-		}
-
-		if (typeComment != null) {
-			content.append(typeComment);
-			content.append(lineDelimiter);
-		} else if (fileComment != null) {
-			// insert an empty file comment to avoid that the file comment becomes the type comment
-			content.append("/**"); //$NON-NLS-1$
-			content.append(lineDelimiter);
-			content.append(" *"); //$NON-NLS-1$
-			content.append(lineDelimiter);
-			content.append(" */"); //$NON-NLS-1$
-			content.append(lineDelimiter);
-		}
-
-		content.append("@"); //$NON-NLS-1$
-		content.append(nonNullByDefaultAnnotationName);
-		content.append(lineDelimiter);
-		content.append("package "); //$NON-NLS-1$
-		content.append(pack.getElementName());
-		content.append(";"); //$NON-NLS-1$
-		content.append(lineDelimiter);
-		String source= content.toString();
-
-		ICompilationUnit unit= pack.getCompilationUnit(JavaModelUtil.PACKAGE_INFO_JAVA);
-		Change change= new CreateCompilationUnitChange(unit, source, null);
-		CreatePackageInfoWithDefaultNullnessProposal proposal= new CreatePackageInfoWithDefaultNullnessProposal(problemId, name, change, relevance, unit);
-		return proposal;
+	private CreatePackageInfoWithDefaultNullnessProposalCore fCore;
+	public CreatePackageInfoWithDefaultNullnessProposal(CreatePackageInfoWithDefaultNullnessProposalCore core) {
+		super(core.getName(), null, core.getRelevance());
+		fCore = core;
 	}
 
-	private final ICompilationUnit fUnit;
-
-	public final int fProblemId;
-
+	@Override
+	protected Change createChange() throws CoreException {
+		return fCore.getChange();
+	}
 	public CreatePackageInfoWithDefaultNullnessProposal(int problemId, String name, Change change, int relevance, ICompilationUnit unit) {
 		super(name, change, relevance);
-		fProblemId= problemId;
-		fUnit= unit;
+		fCore= new CreatePackageInfoWithDefaultNullnessProposalCore(problemId, name, change, relevance, unit);
 	}
 
 	@Override
 	public void apply(org.eclipse.jface.text.IDocument document) {
 		super.apply(document);
 		IEditorPart part= null;
-		if (fUnit.getResource().exists()) {
-			part= EditorUtility.isOpenInEditor(fUnit);
+		if (fCore.fUnit.getResource().exists()) {
+			part= EditorUtility.isOpenInEditor(fCore.fUnit);
 			if (part == null) {
 				try {
-					part= JavaUI.openInEditor(fUnit);
+					part= JavaUI.openInEditor(fCore.fUnit);
 				} catch (PartInitException | JavaModelException e) {
 					return;
 				}
@@ -127,69 +78,15 @@ public final class CreatePackageInfoWithDefaultNullnessProposal extends ChangeCo
 		}
 	}
 
+	public int getProblemId() {
+		return fCore.fProblemId;
+	}
+
 	public void resolve(MultiFixTarget[] problems, IProgressMonitor monitor) throws CoreException {
-		/*
-		 * if there are multiple problems for different source folders with the same package and they are in the same project,
-		 * only create a package-info.java in one of them. prefer main sources to test sources, for now by sorting by folder
-		 * name (e.g. "/proj/src/main/java" < "/proj/src/test/java", "/proj/src" < "/proj/src-tests").
-		 *
-		 * similar, if they are in different projects and one is on the classpath of the other, create it in the
-		 * project that cannot see the other.
-		 */
-		HashMap<String, ArrayList<MultiFixTarget>> packageToTarget= new HashMap<>();
-		ArrayList<IPackageFragment> removeList= new ArrayList<>();
+		List<CleanUpRefactoringCore.MultiFixTarget> coreProblems= new ArrayList<>();
 		for (MultiFixTarget problem : problems) {
-			IPackageFragment packageFragment= (IPackageFragment) problem.getCompilationUnit().getParent();
-			ArrayList<MultiFixTarget> list= packageToTarget.get(packageFragment.getElementName());
-			if (list == null) {
-				list= new ArrayList<>();
-				list.add(problem);
-				packageToTarget.put(packageFragment.getElementName(), list);
-			} else {
-				IPackageFragmentRoot packageFragmentRoot= (IPackageFragmentRoot) packageFragment.getParent();
-				boolean needToAdd= true;
-				for (int i= 0; i < list.size(); i++) {
-					MultiFixTarget previous= list.get(i);
-					IPackageFragmentRoot previousPackageFragmentRoot= (IPackageFragmentRoot) previous.getCompilationUnit().getParent().getParent();
-					if (Objects.equals(packageFragmentRoot.getJavaProject(), previousPackageFragmentRoot.getJavaProject())) {
-						if (packageFragmentRoot.getResource().getProjectRelativePath().toString().compareTo(previousPackageFragmentRoot.getResource().getProjectRelativePath().toString()) < 0) {
-							list.remove(i);
-							i--;
-						} else {
-							needToAdd= false;
-						}
-					} else {
-						if (packageFragmentRoot.getJavaProject().isOnClasspath(previousPackageFragmentRoot.getJavaProject())) {
-							needToAdd= false;
-							removeList.add(packageFragment);
-						} else if (previousPackageFragmentRoot.getJavaProject().isOnClasspath(packageFragmentRoot.getJavaProject())) {
-							list.remove(i);
-							i--;
-							removeList.add((IPackageFragment) previous.getCompilationUnit().getParent());
-						}
-					}
-				}
-				if (needToAdd) {
-					list.add(problem);
-				}
-			}
+			coreProblems.add(new CleanUpRefactoringCore.MultiFixTarget(problem.getCompilationUnit(), problem.getProblems()));
 		}
-		CompositeChange compositeChange= new CompositeChange(this.getName());
-		for (Entry<String, ArrayList<MultiFixTarget>> entry : packageToTarget.entrySet()) {
-			ArrayList<MultiFixTarget> list= entry.getValue();
-			for (MultiFixTarget multiFixTarget : list) {
-				CreatePackageInfoWithDefaultNullnessProposal createPackageInfoProposal= createFor(this.fProblemId, this.getName(),
-						(IPackageFragment) multiFixTarget.getCompilationUnit().getParent());
-				compositeChange.add(createPackageInfoProposal.getChange());
-			}
-		}
-		PerformChangeOperation operation= new PerformChangeOperation(compositeChange);
-		operation.setUndoManager(RefactoringCore.getUndoManager(), compositeChange.getName());
-		operation.run(monitor);
-		// for package fragments on the removeList, a package-info.java has been created in another project on the classpath.
-		// in an incremental build, the markers are not deleted, so delete them here.
-		for (IPackageFragment packageFragment : removeList) {
-			packageFragment.getResource().deleteMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_ZERO);
-		}
+		fCore.resolve(coreProblems.toArray(new CleanUpRefactoringCore.MultiFixTarget[0]), monitor);
 	}
 }


### PR DESCRIPTION
- create CreatePackageInfoWithDefaultNullnessProposalCore based on CreatePackageInfoWithDefaultNullnessProposal
- add new CleanUpRefactoringCore based on CleanUpRefactoring
- move method from NullAnnotationsCorrectionProcessor to NullAnnotationsCorrectionProcessorCore
- change callers as necessary

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Refactors CreatePackageInfoWithDefaultNullnessProposal to jdt.core.manipulation.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run regular JDT testsuite.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
