### PR TITLE
[27] Allow JDT to target Java 27 in compiler preferences

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/util/JavaModelUtil.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Matt Chapman, mpchapman@gmail.com - 89977 Make JDT .java agnostic
@@ -76,7 +80,7 @@ public final class JavaModelUtil {
 	 */
 	public static final String VERSION_LATEST;
 	static {
-		VERSION_LATEST= JavaCore.VERSION_26; // make sure it is not inlined
+		VERSION_LATEST= JavaCore.VERSION_27; // make sure it is not inlined
 	}
 
 	public static final int VALIDATE_EDIT_CHANGED_CONTENT= 10003;
@@ -859,6 +863,10 @@ public final class JavaModelUtil {
 		return !isVersionLessThan(compliance, JavaCore.VERSION_26);
 	}
 
+	public static boolean is27OrHigher(String compliance) {
+		return !isVersionLessThan(compliance, JavaCore.VERSION_27);
+	}
+
 	/**
 	 * Checks if the given project or workspace has source compliance 9 or greater.
 	 *
@@ -1047,6 +1055,17 @@ public final class JavaModelUtil {
 		return is26OrHigher(getSourceCompliance(project));
 	}
 
+	/**
+	 * Checks if the given project or workspace has source compliance 27 or greater.
+	 *
+	 * @param project the project to test or <code>null</code> to test the workspace settings
+	 * @return <code>true</code> if the given project or workspace has source compliance 27 or
+	 *         greater.
+	 */
+	public static boolean is27OrHigher(IJavaProject project) {
+		return is27OrHigher(getSourceCompliance(project));
+	}
+
 	public static String getSourceCompliance(IJavaProject project) {
 		return project != null ? project.getOption(JavaCore.COMPILER_SOURCE, true) : JavaCore.getOption(JavaCore.COMPILER_SOURCE);
 	}
@@ -1072,6 +1091,8 @@ public final class JavaModelUtil {
 		String version= vMInstall.getJavaVersion();
 		if (version == null) {
 			return defaultCompliance;
+		} else if (version.startsWith(JavaCore.VERSION_27)) {
+			return JavaCore.VERSION_27;
 		} else if (version.startsWith(JavaCore.VERSION_26)) {
 			return JavaCore.VERSION_26;
 		} else if (version.startsWith(JavaCore.VERSION_25)) {
@@ -1128,7 +1149,9 @@ public final class JavaModelUtil {
 
 		// fallback:
 		String desc= executionEnvironment.getId();
-		if (desc.indexOf(JavaCore.VERSION_26) != -1) {
+		if (desc.indexOf(JavaCore.VERSION_27) != -1) {
+			return JavaCore.VERSION_27;
+		} else if (desc.indexOf(JavaCore.VERSION_26) != -1) {
 			return JavaCore.VERSION_26;
 		} else if (desc.indexOf(JavaCore.VERSION_25) != -1) {
 			return JavaCore.VERSION_25;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/ComplianceConfigurationBlock.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Jesper S Møller - Bug 529432 - Allow JDT UI to target Java 10
@@ -701,9 +705,8 @@ public class ComplianceConfigurationBlock extends OptionsConfigurationBlock {
 		}
 	}
 
-	protected boolean isBetaVersion(@SuppressWarnings("unused") String compliance) {
-		return false;
-//		return JavaCore.VERSION_26.equals(compliance);
+	protected boolean isBetaVersion(String compliance) {
+		return JavaCore.VERSION_27.equals(compliance);
 	}
 
 	private String addsExportToSystemModule() {


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2931

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
