### PR TITLE
Fix extra spaces in method parameter name hints #1797

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaMethodParameterCodeMining.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaMethodParameterCodeMining.java
@@ -28,7 +28,7 @@ public class JavaMethodParameterCodeMining extends LineContentCodeMining {
 		if (isVarargs && parameterIndex == parameterNames.length - 1) {
 			text.append('…');
 		}
-		text.append(": "); //$NON-NLS-1$
+		text.append(":"); //$NON-NLS-1$
 		setLabel(text.toString());
 	}
 


### PR DESCRIPTION
Description
Fixed the visual bug where an extra space was appearing after the colon in method parameter hints.

Changes
In JavaMethodParameterCodeMining.java, I removed the manual space character from the hint text. The UI rendering engine already handles the necessary spacing, so this manual space was causing a double-space effect (e.g., speed: 100).

Verification
I have verified this fix using the Runtime Workbench. The spacing is now consistent and follows the expected UI behavior.

Before Fix (Double Space):
![BeforeFix](https://github.com/user-attachments/assets/76b687f0-7616-49c6-9a32-f2fd9b6afca8)

After Fix (Correct Single Space):
![AfterFix](https://github.com/user-attachments/assets/0b4badde-4544-4a15-9c80-14bcf4b978f0)

Fixes #1797