### PR TITLE
Fix Java25ProjectTestSetup for Java 26

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest25.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest25.java
@@ -51,11 +51,11 @@ import org.eclipse.jdt.ui.tests.core.rules.Java25ProjectTestSetup;
 
 public class ImportOrganizeTest25 extends CoreTests {
 	@Rule
-	public Java25ProjectTestSetup proj= new Java25ProjectTestSetup(false);
+	public Java25ProjectTestSetup proj= new Java25ProjectTestSetup();
 	@Rule
-	public Java25ProjectTestSetup proj2= new Java25ProjectTestSetup("TestSetupProject25_2", false);
+	public Java25ProjectTestSetup proj2= new Java25ProjectTestSetup("TestSetupProject25_2");
 	@Rule
-	public Java25ProjectTestSetup proj3= new Java25ProjectTestSetup("TestSetupProject25_3", false);
+	public Java25ProjectTestSetup proj3= new Java25ProjectTestSetup("TestSetupProject25_3");
 
 	private IJavaProject fJProject1;
 	private IJavaProject fJProject2;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java25ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/Java25ProjectTestSetup.java
@@ -50,13 +50,13 @@ public class Java25ProjectTestSetup extends ProjectTestSetup {
 		return new IClasspathEntry[] { JavaCore.newLibraryEntry(rtJarPath[0], rtJarPath[1], rtJarPath[2], ClasspathEntry.NO_ACCESS_RULES, extraAttributes, true) };
 	}
 
-	public Java25ProjectTestSetup( boolean enable_preview_feature) {
-		this.enable_preview_feature= enable_preview_feature;
+	public Java25ProjectTestSetup() {
+		this.enable_preview_feature= false;
 		projectName= PROJECT_NAME25;
 	}
 
-	public Java25ProjectTestSetup( String projectName, boolean enable_preview_feature) {
-		this.enable_preview_feature= enable_preview_feature;
+	public Java25ProjectTestSetup( String projectName) {
+		this.enable_preview_feature= false;
 		this.projectName= projectName;
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest25.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest25.java
@@ -37,10 +37,10 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
  */
 public class CleanUpTest25 extends CleanUpTestCase {
 	@Rule
-	public ProjectTestSetup projectSetup= new Java25ProjectTestSetup(false);
+	public ProjectTestSetup projectSetup= new Java25ProjectTestSetup();
 
 	@Rule
-	public ProjectTestSetup projectSetup2= new Java25ProjectTestSetup("project2", false);
+	public ProjectTestSetup projectSetup2= new Java25ProjectTestSetup("project2");
 
 	@After
 	public void teardown2() throws Exception {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/JavadocQuickFixTest25.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/JavadocQuickFixTest25.java
@@ -49,7 +49,7 @@ import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 public class JavadocQuickFixTest25 extends QuickFixTest {
 
 	@Rule
-    public ProjectTestSetup projectSetup = new Java25ProjectTestSetup(true);
+    public ProjectTestSetup projectSetup = new Java25ProjectTestSetup();
 
 	private IJavaProject fJProject1;
 	private IPackageFragmentRoot fSourceFolder;


### PR DESCRIPTION
+ preview is no longer a valid option for release 25

Fixes regressions in JavadocQuickFixTest25
