### PR TITLE
Do not use an AST to calculate foldings (and refactor java foldings)

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Daniel Schmid and others.
+ * Copyright (c) 2025, 2026 Daniel Schmid and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,9 @@ package org.eclipse.jdt.text.tests.folding;
 
 import static org.junit.Assume.assumeTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -42,6 +44,7 @@ import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -96,8 +99,7 @@ public class CustomFoldingRegionTest {
 	public void testNoCustomFoldingRegions() throws Exception {
 		String str= """
 				package org.example.test;
-				public class Test {
-				}
+				public class Test { }
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
 		assertEquals(0, projectionRanges.size());
@@ -107,19 +109,18 @@ public class CustomFoldingRegionTest {
 	public void testCustomFoldingRegionInsideAndOutsideClass() throws Exception {
 		String str= """
 				package org.example.test;
-				// region
+				// region 1
 				// something else
 				// endregion
-				public class Test {
-					// region
+				class Test {
+					// region 2
 					// something else
 					// endregion
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(2, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 3);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 7);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 3); // region 1
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 7); // region 2
 	}
 
 	@Test
@@ -127,7 +128,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					// region outer
 					// region inner
 
@@ -136,7 +137,8 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(2, projectionRanges.size());
+		assertEquals(3, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 8);//class Test
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 7);//outer
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//inner
 	}
@@ -149,47 +151,30 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					// region outer
 
 					// endregion inner
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(0, projectionRanges.size());
-	}
-
-	@Test
-	public void testNoCustomFoldingRegionsInMethod() throws Exception {
-		String str= """
-				package org.example.test;
-				public class Test {
-					void a(){
-
-					}
-				}
-				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(1, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 3);
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);//outer
 	}
 
 	@Test
 	public void testCustomFoldingRegionsInMethod() throws Exception {
 		String str= """
 				package org.example.test;
-				public class Test {
+				class Test {
 					void a(){
-						// region
+						// region 1
 
 						// endregion
 					}
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(2, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 5);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5); // region 1
 	}
 
 	@Test
@@ -213,8 +198,7 @@ public class CustomFoldingRegionTest {
 				// endregion
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(1, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 4);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 4); // imports
 	}
 
 	@Test
@@ -226,7 +210,7 @@ public class CustomFoldingRegionTest {
 
 				}
 
-				// region
+				// region 1
 
 				class B {
 
@@ -242,8 +226,7 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(1, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 15);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 15); // region 1
 	}
 
 	@Test
@@ -251,7 +234,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 				// region outside class
-				public class Test {
+				class Test {
 					// endregion should be ignored with old folding
 					// region outside method
 					void a(){
@@ -265,11 +248,12 @@ public class CustomFoldingRegionTest {
 				// endregion outside class
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(4, projectionRanges.size());
+		assertEquals(5, projectionRanges.size());
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 12);//class Test
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 13);//outside class
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 11);//outside method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 7, 9);//inside method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 9);//void a()
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartAndEndLine(projectionRanges, str, 1, 3);//endregion should be ignored
 	}
 
 	@Test
@@ -277,7 +261,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					void a(){
 						// region inside method
 					}
@@ -286,8 +270,7 @@ public class CustomFoldingRegionTest {
 				// endregion outside class
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(1, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//void a()
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 4);//region inside method
 	}
 
 	@Test
@@ -295,7 +278,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class SpecialCommentTypes {
 					void a(){
 						/* region multiline
 						*/
@@ -309,14 +292,15 @@ public class CustomFoldingRegionTest {
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
 		if (extendedFoldingActive) {
 			assertEquals(5, projectionRanges.size());
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//void a()
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 5);// multiline (comment)
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 11);//class SpecialCommentTypes
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 10);//void a()
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 9);// multiline (folding region)
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);// javadoc
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 8, 9);// multiline (last comment)
 		} else {
-			assertEquals(3, projectionRanges.size());
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//void a()
+			assertEquals(4, projectionRanges.size());
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 11);//class SpecialCommentTypes
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 10);//void a()
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 9);// multiline
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);// javadoc
 		}
@@ -327,9 +311,9 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					void a(){
-						// region
+						// region 1
 						int i;
 
 						// endregion
@@ -340,10 +324,7 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(3, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 10);//void a()
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 7);//region
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 8, 9);//class Inner
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 7);//region 1
 	}
 
 	@Test
@@ -351,16 +332,16 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test{
+				class Test{
 					// region outside
-					public class A {
+					class A {
 						public void helloWorld() {
 
 						}
 						// endregion inside
 					}
 
-					public class B {
+					class B {
 
 
 				    }
@@ -368,13 +349,7 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(3, projectionRanges.size());
-		if (extendedFoldingActive) {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 8);//class A
-		} else {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 9);//class A
-		}
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//void helloWorld()
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);// region outside
 	}
 
 	@Test
@@ -382,8 +357,8 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
-					// region
+				class Test {
+					// region 1
 					int a;
 
 					void b(){
@@ -393,9 +368,7 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(2, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//region
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);//void b()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//region 1
 	}
 
 	@Test
@@ -407,7 +380,7 @@ public class CustomFoldingRegionTest {
 
 		String str= """
 				package org.example.test;
-				public class Test {
+				class Test {
 					// region should be ignored
 					// #regstart this is the region
 					// #regend should end here
@@ -415,15 +388,14 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(1, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4); // this is the region
 	}
 
 	@Test
 	public void testCommentsInEmptyBlocks() throws Exception {
 		String str= """
 				package org.example.test;
-				public class Test {
+				class Test {
 					void a(){
 						{/* region 1*/}
 						System.out.println("Hello World");
@@ -432,9 +404,154 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(2, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 5);//void a()
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5);//region 1
+	}
+
+	@Test
+	public void testNoFoldingRegionWithAdditionalTokensAfterComment() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){
+						{/* region 1*/}
+						System.out.println("Hello World");
+						{/* endregion 1*/;}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);
+	}
+
+	@Test
+	public void testNoFoldingRegionWithAdditionalTokensBeforeComment() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){
+						{;/* region 1*/}
+						System.out.println("Hello World");
+						{/* endregion 1*/}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);
+	}
+
+	@Test
+	public void testBlockFoldingRegionAllowSemicolonBeforeBlock() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){
+						;{/* region 1*/}
+						System.out.println("Hello World");
+						{/* endregion 1*/}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5);//region 1
+	}
+
+	@Test
+	public void testBlockFoldingRegionAllowOtherBlockBeforeBlock() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){
+						{ }
+						{/* region 1*/}
+						System.out.println("Hello World");
+						{/* endregion 1*/}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//region 1
+	}
+
+	@Test
+	public void testBlockFoldingRegionAllowCommentBeforeBlock() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){
+						// Hello
+						{/* region 1*/}
+						// World
+						{/* endregion 1*/}
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//region 1
+	}
+
+	@Test
+	public void testBlockFoldingRegionWithCodeInSameLineAsEnd() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){
+						{/* region 1*/}
+						System.out.println("Hello");
+						{/* endregion 1*/}System.out.println("World");
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//region 1
+	}
+
+	@Test
+	public void testMethodWithSingleCommentIsNotUsedForCustomRegions() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){/* region 1*/}
+
+					/* endregion */
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 2);
+	}
+
+	@Test
+	public void testMethodWithSingleCommentIsNotUsedForEndregionComment() throws Exception {
+		String str= """
+				package org.example.test;
+				class Test {
+					// region a
+
+					void a(){/* endregion*/}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 2);
+	}
+
+	@Test
+	public void testSameStartAndEndMarkersWithinBlock() throws Exception {
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START, "----");
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END, "----");
+		String str= """
+				package org.example.test;
+				class Test {
+					void a(){
+						{/* --------- */}
+						System.out.println("Hello");
+						{/* --------- */}
+						System.out.println("World");
+					}
+				}
+				""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//region 1
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//region 1
 	}
 
 	@Test
@@ -442,15 +559,15 @@ public class CustomFoldingRegionTest {
 		assumeTrue("Only enabled with extended folding", extendedFoldingActive);
 		String str= """
 				package org.example.test;
-				public class Test {
+				class Test {
 					void a() {
-						// region
+						// region 1
 						for (int i = 0; i < 10; i++) {
 							// endregion
-							// region
+							// region 2
 						}
 						boolean b=false;
-						// region
+						// region 3
 						while (b) {
 							// endregion
 						}
@@ -458,10 +575,9 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(3, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 12);//void a()
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//for
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 11);//while
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);// region 1
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 6);// region 2
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 9);// region 3
 	}
 
 	@Test
@@ -469,15 +585,14 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
-					// region
+				class Test {
+					// region 1
 
 					/* endregion */ void test(){}
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(1, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4); // region 1
 	}
 
 	@Test
@@ -489,7 +604,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					// region first start
 
 					// region second start
@@ -497,9 +612,8 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(2, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//outer
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//inner
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//first start
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//second start
 	}
 
 
@@ -512,7 +626,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					// ---- variables
 
 					private int i = 0;
@@ -528,14 +642,8 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(3, projectionRanges.size());
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 7);//variables
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 8, 13);//methods
-		if (extendedFoldingActive) {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 11);//test()
-		} else {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 12);//test()
-		}
 	}
 
 	@Test
@@ -547,7 +655,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					// ---- outer ----
 
 					void test() {
@@ -568,13 +676,9 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(6, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 14);//outer
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 12);//test()
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 9);//inner
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 12);//inner 2
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 15, 19);//outer 2
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 17, 18);//otherMethod()
 	}
 
 	@Test
@@ -586,7 +690,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 					// reg no end marker
 
 					// reg first
@@ -596,7 +700,6 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(3, projectionRanges.size());
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 8);//no end marker
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//first
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 7, 8);//second
@@ -619,9 +722,8 @@ public class CustomFoldingRegionTest {
 				// regend second
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(2, projectionRanges.size());
 		FoldingTestUtils.assertContainsRegionWithOffsetAndLength(projectionRanges, 2, 7, //no end marker
-		FoldingTestUtils.findLineStartIndex(str, 2) + 1, str.length());
+		FoldingTestUtils.findLineStartIndex(str, 2), str.length() - 1);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 5);//first
 	}
 
@@ -634,7 +736,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Test {
+				class Test {
 
 					// reg no region
 
@@ -650,10 +752,38 @@ public class CustomFoldingRegionTest {
 				}
 		""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(3, projectionRanges.size());
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);//first
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 11);//second
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 12, 13);//second
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 12, 13);//third
+	}
+
+	@Test
+	public void testSameStartAndEndMarkerTerminatesAtEOF() throws Exception {
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START, "reg");
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END, "reg");
+
+		String str= """
+		// reg my region
+
+		// some comment without line break""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 0, 2);
+	}
+
+	@Test
+	public void testSameStartAndEndMarkerTerminatesAtEOFEmptyLine() throws Exception {
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_START, "reg");
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGION_END, "reg");
+
+		String str= """
+		// reg my region
+
+
+		""";
+		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 0, 3);
 	}
 
 	@Test
@@ -666,7 +796,7 @@ public class CustomFoldingRegionTest {
 		String str= """
 				package org.example.test;
 
-				public class Repro {
+				class Repro {
 
 					// reg a folding region should start here
 
@@ -680,10 +810,7 @@ public class CustomFoldingRegionTest {
 				}
 				""";
 		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
-		assertEquals(3, projectionRanges.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 11);//custom region
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 10);//test
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 7, 8);//if
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 12);//custom region
 	}
 
 	@Test
@@ -693,7 +820,7 @@ public class CustomFoldingRegionTest {
 
 				// region outer
 
-				public class Test {
+				class Test {
 					// region middle
 
 					// region inner
@@ -713,20 +840,21 @@ public class CustomFoldingRegionTest {
 
 			List<IRegion> initialRegions= FoldingTestUtils.extractRegions(model);
 
-			assertEquals(4, initialRegions.size());
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 2, 15);//outer
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 5, 12);//middle
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 7, 11);//inner
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 8, 9);//someMethod
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 8, 10);//someMethod
 
 			// get the mutable Positions which are in the same order as the extracted regions (copies)
 			List<Position> positions= getFoldingPositionsFromModel(model);
+
 			assertEquals(initialRegions.size(), positions.size());
 
 			String additionalText= "more ";
 			editor.getViewer().getDocument().replace(code.indexOf("content"), 0, additionalText);
 			cu.reconcile(ICompilationUnit.NO_AST, false, null, null);
 
+			// check that regions are in the same order as before and not modified in another way
 			for(int i= 0; i < positions.size(); i++) {
 				assertEquals(initialRegions.get(i).getOffset(), positions.get(i).getOffset());
 				assertEquals(initialRegions.get(i).getLength() + additionalText.length(), positions.get(i).getLength());
@@ -734,6 +862,75 @@ public class CustomFoldingRegionTest {
 		} finally {
 			editor.close(false);
 		}
+	}
+
+	@Test
+	public void testCustomFoldingRegionsAreAssociatedWithCorrectIJavaElements() throws Exception {
+		String code= """
+				package org.example.test;
+
+				// region outside of class
+
+				class Test {
+					// region within class
+
+					// region nested within class
+
+					int i;
+
+					// region 3rd nested within class
+
+					void someMethod() {
+						// region within method
+
+						// endregion within method
+					}
+					// endregion 3rd nested within class
+					// endregion nested within class
+
+					void otherMethod() {}
+
+					// endregion within class
+				}
+
+				// endregion outside of class
+
+				// region at the EOF
+				// endregion
+				""";
+		ICompilationUnit cu= fPackageFragment.createCompilationUnit("Test.java", code, true, null);
+		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
+		try {
+			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
+
+			assertContainsCustomFoldingPositionWithElement(code, model, "// region outside of class", "Test.java", IJavaElement.COMPILATION_UNIT);
+			assertContainsCustomFoldingPositionWithElement(code, model, "// region within class", "Test", IJavaElement.TYPE);
+			assertContainsCustomFoldingPositionWithElement(code, model, "// region nested within class", "Test", IJavaElement.TYPE);
+			assertContainsCustomFoldingPositionWithElement(code, model, "// region 3rd nested within class", "Test", IJavaElement.TYPE);
+			assertContainsCustomFoldingPositionWithElement(code, model, "// region within method", "someMethod", IJavaElement.METHOD);
+			assertContainsCustomFoldingPositionWithElement(code, model, "// region at the EOF", "Test.java", IJavaElement.COMPILATION_UNIT);
+		} finally {
+			editor.close(false);
+		}
+	}
+
+	private void assertContainsCustomFoldingPositionWithElement(String code, ProjectionAnnotationModel model, String startComment, String elementName, int elementType) throws Exception {
+		Iterator<Annotation> it= model.getAnnotationIterator();
+		while (it.hasNext()) {
+			Annotation annotation= it.next();
+			Position position= model.getPosition(annotation);
+			String regionPart= code.substring(position.getOffset(), position.getOffset() + position.getLength());
+			if (regionPart.trim().startsWith(startComment)) {
+				assertEquals("org.eclipse.jdt.ui.text.folding.DefaultJavaFoldingStructureProvider$JavaProjectionAnnotation", annotation.getClass().getName());
+				Method getter= annotation.getClass().getDeclaredMethod("getElement");
+				getter.setAccessible(true);
+				IJavaElement element= (IJavaElement) getter.invoke(annotation);
+				assertEquals(elementName, element.getElementName(), "incorrect IJavaElement associated with the following folding region:" + regionPart);
+				assertEquals(elementType, element.getElementType(), "incorrect IJavaElement type associated with the following folding region:" + regionPart);
+				return;
+			}
+		}
+		fail("No folding region starting with the following comment was found: " + startComment);
 	}
 
 	private List<Position> getFoldingPositionsFromModel(ProjectionAnnotationModel model) {
@@ -750,7 +947,7 @@ public class CustomFoldingRegionTest {
 	}
 
 	private List<IRegion> getProjectionRangesOfFile(String str) throws Exception {
-		return FoldingTestUtils.getProjectionRangesOfFile(fPackageFragment, "Test.java", str);
+		return FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
 	}
 
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingIncludeClosingBracketTests.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingIncludeClosingBracketTests.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Daniel Schmid and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Daniel Schmid - initial API and implementation
+ *     Vector Informatik GmbH - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.text.tests.folding;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import org.eclipse.jface.text.IRegion;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2439
+public class FoldingIncludeClosingBracketTests {
+	@Rule
+	public ProjectTestSetup projectSetup= new ProjectTestSetup();
+
+	private IJavaProject jProject;
+
+	private IPackageFragmentRoot sourceFolder;
+
+	private IPackageFragment packageFragment;
+
+	private IPreferenceStore preferenceStore;
+
+	private boolean originalPreferenceValue;
+
+	@Before
+	public void setUp() throws CoreException {
+		jProject= projectSetup.getProject();
+		sourceFolder= jProject.findPackageFragmentRoot(jProject.getResource().getFullPath().append("src"));
+		if (sourceFolder == null) {
+			sourceFolder= JavaProjectHelper.addSourceContainer(jProject, "src");
+		}
+		packageFragment= sourceFolder.createPackageFragment("org.example.test", false, null);
+		preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
+		originalPreferenceValue= preferenceStore.getBoolean(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED);
+		configureEnhancedFolding(true);
+	}
+
+	@After
+	public void tearDown() {
+		configureEnhancedFolding(originalPreferenceValue);
+	}
+	private void configureEnhancedFolding(boolean useEnhancedFolding) {
+		preferenceStore.setValue(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED, useEnhancedFolding);
+	}
+
+	@Test
+	public void testControlStructures() throws Exception {
+		String str= """
+				package org.example.test;
+				class ControlStructures {
+				    void x() {
+				        if (true) {
+
+				        }
+				        for(int i=0;i<1;i++){
+
+				        }
+				        while(true) {
+
+				        }
+				        do {
+
+				        } while(false);
+				    };
+				}
+				""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // if
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 6, 8); // for
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 11); // while
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 12, 13); // do
+	}
+
+	@Test
+	public void testOtherBlocks_closingBracketsShouldBeIncluded() throws Exception {
+		String str= """
+				package org.example.test;
+				import java.util.function.Supplier;
+				class Suppliers {
+				    void x() {
+				        Supplier<String> s = () -> {
+				            return "";
+				        };
+
+				        Supplier<String> s2 = () -> {
+				            return "";
+				        }; // this line should not be folded
+				    }
+				}
+				""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 11); // x()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // s
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 8, 9); // s2
+	}
+
+	@Test
+	public void testAnnotatedEnums() throws Exception {
+		configureEnhancedFolding(false);
+		String str= """
+				package org.example.test;
+				enum TestEnum {
+					@SomeAnnotation
+					A,
+					@SomeAnnotation
+					@OtherAnnotation
+					B,
+					C,
+					@SomeAnnotation
+					D;
+
+					@SomeAnnotation
+					void someMethod() {
+
+					}
+				}
+				@interface SomeAnnotation {}
+				@interface OtherAnnotation {}
+				""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3); // A
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // B
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 8, 9); // C
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 11, 14); // someMethod
+	}
+}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Vector Informatik GmbH and others.
+ * Copyright (c) 2025, 2026 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -85,10 +85,41 @@ public class FoldingTest {
 	public void testCompilationUnitFolding() throws Exception {
 		String str= """
 				package org.example.test;
-				public class A {		//here should not be an annotation
+				class A {		//here should be an annotation
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 0);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 2); // class
+	}
+
+	@Test
+	public void testDoNotFoldOneLinerEmptyClass() throws Exception {
+		String str= """
+				package org.example.test;
+				class A {		//here should not be an annotation
+				} // This comment prevents this line to be folded
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, str, 0); //
+	}
+
+	@Test
+	public void testDoNotFoldInSameLine() throws Exception {
+		String str= """
+				package org.example.test;
+				class A { }
+				""";
+		FoldingTestUtils.assertCodeHasRegions(packageFragment, str, 0); //
+	}
+
+	@Test
+	public void testFoldOneLinersEmptyClass() throws Exception {
+		String str= """
+				package org.example.test;
+				class A {		//here should be an annotation
+				}
+				""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 2); // class
 	}
 
 	@Test
@@ -98,12 +129,11 @@ public class FoldingTest {
 				/**									//here should be an annotation
 				 * Javadoc
 				 */
-				public class HeaderCommentTest {
+				class HeaderCommentTest {
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // Javadoc
 	}
 
@@ -115,12 +145,11 @@ public class FoldingTest {
 				import java.util.List;				//here should be an annotation
 				import java.util.ArrayList;
 
-				public class ImportsTest {
+				class ImportsTest {
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3); // Imports
 	}
 
@@ -128,7 +157,7 @@ public class FoldingTest {
 	public void testSingleMethodWithJavadoc() throws Exception {
 		String str= """
 				package org.example.test;
-				public class SingleMethodTest {
+				class SingleMethodTest {
 				    /**									//here should be an annotation
 				     * Javadoc
 				     */
@@ -137,18 +166,34 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // Javadoc
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // foo Methode
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // foo Methode
+	}
+
+	@Test
+	public void testSingleMethodWithAnnotation() throws Exception {
+		String str= """
+				package org.example.test;
+				class DeprecatedMethodTest {
+				    @Deprecated						//here should be an annotation
+				    public void foo() {				//here should not be an annotation
+				        System.out.println("Hello");
+				    }
+				}
+				""";
+
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // method
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 3);
 	}
 
 	@Test
 	public void testMultipleMethodsWithoutComments() throws Exception {
 		String str= """
 				package org.example.test;
-				public class MultipleMethodTest {
+				class MultipleMethodTest {
 				    public void foo() {					//here should be an annotation
 
 				    }
@@ -157,18 +202,17 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3); // foo Methode
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // bar Methode
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // foo Methode
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // bar Methode
 	}
 
 	@Test
 	public void testInnerClassFolding() throws Exception {
 		String str= """
 				package org.example.test;
-				public class OuterClass {
+				class OuterClass {
 				    class InnerClass {				//here should be an annotation
 				        void bar() {				//here should be an annotation
 
@@ -176,23 +220,17 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		if (newFoldingActive) {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // InnerClass
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // bar Methode
-		} else {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // InnerClass
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // bar Methode
-		}
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // InnerClass
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // bar Methode
 	}
 
 	@Test
 	public void testInnerClassWithJavadoc() throws Exception {
 		String str= """
 				package org.example.test;
-				public class OuterWithDocs {
+				class OuterWithDocs {
 				    /**										//here should be an annotation
 				     * Javadoc
 				     */
@@ -206,13 +244,12 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 4);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // OuterWithDocs Javadoc
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 11); // InnerWithDocs Klasse
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 12); // InnerWithDocs Klasse
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 6, 8); // InnerWithDocs Javadoc
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 10); // bar Methode
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 11); // bar Methode
 	}
 
 	@Test
@@ -228,11 +265,10 @@ public class FoldingTest {
 				    /**										//here should be an annotation
 				    * Yet another Javadoc
 				    */
-				    public class Example {}
+				    class Example {}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 3);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // 1. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // 2. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 9); // 3. Javadoc
@@ -264,14 +300,13 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, newFoldingActive ? 6 : 5);
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // 1. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // 2. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 9); // 3. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 12, 14); // 4. Javadoc
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 15, 19); // Methode b()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 15, 20); // Methode b()
 		if (newFoldingActive) {
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 16, 18); // 5. Javadoc
 		}
@@ -287,7 +322,8 @@ public class FoldingTest {
 
 				class SomeClass {}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 0, 2);
 	}
 
 	@Test
@@ -305,11 +341,10 @@ public class FoldingTest {
 					}
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 3);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // JavaDoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // 1. Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 8); // 2. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 9); // 2. Method
 	}
 
 	@Test
@@ -317,7 +352,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class D {
+				class D {
 				    void x() {			//here should be an annotation
 				        if (true) {		//here should be an annotation
 
@@ -325,10 +360,9 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // 1. Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // if
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // if
 	}
 
 	@Test
@@ -336,7 +370,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class E {
+				class E {
 				    void x() {						//here should be an annotation
 				        try {						//here should be an annotation
 
@@ -346,11 +380,10 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 3);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 7); // 1. Method
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 8); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // try
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // catch
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // catch
 	}
 
 	@Test
@@ -358,7 +391,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class F {
+				class F {
 				    void x() {				//here should be an annotation
 				        while (true) {		//here should be an annotation
 
@@ -366,10 +399,9 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // 1. Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // while
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // while
 	}
 
 	@Test
@@ -377,7 +409,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class G {
+				class G {
 				    void x() {					//here should be an annotation
 				        for(int i=0;i<1;i++){	//here should be an annotation
 
@@ -385,10 +417,9 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // 1. Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // for
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // for
 	}
 
 	@Test
@@ -396,7 +427,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class H {
+				class H {
 				    void x() {							//here should be an annotation
 				        for(String s: new String[0]){	//here should be an annotation
 
@@ -404,10 +435,9 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // 1. Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // for
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // for
 	}
 
 	@Test
@@ -415,7 +445,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class I {
+				class I {
 				    void x() {				//here should be an annotation
 				        do {				//here should be an annotation
 
@@ -423,9 +453,8 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // 1. Method
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // do
 	}
 
@@ -434,7 +463,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class K {
+				class K {
 				    void x() {					//here should be an annotation
 				        synchronized(this) {	//here should be an annotation
 
@@ -442,10 +471,9 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // 1. Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // synchronized
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // synchronized
 	}
 
 	@Test
@@ -454,7 +482,7 @@ public class FoldingTest {
 		String str= """
 				package org.example.test;
 				import java.util.function.Supplier;
-				public class L {
+				class L {
 				    void x() {							//here should be an annotation
 				        Supplier<String> s = () -> {	//here should be an annotation
 				            return "";
@@ -462,17 +490,16 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 6); // 1. Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 5); // Supplier
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 7); // 1. Method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // Supplier
 	}
 
 	@Test
 	public void testAnonymousClassDeclarationFolding() throws Exception {
 		String str= """
 				package org.example.test;
-				public class M {
+				class M {
 				    Object o = new Object(){		//here should be an annotation
 				        void y() {					//here should be an annotation
 
@@ -480,44 +507,63 @@ public class FoldingTest {
 				    };
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		if (newFoldingActive) {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // Object
-		} else {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // Object
-		}
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // Method
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // Object
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // Method
 	}
 
+	/**
+	 * See <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=130472#c16">Bug 130472 -
+	 * [projection] Bizarre folding behavior</a>
+	 */
 	@Test
-	public void testEnumDeclarationFolding() throws Exception {
-		assumeTrue("Only doable with the new folding", newFoldingActive);
+	public void testAnonymousClassAsParameterFolding() throws Exception {
 		String str= """
 				package org.example.test;
-				public enum N {					//here should be an annotation
+				class Snippet15 {
+					void method() {
+						add(new Runnable() {
+							public void run() {
+
+							}
+						});
+					}
+				}
+							""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 8); // method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 7); // Runnable (anonymous class)
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // run
+	}
+
+	/**
+	 * See <a href="https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2596">GitHub Issue #2596</a>
+	 */
+	@Test
+	public void testEnumDeclarationFolding() throws Exception {
+		String str= """
+				package org.example.test;
+				enum N {					//here should be an annotation
 				    A,
 				    B
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // enum
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 4); // enum
 	}
 
 	@Test
 	public void testInitializerFolding() throws Exception {
 		String str= """
 				package org.example.test;
-				public class O {
+				class O {
 				    static {					//here should be an annotation
 
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3); // static
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // static
 	}
 
 	@Test
@@ -525,7 +571,7 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class P {
+				class P {
 				    void x() {							//here should be an annotation
 				        if (true) {						//here should be an annotation
 				            for(int i=0;i<1;i++){		//here should be an annotation
@@ -539,12 +585,11 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 5);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 11); // method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 10); // if
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 9); // for
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 8); // while
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 12); // method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 11); // if
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 10); // for
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 9); // while
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 6, 7); // do
 	}
 
@@ -560,14 +605,9 @@ public class FoldingTest {
 					}
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // method
-		if (newFoldingActive) {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // inner class
-		} else {
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // inner class
-		}
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // inner class
 	}
 
 
@@ -576,18 +616,18 @@ public class FoldingTest {
 		assumeTrue("Only doable with the new folding", newFoldingActive);
 		String str= """
 				package org.example.test;
-				public class I {
+				class I {
 				    void x() {				//here should be an annotation
 				        do {				//here should not be an annotation
 				        } while(false);
-						for(int i=0;i<1;i++){	//here should not be an annotation
+						for(int i=0;i<1;i++){	//here should be an annotation
 				        }
-				        synchronized(this) {	//here should not be an annotation
+				        synchronized(this) {	//here should be an annotation
 				        }
-				        if (true) {		//here should not be an annotation
+				        if (true) {		//here should be an annotation
 				        }
 				        try {						//here should not be an annotation
-				        } catch (Exception e) {		//here should not be an annotation
+				        } catch (Exception e) {		//here should be an annotation
 				        }
 				        int zaehler = 0;
 						switch (zaehler) {			//here should be an annotation
@@ -597,14 +637,23 @@ public class FoldingTest {
 				            break;
 				    	}
 				    }
-				    public void bar() {					//here should not be an annotation
+				    public void bar() {					//here should be an annotation
 				    }
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 2);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 20); // Method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 15, 19); // switch
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 21); // x()
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 22, 23); // bar()
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 3); // do-while
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // for
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7,8); // synchronized
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 10); // if
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 11); // try
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 12, 13); // catch
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 15, 20); // switch
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 17); // case 0
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 19); // default
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 22, 23); // bar
 	}
 
 	@Test
@@ -613,40 +662,34 @@ public class FoldingTest {
 		String str= """
 				package org.example.test;
 				class Outer {
-					void a() {						//here should be an annotation
+					void a() {
 						int b = 0;
 						int c = switch (b) {		//here should be an annotation
-							case 1 -> 				//here should be an annotation
+							case 1 ->
 
 							1;
-							case 2 -> 				//here should not be an annotation
+							case 2 ->
 							1;
-							case 3 -> 				//here should be an annotation
+							case 3 ->
 
 							break;
 							1;
-							case 4 -> {				//here should be an annotation
+							case 4 -> {
 								b = 2;
 								yield 3;
 							}
-							case 5 -> {				//here should not be an annotation
+							case 5 -> {
 								yield 3;
 							}
-							default -> 				//here should be an annotation
+							default ->
 
 							0;
 						};
 					}
 				}
-				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 6);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 24); // method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 23); // switch
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // 1. case
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 10, 11); // 3. case
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 14, 15); // 4. case
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 21, 22); // default
+								""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 24); // switch expression
 	}
 
 	@Test
@@ -655,29 +698,25 @@ public class FoldingTest {
 		String str= """
 				package org.example.test;
 				class Outer {
-					void a() {						//here should be an annotation
+					void a() {
 						int b = 0;
 						switch (b) {				//here should be an annotation
 					        case 0:					//here should be an annotation
 
 					            break;
 					            b = 1;
-					        case 1:					//here should not be an annotation
+					        case 1:
 					            break;
 
-					        default:				//here should be an annotation
+					        default:
 
 					          	break;
 						}
 					}
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 4);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 15); // method
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 14); // switch
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // case
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 12, 13); // default
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 15); // switch
 	}
 
 	@Test
@@ -693,8 +732,56 @@ public class FoldingTest {
 
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(packageFragment, "TestFolding.java", str, 1);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // @Deprecated
+	}
+
+	/**
+	 * See <a href="https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2571">GitHub Issue #2571</a>
+	 */
+	@Test
+	public void testArrayInitializers() throws Exception {
+		String str= """
+				package org.example.test;
+				class RecordTest {
+					private int[] arr = { // here should be an annotation
+							1,
+							2,
+							3
+					};
+				}
+
+								""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // array
+	}
+
+	@Test
+	public void testAdvancedFoldingAfterChildren() throws Exception {
+		assumeTrue("Only doable with the extended folding", newFoldingActive);
+		String str = """
+				public class Tst {
+					public static void main(String[] args) {
+						Predicate<Object> a = o -> {
+							return true;
+						};
+						List<String> b = new ArrayList<>() {
+
+						};
+						boolean c = true;
+						if (c) {
+							System.out.println("bbb");
+						} else {
+							System.out.println("aaa");
+						}
+					}
+
+				}
+				""";
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // predicate
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // ArrayList
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 10); // if
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 11, 13); // else
 	}
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Daniel Schmid and others.
+ * Copyright (c) 2025, 2026 Daniel Schmid and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,8 @@ import org.junit.platform.suite.api.Suite;
 	FoldingTest.class,
 	MarkdownJavadocFoldingTest.class,
 	CustomFoldingRegionTest.class,
-	FoldingWithShowSelectedElementTests.class
+	FoldingWithShowSelectedElementTests.class,
+	FoldingIncludeClosingBracketTests.class
 })
 public class FoldingTestSuite {
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Vector Informatik GmbH and others.
+ * Copyright (c) 2025, 2026 Vector Informatik GmbH and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,8 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
@@ -36,12 +39,13 @@ import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 
 public final class FoldingTestUtils {
+	private record StartEnd(int start, int end) {}
 
 	private FoldingTestUtils() {
 	}
 
-	public static List<IRegion> getProjectionRangesOfFile(IPackageFragment packageFragment, String fileName, String code) throws Exception {
-		ICompilationUnit cu= packageFragment.createCompilationUnit(fileName, code, true, null);
+	public static List<IRegion> getProjectionRangesOfPackage(IPackageFragment packageFragment, String code) throws Exception {
+		ICompilationUnit cu= packageFragment.createCompilationUnit("A.java", code, true, null);
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
 		ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
 
@@ -60,57 +64,126 @@ public final class FoldingTestUtils {
 				regions.add(new Region(p.getOffset(), p.getLength()));
 			}
 		}
+		assertNoDuplicatedRegions(regions);
+		assertNoRegionsStartInTheSameOffset(regions);
 		return regions;
 	}
 
-	public static void assertCodeHasRegions(IPackageFragment packageFragment, String fileName, String code, int regionsCount) throws Exception {
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, fileName, code);
+	private static void assertNoDuplicatedRegions(List<IRegion> regions) {
+		long distinctRegions= regions.stream()
+				.map(r -> Map.entry(r.getOffset(), r.getLength())) // map to offset-length pairs
+				.distinct()
+				.count();
+		assertEquals(regions.size(), distinctRegions,
+				"Some regions are duplicated: " + sorted(regions));
+	}
+
+	private static void assertNoRegionsStartInTheSameOffset(Collection<IRegion> regions) {
+		long distinctOffsets= regions.stream()
+				.map(IRegion::getOffset)
+				.distinct()
+				.count();
+
+		assertEquals(regions.size(), distinctOffsets,
+				"Some regions start in the same offset: Regions: " + sorted(regions));
+	}
+
+	public static void assertCodeHasRegions(IPackageFragment packageFragment, String code, int regionsCount) throws Exception {
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, code);
 		assertEquals(regionsCount, regions.size(), String.format("Expected %d regions but saw %d.", regionsCount, regions.size()));
 	}
 
+	public static void assertDoesNotContainRegionUsingStartLine(List<IRegion> projectionRanges, String input, int startLine) {
+		int startLineBegin= findLineStartIndex(input, startLine);
+		for (IRegion region : projectionRanges) {
+			if (region.getOffset() == startLineBegin) {
+				fail("found unexpected region at offset=" + region.getOffset() + ", length=" + region.getLength() +
+						" starting at line " + startLine + " (line offset: " + startLineBegin + ")");
+			}
+		}
+	}
+
+	public static void assertDoesNotContainRegionUsingStartAndEndLine(List<IRegion> projectionRanges, String input, int startLine, int endLine) {
+		StartEnd startEnd = getStartEnd(input, startLine, endLine);
+		assertDoesNotContainRegionWithOffsetAndLength(projectionRanges, startLine, endLine, startEnd.start(), startEnd.end());
+	}
+
 	public static void assertContainsRegionUsingStartAndEndLine(List<IRegion> projectionRanges, String input, int startLine, int endLine) {
+		StartEnd startEnd = getStartEnd(input, startLine, endLine);
+		assertContainsRegionWithOffsetAndLength(projectionRanges, startLine, endLine, startEnd.start(), startEnd.end());
+	}
+
+	private static StartEnd getStartEnd(String input, int startLine, int endLine) {
 		assertTrue(startLine <= endLine, "start line must be smaller or equal to end line");
 		int startLineBegin= findLineStartIndex(input, startLine);
 		int endLineBegin= findLineStartIndex(input, endLine);
 		int endLineEnd= findNextLineStart(input, endLineBegin);
-		endLineEnd= getLengthIfNotFound(input, endLineEnd);
-		int expectedRegionOffset= startLineBegin + 1;
-		int expectedRegionLength= endLineEnd + 1;
-		assertContainsRegionWithOffsetAndLength(projectionRanges, startLine, endLine, expectedRegionOffset, expectedRegionLength);
+		endLineEnd= getLastIndexIfNotFound(input, endLineEnd);
+		int expectedRegionBegin= startLineBegin;
+		int expectedRegionEnd= endLineEnd;
+		return new StartEnd(expectedRegionBegin, expectedRegionEnd);
 	}
 
-	static void assertContainsRegionWithOffsetAndLength(List<IRegion> projectionRanges, int startLine, int endLine, int expectedRegionOffset, int expectedRegionLength) {
+	static void assertDoesNotContainRegionWithOffsetAndLength(List<IRegion> projectionRanges, int startLine, int endLine, int expectedRegionBegin, int expectedRegionEnd) {
+		int expectedRegionLength= expectedRegionEnd - expectedRegionBegin + 1;
+
 		for (IRegion region : projectionRanges) {
-			if (region.getOffset() == expectedRegionOffset && region.getOffset() + region.getLength() == expectedRegionLength) {
+			if (region.getOffset() == expectedRegionBegin && region.getLength() == expectedRegionLength) {
+				fail(
+						"The region from line " + startLine + " to line " + endLine + " (offset: " + expectedRegionBegin
+								+ ", length: " + expectedRegionLength + ")" +
+								" shouldn't exist, actual regions: " + sorted(projectionRanges));
+			}
+		}
+	}
+
+	static void assertContainsRegionWithOffsetAndLength(List<IRegion> projectionRanges, int startLine, int endLine, int expectedRegionBegin, int expectedRegionEnd) {
+		int expectedRegionLength= expectedRegionEnd - expectedRegionBegin + 1;
+
+		for (IRegion region : projectionRanges) {
+			if (region.getOffset() == expectedRegionBegin && region.getLength() == expectedRegionLength) {
 				return;
 			}
 		}
+
 		fail(
-				"missing region from line " + startLine + " (index " + expectedRegionOffset + ") " +
-						"to line " + endLine + " (index " + expectedRegionLength + ")" +
-						", actual regions: " + projectionRanges
-		);
+				"missing region from line " + startLine + " to line " + endLine + " (offset: " + expectedRegionBegin
+						+ ", length: " + expectedRegionLength + ")" +
+						", actual regions: " + sorted(projectionRanges));
 	}
 
-	private static int getLengthIfNotFound(String input, int startLineEnd) {
+	/**
+	 * @return a sorted copy of the original regions, for better debugging:
+	 *         <ul>
+	 *         <li>first by offset (ascending)</li>
+	 *         <li>Then by length (descending i.e. longer regions first)</li>
+	 *         </ul>
+	 */
+	private static Collection<IRegion> sorted(Collection<IRegion> regions) {
+		List<IRegion> sortedRegions= new ArrayList<>(regions);
+		sortedRegions.sort(Comparator.comparingInt(IRegion::getOffset).thenComparing(Comparator.comparingInt(IRegion::getLength).reversed()));
+		return sortedRegions;
+	}
+
+	private static int getLastIndexIfNotFound(String input, int startLineEnd) {
 		if (startLineEnd == -1) {
-			startLineEnd= input.length();
+			startLineEnd= input.length() - 1;
 		}
 		return startLineEnd;
 	}
 
 	static int findLineStartIndex(String input, int lineNumber) {
-		int currentInputIndex= 0;
+		int currentInputIndex= -1;
 		for (int i= 0; i < lineNumber; i++) {
-			currentInputIndex= findNextLineStart(input, currentInputIndex);
+			currentInputIndex= findNextLineStart(input, currentInputIndex + 1);
 			if (currentInputIndex == -1) {
 				fail("line number is greater than the total number of lines");
 			}
 		}
-		return currentInputIndex;
+		return currentInputIndex + 1;
 	}
 
 	private static int findNextLineStart(String input, int currentInputIndex) {
-		return input.indexOf('\n', currentInputIndex + 1);
+		return input.indexOf('\n', currentInputIndex);
 	}
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingWithShowSelectedElementTests.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingWithShowSelectedElementTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Daniel Schmid and others.
+ * Copyright (c) 2025, 2026 Daniel Schmid and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -76,15 +76,14 @@ public class FoldingWithShowSelectedElementTests {
 	public void testFoldingActive() throws Exception {
 		String str= """
 				package org.example.test;
-				public class A {
+				class A {
 					void someMethod() {
 						// this method should be folded
 					}
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(packageFragment, "B.java", str);
-		assertEquals(1, regions.size());
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4);
 	}
 
 	@Test
@@ -92,7 +91,7 @@ public class FoldingWithShowSelectedElementTests {
 		JavaPlugin.getDefault().getPreferenceStore().setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED, true);
 		String str= """
 				package org.example.test;
-				public class A {
+				class A {
 					// region
 					void someMethod() {
 						// content here
@@ -118,21 +117,17 @@ public class FoldingWithShowSelectedElementTests {
 
 			List<IRegion> regions= FoldingTestUtils.extractRegions(model);
 
-			assertEquals(2, regions.size());
-
 			IDocument document= editor.getViewer().getDocument();
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6);
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4);
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // region (custom)
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // someMethod
 
 			document.replace(str.indexOf("content"), 0, "method ");
 
 			regions = FoldingTestUtils.extractRegions(model);
 			str = document.get();
 
-			assertEquals(2, regions.size());
-
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6);
-			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4);
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // region (custom)
+			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // someMethod
 		} finally {
 			editor.close(false);
 		}
@@ -143,7 +138,7 @@ public class FoldingWithShowSelectedElementTests {
 		JavaPlugin.getDefault().getPreferenceStore().setValue(PreferenceConstants.EDITOR_FOLDING_CUSTOM_REGIONS_ENABLED, true);
 		String str= """
 				package org.example.test;
-				public class A {
+				class A {
 					void someMethod() {
 						// content here
 					}\t\t\t\t

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/MarkdownJavadocFoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/MarkdownJavadocFoldingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Daniel Schmid and others.
+ * Copyright (c) 2025, 2026 Daniel Schmid and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,8 +12,6 @@
  *     Daniel Schmid - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.text.tests.folding;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -87,11 +85,10 @@ public class MarkdownJavadocFoldingTest {
 				/// Javadoc							//here should be an annotation
 				/// comment
 				/// here
-				public class HeaderCommentTest {
+				class HeaderCommentTest {
 				}
 				""";
-		FoldingTestUtils.assertCodeHasRegions(fPackageFragment, "TestFolding.java", str, 1);
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(fPackageFragment, "TestFolding.java", str);
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // Javadoc
 	}
 
@@ -99,7 +96,7 @@ public class MarkdownJavadocFoldingTest {
 	public void testSingleMethodWithMarkdownJavadoc() throws Exception {
 		String str= """
 				package org.example.test;
-				public class SingleMethodTest {
+				class SingleMethodTest {
 				    /// Javadoc							//here should be an annotation
 				    /// comment
 				    /// here
@@ -108,9 +105,8 @@ public class MarkdownJavadocFoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfFile(fPackageFragment, "TestFolding.java", str);
-		assertEquals(2, regions.size());
+		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // Javadoc
-		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // foo method
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // foo method
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/ProjectTestSetup.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/rules/ProjectTestSetup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -99,7 +99,7 @@ public class ProjectTestSetup extends ExternalResource {
 
 	@Override
 	protected void after() {
-		if (fJProject != null) {
+		if (fJProject != null && fJProject.exists()) {
 			try {
 				JavaProjectHelper.delete(fJProject);
 				CoreUtility.setAutoBuilding(fAutobuilding);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2025 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,10 +24,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.Assert;
 
@@ -37,9 +42,11 @@ import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITypedRegion;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextSelection;
+import org.eclipse.jface.text.TypedRegion;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.projection.IProjectionListener;
 import org.eclipse.jface.text.source.projection.IProjectionPosition;
@@ -72,35 +79,7 @@ import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
-import org.eclipse.jdt.core.dom.AST;
-import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.ASTParser;
-import org.eclipse.jdt.core.dom.ASTVisitor;
-import org.eclipse.jdt.core.dom.AnonymousClassDeclaration;
-import org.eclipse.jdt.core.dom.Block;
-import org.eclipse.jdt.core.dom.BreakStatement;
-import org.eclipse.jdt.core.dom.CatchClause;
-import org.eclipse.jdt.core.dom.Comment;
 import org.eclipse.jdt.core.dom.CompilationUnit;
-import org.eclipse.jdt.core.dom.DoStatement;
-import org.eclipse.jdt.core.dom.EnhancedForStatement;
-import org.eclipse.jdt.core.dom.EnumDeclaration;
-import org.eclipse.jdt.core.dom.ForStatement;
-import org.eclipse.jdt.core.dom.IfStatement;
-import org.eclipse.jdt.core.dom.ImportDeclaration;
-import org.eclipse.jdt.core.dom.Initializer;
-import org.eclipse.jdt.core.dom.LambdaExpression;
-import org.eclipse.jdt.core.dom.MethodDeclaration;
-import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.Statement;
-import org.eclipse.jdt.core.dom.SwitchCase;
-import org.eclipse.jdt.core.dom.SwitchExpression;
-import org.eclipse.jdt.core.dom.SwitchStatement;
-import org.eclipse.jdt.core.dom.SynchronizedStatement;
-import org.eclipse.jdt.core.dom.TryStatement;
-import org.eclipse.jdt.core.dom.TypeDeclaration;
-import org.eclipse.jdt.core.dom.WhileStatement;
-import org.eclipse.jdt.core.dom.YieldStatement;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
 
@@ -122,6 +101,8 @@ import org.eclipse.jdt.internal.ui.text.DocumentCharacterIterator;
  * @since 3.2 (API)
  */
 public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructureProvider, IJavaFoldingStructureProviderExtension {
+
+	private static final String COMMENT_TYPE= "__java_default_folding_structure_provider_comment"; //$NON-NLS-1$
 
 	private static class Preferences {
 		private boolean fCollapseJavadoc= false;
@@ -191,10 +172,6 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		private LinkedHashMap<JavaProjectionAnnotation, Position> fMap= new LinkedHashMap<>();
 		private IScanner fDefaultScanner; // this one may or not be the shared DefaultJavaFoldingStructureProvider.fSharedScanner
 		private IScanner fScannerForProject;
-
-		private Deque<Integer> fOpenCustomRegionStartPositions = new ArrayDeque<>();
-		private Set<IRegion> fCurrentCustomRegions = new HashSet<>();
-		private int fLastScannedIndex;
 
 		private FoldingStructureComputationContext(IDocument document, ProjectionAnnotationModel model, boolean allowCollapsing, IScanner scanner) {
 			Assert.isNotNull(document);
@@ -407,368 +384,6 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		}
 	}
 
-	private class FoldingVisitor extends ASTVisitor {
-
-		private FoldingStructureComputationContext ctx;
-		private List<Position> topLevelTypes = new ArrayList<>();
-		private ICompilationUnit topLevelCompilationUnit;
-
-		public FoldingVisitor(FoldingStructureComputationContext ctx, ICompilationUnit compilationUnit) {
-			this.ctx= ctx;
-			this.topLevelCompilationUnit= compilationUnit;
-		}
-
-		@Override
-		public boolean visit(CompilationUnit node) {
-			List<ImportDeclaration> imports= node.imports();
-			if (imports.size() > 1) {
-				int start= imports.get(0).getStartPosition();
-				ImportDeclaration lastImport= imports.get(imports.size() - 1);
-				int end= lastImport.getStartPosition() + lastImport.getLength();
-				includelastLine = true;
-				createFoldingRegion(start, end - start, ctx.collapseImportContainer());
-			}
-			return super.visit(node);
-		}
-
-		@Override
-		public boolean visit(TypeDeclaration node) {
-			SimpleName name= node.getName();
-			if (node.isMemberTypeDeclaration() || node.isLocalTypeDeclaration()) {
-				int start= name.getStartPosition();
-				int end= node.getStartPosition() + node.getLength();
-				createFoldingRegion(start, end - start, ctx.collapseMembers());
-			} else {
-				topLevelTypes.add(new Position(node.getStartPosition(), node.getLength()-1));
-			}
-			return true;
-		}
-
-		@Override
-		public boolean visit(MethodDeclaration node) {
-			int start= node.getName().getStartPosition();
-			int end= node.getStartPosition() + node.getLength();
-			createFoldingRegion(start, end - start, ctx.collapseMembers());
-			return true;
-		}
-
-		@Override
-		public boolean visit(IfStatement node) {
-			int start= node.getStartPosition();
-			int end= getEndPosition(node.getThenStatement());
-			createFoldingRegion(start, end - start, ctx.collapseMembers());
-			node.getThenStatement().accept(this);
-			if (node.getElseStatement() != null) {
-				if (node.getElseStatement() instanceof IfStatement) {
-					Statement elseIfStatement= node.getElseStatement();
-					start= findElseKeywordStart(elseIfStatement);
-					end= getEndPosition(((IfStatement) elseIfStatement).getThenStatement());
-					createFoldingRegion(start, end - start, ctx.collapseMembers());
-					node.getElseStatement().accept(this);
-				} else {
-					start= findElseKeywordStart(node.getElseStatement());
-					end= getEndPosition(node.getElseStatement());
-					createFoldingRegion(start, end - start, ctx.collapseMembers());
-					node.getElseStatement().accept(this);
-				}
-			}
-			return false;
-		}
-
-		@Override
-		public boolean visit(TryStatement node) {
-			createFoldingRegionForTryBlock(node);
-			node.getBody().accept(this);
-			for (Object obj : node.catchClauses()) {
-				CatchClause catchClause= (CatchClause) obj;
-				createFoldingRegionForCatchClause(catchClause);
-				catchClause.accept(this);
-			}
-			if (node.getFinally() != null) {
-				createFoldingRegionForFinallyBlock(node);
-				node.getFinally().accept(this);
-			}
-			return false;
-		}
-
-		@Override
-		public boolean visit(WhileStatement node) {
-			createFoldingRegionForStatement(node);
-			node.getBody().accept(this);
-			return false;
-		}
-
-		@Override
-		public boolean visit(ForStatement node) {
-			createFoldingRegionForStatement(node);
-			node.getBody().accept(this);
-			return false;
-		}
-
-		@Override
-		public boolean visit(EnhancedForStatement node) {
-			createFoldingRegionForStatement(node);
-			node.getBody().accept(this);
-			return false;
-		}
-
-		@Override
-		public boolean visit(DoStatement node) {
-			createFoldingRegionForStatement(node);
-			node.getBody().accept(this);
-			return false;
-		}
-
-		@Override
-		public boolean visit(SynchronizedStatement node) {
-			createFoldingRegion(node, ctx.collapseMembers());
-			node.getBody().accept(this);
-			return false;
-		}
-
-		@Override
-		public boolean visit(LambdaExpression node) {
-			if (node.getBody() instanceof Block) {
-				createFoldingRegion(node.getBody(), ctx.collapseMembers());
-				node.getBody().accept(this);
-			}
-			return false;
-		}
-
-		@Override
-		public boolean visit(AnonymousClassDeclaration node) {
-			createFoldingRegion(node, ctx.collapseInnerTypes());
-			return true;
-		}
-
-		@Override
-		public boolean visit(EnumDeclaration node) {
-			createFoldingRegion(node, ctx.collapseMembers());
-			return true;
-		}
-
-		@Override
-		public boolean visit(Initializer node) {
-			createFoldingRegion(node, ctx.collapseMembers());
-			return true;
-		}
-
-		@Override
-		public boolean visit(SwitchStatement node) {
-			createFoldingRegionForStatement(node);
-			createFoldingRegionForSwitch(node, node.statements());
-			return false;
-		}
-
-		@Override
-		public boolean visit(SwitchExpression node) {
-			createFoldingRegionForStatement(node);
-			createFoldingRegionForSwitch(node, node.statements());
-			return false;
-		}
-
-		private void createFoldingRegionForSwitch(ASTNode switchNode, List<?> statements) {
-			SwitchCase previousCase= null;
-
-			for (Object obj : statements) {
-				Statement stmt= (Statement) obj;
-
-				if (stmt instanceof SwitchCase currentCase) {
-					if (previousCase != null) {
-						int start= previousCase.getStartPosition();
-						int end= currentCase.getStartPosition();
-						createFoldingRegion(start, end - start, ctx.collapseMembers());
-					}
-					previousCase= currentCase;
-
-				} else if (stmt instanceof BreakStatement || stmt instanceof YieldStatement) {
-					if (previousCase != null) {
-						int start= previousCase.getStartPosition();
-						int end= stmt.getStartPosition();
-						createFoldingRegion(start, end - start, ctx.collapseMembers());
-						previousCase= null;
-					}
-				} else if (stmt instanceof Block block) {
-					List<?> innerStatements= block.statements();
-					for (Object innerObj : innerStatements) {
-						Statement innerStmt= (Statement) innerObj;
-
-						if (innerStmt instanceof BreakStatement || innerStmt instanceof YieldStatement) {
-							if (previousCase != null) {
-								int start= previousCase.getStartPosition();
-								int end= innerStmt.getStartPosition();
-								createFoldingRegion(start, end - start, ctx.collapseMembers());
-								previousCase= null;
-							}
-						}
-					}
-				}
-			}
-
-			if (previousCase != null) {
-				int start= previousCase.getStartPosition();
-				int end= switchNode.getStartPosition() + switchNode.getLength();
-				createFoldingRegion(start, end - start, ctx.collapseMembers());
-			}
-		}
-
-		private void createFoldingRegion(ASTNode node, boolean collapse) {
-			createFoldingRegion(node.getStartPosition(), node.getLength(), collapse);
-		}
-
-		private void createFoldingRegion(int start, int length, boolean collapse) {
-			createFoldingRegion(start, length, collapse, false);
-		}
-
-		private void createFoldingRegion(int start, int length, boolean collapse, boolean isComment) {
-			createFoldingRegion(start, length, collapse, resolveJavaElementAt(start), isComment);
-		}
-
-
-		private IJavaElement resolveJavaElementAt(int offset) {
-			try {
-				IJavaElement element= topLevelCompilationUnit.getElementAt(offset - 1);
-				if (element != null) {
-					return element;
-				}
-			} catch (JavaModelException e) {
-				JavaPlugin.log(e);
-			}
-			return null;
-		}
-
-		private void createFoldingRegion(int start, int length, boolean collapse, IJavaElement element, boolean isComment) {
-			if (length > 0) {
-				IRegion region= new Region(start, length);
-				IRegion aligned= alignRegion(region, ctx);
-
-				if (aligned != null && isMultiline(aligned)) {
-					Position position= new Position(aligned.getOffset(), aligned.getLength());
-					JavaProjectionAnnotation annotation= new JavaProjectionAnnotation(collapse, element, isComment);
-					ctx.addProjectionRange(annotation, position);
-				}
-			}
-		}
-
-		private boolean isMultiline(IRegion region) {
-			try {
-				IDocument document= ctx.getDocument();
-				int startLine= document.getLineOfOffset(region.getOffset());
-				int endLine= document.getLineOfOffset(region.getOffset() + region.getLength());
-				return endLine > startLine + 1;
-			} catch (BadLocationException e) {
-				return false;
-			}
-		}
-
-		private int findElseKeywordStart(ASTNode node) {
-			try {
-				IDocument document= ctx.getDocument();
-				int startSearch= node.getParent().getStartPosition();
-				int endSearch= node.getStartPosition();
-
-				String text= document.get(startSearch, endSearch - startSearch);
-				int index= text.lastIndexOf("else"); //$NON-NLS-1$
-				if (index >= 0) {
-					return startSearch + index;
-				}
-			} catch (BadLocationException e) {
-			}
-			return node.getStartPosition();
-		}
-
-		private int getEndPosition(Statement statement) {
-			if (statement instanceof Block) {
-				return statement.getStartPosition() + statement.getLength();
-			} else {
-				try {
-					IDocument document= ctx.getDocument();
-					int start= statement.getStartPosition();
-					int line= document.getLineOfOffset(start);
-					return document.getLineOffset(line + 1);
-				} catch (BadLocationException e) {
-					return statement.getStartPosition() + statement.getLength();
-				}
-			}
-		}
-
-		private void createFoldingRegionForStatement(ASTNode node) {
-			int start= node.getStartPosition();
-			int length= node.getLength();
-			if (!(node instanceof Block)) {
-				try {
-					IDocument document= ctx.getDocument();
-					int endLine= document.getLineOfOffset(start + length - 1);
-					if (endLine + 1 < document.getNumberOfLines()) {
-						String currentIndent= getIndentOfLine(document, endLine);
-						String nextIndent= getIndentOfLine(document, endLine + 1);
-						if (nextIndent.length() > currentIndent.length()) {
-							int nextLineEndOffset= document.getLineOffset(endLine + 2) - 1;
-							length= nextLineEndOffset - start;
-						} else {
-							length= document.getLineOffset(endLine + 1) - start;
-						}
-					} else {
-						length= document.getLength() - start;
-					}
-				} catch (BadLocationException e) {
-				}
-			}
-			createFoldingRegion(start, length, ctx.collapseMembers());
-		}
-
-		private String getIndentOfLine(IDocument document, int line) throws BadLocationException {
-			IRegion region= document.getLineInformation(line);
-			int lineStart= region.getOffset();
-			int lineLength= region.getLength();
-
-			int whiteSpaceEnd= lineStart;
-			while (whiteSpaceEnd < lineStart + lineLength) {
-				char c= document.getChar(whiteSpaceEnd);
-				if (!Character.isWhitespace(c)) {
-					break;
-				}
-				whiteSpaceEnd++;
-			}
-			return document.get(lineStart, whiteSpaceEnd - lineStart);
-		}
-
-		private void createFoldingRegionForTryBlock(TryStatement node) {
-			int start= node.getStartPosition();
-			int end= getEndPosition(node.getBody());
-			createFoldingRegion(start, end - start, ctx.collapseMembers());
-		}
-
-		private void createFoldingRegionForCatchClause(CatchClause catchClause) {
-			int start= catchClause.getStartPosition();
-			int end= getEndPosition(catchClause.getBody());
-			createFoldingRegion(start, end - start, ctx.collapseMembers());
-		}
-
-		private void createFoldingRegionForFinallyBlock(TryStatement node) {
-			Block finallyBlock= node.getFinally();
-			int start= findFinallyKeywordStart(node);
-			int end= getEndPosition(finallyBlock);
-			createFoldingRegion(start, end - start, ctx.collapseMembers());
-		}
-
-		private int findFinallyKeywordStart(TryStatement node) {
-			try {
-				IDocument document= ctx.getDocument();
-				int startSearch= node.getStartPosition();
-				int endSearch= node.getFinally().getStartPosition();
-				String text= document.get(startSearch, endSearch - startSearch);
-				int index= text.lastIndexOf("finally"); //$NON-NLS-1$
-
-				if (index >= 0) {
-					return startSearch + index;
-				}
-			} catch (BadLocationException e) {
-			}
-			return node.getFinally().getStartPosition();
-		}
-	}
-
 	/**
 	 * Filter for annotations.
 	 */
@@ -928,7 +543,6 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			return null;
 		}
 	}
-
 
 	/**
 	 * Projection position that will return two foldable regions: one folding away the region from
@@ -1150,7 +764,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		}
 	}
 
-	boolean includelastLine = false;
+	private record TokenAtOffset(int offset, int token) {}
 
 	/* context and listeners */
 	private JavaEditor fEditor;
@@ -1368,6 +982,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				!customFoldingRegionBegin.isEmpty() && !customFoldingRegionEnd.isEmpty();
 		// do not include the end region marker in the folded region if the start and end markers are not mutually exclusive
 		temp.fCustomFoldingRegionMarkersCanOverlap = customFoldingRegionBegin.startsWith(customFoldingRegionEnd) || customFoldingRegionEnd.startsWith(customFoldingRegionBegin);
+		temp.fCollapseCustomRegions= store.getBoolean(PreferenceConstants.EDITOR_FOLDING_COLLAPSE_CUSTOM_REGIONS);
 		temp.fNewFolding = store.getBoolean(PreferenceConstants.EDITOR_NEW_FOLDING_ENABLED);
 
 		boolean preferencesChanged = !Objects.equals(temp, fCurrentPreferences);
@@ -1387,6 +1002,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		List<JavaProjectionAnnotation> updates= new ArrayList<>();
 
 		computeFoldingStructure(ctx);
+		keepLargestByPosition(ctx.fMap);
 		Map<IJavaElement, List<Tuple>> oldStructure= computeCurrentStructure(ctx);
 
 		List<Map.Entry<JavaProjectionAnnotation, Position>> newStructureList = new ArrayList<>(ctx.fMap.entrySet());
@@ -1461,290 +1077,8 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	}
 
 	private void computeFoldingStructure(FoldingStructureComputationContext ctx) {
-	    if (fCurrentPreferences.fNewFolding && fInput instanceof ICompilationUnit) {
-	        processCompilationUnit((ICompilationUnit) fInput, ctx);
-	        processComments(ctx);
-	    } else {
-	        processSourceReference(ctx);
-	    }
+		processSourceReference(ctx);
 	}
-
-	private void processCompilationUnit(ICompilationUnit unit, FoldingStructureComputationContext ctx) {
-	    try {
-	        String source = unit.getSource();
-	        if (source == null) return;
-
-	        char[] sourceArray= source.toCharArray();
-			ctx.getScanner().setSource(sourceArray);
-	        ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
-	        parser.setBindingsRecovery(true);
-	        parser.setStatementsRecovery(true);
-	        parser.setKind(ASTParser.K_COMPILATION_UNIT);
-	        parser.setResolveBindings(true);
-	        parser.setUnitName(unit.getElementName());
-	        parser.setProject(unit.getJavaProject());
-	        parser.setSource(unit);
-	        Map<String, String> options = unit.getJavaProject().getOptions(true);
-		    options.put(JavaCore.COMPILER_SOURCE, JavaCore.latestSupportedJavaVersion());
-		    options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.latestSupportedJavaVersion());
-		    options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.latestSupportedJavaVersion());
-		    options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED);
-	        parser.setCompilerOptions(options);
-
-	        CompilationUnit ast = (CompilationUnit) parser.createAST(null);
-	        FoldingVisitor visitor= new FoldingVisitor(ctx, unit);
-			ast.accept(visitor);
-
-			if (fCurrentPreferences.fCustomFoldingRegionsEnabled) {
-				List<Comment> comments= ast.getCommentList();
-				int currentCommentIndex= 0;
-
-				// Go through all already discovered folding regions in order to compute custom regions
-				// Disjoint folding regions are processed sequentially.
-				// Nested folding regions are processed depth-first.
-
-				// stack containing the "current" nested folding regions
-				// the top of the stack is the innermost region
-				Deque<Position> currentFoldingPositions= new ArrayDeque<>();
-				// stack containing the position of "open" regions for each element in currentFoldingPositions
-				// i.e. regions where the start position has been found but no end position
-				// Whenever an element is added/removed from currentFoldingPositions, the same is done with openCustomRegionStartPositions
-				Deque<Deque<Integer>> openCustomRegionStartPositions= new ArrayDeque<>();
-				openCustomRegionStartPositions.add(new ArrayDeque<>());
-
-				for (Position nonCommentFoldingRegion : merge(visitor.topLevelTypes, ctx.fMap.values())) {
-
-					// process regions depth-first until reaching the current region
-					currentCommentIndex= processFoldingRegionsForCustomCommentFolding(
-							sourceArray, visitor, comments, currentCommentIndex,
-							currentFoldingPositions, openCustomRegionStartPositions, nonCommentFoldingRegion.getOffset()
-					);
-					if (currentCommentIndex >= comments.size()) {
-						while(!openCustomRegionStartPositions.isEmpty()) {
-							Deque<Integer> activeFoldingRegions= openCustomRegionStartPositions.removeLast();
-							Position region= currentFoldingPositions.pollLast();
-							int endPosition = sourceArray.length - 1;
-							if (region != null) {
-								endPosition= region.getOffset() + region.getLength() - 1;
-							}
-							endAllActiveFoldingRegions(sourceArray, visitor, activeFoldingRegions, endPosition);
-						}
-
-						return;
-					}
-
-					// process comments before current region starts
-					currentCommentIndex= checkCustomFoldingCommentsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peekLast(), nonCommentFoldingRegion.getOffset());
-
-					currentFoldingPositions.addLast(nonCommentFoldingRegion);
-					openCustomRegionStartPositions.addLast(new ArrayDeque<>());
-				}
-				// process all leftover comments at the end
-				currentCommentIndex= processFoldingRegionsForCustomCommentFolding(sourceArray, visitor, comments, currentCommentIndex, currentFoldingPositions, openCustomRegionStartPositions, Integer.MAX_VALUE);
-				checkCustomFoldingCommentsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, openCustomRegionStartPositions.peek(), Integer.MAX_VALUE);
-
-				for (Deque<Integer> activeFoldingRegions : openCustomRegionStartPositions) {
-					endAllActiveFoldingRegions(sourceArray, visitor, activeFoldingRegions, sourceArray.length - 1);
-				}
-			}
-		} catch (JavaModelException | IllegalStateException e) {
-		}
-	}
-
-	private List<Position> merge(List<Position> topLevelTypes, Collection<Position> nonCustomFoldingRegions) {
-		List<Position> merged = new ArrayList<>(topLevelTypes.size() + nonCustomFoldingRegions.size());
-
-		int topLevelIndex = 0;
-		for (Position region : nonCustomFoldingRegions) {
-			while (topLevelIndex < topLevelTypes.size() && topLevelTypes.get(topLevelIndex).getOffset() < region.getOffset()) {
-				merged.add(topLevelTypes.get(topLevelIndex++));
-			}
-			merged.add(region);
-		}
-
-		while (topLevelIndex < topLevelTypes.size()) {
-			merged.add(topLevelTypes.get(topLevelIndex++));
-		}
-
-		return merged;
-	}
-
-	/**
-	 * Pops regions before limit and checks for custom folding comments.
-	 *
-	 * @param sourceArray the content of the processed source file
-	 * @param visitor the {@link FoldingVisitor} used for adding folding regions
-	 * @param comments all comments in the source file
-	 * @param currentCommentIndex the index of the next comment to process
-	 * @param currentFoldingPositions stack of current nested folding regions
-	 * @param openCustomRegionStartPositions start positions of custom folding regions with the
-	 *            start position being found but the end positions still missing
-	 * @param limit only regions before this position are scanned
-	 * @return the new index of the next comment
-	 */
-	private int processFoldingRegionsForCustomCommentFolding(char[] sourceArray, FoldingVisitor visitor, List<Comment> comments, int currentCommentIndex,
-			Deque<Position> currentFoldingPositions, Deque<Deque<Integer>> openCustomRegionStartPositions, int limit) {
-		Position currentFoldingPosition= currentFoldingPositions.peekLast();
-		while (currentFoldingPosition != null && currentFoldingPosition.getOffset() + currentFoldingPosition.getLength() < limit) {
-			currentFoldingPositions.removeLast();
-			Deque<Integer> innerOpenStartPositions= openCustomRegionStartPositions.removeLast();
-
-			int currentFoldingPositionEnd= currentFoldingPosition.getOffset() + currentFoldingPosition.getLength();
-			currentCommentIndex= checkCustomFoldingCommentsBeforePosition(sourceArray, visitor, comments, currentCommentIndex, innerOpenStartPositions, currentFoldingPositionEnd);
-
-			if (fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap) {
-				endAllActiveFoldingRegions(sourceArray, visitor, innerOpenStartPositions, currentFoldingPositionEnd);
-			}
-
-			if (currentCommentIndex >= comments.size()) {
-				if (fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap) {
-					// end all remaining custom folding regions of all remaining blocks if last comment reached
-					while (!currentFoldingPositions.isEmpty() && !openCustomRegionStartPositions.isEmpty()) {
-						currentFoldingPosition= currentFoldingPositions.removeLast();
-						innerOpenStartPositions= openCustomRegionStartPositions.removeLast();
-						endAllActiveFoldingRegions(sourceArray, visitor, innerOpenStartPositions, currentFoldingPosition.getOffset() + currentFoldingPosition.getLength());
-					}
-				}
-				return currentCommentIndex;
-			}
-
-			currentFoldingPosition= currentFoldingPositions.peekLast();
-		}
-		return currentCommentIndex;
-	}
-
-	private void endAllActiveFoldingRegions(char[] sourceArray, FoldingVisitor visitor, Deque<Integer> openRegionsToEnd, int foldingRegionEnd) {
-		if (fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap) {
-			for (Integer startPosition : openRegionsToEnd) {
-				IRegion region= new Region(startPosition, foldingRegionEnd - startPosition);
-				checkIncludeLastLineAndCreateCustomFoldingRegion(sourceArray, visitor, region, false);
-			}
-		}
-	}
-
-
-	/**
-	 * Searches for custom folding comments before a specified position and adds corresponding folding annotations.
-	 *
-	 * @param sourceArray the content of the processed source file
-	 * @param visitor the {@link FoldingVisitor} used for adding folding annotations
-	 * @param comments all comments in the source file
-	 * @param currentCommentIndex the index of the first comment to process
-	 * @param innerOpenStartPositions start positions of custom folding regions with the start position being found but the end positions still missing
-	 * @param limit only regions before this position are scanned
-	 * @return the new index of the next comment to process (after limit)
-	 */
-	private int checkCustomFoldingCommentsBeforePosition(char[] sourceArray, FoldingVisitor visitor, List<Comment> comments, int currentCommentIndex,
-			Deque<Integer> innerOpenStartPositions, int limit) {
-		while (currentCommentIndex < comments.size() && comments.get(currentCommentIndex).getStartPosition() < limit) {
-			Comment comment= comments.get(currentCommentIndex);
-			checkCustomFolding(innerOpenStartPositions, sourceArray, visitor, comment);
-			currentCommentIndex++;
-		}
-		return currentCommentIndex;
-	}
-
-	private void checkCustomFolding(Deque<Integer> openCustomRegionStartPositions, char[] sourceArray, FoldingVisitor visitor, Comment comment) {
-		int skip= 2;
-		if (comment.isDocComment()) {
-			skip= 3;
-		}
-		int commentTextStart= skipLeadingWhitespace(sourceArray, comment.getStartPosition() + skip);
-		IRegion customFoldingRegion= checkCustomFolding(
-				openCustomRegionStartPositions, commentTextStart, sourceArray,
-				comment.getStartPosition(), comment.getStartPosition() + comment.getLength()
-		);
-		if (customFoldingRegion != null) {
-			checkIncludeLastLineAndCreateCustomFoldingRegion(sourceArray, visitor, customFoldingRegion, fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap);
-		}
-	}
-
-	private void checkIncludeLastLineAndCreateCustomFoldingRegion(char[] sourceArray, FoldingVisitor visitor, IRegion customFoldingRegion, boolean excludeEndregionComment) {
-		includelastLine = includeLastLineInCustomFoldingRegion(sourceArray, customFoldingRegion.getOffset() + customFoldingRegion.getLength(), excludeEndregionComment);
-		visitor.createFoldingRegion(customFoldingRegion.getOffset(), customFoldingRegion.getLength(), fCurrentPreferences.fCollapseCustomRegions, true);
-	}
-
-	private boolean includeLastLineInCustomFoldingRegion(char[] sourceArray, int regionEnd, boolean excludeEndregionComment) {
-		if (excludeEndregionComment) {
-			return false;
-		}
-		char firstCharacter = sourceArray[regionEnd];
-		if (firstCharacter == '\n' || firstCharacter == '\r') {
-			return true;
-		}
-		for (int i= regionEnd + 1; i < sourceArray.length; i++) {
-			char c= sourceArray[i];
-			if (c == '\n' || c == '\r') {
-				return true;
-			}
-			// allow custom regions comments defined in {/* ... */} without that causing the end to be shown
-			if (!Character.isWhitespace(c) && c != '}') {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	private void processComments(FoldingStructureComputationContext ctx) {
-	    try {
-	        IDocument document = ctx.getDocument();
-	        String source = document.get();
-	        IScanner scanner = ctx.getScanner();
-	        scanner.setSource(source.toCharArray());
-	        scanner.resetTo(0, source.length() - 1);
-
-	        int token;
-	        while ((token = scanner.getNextToken()) != ITerminalSymbols.TokenNameEOF) {
-	            if (token == ITerminalSymbols.TokenNameCOMMENT_BLOCK || token == ITerminalSymbols.TokenNameCOMMENT_JAVADOC || token == ITerminalSymbols.TokenNameCOMMENT_MARKDOWN) {
-	                int start = scanner.getCurrentTokenStartPosition();
-	                int end = scanner.getCurrentTokenEndPosition() + 1;
-	                try {
-	                    int endLine = document.getLineOfOffset(end);
-	                    int lineOffset = document.getLineOffset(endLine);
-	                    int lineLength = document.getLineLength(endLine);
-	                    String lineText = document.get(lineOffset, lineLength);
-	                    int commentEndInLine = end - lineOffset;
-	                    String afterComment = lineText.substring(commentEndInLine);
-
-	                    if (afterComment.trim().length() > 0) {
-	                        end = lineOffset;
-	                    } else {
-	                        if (endLine + 1 < document.getNumberOfLines()) {
-	                            end = document.getLineOffset(endLine + 1);
-	                        } else {
-	                            end = document.getLength();
-	                        }
-	                    }
-	                } catch (BadLocationException e) {
-	                }
-
-	                IRegion region = new Region(start, end - start);
-	                includelastLine = true;
-	                IRegion aligned = alignRegion(region, ctx);
-
-	                if (aligned != null && isMultiline(aligned, ctx)) {
-	                    Position position = createCommentPosition(aligned);
-	                    JavaProjectionAnnotation annotation = new JavaProjectionAnnotation(ctx.collapseJavadoc(), null, true);
-	                    ctx.addProjectionRange(annotation, position);
-	                }
-	            }
-	        }
-	    } catch (InvalidInputException e) {
-	    }
-	}
-
-
-	private boolean isMultiline(IRegion region, FoldingStructureComputationContext ctx) {
-	    try {
-	        IDocument document = ctx.getDocument();
-	        int startLine = document.getLineOfOffset(region.getOffset());
-	        int endLine = document.getLineOfOffset(region.getOffset() + region.getLength() - 1);
-	        return endLine > startLine;
-	    } catch (BadLocationException e) {
-	        return false;
-	    }
-	}
-
 
 	private void processSourceReference(FoldingStructureComputationContext ctx) {
 		IParent parent= (IParent) fInput;
@@ -1757,7 +1091,14 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 			ctx.getScanner().setSource(source.toCharArray());
 			computeFoldingStructure(parent.getChildren(), ctx);
-		} catch (JavaModelException x) {
+
+			// also call the custom folding if necessary
+			if (fCurrentPreferences.fCustomFoldingRegionsEnabled) {
+				computeFoldingStructureCustom(fInput, ctx);
+			}
+		} catch (JavaModelException e) {
+			// Do log exceptions, they should not happen
+			JavaPlugin.log(e.getStatus());
 		}
 	}
 
@@ -1775,34 +1116,72 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	 *         only one line)
 	 */
 	protected final IRegion alignRegion(IRegion region, FoldingStructureComputationContext ctx) {
+		return alignRegion(region, ctx, false); // Do not fold the last line (preserve existing behavior for subclasses)
+	}
+
+	private IRegion alignRegion(IRegion region, FoldingStructureComputationContext ctx, boolean mayIncludeLastLine) {
 		if (region == null)
 			return null;
 
 		IDocument document= ctx.getDocument();
 
 		try {
+			boolean includeLastLine= mayIncludeLastLine && !hasLineMoreContent(region.getOffset() + region.getLength(), ctx.fDocument);
+
+			// Line numbers (0-based)
 			int start= document.getLineOfOffset(region.getOffset());
-			int end= document.getLineOfOffset(region.getOffset() - 1 + region.getLength());
-			if (start >= end)
+			int end= document.getLineOfOffset(region.getOffset() + region.getLength());
+
+			if (end >= document.getNumberOfLines()) {
+				end= document.getNumberOfLines() - 1;
+			}
+
+			if (start >= end // ignore regions in the same line and other invalid regions
+					|| (!includeLastLine && end == start + 1)) // ignore regions that span exactly two lines if we don't want to include the last line
 				return null;
+
 			int offset= document.getLineOffset(start);
 			int endOffset;
-			if (includelastLine) {
+
+			if (includeLastLine) {
 				if (document.getNumberOfLines() == end + 1) {
-					endOffset = document.getLength() - 1;
+					// end of document, there are no more lines and therefore no line delimiter to include at the end of the line
+					endOffset = document.getLineOffset(end) + document.getLineLength(end);
 				} else {
+					// this includes the line delimiter of the previous line
 					endOffset= document.getLineOffset(end + 1);
 				}
-				includelastLine = false;
-			}
-			else {
-				endOffset= document.getLineOffset(end);
+			} else {
+				// this includes the line delimiter of the previous line
+				endOffset = document.getLineOffset(end);
 			}
 
 			return new Region(offset, endOffset - offset);
 		} catch (BadLocationException x) {
 			return null;
 		}
+	}
+
+	/**
+	 * Checks whether a line has additional content that should prevent a folding region from including that line
+	 *
+	 * For example, if a folding regions ends at a <code>}</code>, additional code (e.g. an {@code else}-block) prevents the folding region from including the last line.
+	 * @param offset the logical end of the folding region
+	 * @param document the document the offset/folding region applies to
+	 * @return {@code true} if the folding region should exclude the last line containing the offset, else {@code false}
+	 */
+	private boolean hasLineMoreContent(int offset, IDocument document) throws BadLocationException {
+		for (int i= offset; i < document.getLength(); i++) {
+			char c= document.getChar(i);
+			if (c == '\n' || c == '\r') {
+				return false;
+			}
+			// These characters are not interesting enough to show the last line in the folding region
+			if (!Character.isWhitespace(c) && c != ';' && c != ',' && c != ')' ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -1823,17 +1202,32 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 			if (element instanceof IParent) {
 				IParent parent= (IParent) element;
-				Deque<Integer> outerOpenRegions = ctx.fOpenCustomRegionStartPositions;
-				ctx.fOpenCustomRegionStartPositions = new ArrayDeque<>();
-				computeFoldingStructure(parent.getChildren(), ctx);
-				ctx.fOpenCustomRegionStartPositions = outerOpenRegions;
-			}
-			if (fCurrentPreferences.fCustomFoldingRegionsEnabled && element instanceof ISourceReference sourceRef) {
-				// mark as scanned until end after scanning all children
-				ISourceRange sourceRange= sourceRef.getSourceRange();
-				ctx.fLastScannedIndex = sourceRange.getLength()+sourceRange.getOffset();
+				IJavaElement[] children= parent.getChildren();
+				computeFoldingStructure(children, ctx);
+				if (fCurrentPreferences.fNewFolding && element instanceof ISourceReference sourceRef) {
+					// Dives deeper and processes the tokens directly found in the source code.
+					for (IRegion r : computeProjectionRangesUsingTokensInSourceCode(sourceRef, ctx, children)) {
+						boolean isComment= (r instanceof ITypedRegion tr) && COMMENT_TYPE.equals(tr.getType());
+						boolean collapse= isComment ? ctx.collapseJavadoc() : ctx.collapseMembers();
+						normalizeAndAddRegion(ctx, element, collapse, r, isComment);
+					}
+				}
 			}
 		}
+	}
+
+	private Region checkCommentForCustomFolding(Deque<Integer> openCustomRegionStartPositions, int commentTextStart, char[] source, int currentTokenStartPosition, int currentTokenEndPosition) {
+		int currentTokenLengthStartingAtCommentTextStart= currentTokenEndPosition - commentTextStart;
+		Region returnedRegion= null;
+		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCurrentPreferences.fCustomFoldingRegionEnd) && !openCustomRegionStartPositions.isEmpty()) {
+			int end= fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap ? currentTokenStartPosition : currentTokenEndPosition;
+			Integer regionStart= openCustomRegionStartPositions.removeLast();
+			returnedRegion= new Region(regionStart, end - regionStart);
+		}
+		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCurrentPreferences.fCustomFoldingRegionBegin)) {
+			openCustomRegionStartPositions.add(currentTokenStartPosition);
+		}
+		return returnedRegion;
 	}
 
 	/**
@@ -1857,23 +1251,15 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	 */
 	protected void computeFoldingStructure(IJavaElement element, FoldingStructureComputationContext ctx) {
 		boolean collapse= false;
-		boolean collapseCode= true;
 		switch (element.getElementType()) {
 			case IJavaElement.IMPORT_CONTAINER:
 				collapse= ctx.collapseImportContainer();
-				includelastLine= true;
 				break;
 			case IJavaElement.TYPE:
-				collapseCode= includelastLine= isInnerType((IType) element) && !isAnonymousEnum((IType) element);
-				collapse= ctx.collapseInnerTypes() && collapseCode;
-				break;
-			case IJavaElement.FIELD:
-				if (containsAnonymousChild(element)) {
-					return;
-				}
-				collapse= ctx.collapseMembers();
+				collapse= ctx.collapseInnerTypes();
 				break;
 			case IJavaElement.METHOD:
+			case IJavaElement.FIELD:
 			case IJavaElement.INITIALIZER:
 				collapse= ctx.collapseMembers();
 				break;
@@ -1885,73 +1271,18 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		if (regions.length > 0) {
 			// comments
 			for (int i= 0; i < regions.length - 1; i++) {
-				includelastLine= true;
-				IRegion region= regions[i];
-				IRegion normalized= alignRegion(region, ctx);
-				if (normalized != null) {
-					Position position= createCommentPosition(normalized);
-					if (position != null) {
-						boolean commentCollapse;
-						if (i == 0 && (regions.length > 2 || ctx.hasHeaderComment()) && element == ctx.getFirstType()) {
-							commentCollapse= ctx.collapseHeaderComments();
-						} else if (ctx.fCurrentCustomRegions.contains(region)) {
-							commentCollapse= ctx.collapseCustomRegions();
-						} else {
-							commentCollapse= ctx.collapseJavadoc();
-						}
-						ctx.addProjectionRange(new JavaProjectionAnnotation(commentCollapse, element, true), position);
-					}
+				boolean commentCollapse;
+				if (i == 0 && (regions.length > 2 || ctx.hasHeaderComment()) && element == ctx.getFirstType()) {
+					commentCollapse= ctx.collapseHeaderComments();
+				} else {
+					commentCollapse= ctx.collapseJavadoc();
 				}
+
+				normalizeAndAddRegion(ctx, element, commentCollapse, regions[i], true);
 			}
+
 			// code
-			if (collapseCode) {
-				IRegion normalized= alignRegion(regions[regions.length - 1], ctx);
-				if (normalized != null) {
-					Position position;
-					if (element instanceof IMember) {
-						position= createMemberPosition(normalized, (IMember) element);
-					} else {
-						includelastLine= true;
-						position= createCommentPosition(normalized);
-					}
-
-					if (position != null)
-						ctx.addProjectionRange(new JavaProjectionAnnotation(collapse, element, false), position);
-				}
-			}
-		}
-	}
-
-	private boolean containsAnonymousChild(IJavaElement element) {
-		if (!(element instanceof IParent parent)) {
-			return false;
-		}
-
-		try {
-			for (IJavaElement child : parent.getChildren()) {
-				if (child instanceof IType t && t.isAnonymous()) {
-					return true;
-				}
-			}
-		} catch (JavaModelException e) {
-			JavaPlugin.log(e);
-		}
-		return false;
-	}
-
-	/**
-	 * Returns <code>true</code> if <code>type</code> is an anonymous enum declaration,
-	 * <code>false</code> otherwise. See also https://bugs.eclipse.org/bugs/show_bug.cgi?id=143276
-	 *
-	 * @param type the type to test
-	 * @return <code>true</code> if <code>type</code> is an anonymous enum declaration
-	 * @since 3.3
-	 */
-	private boolean isAnonymousEnum(IType type) {
-		try {
-			return type.isEnum() && type.isAnonymous();
-		} catch (JavaModelException x) {
-			return false; // optimistically
+			normalizeAndAddRegion(ctx, element, collapse, regions[regions.length - 1], false);
 		}
 	}
 
@@ -2001,71 +1332,42 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 				final int shift= range.getOffset();
 				IScanner scanner= ctx.getScanner();
-
-				if (fCurrentPreferences.fCustomFoldingRegionsEnabled &&
-						reference instanceof IJavaElement javaElement && javaElement.getParent() != null &&
-							javaElement.getParent() instanceof IParent parent && parent instanceof ISourceReference parentSourceReference) {
-						// check tokens between the last sibling (or the parent) and start of current sibling
-						ISourceRange parentSourceRange= parentSourceReference.getSourceRange();
-						if (ctx.fLastScannedIndex >= parentSourceRange.getOffset() && ctx.fLastScannedIndex < parentSourceRange.getOffset() + parentSourceRange.getLength()
-								&& ctx.fLastScannedIndex < range.getOffset()) {
-							scanner.resetTo(ctx.fLastScannedIndex, range.getOffset());
-							checkCustomFoldingUntilScannerEnd(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner);
-						}
-					}
-
-
 				scanner.resetTo(shift, shift + range.getLength());
 
 				int start= shift;
-
 				while (true) {
 
 					int token= scanner.getNextToken();
 					start= scanner.getCurrentTokenStartPosition();
 
+					// Only consume comment tokens
 					switch (token) {
-						case ITerminalSymbols.TokenNameCOMMENT_JAVADOC, ITerminalSymbols.TokenNameCOMMENT_MARKDOWN, ITerminalSymbols.TokenNameCOMMENT_BLOCK: {
+						case ITerminalSymbols.TokenNameCOMMENT_JAVADOC:
+						case ITerminalSymbols.TokenNameCOMMENT_MARKDOWN:
+						case ITerminalSymbols.TokenNameCOMMENT_BLOCK: {
 							int end= scanner.getCurrentTokenEndPosition() + 1;
-							regions.add(new Region(start, end - start));
-							checkCustomFolding(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner, token, regions.size());
+							regions.add(new TypedRegion(start, end - start, COMMENT_TYPE));
 							continue;
 						}
-						case ITerminalSymbols.TokenNameCOMMENT_LINE: {
-							checkCustomFolding(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner, token, regions.size());
+						case ITerminalSymbols.TokenNameCOMMENT_LINE:
 							continue;
-						}
 					}
 
+					// reached non-comment token: the remainder is the code
 					break;
 				}
 
-				regions.add(new Region(start, shift + range.getLength() - start));
+				// The rest is the code region
+				int length= shift + range.getLength() - start;
 
-				if (fCurrentPreferences.fCustomFoldingRegionsEnabled) {
-					if (reference instanceof IParent parent && !parent.hasChildren()) {
-						// if the element has no children, check content for custom folding region markers
-						Deque<Integer> openCustomRegionStartPositions= new ArrayDeque<>();
-						checkCustomFoldingUntilScannerEnd(ctx, regions, openCustomRegionStartPositions, scanner);
-						addRemainingOpenCustomFoldingRegions(range, regions, ctx, openCustomRegionStartPositions, false);
-					}
-					ctx.fLastScannedIndex= scanner.getCurrentTokenEndPosition();
-					if (reference instanceof IJavaElement javaElement && javaElement.getParent() != null &&
-							javaElement.getParent() instanceof IParent parent && parent instanceof ISourceReference parentSourceReference) {
-						IJavaElement[] siblings= parent.getChildren();
-						if (javaElement == siblings[siblings.length - 1]) {
-							// if the current element is the last sibling
-							// tokens after the current element and before the end of the parent are checked for custom folding region markers
-							int regionStart= range.getOffset() + range.getLength();
-							ISourceRange parentRange= parentSourceReference.getSourceRange();
-							int regionEnd= parentRange.getOffset() + parentRange.getLength();
-							scanner.resetTo(regionStart, regionEnd);
-							checkCustomFoldingUntilScannerEnd(ctx, regions, ctx.fOpenCustomRegionStartPositions, scanner);
-
-							addRemainingOpenCustomFoldingRegions(range, regions, ctx, ctx.fOpenCustomRegionStartPositions, true);
-						}
-					}
+				// Make sure the code region ends with the last closing bracket "}"
+				scanner.resetTo(start, start + length);
+				int lastClosingBracePosition= findLastClosingBracePosition(scanner);
+				if (lastClosingBracePosition != -1) {
+					length= lastClosingBracePosition - start;
 				}
+
+				regions.add(new Region(start, length));
 
 				IRegion[] result= new IRegion[regions.size()];
 				regions.toArray(result);
@@ -2075,94 +1377,20 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		return new IRegion[0];
 	}
 
-	private void addRemainingOpenCustomFoldingRegions(ISourceRange range, List<IRegion> regions, FoldingStructureComputationContext ctx, Deque<Integer> openCustomRegionStartPositions, boolean includeLastLine) {
-		if (fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap) {
-			for (Integer openRegion : openCustomRegionStartPositions) {
-				Region region= new Region(openRegion, range.getOffset() + range.getLength() - openRegion);
-				this.includelastLine= includeLastLine;
-				regions.add(Math.max(regions.size() - 1, 0), alignRegion(region, ctx));
+	private int findLastClosingBracePosition(IScanner scanner) throws InvalidInputException {
+		int lastClosingBracePosition= -1;
+		while (true) {
+
+			int token= scanner.getNextToken();
+
+			if (token == ITerminalSymbols.TokenNameRBRACE) {
+				lastClosingBracePosition= scanner.getCurrentTokenEndPosition() + 1;
+			}
+			if (token == ITerminalSymbols.TokenNameEOF) {
+				break;
 			}
 		}
-	}
-
-	private void checkCustomFoldingUntilScannerEnd(FoldingStructureComputationContext ctx, List<IRegion> regions, Deque<Integer> openCustomRegionStartPositions, IScanner scanner) throws InvalidInputException {
-		for (int token = scanner.getNextToken(); token != ITerminalSymbols.TokenNameEOF; token=scanner.getNextToken()) {
-			if (isCommentToken(token)) {
-				checkCustomFolding(ctx, regions, openCustomRegionStartPositions, scanner, token, Math.max(regions.size() - 1, 0));
-			}
-		}
-	}
-
-	private boolean isCommentToken(int token) {
-		return token == ITerminalSymbols.TokenNameCOMMENT_BLOCK || token == ITerminalSymbols.TokenNameCOMMENT_JAVADOC || token == ITerminalSymbols.TokenNameCOMMENT_MARKDOWN || token == ITerminalSymbols.TokenNameCOMMENT_LINE;
-	}
-
-	private void checkCustomFolding(FoldingStructureComputationContext ctx, List<IRegion> regions, Deque<Integer> openCustomRegionStartPositions, IScanner scanner, int token, int regionArrayIndex) {
-		if (!fCurrentPreferences.fCustomFoldingRegionsEnabled) {
-			return;
-		}
-		int commentTextStart = findPossibleRegionCommentStart(scanner, token);
-
-		char[] source= scanner.getSource();
-		int currentTokenStartPosition= scanner.getCurrentTokenStartPosition();
-		int currentTokenEndPosition= scanner.getCurrentTokenEndPosition();
-
-		IRegion region= checkCustomFolding(openCustomRegionStartPositions, commentTextStart, source, currentTokenStartPosition, currentTokenEndPosition);
-		if (region != null) {
-			if (!includeLastLineInCustomFoldingRegion(source, currentTokenEndPosition, fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap)) {
-				includelastLine= false;
-				region= alignRegion(region, ctx);
-			}
-			regions.add(regionArrayIndex, region);
-			ctx.fCurrentCustomRegions.add(region);
-		}
-	}
-
-	private Region checkCustomFolding(Deque<Integer> openCustomRegionStartPositions, int commentTextStart, char[] source, int currentTokenStartPosition, int currentTokenEndPosition) {
-		int currentTokenLengthStartingAtCommentTextStart= currentTokenEndPosition - commentTextStart;
-
-		Region returnedRegion= null;
-		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCurrentPreferences.fCustomFoldingRegionEnd) && !openCustomRegionStartPositions.isEmpty()) {
-			int end= currentTokenEndPosition;
-			Integer regionStart= openCustomRegionStartPositions.removeLast();
-			returnedRegion= new Region(regionStart, end - regionStart);
-		}
-
-		if (startsWith(source, commentTextStart, currentTokenLengthStartingAtCommentTextStart, fCurrentPreferences.fCustomFoldingRegionBegin)) {
-			openCustomRegionStartPositions.add(currentTokenStartPosition);
-		}
-		return returnedRegion;
-	}
-
-	private int findPossibleRegionCommentStart(IScanner scanner, int token) {
-		char[] source= scanner.getSource();
-		int start= scanner.getCurrentTokenStartPosition();
-		int skip= switch (token) {
-			case ITerminalSymbols.TokenNameCOMMENT_LINE, ITerminalSymbols.TokenNameCOMMENT_BLOCK -> 2;
-			case ITerminalSymbols.TokenNameCOMMENT_JAVADOC, ITerminalSymbols.TokenNameCOMMENT_MARKDOWN -> 3;
-			default -> 0;
-		};
-		int newStart= start + skip;
-		return skipLeadingWhitespace(source, newStart);
-	}
-
-	private int skipLeadingWhitespace(char[] source, int start) {
-		while (start < source.length && Character.isWhitespace(source[start])) {
-			start++;
-		}
-		return start;
-	}
-
-	private boolean startsWith(char[] source, int offset, int length, char[] prefix) {
-		if (length < prefix.length) {
-			return false;
-		}
-		for (int i=0; i < prefix.length; i++) {
-			if (source[offset+i] != prefix[i]) {
-				return false;
-			}
-		}
-		return true;
+		return lastClosingBracePosition;
 	}
 
 	private IRegion computeHeaderComment(FoldingStructureComputationContext ctx) throws JavaModelException {
@@ -2212,7 +1440,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		}
 
 		if (headerEnd != -1) {
-			return new Region(headerStart, headerEnd - headerStart);
+			return new Region(headerStart, headerEnd - headerStart + 1);
 		}
 		return null;
 	}
@@ -2244,6 +1472,332 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			return null;
 
 		return provider.getDocument(editor.getEditorInput());
+	}
+
+	/**
+	 * Remove conflicting entries in the parameter. If 2 entries have a position that starts in the
+	 * same offset, keep the one with the largest length.
+	 */
+	private void keepLargestByPosition(Map<JavaProjectionAnnotation, Position> map) {
+		// Map from offset to information on the region
+		// if two folding regions use the same offset, the larger one is used
+		Map<Integer, Map.Entry<JavaProjectionAnnotation, Position>> bestByOffset= map.entrySet().stream()
+				.collect(Collectors.toMap(
+						e -> e.getValue().getOffset(),
+						Function.identity(),
+						BinaryOperator.maxBy(Comparator.comparingInt(e -> e.getValue().getLength()))));
+
+		// keep only folding regions in bestByOffset
+		map.entrySet().retainAll(new HashSet<>(bestByOffset.values()));
+	}
+
+	private void normalizeAndAddRegion(FoldingStructureComputationContext ctx, IJavaElement element, boolean collapse, IRegion region, boolean isComment) {
+		IRegion normalized= alignRegion(region, ctx, true);
+
+		if (normalized != null) {
+			Position position= element instanceof IMember m && !isComment ? createMemberPosition(normalized, m) : createCommentPosition(normalized);
+
+			ctx.addProjectionRange(new JavaProjectionAnnotation(collapse, element, isComment), position);
+		}
+	}
+
+	/**
+	 * Scan the given source code and find the regions in it by identifying their opening and closing tokens
+	 * Anything inside of any excludedElements should not be scanned
+	 */
+	private IRegion[] computeProjectionRangesUsingTokensInSourceCode(ISourceReference reference, FoldingStructureComputationContext ctx, IJavaElement[] excludedElements) {
+		try {
+			ISourceRange range= reference.getSourceRange();
+			if (!SourceRange.isAvailable(range))
+				return new IRegion[0];
+
+			String contents= reference.getSource();
+			if (contents == null)
+				return new IRegion[0];
+
+			List<IRegion> regions= new ArrayList<>();
+			if (!ctx.hasFirstType() && reference instanceof IType type) {
+				ctx.setFirstType(type);
+				IRegion headerComment= computeHeaderComment(ctx);
+				if (headerComment != null) {
+					regions.add(headerComment);
+					ctx.setHasHeaderComment();
+				}
+			}
+
+			int shift= range.getOffset();
+			IScanner scanner= ctx.getScanner();
+
+			Deque<TokenAtOffset> startPositions= new LinkedList<>();
+			for (IJavaElement excluded : excludedElements) {
+				if (excluded instanceof ISourceReference excludedReference && SourceRange.isAvailable(excludedReference.getSourceRange())) {
+					ISourceRange excludedRange= excludedReference.getSourceRange();
+					scanner.resetTo(shift, excludedRange.getOffset());
+					populateProjectionRegions(regions, startPositions, scanner);
+					shift= excludedRange.getOffset() + excludedRange.getLength();
+				}
+			}
+			scanner.resetTo(shift, range.getOffset() + range.getLength());
+			populateProjectionRegions(regions, startPositions, scanner);
+
+			if (!regions.isEmpty()) {
+				// The last region is the block corresponding to the current element/reference
+				// which is already handled by computeFoldingStructure(children, ctx)
+				regions.removeLast();
+			}
+
+			IRegion[] result= new IRegion[regions.size()];
+			regions.toArray(result);
+			return result;
+		} catch (JavaModelException | InvalidInputException e) {
+		}
+
+		return new IRegion[0];
+	}
+
+	private void populateProjectionRegions(List<IRegion> regions, Deque<TokenAtOffset> startPositions, IScanner scanner) throws InvalidInputException {
+		int start;
+		int token;
+		do {
+			token= scanner.getNextToken();
+			start= scanner.getCurrentTokenStartPosition();
+
+			switch (token) {
+				case ITerminalSymbols.TokenNameCOMMENT_JAVADOC:
+				case ITerminalSymbols.TokenNameCOMMENT_MARKDOWN:
+				case ITerminalSymbols.TokenNameCOMMENT_BLOCK: {
+					int end= scanner.getCurrentTokenEndPosition() + 1;
+					regions.add(new TypedRegion(start, end - start, COMMENT_TYPE));
+					break;
+				}
+				case ITerminalSymbols.TokenNameCOMMENT_LINE:
+					break;
+				case ITerminalSymbols.TokenNameLBRACE: {
+					// All these are "opening" tokens that mark the beginning of a region.
+					startPositions.push(new TokenAtOffset(start, token));
+					break;
+				}
+				case ITerminalSymbols.TokenNameRBRACE: {
+					final int fStart= start;
+					Optional<TokenAtOffset> openingToken= findStartTokenForEndToken(startPositions, token);
+					openingToken.ifPresent(t -> {
+						regions.add(new Region(t.offset(), fStart - t.offset() + 1));
+					});
+					break;
+				}
+			}
+		} while (token != ITerminalSymbols.TokenNameEOF);
+	}
+
+	/**
+	 * @param endToken the token that closes/ends a region
+	 * @return the token that opens the region and its offset.
+	 */
+	private Optional<TokenAtOffset> findStartTokenForEndToken(Deque<TokenAtOffset> startTokens, int endToken) {
+		// find corresponding start token
+		TokenAtOffset found = null;
+		int numberOfTokens= 0;
+		for (TokenAtOffset tokenAtOffset : startTokens) {
+			numberOfTokens++;
+			if (canCloseOpeningTokenWith(tokenAtOffset.token(), endToken)) {
+				found = tokenAtOffset;
+				break;
+			}
+		}
+		if (found != null) {
+			// pop all until the start token
+			for (int i = 0; i < numberOfTokens; i++) {
+				startTokens.pop();
+			}
+			return Optional.of(found);
+		}
+		return Optional.empty();
+	}
+
+	/**
+	 * @return <code>true</code> if <code>endToken</code> is a valid token to close a region that
+	 *         starts with <code>openingToken</code>.
+	 */
+	private boolean canCloseOpeningTokenWith(int openingToken, int endToken) {
+		return openingToken == ITerminalSymbols.TokenNameLBRACE && endToken == ITerminalSymbols.TokenNameRBRACE;
+	}
+
+	private void computeFoldingStructureCustom(IJavaElement rootElement, FoldingStructureComputationContext ctx) throws JavaModelException {
+		IScanner scanner= ctx.getScanner();
+		scanner.resetTo(0, ctx.fDocument.getLength());
+		try {
+			Deque<Deque<Integer>> openCommentStartPositions= new ArrayDeque<>();
+			List<IRegion> customFoldingRegions = new ArrayList<>();
+			openCommentStartPositions.add(new ArrayDeque<>()); // allow folding outside of any block (e.g. fold multiple top level classes)
+
+			boolean currentBlockIsEmpty= true;
+			Region singleCommentBlockCommentRegion= null;
+			int lastToken;
+
+			int token= -1;
+			do {
+				lastToken= token;
+				token= scanner.getNextToken();
+				switch (token) {
+					case ITerminalSymbols.TokenNameLBRACE -> {
+						// To allow custom regions like { /* region */ } with nothing else in the block but not things like if() { /* region +/ }
+						// we need to distinguish based on what is before the region
+						// If this is the case, we set currentBlockIsEmpty to true until we find anything of relevance in the block
+						// see CustomFoldingRegionTest#testCommentsInEmptyBlocks as an example
+						currentBlockIsEmpty= lastToken == ITerminalSymbols.TokenNameSEMICOLON || lastToken == ITerminalSymbols.TokenNameLBRACE || lastToken == ITerminalSymbols.TokenNameRBRACE
+								|| lastToken == ITerminalSymbols.TokenNameCOMMENT_BLOCK || lastToken == ITerminalSymbols.TokenNameCOMMENT_LINE;
+						singleCommentBlockCommentRegion= null;
+						openCommentStartPositions.addLast(new ArrayDeque<>());
+					}
+					case ITerminalSymbols.TokenNameRBRACE -> {
+						if (!openCommentStartPositions.isEmpty()) {
+							Deque<Integer> openRegions= openCommentStartPositions.removeLast();
+							if (fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap && openRegions != null && !openRegions.isEmpty()) {
+								int regionEnd= scanner.getCurrentTokenStartPosition();
+								closeOpenFoldingRegions(openRegions, regionEnd, customFoldingRegions);
+							}
+						}
+						if (singleCommentBlockCommentRegion != null && !openCommentStartPositions.isEmpty()) {
+							// In case of a custom region in an otherwise empty block (e.g. { /* region */ }), the region should be associated with the parent block
+							// see CustomFoldingRegionTest#testCommentsInEmptyBlocks as an example
+							Region customFoldingRegion= checkCommentForCustomFolding(openCommentStartPositions.getLast(),
+									findPossibleRegionCommentStart(scanner.getSource(), singleCommentBlockCommentRegion.getOffset(), lastToken), scanner.getSource(),
+									singleCommentBlockCommentRegion.getOffset(), singleCommentBlockCommentRegion.getOffset() + singleCommentBlockCommentRegion.getLength() + 1);
+							if (customFoldingRegion != null) {
+								customFoldingRegions.add(customFoldingRegion);
+							}
+						}
+						// only allow assigning regions to parent blocks if there's nothing else in the block
+						currentBlockIsEmpty= false;
+						singleCommentBlockCommentRegion= null;
+					}
+					case ITerminalSymbols.TokenNameCOMMENT_LINE, ITerminalSymbols.TokenNameCOMMENT_MARKDOWN, ITerminalSymbols.TokenNameCOMMENT_BLOCK, ITerminalSymbols.TokenNameCOMMENT_JAVADOC -> {
+						// block comment tokens don't seem to include the last character so one additional character has to be checked
+						int tokenEndPosition= findCommentTokenEndPosition(scanner, token);
+						if (!openCommentStartPositions.isEmpty()) {
+							Region customFoldingRegion= checkCommentForCustomFolding(openCommentStartPositions.getLast(),
+									findPossibleRegionCommentStart(scanner.getSource(), scanner.getCurrentTokenStartPosition(), token), scanner.getSource(), scanner.getCurrentTokenStartPosition(),
+									tokenEndPosition);
+							if (customFoldingRegion != null) {
+								customFoldingRegions.add(customFoldingRegion);
+							}
+						}
+						singleCommentBlockCommentRegion= null;
+						if (currentBlockIsEmpty) {
+							singleCommentBlockCommentRegion= new Region(scanner.getCurrentTokenStartPosition(), tokenEndPosition - scanner.getCurrentTokenStartPosition());
+							currentBlockIsEmpty= false;
+						}
+					}
+					default -> {
+						currentBlockIsEmpty= false;
+						singleCommentBlockCommentRegion= null;
+					}
+				}
+			} while (token != ITerminalSymbols.TokenNameEOF);
+			if (fCurrentPreferences.fCustomFoldingRegionMarkersCanOverlap) {
+				for (Deque<Integer> openRegions : openCommentStartPositions.reversed()) {
+					closeOpenFoldingRegions(openRegions, ctx.fDocument.getLength(), customFoldingRegions);
+				}
+			}
+			Collections.sort(customFoldingRegions, Comparator.comparingInt(IRegion::getOffset));
+			addCustomFoldingRegions(ctx, rootElement, customFoldingRegions, 0);
+		} catch (InvalidInputException e) {
+			JavaPlugin.log(e);
+		}
+	}
+
+	private void closeOpenFoldingRegions(Deque<Integer> openRegions, int regionEnd, List<IRegion> customFoldingRegions) {
+		for (Integer start : openRegions.reversed()) {
+			customFoldingRegions.add(new Region(start, regionEnd - start));
+		}
+	}
+
+	/**
+	 * Adds a {@link List} of custom folding regions to the context.
+	 * This method ensures that the correct {@link IJavaElement}s are associated with the folding regions.
+	 * @param ctx The {@link FoldingStructureComputationContext} the regions are added to.
+	 * @param current The current {@link IJavaElement}. The initial value of this parameter should be the {@link CompilationUnit}. Needed for recursion.
+	 * @param customFoldingRegions The folding regions to add, must be sorted by offset.
+	 * @param nextRegionIndex The index of the next folding region to add in customFoldingRegions. The initial value of this parameter should be {@code 0}. Needed for recursion.
+	 * @return The new index of the next folding region to add in customFoldingRegions after calling the method. Needed for recursion.
+	 * @throws JavaModelException should not happen
+	 */
+	private int addCustomFoldingRegions(FoldingStructureComputationContext ctx, IJavaElement current, List<IRegion> customFoldingRegions, int nextRegionIndex) throws JavaModelException {
+		if (nextRegionIndex >= customFoldingRegions.size() || !(current instanceof ISourceReference sourceRef)) {
+			return nextRegionIndex;
+		}
+		ISourceRange nameRange= sourceRef.getNameRange();
+		int rangeOffset= nameRange == null ? sourceRef.getSourceRange().getOffset() : nameRange.getOffset();
+		int rangeLength= sourceRef.getSourceRange().getOffset() + sourceRef.getSourceRange().getLength() - rangeOffset;
+
+		// Any folding regions that start before the offset of the current IJavaElement should be associated with the parent.
+		while (nextRegionIndex < customFoldingRegions.size() && customFoldingRegions.get(nextRegionIndex).getOffset() <= rangeOffset) {
+			addCustomFoldingRegion(ctx, customFoldingRegions.get(nextRegionIndex++), current.getParent());
+		}
+
+		if (nextRegionIndex >= customFoldingRegions.size() || customFoldingRegions.get(nextRegionIndex).getOffset() >= rangeOffset + rangeLength) {
+			return nextRegionIndex;
+		}
+
+		// process children
+		if (current instanceof IParent parent) {
+			for (IJavaElement child : parent.getChildren()) {
+				nextRegionIndex = addCustomFoldingRegions(ctx, child, customFoldingRegions, nextRegionIndex);
+				if (nextRegionIndex >= customFoldingRegions.size()) {
+					return nextRegionIndex;
+				}
+			}
+		}
+
+		// any folding regions starting within the current IJavaElement are associated with it
+		while (nextRegionIndex < customFoldingRegions.size() && customFoldingRegions.get(nextRegionIndex).getOffset() < rangeOffset + rangeLength) {
+			addCustomFoldingRegion(ctx, customFoldingRegions.get(nextRegionIndex++), current);
+		}
+		return nextRegionIndex;
+	}
+
+	private void addCustomFoldingRegion(FoldingStructureComputationContext ctx, IRegion customFoldingRegion, IJavaElement element) {
+		if (customFoldingRegion == null) {
+			return;
+		}
+		normalizeAndAddRegion(ctx, element, fCurrentPreferences.fCollapseCustomRegions, customFoldingRegion, true);
+	}
+
+	private int findPossibleRegionCommentStart(char[] source, int tokenStartPosition, int token) {
+		int skip= switch (token) {
+			case ITerminalSymbols.TokenNameCOMMENT_LINE, ITerminalSymbols.TokenNameCOMMENT_BLOCK -> 2;
+			case ITerminalSymbols.TokenNameCOMMENT_JAVADOC, ITerminalSymbols.TokenNameCOMMENT_MARKDOWN -> 3;
+			default -> 0;
+		};
+		int newStart= tokenStartPosition + skip;
+		return skipLeadingWhitespace(source, newStart);
+	}
+
+	private int findCommentTokenEndPosition(IScanner scanner, int token) {
+		return switch (token) {
+			case ITerminalSymbols.TokenNameCOMMENT_LINE, ITerminalSymbols.TokenNameCOMMENT_MARKDOWN -> scanner.getCurrentTokenEndPosition();
+			case ITerminalSymbols.TokenNameCOMMENT_JAVADOC, ITerminalSymbols.TokenNameCOMMENT_BLOCK -> scanner.getCurrentTokenEndPosition() + 1;
+			default -> 0;
+		};
+	}
+
+	private int skipLeadingWhitespace(char[] source, int start) {
+		while (start < source.length && Character.isWhitespace(source[start])) {
+			start++;
+		}
+		return start;
+	}
+
+	private boolean startsWith(char[] source, int offset, int length, char[] prefix) {
+		if (length < prefix.length) {
+			return false;
+		}
+		for (int i= 0; i < prefix.length; i++) {
+			if (source[offset + i] != prefix[i]) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Credits
This PR is a collaboration between @fedejeanne and @danthe1st.

## What it does
Removes the internal class `DefaultJavaFoldingStructureProvider.FoldingVisitor` (which needed an AST to provide the _extended folding_) and provides the extended folding in a simpler/cheaper way without the need to create an AST. 

**Detailed changes**

- Top level classes are now folded
- Only 1 folding region may start in a line (avoids problems when un/collapsing via the +/- buttons)
- Extended folding is now only applied as when an element is known to have children (because it is an IParent) but its children are unknown (parent.getChildren() returns an empty array)
- Decouple the logic used for custom folding from the logic used for standard and extended folding, improving code readability and maintainability and also providing custom folding functionality to classes that override the protected method
computeFoldingStructure(IJavaElement element,
FoldingStructureComputationContext ctx)
- Cases inside of switch expressions and switch statements are not folded anymore

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/848, https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2085, https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2439, https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2454, https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2470, https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2571, https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2596, https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2760


## How to test
- Run the tests provided in this PR
- Test manually by enabling the _Extended folding_ in the preferences (Java > Editor > Folding)
- Also play with the _Custom Foldings_. They should still work (i.e. no regressions). I mention this because the code changed in this PR touches both functionalities.

## Performance improvement
I generated a class with several thousand folding regions using this generator code (credits to [Andrey](https://github.com/iloveeclipse))

<details><summary>Class generator</summary>
<p>

```java
import java.io.BufferedWriter;
import java.io.FileWriter;
import java.io.IOException;
import java.nio.file.Files;
import java.nio.file.Path;
import java.nio.file.Paths;

public class GenerateJava {

	private static final String ROOT_PATH = Paths.get("").resolve("generated").toAbsolutePath().toString();

	// 1000 inner classes -> 268K file size
	//private static final int NUMBER_OF_INNER_CLASSES = 1_000_000; // ~250 MB, too much, compile runs into OOM
	//private static final int NUMBER_OF_INNER_CLASSES = 200_000; // ~50 MB, too much, compile runs into OOM
	//private static final int NUMBER_OF_INNER_CLASSES = 50_000; // ~16MB, find replace to fix "public x = 42;" freezes UI for minutes or more
//	 private static final int NUMBER_OF_INNER_CLASSES = 25_000; // ~8MB, find replace to fix "public x = 42;" freezes UI for 2-3 minutes, save also
	private static final int NUMBER_OF_INNER_CLASSES = 15_000; // find replace to fix compile errors, and save, take about 30-40 seconds

	private static final String INDENT = "    ";

	public static void main(String[] args) throws IOException {
		Path path = createFile("LargeJavaFile_" + NUMBER_OF_INNER_CLASSES + ".java");
		writeContents(path);
	}

	private static void writeContents(Path path) throws IOException {
		try (BufferedWriter writer = createWriter(path)) {
			writeClass(writer);
		}
	}

	/**
	 * Generate a class that looks like this:
	 * <pre>
	 * package test;
	 *
     * public class TestClass {
     *
     *     public static class InnerClass0 {
     *         public x = 42; // expected error
     *
     *         public void helloWorld() {
     *                 System.out.prinln("Hello World!"); // expected error
     *                 System.out.println("In class " + 0 + ", x=" + x); // expected error
     *         }
     *     } // end of InnerClass0
     *
     *     public static class InnerClass1 {
     *         public x = 42; // expected error
     *
     *         public void helloWorld() {
     *                 System.out.prinln("Hello World!"); // expected error
     *                 System.out.println("In class " + 1 + ", x=" + x); // expected error
     *         }
     *     } // end of InnerClass1
     *
     * }
	 * </pre>
	 */
	private static void writeClass(BufferedWriter writer) throws IOException {
		writeLine(writer, "package z;");
		writeLine(writer);
		writeLine(writer, "public class LargeJavaFile {");
		writeLine(writer);
		int depth = 1;
		int n = NUMBER_OF_INNER_CLASSES;
		double currentPercent = 0.0;
		for (int i = 0; i < n; ++i) {
			writeSubclass(writer, i, depth);
			writeLine(writer);
			if (((double) i / (double)n) * 100.0 > currentPercent) {
				currentPercent += 1.0;
				System.out.println("Progress " + (int) currentPercent + "%...");
			}
		}
		writeLine(writer, "}");
	}

	private static void writeSubclass(BufferedWriter writer, int i, int depth) throws IOException {
		writeIndentedLine(writer, "public static class InnerClass" + i + " {", depth);
		writeSubclassContents(writer, i, depth + 1);
		writeIndentedLine(writer, "} // end of InnerClass" + i, depth);
	}

	private static void writeSubclassContents(BufferedWriter writer, int i, int depth) throws IOException {
		writeIndentedLine(writer, "public int x = 42; // expected error", depth);
		writeIndentedLine(writer, depth);
		writeIndentedLine(writer, "public void helloWorld() {", depth);
		writeIndentedLine(writer, "System.out.println(\"Hello World!\"); // expected error", depth + 2);
		writeIndentedLine(writer, "System.out.println(\"In class \" + " + i + " + \", x=\" + x); // expected error", depth + 2);
		writeIndentedLine(writer, "}", depth);

	}

	private static void writeIndentedLine(BufferedWriter writer, String line, int depth) throws IOException {
		for (int i = 0; i < depth; ++i) {
			writer.write(INDENT);
		}
		writeLine(writer, line);
	}

	private static void writeIndentedLine(BufferedWriter writer, int depth) throws IOException {
		for (int i = 0; i < depth; ++i) {
			writer.write(INDENT);
		}
		writeLine(writer);
	}

	private static void writeLine(BufferedWriter writer, String line) throws IOException {
		writer.write(line);
		writeLine(writer);
	}

	private static void writeLine(BufferedWriter writer) throws IOException {
		writer.write(System.lineSeparator());
	}

	private static BufferedWriter createWriter(Path path) throws IOException {
		return new BufferedWriter(new FileWriter(path.toFile()));
	}

	private static Path createFile(String fileName) throws IOException {
		Path root = Paths.get(ROOT_PATH);
		Path filePath = root.resolve(fileName);
		Files.deleteIfExists(filePath);
//		Files.deleteIfExists(root);
//		Files.createDirectories(root);
		return Files.createFile(filePath);
	}

}
```

</p>
</details> 

... and then I simply opened that class and compared the time between the current `master` and this PR.

**Results**
| Branch | Custom Foldings | Run 1 | Run 2 |
|-------|------------------|------|------|
| master | Enabled | 44s | 37s |
| master | Disabled | 50s | 46s |
| PR | Disabled | 10s | 5s |
| PR | Enabled | 5s | 5s |

If I discard the 1st run in both branches (caching seems to kick in) then I notice an improvement of:

| Custom Foldings | master | PR | Factor |
|------------------|------|------|------|
| Enabled | 37s | 5s | >7x |
| Disabled | 46s | 5s | >9x |

**Samples**
- [VisualVM samples.zip](https://github.com/user-attachments/files/25912731/VisualVM.samples.zip)

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
