### PR TITLE
Replace deprecated Color(Device, ...) constructors

### DIFF
--- a/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTViewLabelProvider.java
+++ b/org.eclipse.jdt.astview/src/org/eclipse/jdt/astview/views/ASTViewLabelProvider.java
@@ -62,17 +62,17 @@ public class ASTViewLabelProvider extends LabelProvider implements IColorProvide
 		fDarkGreen= display.getSystemColor(SWT.COLOR_DARK_GREEN);
 		fDarkRed= display.getSystemColor(SWT.COLOR_DARK_RED);
 
-		fSelectedElemBGColor= new Color(display, 232, 242, 254);
+		fSelectedElemBGColor= new Color(232, 242, 254);
 		String currLineColor= EditorsUI.getPreferenceStore().getString(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_CURRENT_LINE_COLOR);
 		String[] rgb= currLineColor.split(","); //$NON-NLS-1$
 		if (rgb.length == 3) {
 			try {
-				fSelectedElemBGColor= new Color(display, Integer.parseInt(rgb[0]), Integer.parseInt(rgb[1]), Integer.parseInt(rgb[2]));
+				fSelectedElemBGColor= new Color(Integer.parseInt(rgb[0]), Integer.parseInt(rgb[1]), Integer.parseInt(rgb[2]));
 			} catch (NumberFormatException e) {
 				// do nothing, colour would remain the backup value
 			}
 		}
-		fLightRed= new Color(display, 255, 190, 190);
+		fLightRed= new Color(255, 190, 190);
 
 		fBold= PlatformUI.getWorkbench().getThemeManager().getCurrentTheme().getFontRegistry().getBold(JFaceResources.DEFAULT_FONT);
 		FontData[] fontData= fBold.getFontData();

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitProgressBar.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitProgressBar.java
@@ -53,10 +53,9 @@ public class JUnitProgressBar extends Canvas {
 			}
 		});
 		addPaintListener(this::paint);
-		Display display= parent.getDisplay();
-		fFailureColor= new Color(display, 159, 63, 63);
-		fOKColor= new Color(display, 95, 191, 95);
-		fStoppedColor= new Color(display, 120, 120, 120);
+		fFailureColor= new Color(159, 63, 63);
+		fOKColor= new Color(95, 191, 95);
+		fStoppedColor= new Color(120, 120, 120);
 	}
 
 	public void setMaximum(int max) {

--- a/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/CreateTextFileChangePreviewViewer.java
+++ b/org.eclipse.jdt.ui/ui refactoring/org/eclipse/jdt/internal/ui/refactoring/CreateTextFileChangePreviewViewer.java
@@ -23,7 +23,6 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.core.runtime.IAdaptable;
 
@@ -149,7 +148,7 @@ public final class CreateTextFileChangePreviewViewer implements IChangePreviewVi
 				String key, boolean useDefault) {
 			Color newColor= useDefault
 					? null
-					: createColor(styledText.getDisplay(), store, key);
+					: createColor(store, key);
 			switch (key) {
 				case AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND:
 					styledText.setForeground(newColor);
@@ -170,7 +169,7 @@ public final class CreateTextFileChangePreviewViewer implements IChangePreviewVi
 			customColors.put(key, newColor);
 		}
 
-		private static Color createColor(Display display, IPreferenceStore store,
+		private static Color createColor(IPreferenceStore store,
 				String key) {
 			RGB rgb= null;
 			if (store.contains(key)) {
@@ -180,7 +179,7 @@ public final class CreateTextFileChangePreviewViewer implements IChangePreviewVi
 					rgb= PreferenceConverter.getColor(store, key);
 				}
 				if (rgb != null) {
-					return new Color(display, rgb);
+					return new Color(rgb);
 				}
 			}
 			return null;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditor.java
@@ -240,7 +240,7 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 			Display display= parent.getDisplay();
 			fBackgroundColor= display.getSystemColor(SWT.COLOR_LIST_BACKGROUND);
 			fForegroundColor= display.getSystemColor(SWT.COLOR_LIST_FOREGROUND);
-			fSeparatorColor= new Color(display, 152, 170, 203);
+			fSeparatorColor= new Color(152, 170, 203);
 
 			JFaceResources.getFontRegistry().addListener(this);
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaSourceViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaSourceViewer.java
@@ -26,7 +26,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.core.runtime.Assert;
 
@@ -255,25 +254,25 @@ public class JavaSourceViewer extends ProjectionViewer implements IPropertyChang
 			// ----------- foreground color --------------------
 			Color color= fPreferenceStore.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND_SYSTEM_DEFAULT)
 			? null
-			: createColor(fPreferenceStore, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND, styledText.getDisplay());
+			: createColor(fPreferenceStore, AbstractTextEditor.PREFERENCE_COLOR_FOREGROUND);
 			styledText.setForeground(color);
 
 			// ---------- background color ----------------------
 			color= fPreferenceStore.getBoolean(AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND_SYSTEM_DEFAULT)
 			? null
-			: createColor(fPreferenceStore, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND, styledText.getDisplay());
+			: createColor(fPreferenceStore, AbstractTextEditor.PREFERENCE_COLOR_BACKGROUND);
 			styledText.setBackground(color);
 
 			// ----------- selection foreground color --------------------
 			color= fPreferenceStore.getBoolean(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SELECTION_FOREGROUND_DEFAULT_COLOR)
 				? null
-				: createColor(fPreferenceStore, AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SELECTION_FOREGROUND_COLOR, styledText.getDisplay());
+				: createColor(fPreferenceStore, AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SELECTION_FOREGROUND_COLOR);
 			styledText.setSelectionForeground(color);
 
 			// ---------- selection background color ----------------------
 			color= fPreferenceStore.getBoolean(AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SELECTION_BACKGROUND_DEFAULT_COLOR)
 				? null
-				: createColor(fPreferenceStore, AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SELECTION_BACKGROUND_COLOR, styledText.getDisplay());
+				: createColor(fPreferenceStore, AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SELECTION_BACKGROUND_COLOR);
 			styledText.setSelectionBackground(color);
 
 		}
@@ -285,11 +284,10 @@ public class JavaSourceViewer extends ProjectionViewer implements IPropertyChang
      *
      * @param store the store to read from
      * @param key the key used for the lookup in the preference store
-     * @param display the display used create the color
      * @return the created color according to the specification in the preference store
      * @since 3.0
      */
-    private Color createColor(IPreferenceStore store, String key, Display display) {
+    private Color createColor(IPreferenceStore store, String key) {
 
         RGB rgb= null;
 
@@ -301,7 +299,7 @@ public class JavaSourceViewer extends ProjectionViewer implements IPropertyChang
                 rgb= PreferenceConverter.getColor(store, key);
 
             if (rgb != null)
-                return new Color(display, rgb);
+                return new Color(rgb);
         }
 
         return null;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/BreadcrumbItemDropDown.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/breadcrumb/BreadcrumbItemDropDown.java
@@ -161,7 +161,7 @@ class BreadcrumbItemDropDown {
 
 			RGB blend= FormColors.blend(rgb2, rgb1, ratio);
 
-			return new Color(display, blend);
+			return new Color(blend);
 		}
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaColorManager.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaColorManager.java
@@ -50,7 +50,7 @@ public class JavaColorManager implements IColorManager, IColorManagerExtension {
 
 		Color color= colorTable.get(rgb);
 		if (color == null) {
-			color= new Color(Display.getCurrent(), rgb);
+			color= new Color(rgb);
 			colorTable.put(rgb, color);
 		}
 


### PR DESCRIPTION
## Summary
- Replace all `Color(Device, int, int, int)` and `Color(Device, RGB)` constructor calls with device-free `Color(int, int, int)` and `Color(RGB)` variants
- Remove unused `Display` parameters, variables, and imports where they were only needed for the old Color constructors
- 7 files updated across `org.eclipse.jdt.ui`, `org.eclipse.jdt.junit`, and `org.eclipse.jdt.astview`

See https://github.com/eclipse-platform/eclipse.platform.swt/pull/3233

## Test plan
- [x] `mvn clean verify -DskipTests` builds successfully with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)