### PR TITLE
Use bundled Jupiter version for JUnit platform console standalone JARs

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -80,6 +80,9 @@ public class CoreTestSearchEngine {
 	private static final String JUNIT_PLATFORM_SUITE_API_PREFIX= BuildPathSupport.JUNIT_PLATFORM_SUITE_API;
 	private static final String JUNIT_PLATFORM_COMMONS_PREFIX= BuildPathSupport.JUNIT_PLATFORM_COMMONS;
 	private static final String JUNIT_JUPITER_API_PREFIX= BuildPathSupport.JUNIT_JUPITER_API;
+	private static final String JUNIT_PLATFORM_CONSOLE_STANDALONE_PREFIX= "junit-platform-console-standalone"; //$NON-NLS-1$
+	private static final String ENGINE_VERSION_JUNIT_JUPITER= "Engine-Version-junit-jupiter"; //$NON-NLS-1$
+	private static final String SPECIFICATION_VERSION= "Specification-Version"; //$NON-NLS-1$
 	private static final String JAR_EXTENSION= ".jar"; //$NON-NLS-1$
 
 	public static boolean isTestOrTestSuite(IType declaringType) throws CoreException {
@@ -198,7 +201,8 @@ public class CoreTestSearchEngine {
 				if (type != null) {
 					// check if we have the right JUnit JUpiter version
 					Version version = null;
-					String filename= type.getPath().lastSegment();
+					PackageFragmentRoot root= (PackageFragmentRoot) type.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
+					String filename= root != null ? root.getPath().lastSegment() : type.getPath().lastSegment();
 					boolean isJar = filename.endsWith(JAR_EXTENSION);
 					// Try matching the library name, this should be enough for many cases.
 					if (isJar && (filename.startsWith(junitBundlePrefix + "_") || filename.startsWith(junitBundlePrefix + "-"))) { //$NON-NLS-1$ //$NON-NLS-2$
@@ -214,14 +218,13 @@ public class CoreTestSearchEngine {
 					}
 					if (isJar && version == null) {
 						try {
-							PackageFragmentRoot root= (PackageFragmentRoot) type.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
 							Manifest manifest= null;
 							if (root != null) {
 								manifest= root.getManifest();
 							}
 							if (manifest != null) {
 								Attributes attributes= manifest.getMainAttributes();
-								String versionString= attributes.getValue("Specification-Version"); //$NON-NLS-1$
+								String versionString= getJUnitVersionFromManifest(filename, attributes);
 								if (versionString != null) {
 									version= Version.parseVersion(versionString);
 								}
@@ -233,9 +236,11 @@ public class CoreTestSearchEngine {
 					if (version != null && version.getMajor() != junitMajorVersion) {
 						return false;
 					}
+					if (root == null) {
+						return false;
+					}
 					// @Testable/@Suite annotations are not accessible if the JUnit classpath container is set to JUnit 3 or JUnit 4
 					// (although it may resolve to a JUnit 5 JAR)
-					IPackageFragmentRoot root= (IPackageFragmentRoot) type.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
 					IClasspathEntry cpEntry= root.getRawClasspathEntry();
 					IPath entryPath= cpEntry.getPath();
 					return !Arrays.asList(disallowedJunitContainerPaths).contains(entryPath);
@@ -245,6 +250,16 @@ public class CoreTestSearchEngine {
 			// not available
 		}
 		return false;
+	}
+
+	private static String getJUnitVersionFromManifest(String filename, Attributes attributes) {
+		if (filename.startsWith(JUNIT_PLATFORM_CONSOLE_STANDALONE_PREFIX + "_") || filename.startsWith(JUNIT_PLATFORM_CONSOLE_STANDALONE_PREFIX + "-")) { //$NON-NLS-1$ //$NON-NLS-2$
+			String versionString= attributes.getValue(ENGINE_VERSION_JUNIT_JUPITER);
+			if (versionString != null) {
+				return versionString;
+			}
+		}
+		return attributes.getValue(SPECIFICATION_VERSION);
 	}
 
 	public static boolean isTestImplementor(IType type) throws JavaModelException {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -44,6 +44,7 @@ JUnitTestFinderTest.class,
 JUnit4TestFinderTest16.class,
 JUnit5TestFinderJupiterTest.class,
 JUnit6TestFinderJupiterTest.class,
+JUnitStandaloneDetectionTest.class,
 
 JUnitQuickAssistTest.class,
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitStandaloneDetectionTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitStandaloneDetectionTest.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.junit.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.eclipse.core.runtime.Path;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.ui.tests.quickfix.JarUtil;
+
+import org.eclipse.jdt.internal.junit.util.CoreTestSearchEngine;
+
+public class JUnitStandaloneDetectionTest {
+
+	private static final String[] JUNIT_JUPITER_API_STUBS= {
+			"org/junit/jupiter/api/Test.java",
+			"""
+			package org.junit.jupiter.api;
+
+			public @interface Test {
+			}
+			""",
+			"org/junit/jupiter/api/TestTemplate.java",
+			"""
+			package org.junit.jupiter.api;
+
+			public @interface TestTemplate {
+			}
+			""",
+			"org/junit/jupiter/api/ClassTemplate.java",
+			"""
+			package org.junit.jupiter.api;
+
+			public @interface ClassTemplate {
+			}
+			""",
+			"org/junit/platform/commons/annotation/Testable.java",
+			"""
+			package org.junit.platform.commons.annotation;
+
+			public @interface Testable {
+			}
+			"""
+	};
+
+	private IJavaProject javaProject;
+
+	@After
+	public void tearDown() throws Exception {
+		if (javaProject != null) {
+			JavaProjectHelper.delete(javaProject);
+		}
+	}
+
+	@Test
+	public void testDetectJUnit5FromPlatformConsoleStandaloneJar() throws Exception {
+		javaProject= createProjectWithStandaloneJar("junit-platform-console-standalone-1.13.4.jar", "1.13.4", "5.13.4");
+
+		assertThat(CoreTestSearchEngine.hasJUnit5TestAnnotation(javaProject)).isTrue();
+		assertThat(CoreTestSearchEngine.hasJUnit6TestAnnotation(javaProject)).isFalse();
+	}
+
+	@Test
+	public void testDetectJUnit6FromPlatformConsoleStandaloneJar() throws Exception {
+		javaProject= createProjectWithStandaloneJar("junit-platform-console-standalone-6.0.3.jar", "6.0.3", "6.0.3");
+
+		assertThat(CoreTestSearchEngine.hasJUnit5TestAnnotation(javaProject)).isFalse();
+		assertThat(CoreTestSearchEngine.hasJUnit6TestAnnotation(javaProject)).isTrue();
+	}
+
+	private static IJavaProject createProjectWithStandaloneJar(String jarName, String specificationVersion, String jupiterVersion) throws Exception {
+		IJavaProject project= JavaProjectHelper.createJavaProject("JUnitStandaloneDetectionTest", "bin");
+		JavaProjectHelper.addRTJar_17(project, false);
+		File jar= new File(project.getProject().getLocation().toFile(), jarName);
+		String rtStubs= JavaProjectHelper.findRtJar(JavaProjectHelper.RT_STUBS17)[0].toOSString();
+		JarUtil.createJar(JUNIT_JUPITER_API_STUBS, new String[] {
+				"META-INF/MANIFEST.MF",
+				"""
+				Manifest-Version: 1.0
+				Automatic-Module-Name: org.junit.platform.console.standalone
+				Multi-Release: true
+				Specification-Version: %s
+				Engine-Version-junit-jupiter: %s
+
+				""".formatted(specificationVersion, jupiterVersion)
+		}, jar.getAbsolutePath(), new String[] { rtStubs }, "17", null, null);
+		JavaProjectHelper.addLibrary(project, Path.fromOSString(jar.getAbsolutePath()));
+		return project;
+	}
+}


### PR DESCRIPTION
## Summary

Fix JUnit 5/6 detection for `junit-platform-console-standalone` JARs whose manifest exposes different Platform and Jupiter engine versions.

## Problem

`junit-platform-console-standalone-1.13.4.jar` contains JUnit Jupiter 5.13.4, but its manifest `Specification-Version` represents the JUnit Platform version (`1.13.4`), not the bundled Jupiter engine version.

`CoreTestSearchEngine.hasJUnit5TestAnnotation()` uses the resolved annotation type to inspect the containing JAR version. For standalone console JARs, reading `Specification-Version` causes the detected major version to be `1`, so the JAR is not recognized as JUnit 5.

This can prevent a plain Eclipse Java project using `junit-platform-console-standalone-1.13.4.jar` from launching JUnit 5 tests correctly.

## Fix

When the containing JAR is `junit-platform-console-standalone-*`, prefer the manifest attribute:

```text
Engine-Version-junit-jupiter
```

and fall back to:

```text
Specification-Version
```

for the existing non-standalone cases.

This keeps the existing annotation lookup and access-restriction behavior unchanged.

## Behavior Matrix

| Scenario | Before | After |
|----------|--------|-------|
| Direct `junit-jupiter-api-*.jar` on classpath | Works | Works |
| `junit-platform-console-standalone-1.13.4.jar` with Jupiter 5.13.4 | Detected as Platform `1.x`, not JUnit 5 | Detected as JUnit 5 |
| `junit-platform-console-standalone-6.0.3.jar` | Detected as JUnit 6 | Detected as JUnit 6 |
| PDE forbidden/transitive JUnit dependency case from #2830/#2903 | Access restrictions preserved | Access restrictions preserved |

## Tests

Added `JUnitStandaloneDetectionTest` covering:

- `junit-platform-console-standalone-1.13.4.jar`: `Specification-Version=1.13.4`, `Engine-Version-junit-jupiter=5.13.4`
- `junit-platform-console-standalone-6.0.3.jar`: `Specification-Version=6.0.3`, `Engine-Version-junit-jupiter=6.0.3`

## Related

- Fixes: #2959
- Downstream: https://github.com/redhat-developer/vscode-java/issues/4396
- Related: #2830, #2903