### PR TITLE
Add auto-closing support for Markdown fenced code blocks

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/MarkdownTypingTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/MarkdownTypingTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.editor;
 
+import java.util.Map;
+
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -26,6 +28,9 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.ui.PreferenceConstants;
 
 import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitEditor;
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
@@ -57,11 +62,29 @@ public class MarkdownTypingTest extends TestCase {
 	private ICompilationUnit createCompilationUnit() throws Exception {
 		IPackageFragment fragment= javaProject.findPackageFragment(
 				javaProject.getProject().getFullPath().append("src"));
-
 		String content= """
-					/// markdown comment
-					public class Test {}
-				""";
+				/// markdown comment
+				public class Test {}
+			""";
+		ICompilationUnit cu= fragment.createCompilationUnit(
+				"Test.java", content, true, new NullProgressMonitor());
+		javaProject.getProject().build(
+				IncrementalProjectBuilder.FULL_BUILD, new NullProgressMonitor());
+		return cu;
+	}
+
+	private ICompilationUnit createCompilationUnit(String customContent) throws Exception {
+		IPackageFragment fragment= javaProject.findPackageFragment(
+				javaProject.getProject().getFullPath().append("src"));
+		String content = null;
+		if (customContent == null) {
+			content= """
+						/// markdown comment
+						public class Test {}
+					""";
+		} else {
+			content = customContent;
+		}
 
 		ICompilationUnit cu= fragment.createCompilationUnit(
 				"Test.java", content, true, new NullProgressMonitor());
@@ -80,11 +103,20 @@ public class MarkdownTypingTest extends TestCase {
 
 	private void typeCharacter(CompilationUnitEditor editr, char c) throws Exception {
 		IDocument doc = editr.getDocumentProvider().getDocument(editr.getEditorInput());
+		var viewer = editr.getViewer();
+		var textWidget = viewer.getTextWidget();
+		int offset = doc.get().indexOf("markdown comment") + "markdown comment".length();
+		textWidget.setCaretOffset(offset);
+		org.eclipse.swt.widgets.Event event = new org.eclipse.swt.widgets.Event();
+		event.character = c;
+		event.doit = true;
+		textWidget.notifyListeners(org.eclipse.swt.SWT.KeyDown, event);
+	}
 
+	private void typeCharacter(CompilationUnitEditor editr, char c, int offset) throws Exception {
 		var viewer = editr.getViewer();
 		var textWidget = viewer.getTextWidget();
 
-		int offset = doc.get().indexOf("markdown comment") + "markdown comment".length();
 		textWidget.setCaretOffset(offset);
 
 		org.eclipse.swt.widgets.Event event = new org.eclipse.swt.widgets.Event();
@@ -149,6 +181,208 @@ public class MarkdownTypingTest extends TestCase {
 
 		String expected = """
 					/// markdown comment[
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testEnableFencedCodeBlockTypingInMarkdown_supported_java_version() throws Exception {
+		String customContent = """
+					///
+					public class Test {}
+				""";
+		ICompilationUnit cu= createCompilationUnit(customContent);
+
+		IJavaProject project = cu.getJavaProject();
+		Map<String, String> options = project.getOptions(true);
+		JavaCore.setComplianceOptions(JavaCore.VERSION_26, options);
+		project.setOptions(options);
+
+		assertEquals(JavaCore.VERSION_26, project.getOption(JavaCore.COMPILER_COMPLIANCE, true));
+
+		editor = openEditor(cu);
+
+		PreferenceConstants.getPreferenceStore()
+        .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
+
+		int offset = customContent.indexOf("///") + 3;
+		typeCharacter(editor, '`', offset);
+		typeCharacter(editor, '`', offset + 1);
+		typeCharacter(editor, '`', offset + 2);
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					///``````
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testEnableFencedCodeBlockTypingInMarkdown_unsupported_java_version() throws Exception {
+		String customContent = """
+					///
+					public class Test {}
+				""";
+		ICompilationUnit cu= createCompilationUnit(customContent);
+
+		IJavaProject project = cu.getJavaProject();
+		Map<String, String> options = project.getOptions(true);
+		JavaCore.setComplianceOptions(JavaCore.VERSION_21, options);
+		project.setOptions(options);
+
+		assertEquals(JavaCore.VERSION_21, project.getOption(JavaCore.COMPILER_COMPLIANCE, true));
+
+		editor = openEditor(cu);
+
+		PreferenceConstants.getPreferenceStore()
+        .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
+
+		int offset = customContent.indexOf("///") + 3;
+		typeCharacter(editor, '`', offset);
+		typeCharacter(editor, '`', offset + 1);
+		typeCharacter(editor, '`', offset + 2);
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					///```
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testDiableFencedCodeBlockTypingInMarkdown() throws Exception {
+		String customContent = """
+					///
+					public class Test {}
+				""";
+		ICompilationUnit cu= createCompilationUnit(customContent);
+
+		IJavaProject project = cu.getJavaProject();
+		Map<String, String> options = project.getOptions(true);
+		JavaCore.setComplianceOptions(JavaCore.VERSION_26, options);
+		project.setOptions(options);
+
+		assertEquals(JavaCore.VERSION_26, project.getOption(JavaCore.COMPILER_COMPLIANCE, true));
+
+		editor = openEditor(cu);
+
+		PreferenceConstants.getPreferenceStore()
+        .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, false);
+
+		int offset = customContent.indexOf("///") + 3;
+		typeCharacter(editor, '`', offset);
+		typeCharacter(editor, '`', offset + 1);
+		typeCharacter(editor, '`', offset + 2);
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					///```
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testEnableFencedCodeBlockInsideDoubleQuote_supported_java_version() throws Exception {
+		String customContent = """
+					/// int x = "";
+					public class Test {}
+				""";
+		ICompilationUnit cu= createCompilationUnit(customContent);
+
+		IJavaProject project = cu.getJavaProject();
+		Map<String, String> options = project.getOptions(true);
+		JavaCore.setComplianceOptions(JavaCore.VERSION_26, options);
+		project.setOptions(options);
+
+		assertEquals(JavaCore.VERSION_26, project.getOption(JavaCore.COMPILER_COMPLIANCE, true));
+
+		editor = openEditor(cu);
+
+		PreferenceConstants.getPreferenceStore()
+        .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
+
+		int offset = customContent.indexOf("\"\"") + 1;
+		typeCharacter(editor, '`', offset);
+		typeCharacter(editor, '`', offset + 1);
+		typeCharacter(editor, '`', offset + 2);
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					/// int x = "```";
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testEnableFencedCodeBlockInsideMethod_supported_java_version() throws Exception {
+		String customContent = """
+					/// foo();
+					public class Test {}
+				""";
+		ICompilationUnit cu= createCompilationUnit(customContent);
+
+		IJavaProject project = cu.getJavaProject();
+		Map<String, String> options = project.getOptions(true);
+		JavaCore.setComplianceOptions(JavaCore.VERSION_26, options);
+		project.setOptions(options);
+
+		assertEquals(JavaCore.VERSION_26, project.getOption(JavaCore.COMPILER_COMPLIANCE, true));
+
+		editor = openEditor(cu);
+
+		PreferenceConstants.getPreferenceStore()
+        .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
+
+		int offset = customContent.indexOf("()") + 1;
+		typeCharacter(editor, '`', offset);
+		typeCharacter(editor, '`', offset + 1);
+		typeCharacter(editor, '`', offset + 2);
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					/// foo(```);
+					public class Test {}
+				""";
+		assertEquals(expected, doc.get());
+	}
+
+	public void testEnableFencedCodeBlockInsideJavadoc_supported_java_version() throws Exception {
+		String customContent = """
+					/**
+					 *
+					 */
+					public class Test {}
+				""";
+		ICompilationUnit cu= createCompilationUnit(customContent);
+
+		IJavaProject project = cu.getJavaProject();
+		Map<String, String> options = project.getOptions(true);
+		JavaCore.setComplianceOptions(JavaCore.VERSION_26, options);
+		project.setOptions(options);
+
+		assertEquals(JavaCore.VERSION_26, project.getOption(JavaCore.COMPILER_COMPLIANCE, true));
+
+		editor = openEditor(cu);
+
+		PreferenceConstants.getPreferenceStore()
+        .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
+
+		int offset = customContent.indexOf("\n", customContent.indexOf("\n") + 1);
+		typeCharacter(editor, '`', offset);
+		typeCharacter(editor, '`', offset + 1);
+		typeCharacter(editor, '`', offset + 2);
+
+		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
+
+		String expected = """
+					/**
+					 *```
+					 */
 					public class Test {}
 				""";
 		assertEquals(expected, doc.get());

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.37.100.qualifier
+Bundle-Version: 3.38.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.37.100-SNAPSHOT</version>
+  <version>3.38.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
@@ -453,6 +453,7 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 				case '[':
 				case '\'':
 				case '\"':
+				case '`':
 					break;
 				default:
 					return;
@@ -480,6 +481,7 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 				IJavaProject project= cu.getJavaProject();
 				boolean textBlockSupported= JavaModelUtil.is15OrHigher(project);
 
+				ITypedRegion partition= TextUtilities.getPartition(document, IJavaPartitions.JAVA_PARTITIONING, offset, true);
 				switch (event.character) {
 					case '(':
 						if (!fCloseBrackets
@@ -521,12 +523,48 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 								|| textBlockSupported && previous == null && offset > 2 && document.get(offset - 2, 2).equals("\"\"")) //$NON-NLS-1$
 							return;
 						break;
+					case '`':
+						String compliance = project != null
+				        ? project.getOption(JavaCore.COMPILER_COMPLIANCE, true)
+				        : JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE);
+						if (validateEditorInputState()
+						        && IJavaPartitions.JAVA_MARKDOWN_COMMENT.equals(partition.getType())
+						        && JavaCore.compareJavaVersions(
+						        		compliance,
+					                    JavaCore.VERSION_23) >= 0) {
+							IDocument doc = sourceViewer.getDocument();
+						    int backtickOffset = selection.x;
+
+						    if (backtickOffset >= 2) {
+						        String prev = doc.get(backtickOffset - 2, 2);
+
+						        if ("``".equals(prev) //$NON-NLS-1$
+						        		&& isPreferenceTrue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK)
+						        		&& !shouldSuppressFenceAutoClose(doc, backtickOffset)) {
+
+						            String delimiter = TextUtilities.getDefaultLineDelimiter(doc);
+						            String insertion = "```" + "```"; //$NON-NLS-1$ //$NON-NLS-2$
+
+						            doc.replace(backtickOffset - 2, 2, insertion);
+
+						            sourceViewer.setSelectedRange(
+						            		backtickOffset + delimiter.length(),
+						                0
+						            );
+
+						            event.doit = false;
+						            return;
+						        }
+						    }
+					    } else {
+					    	return;
+					    }
+					    break;
 
 					default:
 						return;
 				}
 
-				ITypedRegion partition= TextUtilities.getPartition(document, IJavaPartitions.JAVA_PARTITIONING, offset, true);
 				// Markdown checking is not required since Markdown should behave the same as Javadoc
 				if (!IDocument.DEFAULT_CONTENT_TYPE.equals(partition.getType()))
 					return;
@@ -579,6 +617,59 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 			} catch (BadLocationException | BadPositionCategoryException e) {
 				JavaPlugin.log(e);
 			}
+		}
+
+		private boolean shouldSuppressFenceAutoClose(IDocument doc, int offset) throws BadLocationException {
+		    IRegion lineInfo = doc.getLineInformationOfOffset(offset);
+		    int lineStart = lineInfo.getOffset();
+
+		    String text = doc.get(lineStart, offset - lineStart);
+
+		    // Optional: only for markdown doc comment lines
+		    String trimmed = text.trim();
+		    if (!trimmed.startsWith("///")) { //$NON-NLS-1$
+		        return false;
+		    }
+		    return hasUnclosedQuote(text) || hasUnclosedParen(text);
+		}
+
+		// handles int x = "
+		private boolean hasUnclosedQuote(String s) {
+		    boolean escaped = false;
+		    int quotes = 0;
+
+		    for (char c : s.toCharArray()) {
+		        if (escaped) {
+		            escaped = false;
+		            continue;
+		        }
+		        if (c == '\\') {
+		            escaped = true;
+		        } else if (c == '"') {
+		            quotes++;
+		        }
+		    }
+		    return (quotes % 2) == 1;
+		}
+
+		// handles abc(
+		private boolean hasUnclosedParen(String s) {
+		    int count = 0;
+		    for (char c : s.toCharArray()) {
+		        if (c == '(') count++;
+		        else if (c == ')' && count > 0) count--;
+		    }
+		    return count > 0;
+		}
+
+		/**
+		 * Returns the value of the given boolean-typed preference.
+		 *
+		 * @param preference the preference to look up
+		 * @return the value of the given preference in the Java plug-in's default preference store
+		 */
+		private boolean isPreferenceTrue(String preference) {
+			return JavaPlugin.getDefault().getPreferenceStore().getBoolean(preference);
 		}
 
 		/*

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
@@ -203,6 +203,7 @@ public final class PreferencesMessages extends NLS {
 	public static String JavaEditorPreferencePage_closeBrackets;
 	public static String JavaEditorPreferencePage_closeBraces;
 	public static String JavaEditorPreferencePage_closeJavaDocs;
+	public static String JavaEditorPreferencePage_closeMarkdownThreeBacktick;
 	public static String JavaEditorPreferencePage_wrapStrings;
 	public static String JavaEditorPreferencePage_escapeStrings;
 	public static String JavaEditorPreferencePage_escapeStringsNonAscii;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -184,6 +184,7 @@ JavaEditorPreferencePage_closeStrings= "&Strings"
 JavaEditorPreferencePage_closeBrackets= (Parentheses), [square] and <angle> brac&kets
 JavaEditorPreferencePage_closeBraces= {B&races}
 JavaEditorPreferencePage_closeJavaDocs= Ja&vadoc and comment regions
+JavaEditorPreferencePage_closeMarkdownThreeBacktick= Fenced code block
 JavaEditorPreferencePage_wrapStrings= &Wrap automatically
 JavaEditorPreferencePage_escapeStrings= Escape text w&hen pasting into a string literal
 JavaEditorPreferencePage_escapeStringsNonAscii= Use Unicode escape synta&x for non-ASCII characters 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/SmartTypingConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/SmartTypingConfigurationBlock.java
@@ -70,6 +70,7 @@ class SmartTypingConfigurationBlock extends AbstractConfigurationBlock {
 				new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_CLOSE_BRACKETS),
 				new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_CLOSE_BRACES),
 				new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_CLOSE_JAVADOCS),
+				new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK),
 				new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_WRAP_STRINGS),
 				new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_ESCAPE_STRINGS),
 				new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, PreferenceConstants.EDITOR_ESCAPE_STRINGS_NON_ASCII),
@@ -224,6 +225,12 @@ class SmartTypingConfigurationBlock extends AbstractConfigurationBlock {
 		label= PreferencesMessages.JavaEditorPreferencePage_addJavaDocTags;
 		slave= addCheckBox(composite, label, PreferenceConstants.EDITOR_ADD_JAVADOC_TAGS, 0);
 		createDependency(master, slave);
+
+		if (JavaCore.compareJavaVersions(
+				JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE), JavaCore.VERSION_23) >= 0) {
+			label= PreferencesMessages.JavaEditorPreferencePage_closeMarkdownThreeBacktick;
+			master= addCheckBox(composite, label, PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, 0);
+		}
 	}
 
 	private void createMessage(final Composite composite) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -1205,6 +1205,15 @@ public class PreferenceConstants {
 	public final static String EDITOR_CLOSE_JAVADOCS= "closeJavaDocs"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that controls whether the 'close markdown fenced code block' feature is
+	 * enabled.
+	 * <p>
+	 * Value is of type <code>Boolean</code>.
+	 * </p>
+	 * @since 3.38
+	 */
+	public final static String EDITOR_CLOSE_FENCED_CODE_BLOCK= "closeFencedCodeBlock"; //$NON-NLS-1$
+	/**
 	 * A named preference that controls whether the 'add JavaDoc tags' feature
 	 * is enabled.
 	 * <p>
@@ -4288,6 +4297,7 @@ public class PreferenceConstants {
 		store.setDefault(PreferenceConstants.EDITOR_CLOSE_BRACKETS, true);
 		store.setDefault(PreferenceConstants.EDITOR_CLOSE_BRACES, true);
 		store.setDefault(PreferenceConstants.EDITOR_CLOSE_JAVADOCS, true);
+		store.setDefault(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
 		store.setDefault(PreferenceConstants.EDITOR_SMART_OPENING_BRACE, true);
 		store.setDefault(PreferenceConstants.EDITOR_WRAP_STRINGS, true);
 		store.setDefault(PreferenceConstants.EDITOR_ESCAPE_STRINGS, true);


### PR DESCRIPTION

<img width="1386" height="528" alt="image" src="https://github.com/user-attachments/assets/8b10bf28-a830-45e1-a086-b134943e7464" />


Adds support for automatically inserting a closing triple backtick when typing ``` in Markdown comments, improving the typing experience. This behavior is controlled by a new preference so users can enable or disable it as needed.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2529

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
