### PR TITLE
Version bump for o.e.j.core.manipulation which has changes in the branch

### DIFF
--- a/org.eclipse.jdt.core.manipulation/.settings/.api_filters
+++ b/org.eclipse.jdt.core.manipulation/.settings/.api_filters
@@ -3,7 +3,7 @@
     <resource path="META-INF/MANIFEST.MF">
         <filter id="931135546">
             <message_arguments>
-                <message_argument value="1.23.350"/>
+                <message_argument value="1.24.50"/>
                 <message_argument value="1.23.200"/>
             </message_arguments>
         </filter>

--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.24.0.qualifier
+Bundle-Version: 1.24.50.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin


### PR DESCRIPTION
In BETA_JAVA26, plug-in org.eclipse.jdt.core.manipulation has changes from #2726 , so it must have a higher version than in master (where meanwhile it is at 1.24.0.qualifier).