### PR TITLE
Prevent auto-closing quotes and brackets in Markdown comments

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/AutomatedSuite.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.ui.tests.core.CoreTestSuite;
 import org.eclipse.jdt.ui.tests.core.CoreTests;
 import org.eclipse.jdt.ui.tests.dialogs.FilteredTypesSelectionDialogTests;
 import org.eclipse.jdt.ui.tests.editor.ClassFileInputTests;
+import org.eclipse.jdt.ui.tests.editor.MarkdownTypingTest;
 import org.eclipse.jdt.ui.tests.hover.JavadocHoverTests;
 import org.eclipse.jdt.ui.tests.hover.MarkdownCommentTests;
 import org.eclipse.jdt.ui.tests.hover.PackageJavadocTests;
@@ -91,7 +92,8 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 	MarkdownCommentTests.class,
 	SmokeViewsTest.class,
 	ClassFileInputTests.class,
-	FilteredTypesSelectionDialogTests.class
+	FilteredTypesSelectionDialogTests.class,
+	MarkdownTypingTest.class
 })
 public class AutomatedSuite {
 	@BeforeEach

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/MarkdownTypingTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/MarkdownTypingTest.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.editor;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.core.resources.IncrementalProjectBuilder;
+
+import org.eclipse.jface.text.IDocument;
+
+import org.eclipse.ui.IEditorPart;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+
+import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitEditor;
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
+
+import junit.framework.TestCase;
+
+public class MarkdownTypingTest extends TestCase {
+	private IJavaProject javaProject;
+	private CompilationUnitEditor editor;
+
+	@Override
+	protected void setUp() throws Exception {
+		javaProject= JavaProjectHelper.createJavaProject("MarkdownTypingTests", "bin");
+		JavaProjectHelper.addSourceContainer(javaProject, "src");
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		if (editor != null) {
+	        editor.getSite().getPage().closeEditor(editor, false);
+	        editor = null;
+	    }
+
+		if (javaProject != null) {
+			JavaProjectHelper.delete(javaProject);
+		}
+	}
+
+	private ICompilationUnit createCompilationUnit() throws Exception {
+		IPackageFragment fragment= javaProject.findPackageFragment(
+				javaProject.getProject().getFullPath().append("src"));
+
+		String content= """
+					/// markdown comment
+					public class Test {}
+				""";
+
+		ICompilationUnit cu= fragment.createCompilationUnit(
+				"Test.java", content, true, new NullProgressMonitor());
+
+		javaProject.getProject().build(
+				IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+
+		return cu;
+	}
+
+	private CompilationUnitEditor openEditor(ICompilationUnit cu) throws Exception {
+		IEditorPart part= EditorUtility.openInEditor(cu);
+		assertNotNull(part);
+		return (CompilationUnitEditor) part;
+	}
+
+	private void typeCharacter(CompilationUnitEditor editr, char c) throws Exception {
+		IDocument doc = editr.getDocumentProvider().getDocument(editr.getEditorInput());
+
+		var viewer = editr.getViewer();
+		var textWidget = viewer.getTextWidget();
+
+		int offset = doc.get().indexOf("markdown comment") + "markdown comment".length();
+		textWidget.setCaretOffset(offset);
+
+		org.eclipse.swt.widgets.Event event = new org.eclipse.swt.widgets.Event();
+		event.character = c;
+		event.doit = true;
+
+		textWidget.notifyListeners(org.eclipse.swt.SWT.KeyDown, event);
+	}
+
+	public void testSingleQuoteTypingInMarkdown() throws Exception {
+		ICompilationUnit cu= createCompilationUnit();
+		editor = openEditor(cu);
+
+		typeCharacter(editor, '\'');
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected= """
+					/// markdown comment'
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testDoubleQuoteTypingInMarkdown() throws Exception {
+		ICompilationUnit cu= createCompilationUnit();
+		editor = openEditor(cu);
+
+		typeCharacter(editor, '"');
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected= """
+					/// markdown comment"
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testOpeningParenthesisTypingInMarkdown() throws Exception {
+		ICompilationUnit cu= createCompilationUnit();
+		editor = openEditor(cu);
+
+		typeCharacter(editor, '(');
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					/// markdown comment(
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testOpeningSquareBracketTypingInMarkdown() throws Exception {
+		ICompilationUnit cu= createCompilationUnit();
+		editor = openEditor(cu);
+
+		typeCharacter(editor, '[');
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					/// markdown comment[
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
@@ -527,7 +527,8 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 				}
 
 				ITypedRegion partition= TextUtilities.getPartition(document, IJavaPartitions.JAVA_PARTITIONING, offset, true);
-				if (!IDocument.DEFAULT_CONTENT_TYPE.equals(partition.getType()) && !IJavaPartitions.JAVA_MARKDOWN_COMMENT.equals(partition.getType()))
+				// Markdown checking is not required since Markdown should behave the same as Javadoc
+				if (!IDocument.DEFAULT_CONTENT_TYPE.equals(partition.getType()))
 					return;
 				if (!validateEditorInputState())
 					return;


### PR DESCRIPTION
Typing characters such as ', ", (, and [ inside Markdown documentation comments (///) currently inserts the corresponding closing character automatically. While this behavior is useful in Java code, it interrupts normal typing in Markdown text, so the editor is updated to avoid auto-closing these characters in Markdown comments.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2528

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
