### PR TITLE
Fix color hierarchy so test for record goes ahead of test for class

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightings.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/SemanticHighlightings.java
@@ -2145,8 +2145,8 @@ public class SemanticHighlightings {
 				new MethodHighlighting(), // before types to get ctors
 				new TypeArgumentHighlighting(), // before other types
 				new AbstractClassHighlighting(), // before classes
-				new ClassHighlighting(),
 				new RecordHighlighting(),
+				new ClassHighlighting(),
 				new EnumHighlighting(),
 				new AnnotationHighlighting(), // before interfaces
 				new InterfaceHighlighting(),


### PR DESCRIPTION
- fix SemanticHighlighting.getSemanticHighlightings() to put RecordHighlighting before ClassHighlighting so when TypeArguments coloring is turned off, the record color will be used in the type argument
- fixes #2742

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
