### PR TITLE
Add wait for reconciler thread in completion tests

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/AbstractCompletionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/AbstractCompletionTest.java
@@ -70,6 +70,7 @@ import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
 import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 
 import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.util.TestUtils;
 import org.eclipse.jdt.ui.text.IJavaPartitions;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
@@ -185,6 +186,7 @@ public abstract class AbstractCompletionTest {
 		}
 
 		JavaProjectHelper.emptyDisplayLoop();
+		TestUtils.waitForEditorJobs(30_000, true);
 	}
 
 	protected void addImport(String imp) {


### PR DESCRIPTION
The following test cases have infrequent multiple fails in the same I-build:

* `org.eclipse.jdt.text.tests.contentassist.TypeCompletionTest`
* `org.eclipse.jdt.text.tests.contentassist.JavadocCompletionTest`
* `org.eclipse.jdt.text.tests.contentassist.CodeCompletionTest`

These test cases open a Java editor and so should wait on the Java reconciler to finish. Otherwise the reconciler can run JDT model operations during subsequent tests.

This change adds such waiting in `AbstractCompletionTest`.

See: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/735