### PR TITLE
Wait for reconciler in tests that open editors

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ASTProviderTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ASTProviderTest.java
@@ -46,6 +46,7 @@ import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
 
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.util.TestUtils;
 
 
 /**
@@ -113,6 +114,7 @@ public class ASTProviderTest extends CoreTests {
 	@After
 	public void tearDown() throws Exception {
 		JavaProjectHelper.clear(fJProject1, pts.getDefaultClasspath());
+		TestUtils.waitForEditorJobs(60_000L, true);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/CodeFormatterTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/CodeFormatterTest.java
@@ -51,6 +51,7 @@ import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.util.TestUtils;
 
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
@@ -81,6 +82,7 @@ public class CodeFormatterTest extends CoreTests {
 	@After
 	public void tearDown() throws Exception {
 		JavaProjectHelper.delete(fJProject1);
+		TestUtils.waitForEditorJobs(60_000L, true);
 	}
 
 	protected static String format(ICompilationUnit cu, int offset, int length) throws PartInitException, JavaModelException {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/TypeHierarchyTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/TypeHierarchyTest.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.util.TestUtils;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 
@@ -59,6 +60,7 @@ public class TypeHierarchyTest {
 	public void tearDown () throws Exception {
 		JavaProjectHelper.clear(fJavaProject1, pts.getDefaultClasspath());
 		JavaProjectHelper.delete(fJavaProject2);
+		TestUtils.waitForEditorJobs(60_000L, true);
 	}
 
 	@Test


### PR DESCRIPTION
Try to avoid test failures due to inconsistent JDT model and platform resource state, by waiting on the Java reconciler.

See: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2287