### PR TITLE
Exclude org.eclipse.text from check in PluginsNotLoadedTest

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
@@ -128,7 +128,7 @@ public class PluginsNotLoadedTest {
 			"org.eclipse.test.performance",
 			"org.eclipse.test.performance.ui",
 			"org.eclipse.test.performance.win32",
-			"org.eclipse.text",
+//			"org.eclipse.text", https://github.com/eclipse-platform/eclipse.platform.ui/pull/3801, debug tracing for text stores
 			"org.eclipse.text.tests",
 			"org.eclipse.ui.cheatsheets",
 //			"org.eclipse.ui.console", bug 507546: debug code minings


### PR DESCRIPTION
Due to debug tracing added to `org.eclipse.text`,
the bundle now activates when a class from it is loaded. This results in a test fail in `PluginsNotLoadedTest`.

This change excludes org.eclipse.text from the check in the test, similar to how other plug-ins have been excluded over time.

See also: https://github.com/eclipse-platform/eclipse.platform.ui/pull/3801

Fixes: #2889

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
