### PR TITLE
Log test start and end for org.eclipse.jdt.text.tests

### DIFF
--- a/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.text.tests/META-INF/MANIFEST.MF
@@ -50,6 +50,8 @@ Import-Package: org.junit.jupiter.api;version="[5.14.0,6.0.0)",
  org.junit.jupiter.params.converter;version="[5.14.0,6.0.0)",
  org.junit.jupiter.params.provider;version="[5.14.0,6.0.0)",
  org.junit.jupiter.params.support;version="[5.14.0,6.0.0)",
+ org.junit.platform.engine;version="[1.14.0,2.0.0)",
+ org.junit.platform.launcher;version="[1.14.0,2.0.0)",
  org.junit.platform.suite.api;version="[1.14.0,2.0.0)",
  org.junit.platform.suite.commons;status=INTERNAL;version="[1.14.0,2.0.0)",
  org.junit.platform.suite.engine;status=INTERNAL;version="[1.14.0,2.0.0)"

--- a/org.eclipse.jdt.text.tests/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/org.eclipse.jdt.text.tests/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+org.eclipse.jdt.ui.tests.LogTestListener


### PR DESCRIPTION
Adds service `org.junit.platform.launcher.TestExecutionListener` with implementer  `org.eclipse.jdt.ui.tests.LogTestListener` to `org.eclipse.jdt.text.tests`, so that test starts and ends are logged.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2926