### PR TITLE
Don't report AbortCompilation exceptions from parser

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CoreASTProvider.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/CoreASTProvider.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.core.manipulation;
 
 import java.util.List;
+import java.util.concurrent.CancellationException;
 
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -297,6 +298,12 @@ public final class CoreASTProvider {
 					ASTNodes.setFlagsToAST(root[0], ASTNode.PROTECT);
 				} catch (OperationCanceledException ex) {
 					return;
+				} catch (RuntimeException ex) {
+					// We would love to catch AbortCompilation from Parser,
+					// but it is compiler internal
+					if(ex.getCause() instanceof CancellationException) {
+						return;
+					}
 				}
 			}
 			@Override


### PR DESCRIPTION
Regression from
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4451 & https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4302.

If Java Editor interrupts hover computation, nothing should be reported, as it is expected. After changes above two errors are reported into the log (with same stack).

This change depends on the PR from JDT core below: https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4807

See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2769
