### PR TITLE
Fix ConstantsForSystemPropertiesCleanUpCore to not use emptyList()

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ConstantsForSystemPropertiesCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/ConstantsForSystemPropertiesCleanUpCore.java
@@ -33,7 +33,7 @@ import static org.eclipse.jdt.internal.corext.fix.UpdateProperty.LONG_PROPERTY;
 import static org.eclipse.jdt.internal.corext.fix.UpdateProperty.PATH_SEPARATOR;
 import static org.eclipse.jdt.internal.ui.fix.MultiFixMessages.ConstantsCleanUp_description;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -145,7 +145,7 @@ public class ConstantsForSystemPropertiesCleanUpCore extends AbstractCleanUp {
 		if (isEnabled(CONSTANTS_FOR_SYSTEM_PROPERTY)) {
 			result= computeFixSet().stream().map(e->(Messages.format(ConstantsCleanUp_description,e.toString()))).collect(Collectors.toList());
 		} else {
-			result= Collections.emptyList();
+			result= new ArrayList<>();
 		}
 
 		result.addAll(computeFixSet2(null).stream().map(e->(Messages.format(ConstantsCleanUp_description,e.toString()))).collect(Collectors.toList()));


### PR DESCRIPTION
- use new ArrayList instead of Collections.emptyList() as latter is immutable
- fixes #2954

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Removes exception.  See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
