### PR TITLE
Recreate test project if it doesnt exist

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ProjectTestSetup.java
@@ -13,9 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.core;
 
-import junit.extensions.TestSetup;
-import junit.framework.Test;
-
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.TestOptions;
 
@@ -31,6 +28,9 @@ import org.eclipse.jdt.core.JavaCore;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.util.CoreUtility;
+
+import junit.extensions.TestSetup;
+import junit.framework.Test;
 
 
 /**
@@ -63,7 +63,7 @@ public class ProjectTestSetup extends TestSetup {
 	protected void setUp() throws Exception {
 		super.setUp();
 
-		if (projectExists()) { // allow nesting of ProjectTestSetups
+		if (projectExists() && getProject().getProject().isAccessible()) { // allow nesting of ProjectTestSetups
 			return;
 		}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/ProjectTestSetup.java
@@ -33,6 +33,9 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 
+import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.JavaProject;
+
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.util.CoreUtility;
 
@@ -72,9 +75,17 @@ public class ProjectTestSetup extends ExternalResource {
 
 	@Override
 	protected void before() throws Throwable {
-
 		if (projectExists()) { // allow nesting of ProjectTestSetups
-			return;
+			IJavaProject project= getProject();
+			if (project.getProject().exists()) {
+				return;
+			}
+			/*
+			 * Tests run into cases where the JDT model contains the project,
+			 * but the platform resources model doesn't - causing many resource exceptions.
+			 * To avoid them, we remove the Java project from the JDT model and recreate the test project.
+			 */
+			JavaModelManager.getJavaModelManager().removeInfoAndChildren((JavaProject) project);
 		}
 
 		fAutobuilding = CoreUtility.setAutoBuilding(false);


### PR DESCRIPTION
JDT UI tests sporadically run into multiple failures in `CleanUpTestCase.setUp`:

```
Resource '/TestSetupProject' does not exist.
```

The error is thrown when a Java project exists in the JDT Model, but doesn't exist as a project in the resources model.

This change recreates the test project in this case, removing the project from the JDT model cache beforehand.

See: #2287