### PR TITLE
Fix Javadoc hover for char constant that is 0

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -430,5 +430,36 @@ public class JavadocHoverTests extends CoreTests {
 			assertEquals("sequence doesn't match", expectedCodeSequence, actualSnippet);
 		}
 	}
+
+	@Test
+	public void testCharConstant() throws Exception {
+		String source=
+				"""
+				package p;
+				public class Javadoc {
+					static final char c = (char)0;
+				}
+			""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Javadoc.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		IType type= cu.getType("Javadoc");
+		// check javadoc on each member:
+		for (IJavaElement member : type.getChildren()) {
+			IJavaElement[] elements= { member };
+			ISourceRange range= ((ISourceReference) member).getNameRange();
+			JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(elements, cu, new Region(range.getOffset(), range.getLength()), null);
+			String actualHtmlContent= hoverInfo.getHtml();
+			System.out.println(actualHtmlContent);
+
+			String expectedCodeSequence = "char <a class='header' href='eclipse-javadoc:%E2%98%82=TestSetupProject/src%3Cp'>p</a>.<a class='header' href='eclipse-javadoc:%E2%98%82=TestSetupProject/src%3Cp%7BJavadoc.java%E2%98%83Javadoc'>Javadoc</a>.c</span> : <span style='white-space:pre'>'' [\\u0000]";
+
+			int index= actualHtmlContent.lastIndexOf("char");
+			assertNotEquals(-1, index);
+			String actualSnippet= actualHtmlContent.substring(index, index + expectedCodeSequence.length());
+			assertEquals("sequence doesn't match", expectedCodeSequence, actualSnippet);
+		}
+	}
+
 }
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
@@ -1362,9 +1362,9 @@ public class JavadocHover extends AbstractJavaEditorTextHover {
 
 	public static String getHexConstantValue(Object constantValue) {
 		if (constantValue instanceof Character) {
-			String constantResult= '\'' + constantValue.toString() + '\'';
-
 			char charValue= ((Character) constantValue);
+			String constantResult= '\'' + (charValue == 0 ? "" : constantValue.toString()) + '\''; //$NON-NLS-1$
+
 			String hexString= Integer.toHexString(charValue);
 			StringBuilder hexResult= new StringBuilder("\\u"); //$NON-NLS-1$
 			for (int i= hexString.length(); i < 4; i++) {


### PR DESCRIPTION
- modify JavadocHover.getHexConstantValue() to recognize when a char constant is 0 and format the output string properly
- add new test to JavadocHoverTests
- fixes #2730

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
