### PR TITLE
[Javadoc] Snippet inline tag's link text does not handled properly

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavaDocSnippetStringEvaluator.java
@@ -202,8 +202,7 @@ public class CoreJavaDocSnippetStringEvaluator {
 	}
 
 	private String getString(String str, List<ActionElement> actionElements) {
-		String modifiedStr= str.replaceAll(">", "&gt;"); //$NON-NLS-1$ //$NON-NLS-2$
-		modifiedStr= modifiedStr.replaceAll("<", "&lt;"); //$NON-NLS-1$ //$NON-NLS-2$
+		String modifiedStr = str;
 		List<StringItem> items= new ArrayList<>();
 		for (ActionElement actElem : actionElements) {
 			StringItem startItem= new StringItem(actElem.start, actElem.startTag);
@@ -236,6 +235,14 @@ public class CoreJavaDocSnippetStringEvaluator {
 				items.add(startItem);
 			}
 		}
+		items.sort((a, b) -> {
+		    if (b.index != a.index) {
+		        return Integer.compare(b.index, a.index);
+		    }
+		    boolean aIsEnd = a.tag.startsWith("</"); //$NON-NLS-1$
+		    boolean bIsEnd = b.tag.startsWith("</"); //$NON-NLS-1$
+		    return Boolean.compare(bIsEnd, aIsEnd);
+		});
 		for (StringItem item : items) {
 			modifiedStr= modifiedStr.substring(0, item.index) + item.tag + modifiedStr.substring(item.index);
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.After;
 import org.junit.Before;
@@ -493,6 +496,50 @@ public class JavadocHoverTests extends CoreTests {
 		    String actualSnippetContent = actualHtmlContent.substring(contentStart, contentEnd).trim();
 		    String expectedSnippetContent = "var s = \"\";";
 		    assertEquals(expectedSnippetContent, actualSnippetContent);
+		}
+	}
+
+	@Test
+	public void testSnippetInlineLinkAppliedOnCorrectSubstring() throws Exception {
+		String source="""
+					package p;
+						public class Javadoc {
+						    /**
+							 * Snippet with advanced highlighting and linking.
+							 *
+							 * {@snippet :
+							 *   List<String> items = new ArrayList<>(); // @link substring="ArrayList" target="java.util.ArrayList"
+							 *   items.add("Java 18");                   // @highlight substring="items.add" type="highlighted"
+							 *   System.out.println(items.get(0));       // @highlight regex="\".*\""
+							 * }
+							 */
+						    public static void foo(Object object) {
+						    }
+						}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Javadoc.java", source, null);
+		Map<String, String> options = JavaCore.getOptions();
+		JavaCore.setComplianceOptions(JavaCore.VERSION_26, options);
+		options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED);
+		fJProject1.setOptions(options);
+		IType type= cu.getType("Javadoc");
+		for (IJavaElement member : type.getChildren()) {
+			IJavaElement[] elements= { member };
+			ISourceRange range= ((ISourceReference) member).getNameRange();
+			JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(elements, cu, new Region(range.getOffset(), range.getLength()), null);
+			String actualHtmlContent= hoverInfo.getHtml();
+			Pattern pattern = Pattern.compile("<a\\b[^>]*>.*?</a>", Pattern.DOTALL);
+	        Matcher matcher = pattern.matcher(actualHtmlContent);
+	        String lastAnchor = null;
+	        while (matcher.find()) {
+	            lastAnchor = matcher.group();
+	        }
+	        assertNotNull("Anchor tag not found", lastAnchor);
+            Pattern codePattern = Pattern.compile("<code>(.*?)</code>");
+            Matcher codeMatcher = codePattern.matcher(lastAnchor);
+
+            assertTrue("Code tag not found inside anchor", codeMatcher.find());
+        	assertEquals("sequence doesn't match", "ArrayList", codeMatcher.group(1));
 		}
 	}
 


### PR DESCRIPTION

<img width="380" height="119" alt="image" src="https://github.com/user-attachments/assets/c9e342be-b0c8-42a7-bfcf-cc41a053dfa5" />

This PR fixes an issue where @link inside Javadoc {@snippet} tags was applied to the wrong substring during HTML rendering in Javadoc hover/view. The anchor tag is now correctly mapped to the intended target text instead of wrapping an incorrect partial sequence caused by index ordering during tag insertion.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2944

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
