### PR TITLE
Wait for indexer at end of AssistQuickFixTest.setUp()

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest.java
@@ -53,6 +53,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.fix.FixMessages;
@@ -106,6 +107,7 @@ public class AssistQuickFixTest extends QuickFixTest {
 		fJProject1= projectSetup.getProject();
 
 		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		JavaModelManager.getIndexManager().waitForIndex(false, null);
 	}
 
 


### PR DESCRIPTION
Currently the JDT indexer potentially runs in parallel to tests in `AssistQuickFixTest`. This causes a race condition in `JavaModelManager.optionsCache`, which can result in unexpected Java options during the tests.

This change adds a wait for the indexer in `AssistQuickFixTest.setUp()`, to hopefully prevent such race conditions.

Fixes: #2811
