### PR TITLE
Remove unwanted single quote from links

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2025 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -191,7 +191,7 @@ JavaEditorPreferencePage_addJavaDocTags= Add &Javadoc tags
 JavaEditorPreferencePage_smartPaste= Adjust &indentation
 
 # DO NOT TRANSLATE "org.eclipse.ui.preferencePages.GeneralTextEditor" and "org.eclipse.ui.preferencePages.ColorsAndFonts"
-JavaEditorPreferencePage_link=Java editor preferences. See <a href=\"org.eclipse.ui.preferencePages.GeneralTextEditor\">'Text Editors'</a> for general text editor preferences and <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">'Colors and Fonts'</a> to configure the font.
+JavaEditorPreferencePage_link=Java editor preferences. See <a href=\"org.eclipse.ui.preferencePages.GeneralTextEditor\">Text Editors</a> for general text editor preferences and <a href=\"org.eclipse.ui.preferencePages.ColorsAndFonts\">Colors and Fonts</a> to configure the font.
 
 JavaEditorPreferencePage_importsOnPaste=&Update imports
 JavaEditorPreferencePage_subWordNavigation= Smart &caret positioning in Java names (overrides platform behavior)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
This commit removes unwanted single quotes from label links in the Java editor’s Preference pages and makes links across Preference pages consistent.
Before:
<img width="1328" height="1598" alt="image" src="https://github.com/user-attachments/assets/737a9218-4c08-4d87-a9d3-587248f1eae6" />
After:
<img width="1380" height="1604" alt="image" src="https://github.com/user-attachments/assets/eccc0353-ea39-47f5-b02f-aad4fd19f7c9" />
