### PR TITLE
Add semantic highlighting to the Java compare/merge viewer #2929

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/compare/JavaMergeViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/compare/JavaMergeViewer.java
@@ -622,6 +622,10 @@ public class JavaMergeViewer extends TextMergeViewer {
 			super.doSetInput(input);
 			// the editor input has been explicitly set
 			fInputSet = true;
+
+			if (getInputJavaElement() != null) {
+				installSemanticHighlighting();
+			}
 		}
 		// called by org.eclipse.ui.texteditor.TextEditorAction.canModifyEditor()
 		@Override


### PR DESCRIPTION
This change installs semantic highlighting in `CompilationUnitEditorAdapter.doSetInput()` when the user preference is enabled to have the same syntax higlighting in the compare viewer than in the regular java editor. 

Fixes #2929

**Compare view before:** 
<img width="1994" height="1091" alt="compareViewBefore" src="https://github.com/user-attachments/assets/6eecc4f5-0756-45e1-9305-2adedbf21734" />

**Compare view after:** 
<img width="1994" height="1091" alt="compareViewAfter" src="https://github.com/user-attachments/assets/a93e494a-0af0-48e4-bffa-57c991f7491e" />
