### PR TITLE
Refactoring for jdt.ls usage

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/Java50CleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/Java50CleanUpCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,6 +10,7 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     IBM Corporation - refactored to jdt.core.manipulation
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.fix;
 
@@ -39,13 +40,13 @@ import org.eclipse.jdt.internal.ui.text.correction.ProblemLocation;
  * Create fixes which can transform pre Java50 code to Java50 code
  * @see org.eclipse.jdt.internal.corext.fix.Java50FixCore
  */
-public class Java50CleanUp extends AbstractMultiFix {
+public class Java50CleanUpCore extends AbstractMultiFix {
 
-	public Java50CleanUp(Map<String, String> options) {
+	public Java50CleanUpCore(Map<String, String> options) {
 		super(options);
 	}
 
-	public Java50CleanUp() {
+	public Java50CleanUpCore() {
 		super();
 	}
 

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ModifierCorrectionSubProcessorCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/ModifierCorrectionSubProcessorCore.java
@@ -20,8 +20,10 @@ package org.eclipse.jdt.internal.ui.text.correction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Hashtable;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -83,8 +85,10 @@ import org.eclipse.jdt.internal.corext.dom.ASTNodeFactory;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.Bindings;
 import org.eclipse.jdt.internal.corext.dom.ModifierRewrite;
+import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 import org.eclipse.jdt.internal.corext.fix.CompilationUnitRewriteOperationsFixCore;
 import org.eclipse.jdt.internal.corext.fix.IProposableFix;
+import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalModelCore;
 import org.eclipse.jdt.internal.corext.fix.LinkedProposalPositionGroupCore;
 import org.eclipse.jdt.internal.corext.fix.UnimplementedCodeFixCore;
@@ -92,10 +96,12 @@ import org.eclipse.jdt.internal.corext.fix.UnimplementedCodeFixCore.MakeTypeAbst
 import org.eclipse.jdt.internal.corext.util.JdtFlags;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
+import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposalCore;
 
+import org.eclipse.jdt.internal.ui.fix.Java50CleanUpCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ModifierChangeCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewDefiningMethodProposalCore;
@@ -130,6 +136,7 @@ public abstract class ModifierCorrectionSubProcessorCore<T> {
 	private static final int REMOVE_NATIVE_MODIFIER=0x400;
 	private static final int CHANGE_TO_SEALED=0x500;
 	private static final int CHANGE_TO_NONSEALED=0x501;
+	private static final int CORRECTION_CHANGE=0x502;
 	public static final int MAKE_DEPRECATED= 0x600;
 
 	private static class ModifierLinkedModeProposal extends LinkedProposalPositionGroupCore.ProposalCore {
@@ -1033,6 +1040,29 @@ public abstract class ModifierCorrectionSubProcessorCore<T> {
 		ModifierChangeCorrectionProposalCore proposal2 = new ModifierChangeCorrectionProposalCore(label, cu, typeDeclBinding, typeDecl, Modifier.NON_SEALED, 0, relevance);
 		proposals.add(modifierChangeCorrectionProposalCoreToT(proposal2, CHANGE_TO_NONSEALED));
 
+	}
+
+	public void getOverrideAnnotationProposal(IInvocationContext context, IProblemLocation problem, Collection<T> proposals) {
+		IProposableFix fix= Java50FixCore.createAddOverrideAnnotationFix(context.getASTRoot(), problem);
+		if (fix != null) {
+			Map<String, String> options= new Hashtable<>();
+			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS, CleanUpOptions.TRUE);
+			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS_OVERRIDE, CleanUpOptions.TRUE);
+			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS_OVERRIDE_FOR_INTERFACE_METHOD_IMPLEMENTATION, CleanUpOptions.TRUE);
+			FixCorrectionProposalCore proposal= new FixCorrectionProposalCore(fix, new Java50CleanUpCore(options), IProposalRelevance.ADD_OVERRIDE_ANNOTATION, context);
+			proposals.add(fixCorrectionProposalCoreToT(proposal, CORRECTION_CHANGE));
+		}
+	}
+
+	public void getDeprecatedAnnotationProposal(IInvocationContext context, IProblemLocation problem, Collection<T> proposals) {
+		IProposableFix fix= Java50FixCore.createAddDeprectatedAnnotation(context.getASTRoot(), problem);
+		if (fix != null) {
+			Map<String, String> options= new Hashtable<>();
+			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS, CleanUpOptions.TRUE);
+			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS_DEPRECATED, CleanUpOptions.TRUE);
+			FixCorrectionProposalCore proposal= new FixCorrectionProposalCore(fix, new Java50CleanUpCore(options), IProposalRelevance.ADD_DEPRECATED_ANNOTATION, context);
+			proposals.add(fixCorrectionProposalCoreToT(proposal, CORRECTION_CHANGE));
+		}
 	}
 
 	static int getNeededVisibility(ASTNode currNode, ITypeBinding targetType, IBinding binding) {

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/TypeArgumentMismatchBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/TypeArgumentMismatchBaseSubProcessor.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - refactored from TypeArgumentMismatchSubProcessor
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.text.correction;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ParameterizedType;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+
+import org.eclipse.jdt.ui.text.java.IInvocationContext;
+import org.eclipse.jdt.ui.text.java.IProblemLocation;
+import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposalCore;
+
+public abstract class TypeArgumentMismatchBaseSubProcessor<T> {
+
+	protected TypeArgumentMismatchBaseSubProcessor() {
+	}
+
+	public void addRemoveMismatchedArgumentProposals(IInvocationContext context, IProblemLocation problem, Collection<T> proposals) {
+
+		ICompilationUnit cu= context.getCompilationUnit();
+		ASTNode selectedNode= problem.getCoveredNode(context.getASTRoot());
+		if (!(selectedNode instanceof SimpleName)) {
+			return;
+		}
+
+		ASTNode normalizedNode=ASTNodes.getNormalizedNode(selectedNode);
+		if (normalizedNode instanceof ParameterizedType) {
+			ASTRewrite rewrite = ASTRewrite.create(normalizedNode.getAST());
+			ParameterizedType pt = (ParameterizedType) normalizedNode;
+			ASTNode mt = rewrite.createMoveTarget(pt.getType());
+			rewrite.replace(pt, mt, null);
+			String label= CorrectionMessages.TypeArgumentMismatchSubProcessor_removeTypeArguments;
+			T proposal= astRewriteCorrectionProposalToT(new ASTRewriteCorrectionProposalCore(label, cu, rewrite, IProposalRelevance.REMOVE_TYPE_ARGUMENTS));
+			proposals.add(proposal);
+		}
+	}
+
+	public abstract T astRewriteCorrectionProposalToT(ASTRewriteCorrectionProposalCore core);
+}

--- a/org.eclipse.jdt.ui.tests/performance/org/eclipse/jdt/ui/tests/performance/views/CleanUpPerfTest.java
+++ b/org.eclipse.jdt.ui.tests/performance/org/eclipse/jdt/ui/tests/performance/views/CleanUpPerfTest.java
@@ -81,7 +81,7 @@ import org.eclipse.jdt.internal.ui.fix.ExpressionsCleanUp;
 import org.eclipse.jdt.internal.ui.fix.HashCleanUp;
 import org.eclipse.jdt.internal.ui.fix.ImportsCleanUp;
 import org.eclipse.jdt.internal.ui.fix.InvertEqualsCleanUpCore;
-import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
+import org.eclipse.jdt.internal.ui.fix.Java50CleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.JoinCleanUp;
 import org.eclipse.jdt.internal.ui.fix.LazyLogicalCleanUp;
 import org.eclipse.jdt.internal.ui.fix.MapCloningCleanUp;
@@ -371,7 +371,7 @@ public class CleanUpPerfTest extends JdtPerformanceTestCaseCommon {
 
 		storeSettings(node);
 
-		cleanUpRefactoring.addCleanUp(new Java50CleanUp());
+		cleanUpRefactoring.addCleanUp(new Java50CleanUpCore());
 
 		doCleanUp(cleanUpRefactoring);
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -73,7 +73,7 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
-import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
+import org.eclipse.jdt.internal.ui.fix.Java50CleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 import org.eclipse.jdt.internal.ui.fix.PlainReplacementCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PrimitiveRatherThanWrapperCleanUpCore;
@@ -1918,7 +1918,7 @@ public class CleanUpTest extends CleanUpTestCase {
 
 		HashMap<String, String> map= new HashMap<>();
 		map.put(CleanUpConstants.VARIABLE_DECLARATION_USE_TYPE_ARGUMENTS_FOR_RAW_TYPE_REFERENCES, CleanUpOptions.TRUE);
-		Java50CleanUp cleanUp= new Java50CleanUp(map);
+		Java50CleanUpCore cleanUp= new Java50CleanUpCore(map);
 
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 		parser.setResolveBindings(true);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest1d5.java
@@ -55,7 +55,7 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 
 import org.eclipse.jdt.internal.ui.fix.IMultiFix;
-import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
+import org.eclipse.jdt.internal.ui.fix.Java50CleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMarkerResolutionGenerator;
@@ -4608,7 +4608,7 @@ public class CleanUpTest1d5 extends CleanUpTestCase {
 		cleanUpOptions.setOption(CleanUpConstants.ADD_MISSING_ANNOTATIONS_OVERRIDE, CleanUpOptions.TRUE);
 		cleanUpOptions.setOption(CleanUpConstants.ADD_MISSING_ANNOTATIONS_OVERRIDE_FOR_INTERFACE_METHOD_IMPLEMENTATION, CleanUpOptions.TRUE);
 
-		Java50CleanUp cleanUp = new Java50CleanUp();
+		Java50CleanUpCore cleanUp = new Java50CleanUpCore();
 		cleanUp.setOptions(cleanUpOptions);
 
 		ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -7291,7 +7291,7 @@
             runAfter="org.eclipse.jdt.ui.cleanup.boolean_literal">
       </cleanUp>
       <cleanUp
-            class="org.eclipse.jdt.internal.ui.fix.Java50CleanUp"
+            class="org.eclipse.jdt.internal.ui.fix.Java50CleanUpCore"
             id="org.eclipse.jdt.ui.cleanup.java50"
             runAfter="org.eclipse.jdt.ui.cleanup.unused_code">
       </cleanUp>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/MissingCodeTabPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/cleanup/MissingCodeTabPage.java
@@ -21,7 +21,7 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
 
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
-import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
+import org.eclipse.jdt.internal.ui.fix.Java50CleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.PotentialProgrammingProblemsCleanUpCore;
 import org.eclipse.jdt.internal.ui.fix.UnimplementedCodeCleanUpCore;
 
@@ -35,7 +35,7 @@ public final class MissingCodeTabPage extends AbstractCleanUpTabPage {
 
 	@Override
 	protected AbstractCleanUp[] createPreviewCleanUps(Map<String, String> values) {
-		return new AbstractCleanUp[] { new Java50CleanUp(values), new PotentialProgrammingProblemsCleanUpCore(values), new UnimplementedCodeCleanUpCore(values) };
+		return new AbstractCleanUp[] { new Java50CleanUpCore(values), new PotentialProgrammingProblemsCleanUpCore(values), new UnimplementedCodeCleanUpCore(values) };
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/LocalCorrectionsSubProcessor.java
@@ -101,7 +101,7 @@ import org.eclipse.jdt.ui.text.java.correction.ICommandAccess;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
-import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
+import org.eclipse.jdt.internal.ui.fix.Java50CleanUpCore;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
 import org.eclipse.jdt.internal.ui.refactoring.nls.ExternalizeWizard;
@@ -374,7 +374,7 @@ public class LocalCorrectionsSubProcessor extends LocalCorrectionsBaseSubProcess
 			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
 			Map<String, String> options= new Hashtable<>();
 			options.put(CleanUpConstants.VARIABLE_DECLARATION_USE_TYPE_ARGUMENTS_FOR_RAW_TYPE_REFERENCES, CleanUpOptions.TRUE);
-			FixCorrectionProposal proposal= new FixCorrectionProposal(fix, new Java50CleanUp(options), IProposalRelevance.RAW_TYPE_REFERENCE, image, context);
+			FixCorrectionProposal proposal= new FixCorrectionProposal(fix, new Java50CleanUpCore(options), IProposalRelevance.RAW_TYPE_REFERENCE, image, context);
 			proposal.setCommandId(RAW_TYPE_REFERENCE_ID);
 			proposals.add(proposal);
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ModifierCorrectionSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/ModifierCorrectionSubProcessor.java
@@ -18,10 +18,6 @@
 package org.eclipse.jdt.internal.ui.text.correction;
 
 import java.util.Collection;
-import java.util.Hashtable;
-import java.util.Map;
-
-import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.core.runtime.CoreException;
 
@@ -29,11 +25,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.Modifier;
 
-import org.eclipse.jdt.internal.corext.fix.CleanUpConstants;
-import org.eclipse.jdt.internal.corext.fix.IProposableFix;
-import org.eclipse.jdt.internal.corext.fix.Java50FixCore;
-
-import org.eclipse.jdt.ui.cleanup.CleanUpOptions;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposal;
@@ -41,7 +32,6 @@ import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposalCore;
 import org.eclipse.jdt.ui.text.java.correction.ICommandAccess;
 
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
-import org.eclipse.jdt.internal.ui.fix.Java50CleanUp;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposal;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionProposalCore;
 import org.eclipse.jdt.internal.ui.text.correction.proposals.ModifierChangeCorrectionProposal;
@@ -88,28 +78,11 @@ public class ModifierCorrectionSubProcessor extends ModifierCorrectionSubProcess
 	}
 
 	public static void addOverrideAnnotationProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
-		IProposableFix fix= Java50FixCore.createAddOverrideAnnotationFix(context.getASTRoot(), problem);
-		if (fix != null) {
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-			Map<String, String> options= new Hashtable<>();
-			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS, CleanUpOptions.TRUE);
-			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS_OVERRIDE, CleanUpOptions.TRUE);
-			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS_OVERRIDE_FOR_INTERFACE_METHOD_IMPLEMENTATION, CleanUpOptions.TRUE);
-			FixCorrectionProposal proposal= new FixCorrectionProposal(fix, new Java50CleanUp(options), IProposalRelevance.ADD_OVERRIDE_ANNOTATION, image, context);
-			proposals.add(proposal);
-		}
+		new ModifierCorrectionSubProcessor().getOverrideAnnotationProposal(context, problem, proposals);
 	}
 
 	public static void addDeprecatedAnnotationProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {
-		IProposableFix fix= Java50FixCore.createAddDeprectatedAnnotation(context.getASTRoot(), problem);
-		if (fix != null) {
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-			Map<String, String> options= new Hashtable<>();
-			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS, CleanUpOptions.TRUE);
-			options.put(CleanUpConstants.ADD_MISSING_ANNOTATIONS_DEPRECATED, CleanUpOptions.TRUE);
-			FixCorrectionProposal proposal= new FixCorrectionProposal(fix, new Java50CleanUp(options), IProposalRelevance.ADD_DEPRECATED_ANNOTATION, image, context);
-			proposals.add(proposal);
-		}
+		new ModifierCorrectionSubProcessor().getDeprecatedAnnotationProposal(context, problem, proposals);
 	}
 
 	public static void addOverridingDeprecatedMethodProposal(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/TypeArgumentMismatchSubProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/TypeArgumentMismatchSubProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,25 +15,16 @@ package org.eclipse.jdt.internal.ui.text.correction;
 
 import java.util.Collection;
 
-import org.eclipse.swt.graphics.Image;
-
-import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.dom.ASTNode;
-import org.eclipse.jdt.core.dom.ParameterizedType;
-import org.eclipse.jdt.core.dom.SimpleName;
-import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
-
-import org.eclipse.jdt.internal.corext.dom.ASTNodes;
-
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IProblemLocation;
 import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposal;
+import org.eclipse.jdt.ui.text.java.correction.ASTRewriteCorrectionProposalCore;
 import org.eclipse.jdt.ui.text.java.correction.ICommandAccess;
 
 import org.eclipse.jdt.internal.ui.JavaPluginImages;
 
 
-public class TypeArgumentMismatchSubProcessor {
+public class TypeArgumentMismatchSubProcessor extends TypeArgumentMismatchBaseSubProcessor<ICommandAccess>{
 
 //	public static void getTypeParameterMismatchProposals(IInvocationContext context, IProblemLocation problem, Collection proposals) {
 //	CompilationUnit astRoot= context.getASTRoot();
@@ -52,26 +43,15 @@ public class TypeArgumentMismatchSubProcessor {
 //	}
 
 	public static void removeMismatchedArguments(IInvocationContext context, IProblemLocation problem, Collection<ICommandAccess> proposals){
-		ICompilationUnit cu= context.getCompilationUnit();
-		ASTNode selectedNode= problem.getCoveredNode(context.getASTRoot());
-		if (!(selectedNode instanceof SimpleName)) {
-			return;
-		}
-
-		ASTNode normalizedNode=ASTNodes.getNormalizedNode(selectedNode);
-		if (normalizedNode instanceof ParameterizedType) {
-			ASTRewrite rewrite = ASTRewrite.create(normalizedNode.getAST());
-			ParameterizedType pt = (ParameterizedType) normalizedNode;
-			ASTNode mt = rewrite.createMoveTarget(pt.getType());
-			rewrite.replace(pt, mt, null);
-			String label= CorrectionMessages.TypeArgumentMismatchSubProcessor_removeTypeArguments;
-			Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
-			ASTRewriteCorrectionProposal proposal= new ASTRewriteCorrectionProposal(label, cu, rewrite, IProposalRelevance.REMOVE_TYPE_ARGUMENTS, image);
-			proposals.add(proposal);
-		}
+		new TypeArgumentMismatchSubProcessor().addRemoveMismatchedArgumentProposals(context, problem, proposals);
 	}
 
 	private TypeArgumentMismatchSubProcessor() {
+	}
+
+	@Override
+	public ICommandAccess astRewriteCorrectionProposalToT(ASTRewriteCorrectionProposalCore core) {
+		return new ASTRewriteCorrectionProposal(core, JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE));
 	}
 
 }


### PR DESCRIPTION
- refactor JavaCleanUp to new JavaCleanUpCore
- refactor remaining methods from ModifierCorrectionSubProcessor to ModifierCorrectionSubProcessorCore
- refactor methods from TypeArgumentMismatchSubProcessor to new TypeArgumentMismatchBaseSubProcessor

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Refactors additional functionality from JDT UI to jdt.core.manipulation for use by jdt.ls.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run regular JDT test-suite.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
