### PR TITLE
Cancel decoration job after opening Java editor in SaveParticipantTest

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertNotEquals;
 
 import java.util.Hashtable;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,8 @@ import org.eclipse.jface.internal.text.reconciler.ReconcilerJobFamilies;
 
 import org.eclipse.jface.text.CopyOnWriteTextStore;
 
+import org.eclipse.ui.internal.decorators.DecoratorManager;
+
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -41,7 +45,6 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 
-import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CleanUpPostSaveListener;
 import org.eclipse.jdt.internal.corext.fix.CleanUpPreferenceUtil;
@@ -64,7 +67,15 @@ public class SaveParticipantTest extends CleanUpTestCase {
 	@Rule
     public ProjectTestSetup projectSetup = new ProjectTestSetup();
 
-	private boolean wasVerbose;
+	@BeforeClass
+	public static void enableDebugTraces() {
+		setDebugTracesEnabled(true);
+	}
+
+	@AfterClass
+	public static void disableDebugTraces() {
+		setDebugTracesEnabled(false);
+	}
 
 	@Override
 	protected IJavaProject getProject() {
@@ -78,9 +89,6 @@ public class SaveParticipantTest extends CleanUpTestCase {
 
 	@Override
 	public void setUp() throws Exception {
-		wasVerbose = JavaModelManager.VERBOSE;
-		JavaModelManager.VERBOSE = true;
-		TestUtils.setDebugEnabled(CopyOnWriteTextStore.class, true);
 		super.setUp();
 
 		IEclipsePreferences node= InstanceScope.INSTANCE.getNode(JavaUI.ID_PLUGIN);
@@ -92,8 +100,7 @@ public class SaveParticipantTest extends CleanUpTestCase {
 	@Override
 	public void tearDown() throws Exception {
 		super.tearDown();
-		JavaModelManager.VERBOSE = wasVerbose;
-		TestUtils.setDebugEnabled(CopyOnWriteTextStore.class, false);
+		cancelDecorationJob();
 		TestUtils.waitForReconciler(60_000L);
 	}
 
@@ -101,6 +108,7 @@ public class SaveParticipantTest extends CleanUpTestCase {
 	private static void editCUInEditor(ICompilationUnit cu, String newContent) throws Exception {
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
 		Job.getJobManager().join(ReconcilerJobFamilies.FAMILY_RECONCILER, null);
+		cancelDecorationJob();
 
 		cu.getBuffer().setContents(newContent);
 		editor.doSave(null);
@@ -1324,5 +1332,25 @@ public class SaveParticipantTest extends CleanUpTestCase {
 
 		assertChangedFromTo(cu1, fileOnDisk, fileOnEditor, expected1);
 
+	}
+
+	@SuppressWarnings("restriction")
+	private static void cancelDecorationJob() throws InterruptedException {
+		/*
+		 * The decoration job opens and closes buffers in BufferManager,
+		 * those buffers are used by the formatter code.
+		 * We don't want the job to run in parallel to the formatting done by the test,
+		 * but waiting for the job makes the test case up to 5 times slower.
+		 * So we cancel the job and then make sure it exits before formatting.
+		 */
+		Job.getJobManager().cancel(DecoratorManager.FAMILY_DECORATE);
+		Job.getJobManager().join(DecoratorManager.FAMILY_DECORATE, null);
+	}
+
+	// Use debug tracing for: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/79
+	private static void setDebugTracesEnabled(boolean enable) {
+		TestUtils.setDebugEnabled(CopyOnWriteTextStore.class, enable);
+		TestUtils.setDebugEnabled(JavaCore.getPlugin().getBundle(), enable,
+				"/debug", "/debug/buffermanager", "/debug/javamodel");
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/util/TestUtils.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/util/TestUtils.java
@@ -52,13 +52,7 @@ public class TestUtils {
 	public static void waitForReconciler(long timeout) throws Exception {
 		JavaPlugin.getActivePage().closeAllEditors(false);
 		long s = System.currentTimeMillis();
-		while (System.currentTimeMillis() - s < timeout) {
-			Job[] jobs = Job.getJobManager().find(ReconcilerJobFamilies.FAMILY_RECONCILER);
-			if (jobs.length == 0) {
-				break;
-			}
-			Thread.sleep(50);
-		}
+		waitForJobFamily(timeout, ReconcilerJobFamilies.FAMILY_RECONCILER);
 		// the reconciler starts a background thread, wait for it here
 		while (System.currentTimeMillis() - s < timeout) {
 			boolean reconcilerDone = Thread.getAllStackTraces().keySet().stream().noneMatch(TestUtils::isReconcilerThread);
@@ -73,19 +67,51 @@ public class TestUtils {
 	}
 
 	/**
+	 * Waits for all scheduled and running jobs of the specified job {@code family}.
+	 * @param timeout wait timeout in milliseconds
+	 * @param family the job family to wait on
+	 * @throws RuntimeException if a timeout occurs while waiting
+	 */
+	public static void waitForJobFamily(long timeout, Object family) throws InterruptedException {
+		long s= System.currentTimeMillis();
+		while (System.currentTimeMillis() - s < timeout) {
+			Job[] jobs = Job.getJobManager().find(family);
+			if (jobs.length == 0) {
+				break;
+			}
+			Thread.sleep(50);
+		}
+		if (System.currentTimeMillis() - s > timeout) {
+			throw new RuntimeException("Timeout occurred while waiting on job family: " + family);
+		}
+	}
+
+	/**
 	 * Enables or disables debug traces.
 	 * @param classFromBundle A class from the bundle for which the debug tracing should be enabled or disabled.
 	 * @param enable whether to enable or disable debug tracing
 	 */
 	public static void setDebugEnabled(Class<?> classFromBundle, boolean enable) {
 		Bundle bundle= FrameworkUtil.getBundle(classFromBundle);
+		setDebugEnabled(bundle, enable, "/debug");
+	}
+
+	/**
+	 * Enables or disables debug traces for the specified bundle and debug option.
+	 * @param bundle The bundle for which the debug tracing should be enabled or disabled.
+	 * @param debugOptions The debug options to enable or disable, e.g.: {@code "/debug"}, {@code "/debug/buffermanager"}
+	 * @param enable whether to enable or disable debug tracing
+	 */
+	public static void setDebugEnabled(Bundle bundle, boolean enable, String... debugOptions) {
 		BundleContext context= bundle.getBundleContext();
 		ServiceReference<DebugOptions> reference= context.getServiceReference(DebugOptions.class);
 		try {
 			DebugOptions options= context.getService(reference);
 			options.setDebugEnabled(enable);
-			String key= bundle.getSymbolicName() + "/debug";
-			options.setOption(key, enable ? Boolean.TRUE.toString() : Boolean.FALSE.toString());
+			for (String debugOption : debugOptions) {
+				String key= bundle.getSymbolicName() + debugOption;
+				options.setOption(key, enable ? Boolean.TRUE.toString() : Boolean.FALSE.toString());
+			}
 		} finally {
 			context.ungetService(reference);
 		}


### PR DESCRIPTION
This change cancels and joins the family `DecoratorManager.FAMILY_DECORATE` after a Java editor is opened in `SaveParticipantTest`.

The job is occasionally seen in debug traces, adding element infos to `JavaModelManager.cache`. Additionally it can open and close buffers at `org.eclipse.jdt.internal.core.BufferManager`, where buffers from the `BufferManager` are used for retrieving the contents of files that should be formatted on save.

The change also adds debug traces for `BufferManager`.

See: #79