### PR TITLE
Fix hashCode() generation using Objects.hashCode() and primitive fields

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
@@ -512,7 +512,41 @@ public final class GenerateHashCodeEqualsOperation implements IWorkspaceRunnable
 	private MethodInvocation createStandaloneJ7HashCall() {
 		MethodInvocation j7Invoc= fAst.newMethodInvocation();
 		for (IVariableBinding field : fFields) {
-			j7Invoc.arguments().add(fAst.newSimpleName(field.getName()));
+			if (field.getType().isPrimitive()) {
+				MethodInvocation invocation= fAst.newMethodInvocation();
+				invocation.setName(fAst.newSimpleName("valueOf")); //$NON-NLS-1$
+				invocation.arguments().add(fAst.newSimpleName(field.getName()));
+				switch (field.getType().getName()) {
+					case "byte": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Byte")); //$NON-NLS-1$
+						break;
+					case "short": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Short")); //$NON-NLS-1$
+						break;
+					case "int": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Integer")); //$NON-NLS-1$
+						break;
+					case "long": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Long")); //$NON-NLS-1$
+						break;
+					case "float": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Float")); //$NON-NLS-1$
+						break;
+					case "double": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Double")); //$NON-NLS-1$
+						break;
+					case "char": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Character")); //$NON-NLS-1$
+						break;
+					case "boolean": //$NON-NLS-1$
+						invocation.setExpression(fAst.newSimpleName("Boolean")); //$NON-NLS-1$
+						break;
+				}
+				j7Invoc.arguments().add(invocation);
+			}
+			else {
+				j7Invoc.arguments().add(fAst.newSimpleName(field.getName()));
+			}
 		}
 		j7Invoc.setExpression(getQualifiedName(JAVA_UTIL_OBJECTS));
 		j7Invoc.setName(fAst.newSimpleName(METHODNAME_HASH));

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateHashCodeEqualsTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateHashCodeEqualsTest.java
@@ -1003,7 +1003,7 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 				"	ElementType anEnum;\r\n" +
 				"	@Override\r\n" +
 				"	public int hashCode() {\r\n" +
-				"		return Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings, anEnum);\r\n" +
+				"		return Objects.hash(Boolean.valueOf(aBool), Byte.valueOf(aByte), Character.valueOf(aChar), Integer.valueOf(anInt), Double.valueOf(aDouble), Float.valueOf(aFloat), Long.valueOf(aLong), aString, aListOfStrings, anEnum);\r\n" +
 				"	}\r\n" +
 				"	@Override\r\n" +
 				"	public boolean equals(Object obj) {\r\n" +
@@ -1112,7 +1112,7 @@ public class GenerateHashCodeEqualsTest extends SourceTestCase {
 				"	List<String> aListOfStrings;\r\n" +
 				"	@Override\r\n" +
 				"	public int hashCode() {\r\n" +
-				"		return Objects.hash(aBool, aByte, aChar, anInt, aDouble, aFloat, aLong, aString, aListOfStrings);\r\n" +
+				"		return Objects.hash(Boolean.valueOf(aBool), Byte.valueOf(aByte), Character.valueOf(aChar), Integer.valueOf(anInt), Double.valueOf(aDouble), Float.valueOf(aFloat), Long.valueOf(aLong), aString, aListOfStrings);\r\n" +
 				"	}\r\n" +
 				"	@Override\r\n" +
 				"	public boolean equals(Object obj) {\r\n" +


### PR DESCRIPTION
- modify GenerateHashCodeEqualsOperation.createStandAloneJ7HashCall() to convert primitive fields into their boxed values when calling Objects.hashCode()
- modify GenerateHashCodeEqualsTest
- fixes #2846

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or modified tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
