### PR TITLE
Wait for reconciler background thread in tests

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
@@ -74,6 +74,7 @@ import org.eclipse.jdt.internal.core.CompilationUnitElementInfo;
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.util.TestUtils;
 
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 
@@ -97,6 +98,7 @@ public class ImportOrganizeTest extends CoreTests {
 	public void tearDown() throws Exception {
 		setOrganizeImportSettings(null, 99, 99, fJProject1);
 		JavaProjectHelper.clear(fJProject1, pts.getDefaultClasspath());
+		TestUtils.waitForReconciler(60_000L);
 	}
 
 	protected IChooseImportQuery createQuery(final String name, final String[] choices, final int[] nEntries) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
@@ -94,6 +94,7 @@ public class SaveParticipantTest extends CleanUpTestCase {
 		super.tearDown();
 		JavaModelManager.VERBOSE = wasVerbose;
 		TestUtils.setDebugEnabled(CopyOnWriteTextStore.class, false);
+		TestUtils.waitForReconciler(60_000L);
 	}
 
 	@SuppressWarnings("restriction")

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/util/TestUtils.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/util/TestUtils.java
@@ -20,13 +20,56 @@ import org.osgi.framework.ServiceReference;
 
 import org.eclipse.osgi.service.debug.DebugOptions;
 
+import org.eclipse.core.runtime.jobs.Job;
+
+import org.eclipse.jface.internal.text.reconciler.ReconcilerJobFamilies;
+
 import org.eclipse.jdt.internal.core.JavaModelManager;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.text.JavaReconciler;
 
 public class TestUtils {
 
+	private static final String RECONCILER_BACKGROUND_WORKER_THREAD_NAME = JavaReconciler.class.getName();
 
 	public static void waitForIndexer() {
 		JavaModelManager.getIndexManager().waitForIndex(false, null);
+	}
+
+	/**
+	 * Closes all open editors (without saving them), then waits for:
+	 *
+	 * <pre>
+	 * 1. Reconciler family, {@link ReconcilerJobFamilies#FAMILY_RECONCILER}
+	 * 2. Background reconciler threads, {@link JavaReconciler}
+	 * </pre>
+	 *
+	 * @param timeout wait timeout in milliseconds
+	 * @throws RuntimeException if a timeout occurs while waiting
+	 */
+	@SuppressWarnings("restriction")
+	public static void waitForReconciler(long timeout) throws Exception {
+		JavaPlugin.getActivePage().closeAllEditors(false);
+		long s = System.currentTimeMillis();
+		while (System.currentTimeMillis() - s < timeout) {
+			Job[] jobs = Job.getJobManager().find(ReconcilerJobFamilies.FAMILY_RECONCILER);
+			if (jobs.length == 0) {
+				break;
+			}
+			Thread.sleep(50);
+		}
+		// the reconciler starts a background thread, wait for it here
+		while (System.currentTimeMillis() - s < timeout) {
+			boolean reconcilerDone = Thread.getAllStackTraces().keySet().stream().noneMatch(TestUtils::isReconcilerThread);
+			if (reconcilerDone) {
+				break;
+			}
+			Thread.sleep(50);
+		}
+		if (System.currentTimeMillis() - s > timeout) {
+			throw new RuntimeException("Timeout occurred while waiting on reconciler");
+		}
 	}
 
 	/**
@@ -46,5 +89,9 @@ public class TestUtils {
 		} finally {
 			context.ungetService(reference);
 		}
+	}
+
+	private static boolean isReconcilerThread(Thread thread) {
+		return thread != null && RECONCILER_BACKGROUND_WORKER_THREAD_NAME.equals(thread.getName());
 	}
 }


### PR DESCRIPTION
Tests which open a Java editor should wait on the Java reconciler to finish, otherwise the reconciler can run JDT model operations during subsequent tests.

This change adds a wait also for the reconciler background thread, on top of waiting on the reconciler family, in `SaveParticipantTest` and `ImportOrganizeTest`.

See: #2287
