### PR TITLE
Fix JunitQuickAssistProcessor to screen out disable test suggestions

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/AddAnnotationProposal.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/AddAnnotationProposal.java
@@ -123,7 +123,8 @@ public class AddAnnotationProposal implements IJavaCompletionProposal {
 	@Override
 	public int getRelevance() {
 		ASTNode coveringNode = fContext.getCoveringNode();
-		if (coveringNode.getParent() instanceof MethodDeclaration) {
+		if (fMethodDecl.getBody() != null &&
+				coveringNode.getStartPosition() < fMethodDecl.getBody().getStartPosition()) {
 			return 10;
 		} else {
 			return IProposalRelevance.ADD_SUPPRESSWARNINGS - 1;

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitQuickAssistProcessor.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitQuickAssistProcessor.java
@@ -72,10 +72,34 @@ public class JUnitQuickAssistProcessor implements IQuickAssistProcessor {
 			return null;
 		}
 
+
 		List<IJavaCompletionProposal> proposals = new ArrayList<>();
 
 		boolean hasDisabledAnnotation = hasAnnotation(methodDecl, JUNIT5_DISABLED_ANNOTATION);
 		boolean hasIgnoreAnnotation = hasAnnotation(methodDecl, JUNIT4_IGNORE_ANNOTATION);
+
+		// if user selects code within the method, only continue if we can disable the test and
+		// there is a problem found in the selection
+		if (context.getSelectionLength() > 0 &&
+				methodDecl.getBody() != null &&
+				coveringNode.getStartPosition() >= methodDecl.getBody().getStartPosition()) {
+			boolean problemFoundInSelection= false;
+			if (!hasDisabledAnnotation && !hasIgnoreAnnotation) {
+				int contextStart= context.getSelectionOffset();
+				int contextEnd= context.getSelectionOffset() + context.getSelectionLength();
+				for (IProblemLocation location : locations) {
+					int locationEnd= location.getOffset() + location.getLength();
+					if (location.getOffset() >= contextStart &&
+							locationEnd <= contextEnd) {
+						problemFoundInSelection= true;
+						break;
+					}
+				}
+			}
+			if (!problemFoundInSelection) {
+				return null;
+			}
+		}
 
 		if (hasDisabledAnnotation || hasIgnoreAnnotation) {
 			// Offer to remove the annotation


### PR DESCRIPTION
- modify logic to check if selection is within method body and if so, only offer to add test disablement, if possible, if the selection is for a problem
- fixes #2843

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
