### PR TITLE
Remove debugging println left in ConvertToRecordRefactoring

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/ConvertToRecordRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/ConvertToRecordRefactoring.java
@@ -449,7 +449,6 @@ public class ConvertToRecordRefactoring extends Refactoring {
 			updateReferences(pm);
 
 			CompilationUnitChange rewriteChange= fBaseCURewrite.createChange(true, pm);
-			System.out.println(rewriteChange.getEdit());
 			fChangeManager.manage(typeCU, rewriteChange);
 			changes.addAll(Arrays.asList(fChangeManager.getAllChanges()));
 			final Map<String, String> arguments= new HashMap<>();

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ConvertToRecordTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ConvertToRecordTests.java
@@ -135,7 +135,8 @@ public class ConvertToRecordTests extends GenericRefactoringTest {
 	public void test1() throws Exception {
 		helper1(8, 18, 8, 23);
 	}
-@Test
+
+	@Test
 	public void test2() throws Exception {
 		helper1(12, 16, 12, 21);
 	}


### PR DESCRIPTION
- fixes #2797

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Removes extraneous println.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
