### PR TITLE
Add missing descriptions to Colours and Fonts theme entries in Preferences

### DIFF
--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -155,6 +155,8 @@ ModuleInfoClassFileViewerName=Module-Info Class File Viewer
 javaEditorFontDefiniton.label= Java Editor Text Font
 javaEditorFontDefintion.description= The Java editor text font is used by Java editors.
 
+JavaTheme.description= Colors and fonts used in the Java editor, Javadoc and Java views.
+
 javaCompareFontDefiniton.label= Java compare text font
 javaCompareFontDefiniton.description= The Java compare text font is used by Java compare/merge tools.
 

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -1190,9 +1190,14 @@
             class="org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitDocumentProvider"/>
    </extension>
 
-   <extension
-         point="org.eclipse.ui.themes">
-        <themeElementCategory label="%javaPresentation.label" id="org.eclipse.jdt.ui.presentation"/>
+   <extension point="org.eclipse.ui.themes">
+        <themeElementCategory 
+        	label="%javaPresentation.label" 
+        	id="org.eclipse.jdt.ui.presentation">
+         	<description>
+            	%JavaTheme.description
+         	</description>
+        </themeElementCategory>
       <fontDefinition
             label="%javaEditorFontDefiniton.label"
             defaultsTo="org.eclipse.jface.textfont"


### PR DESCRIPTION

## What it does

Refs : https://github.com/eclipse-platform/eclipse.platform.ui/pull/3666 and https://github.com/eclipse-platform/eclipse.platform/pull/2453

Some entries in the Colours and Fonts preference page already provide descriptions, while others leave the description area empty. This change makes use of the existing descriptions and applies them to theme entries so that the description box is consistently populated and available descriptions are properly utilised. This improves clarity and aligns the presentation with the approach used with the subtree elements in Eclipse preference pages and gives more clarity on what each entity is used for. The Colours and Fonts preference page shows a description panel which is empty now. There are already descriptions available for some and not available for rest and they are not being used so as to display in the box. This change adds the existing description usage to theme entries so that users always see meaningful information when navigating these settings.

The main change pertaining to this PR has been merged via https://github.com/eclipse-platform/eclipse.platform.ui/pull/3666 and https://github.com/eclipse-platform/eclipse.platform/pull/2453. Few of the remaining changes are addressed here.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
