### PR TITLE
Use `IType.newSupertypeHierarchy` to determine the super type(s) of type

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/util/TestSearchEngine.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.jface.operation.IRunnableContext;
@@ -64,36 +63,24 @@ public class TestSearchEngine extends CoreTestSearchEngine {
 		var result= new HashSet<String>();
 		context.run(true, true, (progressMonitor) -> {
 			String message= Messages.format(JUnitMessages.TestSearchEngine_search_message_progress_monitor, type.getElementName());
-			SubMonitor subMonitor= SubMonitor.convert(progressMonitor, message, 1);
+			SubMonitor subMonitor= SubMonitor.convert(progressMonitor, message, 2);
 			try {
-				collectMethodNames(type, javaProject, testKind.getId(), result, subMonitor);
+				IType[] types= type.newSupertypeHierarchy(subMonitor.split(1)).getAllTypes();
+
+				subMonitor= subMonitor.split(1);
+				subMonitor.setWorkRemaining(types.length);
+
+				for (IType it : types) {
+					if (!"java.lang.Object".equals(it.getFullyQualifiedName())) {//$NON-NLS-1$
+						collectDeclaredMethodNames(it, javaProject, testKind.getId(), result);
+					}
+					subMonitor.worked(1);
+				}
 			} catch (CoreException e) {
 				throw new InvocationTargetException(e);
 			}
 		});
 		return result;
-	}
-
-	private static void collectMethodNames(IType type, IJavaProject javaProject, String testKindId, Set<String> methodNames, IProgressMonitor monitor) throws JavaModelException {
-		if (type == null) {
-			return;
-		}
-
-		SubMonitor subMonitor= SubMonitor.convert(monitor, 3);
-
-		collectDeclaredMethodNames(type, javaProject, testKindId, methodNames);
-		subMonitor.split(1);
-
-		String superclassName= type.getSuperclassName();
-		IType superType= getResolvedType(superclassName, type, javaProject);
-		collectMethodNames(superType, javaProject, testKindId, methodNames, subMonitor.split(1));
-
-		String[] superInterfaceNames= type.getSuperInterfaceNames();
-		subMonitor.setWorkRemaining(superInterfaceNames.length);
-		for (String interfaceName : superInterfaceNames) {
-			superType= getResolvedType(interfaceName, type, javaProject);
-			collectMethodNames(superType, javaProject, testKindId, methodNames, subMonitor.split(1));
-		}
 	}
 
 	private static IType getResolvedType(String typeName, IType type, IJavaProject javaProject) throws JavaModelException {


### PR DESCRIPTION
This is faster (in my experience) than using `getResolvedType`, which parses the source unit, throws away the body and sets a dummy field to get a resolved type (for each type name).

see #2905 -- Run Configurations dialog can be very slow to open

## How to test
Create project with 1 JUnit test.  Run it.  Open Run Configurations dialog to see test methods.

## Author checklist
- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)