### PR TITLE
Fix incorrect indentation & trailing whitespace in Javadoc snippet

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -159,7 +159,7 @@ public class CoreJavaDocSnippetStringEvaluator {
 			List<TagElement> tagElements= getTagElementsForTagElement(snippetTag, tagElement);
 			str= getModifiedStringForTagElement(tagElement, tagElements);
 		}
-		return str;
+		return str.stripLeading();
 	}
 
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -461,5 +461,40 @@ public class JavadocHoverTests extends CoreTests {
 		}
 	}
 
+	@Test
+	public void testSnippetWringIndentation() throws Exception {
+		String source=
+				"""
+				package p;
+				public class Javadoc {
+					/**
+					 * {@snippet :
+					 *     var s = "";
+					 * }
+					 */
+					void foo(){}
+				}
+			""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Javadoc.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		IType type= cu.getType("Javadoc");
+		// check javadoc on each member:
+		for (IJavaElement member : type.getChildren()) {
+			IJavaElement[] elements= { member };
+			ISourceRange range= ((ISourceReference) member).getNameRange();
+			JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(elements, cu, new Region(range.getOffset(), range.getLength()), null);
+			String actualHtmlContent= hoverInfo.getHtml();
+
+			int snippetStartIndex = actualHtmlContent.indexOf("{@snippet :");
+			assertNotEquals(-1, snippetStartIndex);
+		    int contentStart = snippetStartIndex + "{@snippet :".length();
+		    int contentEnd = actualHtmlContent.indexOf("}", contentStart);
+		    String actualSnippetContent = actualHtmlContent.substring(contentStart, contentEnd).trim();
+		    String expectedSnippetContent = "var s = \"\";";
+		    assertEquals(expectedSnippetContent, actualSnippetContent);
+		}
+	}
+
 }
 


### PR DESCRIPTION
Javadoc snippets in the Javadoc view incorrectly include leading and trailing whitespace, causing mismatched indentation and highlight regions. This change normalises whitespace to align with the behavior of generated HTML documentation.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2053

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
