### PR TITLE
Add comprehensive JavaDoc documentation to DOM utility classes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/CodeScopeBuilder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/CodeScopeBuilder.java
@@ -30,7 +30,11 @@ import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.TypeDeclarationStatement;
 
-
+/**
+ * Builds a scope tree for code blocks, tracking variable declarations and their visibility.
+ * Used to analyze variable scoping and name conflicts in Java code.
+ *
+ */
 public class CodeScopeBuilder extends ASTVisitor {
 
 	public static class Scope {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/IASTSharedValues.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/IASTSharedValues.java
@@ -23,7 +23,13 @@ public interface IASTSharedValues {
 	 */
 	int SHARED_AST_LEVEL= AST.getJLSLatest();
 
+	/**
+	 * Enables statement recovery to allow partial AST construction when source contains syntax errors.
+	 */
 	boolean SHARED_AST_STATEMENT_RECOVERY= true;
 
+	/**
+	 * Enables binding recovery to provide best-effort type resolution when source contains errors.
+	 */
 	boolean SHARED_BINDING_RECOVERY= true;
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/LinkedNodeFinder.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/LinkedNodeFinder.java
@@ -39,11 +39,11 @@ import org.eclipse.jdt.internal.ui.util.ASTHelper;
 
 
 /**
- * Find all nodes connected to a given binding or node. e.g. Declaration of a field and all references.
- * For types this includes also the constructor declaration, for methods also overridden methods
- * or methods overriding (if existing in the same AST), for constructors also the type and all other constructors.
-  */
-
+ * Finds all AST nodes connected to a given binding or node. For example, finds a field declaration
+ * and all its references. For types, includes constructor declarations. For methods, includes
+ * overridden methods or methods that override (if in the same AST). For constructors, includes
+ * the type and all other constructors.
+ */
 public class LinkedNodeFinder  {
 
 	private LinkedNodeFinder() {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/LocalVariableIndex.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/LocalVariableIndex.java
@@ -26,7 +26,10 @@ import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 
-
+/**
+ * Computes the maximum number of local variable declarations in a method, initializer, or field.
+ * Used to determine the local variable table size for bytecode generation.
+ */
 public class LocalVariableIndex extends ASTVisitor {
 
 	private int fTopIndex;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/Selection.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/dom/Selection.java
@@ -19,7 +19,10 @@ import org.eclipse.jface.text.IRegion;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 
-
+/**
+ * A text selection in a compilation unit. Used to determine which AST nodes
+ * are affected by a user's selection during refactoring and code manipulation operations.
+ */
 public class Selection {
 
 	/** Flag indicating that the AST node somehow intersects with the selection. */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
This PR enhances the documentation for three core utility classes in the org.eclipse.jdt.internal.corext.dom package by adding comprehensive JavaDoc comments.


