### PR TITLE
Use junit-jupiter-api test annotations to detect JUnit 5 and 6

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitCorePlugin.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitCorePlugin.java
@@ -67,6 +67,8 @@ public class JUnitCorePlugin extends Plugin {
 	public final static String JUNIT5_SUITE_ANNOTATION_NAME= "org.junit.platform.suite.api.Suite"; //$NON-NLS-1$
 	public final static String JUNIT5_JUPITER_TEST_ANNOTATION_NAME= "org.junit.jupiter.api.Test"; //$NON-NLS-1$
 	public final static String JUNIT5_JUPITER_NESTED_ANNOTATION_NAME= "org.junit.jupiter.api.Nested"; //$NON-NLS-1$
+	public final static String JUNIT5_JUPITER_TEST_TEMPLATE_ANNOTATION= "org.junit.jupiter.api.TestTemplate"; //$NON-NLS-1$
+	public final static String JUNIT5_JUPITER_CLASS_TEMPLATE_ANNOTATION= "org.junit.jupiter.api.ClassTemplate"; //$NON-NLS-1$
 
 	public final static String JUNIT4_ANNOTATION_NAME= "org.junit.Test"; //$NON-NLS-1$
 	public static final String SIMPLE_TEST_INTERFACE_NAME= "Test"; //$NON-NLS-1$

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -67,8 +67,19 @@ import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
  */
 public class CoreTestSearchEngine {
 
+	/*
+	 * We use these annotations to try to determine if we have a JUnit 5 or 6 test,
+	 * see: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2903
+	 */
+	private static final String[] JUNIT_JUPITER_TEST_ANNOTATIONS = {
+		JUnitCorePlugin.JUNIT5_JUPITER_TEST_ANNOTATION_NAME,
+		JUnitCorePlugin.JUNIT5_JUPITER_TEST_TEMPLATE_ANNOTATION,
+		JUnitCorePlugin.JUNIT5_JUPITER_CLASS_TEMPLATE_ANNOTATION,
+	};
+
 	private static final String JUNIT_PLATFORM_SUITE_API_PREFIX= BuildPathSupport.JUNIT_PLATFORM_SUITE_API;
 	private static final String JUNIT_PLATFORM_COMMONS_PREFIX= BuildPathSupport.JUNIT_PLATFORM_COMMONS;
+	private static final String JUNIT_JUPITER_API_PREFIX= BuildPathSupport.JUNIT_JUPITER_API;
 	private static final String JAR_EXTENSION= ".jar"; //$NON-NLS-1$
 
 	public static boolean isTestOrTestSuite(IType declaringType) throws CoreException {
@@ -143,7 +154,7 @@ public class CoreTestSearchEngine {
 	public static boolean hasJUnit4TestAnnotation(IJavaProject project) {
 		try {
 			if (project != null) {
-				IType type= project.findType(JUnitCorePlugin.JUNIT4_ANNOTATION_NAME);
+				IType type= findAnnotations(project, JUnitCorePlugin.JUNIT4_ANNOTATION_NAME);
 				if (type != null) {
 					// @Test annotation is not accessible if the JUnit classpath container is set to JUnit 3
 					// (although it may resolve to a JUnit 4 JAR)
@@ -159,7 +170,7 @@ public class CoreTestSearchEngine {
 	}
 
 	public static boolean hasJUnit5TestAnnotation(IJavaProject project) {
-		return hasJUnitJupiterTestAnnotation(project, 1, // we check JUnit 5 platform bundles, they range in [1.0,2.0)
+		return hasJUnitJupiterTestAnnotation(project, 5, // we check JUnit 5 platform bundles, they range in [1.0,2.0)
 				JUnitCore.JUNIT3_CONTAINER_PATH, JUnitCore.JUNIT4_CONTAINER_PATH, JUnitCore.JUNIT6_CONTAINER_PATH);
 	}
 
@@ -171,11 +182,18 @@ public class CoreTestSearchEngine {
 	private static boolean hasJUnitJupiterTestAnnotation(IJavaProject project, int junitMajorVersion, IPath... disallowedJunitContainerPaths) {
 		try {
 			if (project != null) {
-				String junitBundlePrefix = JUNIT_PLATFORM_COMMONS_PREFIX;
-				IType type= findAnnotation(project, JUnitCorePlugin.JUNIT5_TESTABLE_ANNOTATION_NAME);
+				String junitBundlePrefix = JUNIT_JUPITER_API_PREFIX;
+				IType type= findAnnotations(project, JUNIT_JUPITER_TEST_ANNOTATIONS);
 				if (type == null) {
-					junitBundlePrefix = JUNIT_PLATFORM_SUITE_API_PREFIX;
-					type= findAnnotation(project, JUnitCorePlugin.JUNIT5_SUITE_ANNOTATION_NAME);
+					if (junitMajorVersion == 5) {
+						junitMajorVersion = 1;
+					}
+					junitBundlePrefix = JUNIT_PLATFORM_COMMONS_PREFIX;
+					type= findAnnotations(project, JUnitCorePlugin.JUNIT5_TESTABLE_ANNOTATION_NAME);
+					if (type == null) {
+						junitBundlePrefix = JUNIT_PLATFORM_SUITE_API_PREFIX;
+						type= findAnnotations(project, JUnitCorePlugin.JUNIT5_SUITE_ANNOTATION_NAME);
+					}
 				}
 				if (type != null) {
 					// check if we have the right JUnit JUpiter version
@@ -335,19 +353,21 @@ public class CoreTestSearchEngine {
 		new SearchEngine().search(suitePattern, participants, scope, requestor, pm);
 	}
 
-	private static IType findAnnotation(IJavaProject project, String fullyQualifiedName) throws JavaModelException {
+	private static IType findAnnotations(IJavaProject project, String... fullyQualifiedNames) throws JavaModelException {
 		if (project instanceof JavaProject p) {
 			NameLookup lookup= p.newNameLookup(DefaultWorkingCopyOwner.PRIMARY);
-			NameLookup.Answer answer = lookup.findType(
-					fullyQualifiedName,
-					false /* no partial matches */,
-					NameLookup.ACCEPT_ANNOTATIONS,
-					false /* no secondary types */,
-					true /* wait for indexer */,
-					true /* check restrictions */,
-					null);
-			if (answer != null) {
-				return answer.type;
+			for (String fullyQualifiedName : fullyQualifiedNames) {
+				NameLookup.Answer answer = lookup.findType(
+						fullyQualifiedName,
+						false /* no partial matches */,
+						NameLookup.ACCEPT_ANNOTATIONS,
+						false /* no secondary types */,
+						true /* wait for indexer */,
+						true /* check restrictions */,
+						null);
+				if (answer != null && !answer.isNonAccessible()) {
+					return answer.type;
+				}
 			}
 		}
 		return null;

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/JUnitTestPlugin.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/JUnitTestPlugin.java
@@ -36,13 +36,12 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMemberValuePair;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.jdt.internal.junit.launcher.ITestKind;
-import org.eclipse.jdt.internal.junit.util.CoreTestSearchEngine;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 
 /**
  * The plug-in runtime class for the JUnit core plug-in.
@@ -132,22 +131,13 @@ public class JUnitTestPlugin extends AbstractUIPlugin {
 	}
 
 	public static JUnitVersion getJUnitVersion(IJavaElement element) {
-		if (element != null) {
-			IJavaProject project = element.getJavaProject();
-			if (isRunWithJUnitPlatform(element)) {
-				return JUnitVersion.JUNIT4;
-			}
-			if (CoreTestSearchEngine.hasJUnit6TestAnnotation(project)) {
-				return JUnitVersion.JUNIT6;
-			}
-			if (CoreTestSearchEngine.hasJUnit5TestAnnotation(project)) {
-				return JUnitVersion.JUNIT5;
-			}
-			if (CoreTestSearchEngine.hasJUnit4TestAnnotation(project)) {
-				return JUnitVersion.JUNIT4;
-			}
-		}
-		return JUnitVersion.JUNIT3;
+		String kind = TestKindRegistry.getContainerTestKindId(element);
+		return switch (kind) {
+		case TestKindRegistry.JUNIT6_TEST_KIND_ID -> JUnitVersion.JUNIT6;
+		case TestKindRegistry.JUNIT5_TEST_KIND_ID -> JUnitVersion.JUNIT5;
+		case TestKindRegistry.JUNIT4_TEST_KIND_ID -> JUnitVersion.JUNIT4;
+		default -> JUnitVersion.JUNIT3;
+		};
 	}
 
 	/**


### PR DESCRIPTION
This change adds the following annotations to the search performed in `CoreTestSearchEngine.hasJUnitJupiterTestAnnotation()`:

* `org.junit.jupiter.api.Test`
* `org.junit.jupiter.api.TestTemplate`
* `org.junit.jupiter.api.ClassTemplate`

Additionally access restrictions on the found annotation type are applied, in order to handle JUnit 5 or 6 as transitive classapth entries of a plug-in. Such classpath entries come from the PDE classpath container and are have forbidden access pattern for all classes.

Applying the access restrictions prevents detecting the wrong JUnit version for plug-in tests, but may also fail to detect the correct JUnit version. For this reason we search also for the mentioned annotation types.

The change doesn't handle cases where the JUnit annotation `Testable` is extended, but neither `Testable` nor the annotations above are found on the accessible classpath. In such cases the version detection defaults to JUnit 3, which is the current default.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2903
