### PR TITLE
Check access rules when determining JUnit version from Test annotation

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -346,7 +346,7 @@ public class CoreTestSearchEngine {
 					true /* wait for indexer */,
 					true /* check restrictions */,
 					null);
-			if (answer != null) {
+			if (answer != null && !answer.isNonAccessible()) {
 				return answer.type;
 			}
 		}


### PR DESCRIPTION
This change ensures that when searching for `@Test` from JUnit 5 and 6, classpath container access rules are checked for forbidden access. If the annotation is found in a forbidden classpath entry, the respective JUnit type is ruled out.

Fixes: #2830

This PR depends on: https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4965

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
