### PR TITLE
Fixed class dialog with abstract and final

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
@@ -1399,6 +1399,7 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 			fModifierStatus= modifiersChanged();
 			fieldName= MODIFIERS;
 		} else if (field == fSealedMdfButtons) {
+			fModifierStatus= modifiersChanged();
 			fSealedModifierStatus= sealedModifiersChanged();
 			fieldName= SEALEDMODIFIERS;
 		} else {


### PR DESCRIPTION

To fix issue: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2537
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
File Modified: eclipse.jdt.ui/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java

Change Location: Line 1402 in the dialogFieldChanged() method

What Changed:
Added a call to modifiersChanged() when sealed modifier buttons change:


```
} else if (field == fSealedMdfButtons) {
    fModifierStatus= modifiersChanged();           // ← ADDED THIS LINE
    fSealedModifierStatus= sealedModifiersChanged();
    fieldName= SEALEDMODIFIERS;
}
```

## How to test
Prerequisites:

Eclipse IDE with JDT UI plugin
Java 17+ project (for sealed class support)
Test Case 1: Final → Abstract (This was working before)

Open Eclipse
Right-click on a Java project → New → Class
In the "New Java Class" dialog:
Enter a class name (e.g., "Test")
In the Modifiers section, click the "final" radio button
Check the "abstract" checkbox
Expected Result: Error message appears: "Class cannot be both final and abstract"
Test Case 2: Abstract → Final (This was broken, now fixed)

Open Eclipse
Right-click on a Java project → New → Class
In the "New Java Class" dialog:
Enter a class name (e.g., "Test")
In the Modifiers section, check the "abstract" checkbox first
Then click the "final" radio button
Expected Result: Error message appears: "Class cannot be both final and abstract"
Test Case 3: Verify Error Prevents Creation


## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)



https://github.com/user-attachments/assets/556158b6-fb33-42b2-85d3-74a9cc537c9d

