### PR TITLE
Allow chain constructors for convert to record

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringAvailabilityTesterCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringAvailabilityTesterCore.java
@@ -361,17 +361,16 @@ public final class RefactoringAvailabilityTesterCore  {
 				boolean hasConstructor= false;
 				for (IMethod method : methods) {
 					if (method.isConstructor()) {
-						if (hasConstructor) {
-							return false;
-						}
-						hasConstructor= true;
-						if (method.getNumberOfParameters() < fields.length) {
-							return false;
+						if (method.getNumberOfParameters() == fields.length) {
+							hasConstructor= true;
 						}
 					}
 					if (Modifier.isStatic(method.getFlags())) {
 						return false;
 					}
+				}
+				if (!hasConstructor) {
+					return false;
 				}
 			}
 			return type.isClass();

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/canConvert/A_test5_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/canConvert/A_test5_in.java
@@ -1,0 +1,28 @@
+package p;
+// Class A
+public final class A {
+
+	private final int a;
+	private final String b;
+
+	public A(int a, String b) {
+		this.a= a;
+		this.b= b;
+	}
+
+	public A(String b) {
+		this(3, b);
+	}
+
+	public A() {
+		this(3, "abc");
+	}
+
+	public int getA() {
+		return a;
+	}
+
+	public String getB() {
+		return b;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/canConvert/A_test5_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/canConvert/A_test5_out.java
@@ -1,0 +1,10 @@
+package p;
+// Class A
+public record A(int a, String b) {
+	public A(String b) {
+		this(3, b);
+	}
+	public A() {
+		this(3, "abc");
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/cannotConvert/A_testFail10.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/cannotConvert/A_testFail10.java
@@ -1,0 +1,24 @@
+package p;
+// Class A
+public class A {
+
+	/**
+	 * Inner
+	 */
+	static class Inner {
+		private int a;
+		private final String b;
+
+		public Inner(int a, String b) {
+			this.b= b;
+		}
+		
+		public int getA() {
+			return a;
+		}
+
+		public String getB() {
+			return b;
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/cannotConvert/A_testFail9.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ConvertToRecord/cannotConvert/A_testFail9.java
@@ -1,0 +1,24 @@
+package p;
+// Class A
+public class A {
+
+	/**
+	 * Inner
+	 */
+	static class Inner {
+		private int a;
+		private final String b;
+
+		public Inner(String b) {
+			this.b= b;
+		}
+		
+		public int getA() {
+			return a;
+		}
+
+		public String getB() {
+			return b;
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ConvertToRecordTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ConvertToRecordTests.java
@@ -152,6 +152,11 @@ public class ConvertToRecordTests extends GenericRefactoringTest {
 	}
 
 	@Test
+	public void test5() throws Exception {
+		helper1(9, 17, 9, 18);
+	}
+
+	@Test
 	public void testFail0() throws Exception {
 		helper2(12, 16, 12, 21);
 	}
@@ -188,6 +193,16 @@ public class ConvertToRecordTests extends GenericRefactoringTest {
 
 	@Test
 	public void testFail8() throws Exception {
+		helper2(8, 18, 8, 23);
+	}
+
+	@Test
+	public void testFail9() throws Exception {
+		helper2(8, 18, 8, 23);
+	}
+
+	@Test
+	public void testFail10() throws Exception {
 		helper2(8, 18, 8, 23);
 	}
 


### PR DESCRIPTION
- modify ConvertToRecordRefactoring to allow multiple constructors if they simply call another constructor
- ensure that there is one constructor that has arguments for every field and sets them via assignment
- add new tests to ConvertToRecordTests
- add new tests to AssistQuickFixTest16
- fixes #2789

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
