### PR TITLE
Revert "Check access rules when determining JUnit version from Test annotation"

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -346,7 +346,7 @@ public class CoreTestSearchEngine {
 					true /* wait for indexer */,
 					true /* check restrictions */,
 					null);
-			if (answer != null && !answer.isNonAccessible()) {
+			if (answer != null) {
 				return answer.type;
 			}
 		}


### PR DESCRIPTION
Reverting the change, since it causes regressions when launching trivial plug-in tests.

See: https://github.com/eclipse-pde/eclipse.pde/issues/2278

This reverts commit be18086770a79a675b5177e2ec20ffe43592e6a3.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
