### PR TITLE
Fix convert to record to work without class name being selected

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ConvertRecordBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ConvertRecordBaseSubProcessor.java
@@ -51,7 +51,7 @@ public abstract class ConvertRecordBaseSubProcessor<T> {
 
 		Assert.isNotNull(context);
 
-		ConvertToRecordRefactoring refactoring= new ConvertToRecordRefactoring(context.getCompilationUnit(), (CompilationUnit) node.getRoot(), context.getSelectionOffset(), context.getSelectionLength());
+		ConvertToRecordRefactoring refactoring= new ConvertToRecordRefactoring(context.getCompilationUnit(), (CompilationUnit) node.getRoot(), node.getStartPosition(), node.getLength());
 		try {
 			if (refactoring.checkAllConditions(null).isOK()) {
 				if (proposals == null) {

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ConvertToRecordTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ConvertToRecordTests.java
@@ -128,7 +128,7 @@ public class ConvertToRecordTests extends GenericRefactoringTest {
 
 	@Test
 	public void test0() throws Exception {
-		helper1(8, 12, 8, 13);
+		helper1(9, 17, 9, 18);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
@@ -840,8 +840,8 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 				""";
 		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
 
-		int index= str1.indexOf("Cls(");
-		IInvocationContext ctx= getCorrectionContext(cu, index, 3);
+		int index= str1.indexOf("a;");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 1);
 		assertNoErrors(ctx);
 		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
 		ChangeCorrectionProposal proposal= (ChangeCorrectionProposal) proposals.get(0);

--- a/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/RefactoringExecutionStarter.java
+++ b/org.eclipse.jdt.ui/core refactoring/org/eclipse/jdt/internal/corext/refactoring/RefactoringExecutionStarter.java
@@ -58,6 +58,8 @@ import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IModuleDescription;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.ITypeRoot;
@@ -271,9 +273,19 @@ public final class RefactoringExecutionStarter {
 				IRefactoringSaveModes.SAVE_REFACTORING);
 	}
 
-	public static void startConvertToRecordRefactoring(final ICompilationUnit unit, final int offset, final int length, final Shell shell) {
-		final ConvertToRecordRefactoring refactoring= new ConvertToRecordRefactoring(unit, offset, length);
-		new RefactoringStarter().activate(new ConvertToRecordWizard(refactoring), shell, RefactoringMessages.ConvertToRecord_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
+	public static void startConvertToRecordRefactoring(final ICompilationUnit unit, final int offset, @SuppressWarnings("unused") final int length, final Shell shell) {
+		try {
+			IJavaElement element= unit.getElementAt(offset);
+			if (!(element instanceof ITypeRoot) && element instanceof ISourceReference ref) {
+				ISourceRange range= ref.getNameRange();
+				if (range != null) {
+					final ConvertToRecordRefactoring refactoring= new ConvertToRecordRefactoring(unit, range.getOffset(), range.getLength());
+					new RefactoringStarter().activate(new ConvertToRecordWizard(refactoring), shell, RefactoringMessages.ConvertToRecord_dialog_title, IRefactoringSaveModes.SAVE_REFACTORING);
+				}
+			}
+		} catch (JavaModelException e) {
+			// do nothing
+		}
 	}
 
 	public static void startCopyRefactoring(IResource[] resources, IJavaElement[] javaElements, Shell shell) throws JavaModelException {


### PR DESCRIPTION
- modify ConvertRecordBaseSubProcessor.addConvertToRecordProposals() to pass the offset and length of the node passed in
- modify RefactoringExecutionStarter.startConvertToRecordRefactoring() so it finds the IJavaElement for the offset and then gets the offset and length from that to remove the chance the offset and length are not correct for an ASTNode
- modify AssistQuickFixTest14 to try selecting a simple name in the type
- modify ConvertToRecordTests to select a non-class name for one test
- fixes #2783

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or modified tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
