### PR TITLE
Revert changes for single child of dynamic tests

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestSuiteElement.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestSuiteElement.java
@@ -33,10 +33,6 @@ public class TestSuiteElement extends TestElement implements ITestSuiteElement {
 
 	@Override
 	public Result getTestResult(boolean includeChildren) {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child != null) {
-			return child.getStatus().convertToResult();
-		}
 		if (includeChildren) {
 			return getStatus().convertToResult();
 		} else {
@@ -51,12 +47,7 @@ public class TestSuiteElement extends TestElement implements ITestSuiteElement {
 
 	@Override
 	public ITestElement[] getChildren() {
-		TestElement[] elements= fChildren.toArray(new TestElement[fChildren.size()]);
-		if (elements.length != 1 || !isSingleDynamicTest(elements[0])) {
-			return elements;
-		}
-		// Filter out if this is a single dynamic test inside a testsuite
-		return new ITestElement[0];
+		return fChildren.toArray(new ITestElement[fChildren.size()]);
 	}
 
 	public void addChild(TestElement child) {
@@ -163,84 +154,4 @@ public class TestSuiteElement extends TestElement implements ITestSuiteElement {
 		return "TestSuite: " + getTestName() + " : " + super.toString() + " (" + fChildren.size() + ")";   //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 	}
 
-	private boolean isSingleDynamicTest(TestElement element) {
-		if (element instanceof TestCaseElement testCase) {
-			if (testCase.isDynamicTest() && fChildren.size() == 1) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * If this test suite is a {@code @TestTemplate} test case with a single child, return that child.
-	 * @return The single dynamic test case child or {@code null} if the suite has no children or multiple or non-dynamid children.
-	 */
-	public TestCaseElement getSingleDynamicChild() {
-		try {
-			if (fChildren.size() == 1) {
-				TestElement child= fChildren.get(0);
-				if (isSingleDynamicTest(child)) {
-					return (TestCaseElement) child;
-				}
-			}
-		} catch (IndexOutOfBoundsException e) {
-			// don't care, children changed concurrently
-		}
-		return null;
-	}
-
-	@Override
-	public boolean isComparisonFailure() {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child == null) {
-			return super.isComparisonFailure();
-		}
-		return child.isComparisonFailure();
-	}
-
-	@Override
-	public boolean isAssumptionFailure() {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child == null) {
-			return super.isAssumptionFailure();
-		}
-		return child.isAssumptionFailure();
-	}
-
-	@Override
-	public FailureTrace getFailureTrace() {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child == null) {
-			return super.getFailureTrace();
-		}
-		return child.getFailureTrace();
-	}
-
-	@Override
-	public String getTrace() {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child != null) {
-			return child.getTrace();
-		}
-		return super.getTrace();
-	}
-
-	@Override
-	public String getExpected() {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child == null) {
-			return super.getExpected();
-		}
-		return child.getExpected();
-	}
-
-	@Override
-	public String getActual() {
-		TestCaseElement child= getSingleDynamicChild();
-		if (child == null) {
-			return super.getActual();
-		}
-		return child.getActual();
-	}
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -448,17 +448,9 @@ public class TestViewer {
 		String testName= testSuite.getTestName();
 		ITestElement[] children= testSuite.getChildren();
 
-		if (children.length > 0 && children[0] instanceof TestCaseElement tce && tce.isDynamicTest()) {
+		if (children.length > 0 && children[0] instanceof TestCaseElement tce) {
 			// a group of parameterized tests
 			return new OpenTestAction(fTestRunnerPart, tce, tce.getParameterTypes());
-		}
-		if (children.length == 0) {
-			// check if we have applied the workaround for: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/945
-			TestCaseElement child= testSuite.getSingleDynamicChild();
-			if (child != null) {
-				// a parameterized test that ran only one test
-				return new OpenTestAction(fTestRunnerPart, child, child.getParameterTypes());
-			}
 		}
 
 		int index= testName.indexOf('(');


### PR DESCRIPTION
See: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/945

In order to avoid showing unnecessary nodes in the JUnit view, we applied a change to hide a single child of dynamic tests.

Running a dynamic test as follows:

```
public class MyDynamicTestCase {

	@RepeatedTest(value = 1)
	public void test1() throws Exception {
		Thread.sleep(500);
	}

	@RepeatedTest(value = 2)
	public void test2() throws Exception {
		Thread.sleep(500);
	}
}
```
Normally results in the following tree in the JUnit view:
```
MyDynamicTestCase
|- test1
|  |- repetition 1 of 1
|- test2
   |- repetition 1 of 2
   |- repetition 1 of 2
```
The fix for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/945 hides the `repetition 1 of 1` node.

Unfortunately it results in many other issues:

* https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1021
* https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1216
* https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2692

And potentially other unknown problems.

This change reverts the initial change and the workarounds added on top of it.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2900

