### PR TITLE
Enable org.eclipse.text debug tracing during SaveParticipantTest

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
@@ -31,6 +31,8 @@ import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.jface.internal.text.reconciler.ReconcilerJobFamilies;
 
+import org.eclipse.jface.text.CopyOnWriteTextStore;
+
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -78,6 +80,7 @@ public class SaveParticipantTest extends CleanUpTestCase {
 	public void setUp() throws Exception {
 		wasVerbose = JavaModelManager.VERBOSE;
 		JavaModelManager.VERBOSE = true;
+		TestUtils.setDebugEnabled(CopyOnWriteTextStore.class, true);
 		super.setUp();
 
 		IEclipsePreferences node= InstanceScope.INSTANCE.getNode(JavaUI.ID_PLUGIN);
@@ -90,6 +93,7 @@ public class SaveParticipantTest extends CleanUpTestCase {
 	public void tearDown() throws Exception {
 		super.tearDown();
 		JavaModelManager.VERBOSE = wasVerbose;
+		TestUtils.setDebugEnabled(CopyOnWriteTextStore.class, false);
 	}
 
 	@SuppressWarnings("restriction")

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/util/TestUtils.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/util/TestUtils.java
@@ -13,6 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.ui.tests.util;
 
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+
+import org.eclipse.osgi.service.debug.DebugOptions;
+
 import org.eclipse.jdt.internal.core.JavaModelManager;
 
 public class TestUtils {
@@ -20,5 +27,24 @@ public class TestUtils {
 
 	public static void waitForIndexer() {
 		JavaModelManager.getIndexManager().waitForIndex(false, null);
+	}
+
+	/**
+	 * Enables or disables debug traces.
+	 * @param classFromBundle A class from the bundle for which the debug tracing should be enabled or disabled.
+	 * @param enable whether to enable or disable debug tracing
+	 */
+	public static void setDebugEnabled(Class<?> classFromBundle, boolean enable) {
+		Bundle bundle= FrameworkUtil.getBundle(classFromBundle);
+		BundleContext context= bundle.getBundleContext();
+		ServiceReference<DebugOptions> reference= context.getServiceReference(DebugOptions.class);
+		try {
+			DebugOptions options= context.getService(reference);
+			options.setDebugEnabled(enable);
+			String key= bundle.getSymbolicName() + "/debug";
+			options.setOption(key, enable ? Boolean.TRUE.toString() : Boolean.FALSE.toString());
+		} finally {
+			context.ungetService(reference);
+		}
 	}
 }


### PR DESCRIPTION
Tests in `SaveParticipantTest` sporadically fail with `org.eclipse.text.edits.MalformedTreeException`,
potentially due to concurrent text store modifications.

This change enables debug tracing of `org.eclipse.text` during the test, so that text store modifications are traced.

See: #79

