### PR TITLE
Fix UnresolvedElementsBaseSubProcessor to create an import quick-fix proposal

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
@@ -957,7 +957,7 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 		String resolvedTypeName= null;
 		ITypeBinding binding= ASTResolving.guessBindingForTypeReference(node);
 		ITypeBinding simpleBinding= null;
-		if (binding != null) {
+		if (binding != null && !binding.getQualifiedName().equals("java.lang.Object")) { //$NON-NLS-1$
 			simpleBinding= binding;
 			if (simpleBinding.isArray()) {
 				simpleBinding= simpleBinding.getElementType();
@@ -1045,7 +1045,7 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 			}
 		}
 		if (elements.length == 0) {
-			collectRequiresModuleProposals(cu, node, IProposalRelevance.IMPORT_NOT_FOUND_ADD_REQUIRES_MODULE, proposals, true);
+			collectRequiresModuleProposals(cu, node, IProposalRelevance.IMPORT_NOT_FOUND_ADD_REQUIRES_MODULE + 100, proposals, true);
 		}
 	}
 
@@ -1094,7 +1094,7 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 					String moduleRequiresChangeName= change.getName();
 					moduleRequiresChangeName= moduleRequiresChangeName.substring(0, 1).toLowerCase() + moduleRequiresChangeName.substring(1);
 					String changeName= Messages.format(CorrectionMessages.UnresolvedElementsSubProcessor_combine_two_proposals_info, new String[] { importChangeName, moduleRequiresChangeName });
-					compositeProposal= new ChangeCorrectionProposalCore(changeName, null, IProposalRelevance.IMPORT_NOT_FOUND_ADD_REQUIRES_MODULE) {
+					compositeProposal= new ChangeCorrectionProposalCore(changeName, null, aicpc.getRelevance()) {
 						@Override
 						protected Change createChange() throws CoreException {
 							return new CompositeChange(changeName, new Change[] { change, importChange });

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/text/correction/UnresolvedElementsBaseSubProcessor.java
@@ -957,7 +957,8 @@ public abstract class UnresolvedElementsBaseSubProcessor<T> {
 		String resolvedTypeName= null;
 		ITypeBinding binding= ASTResolving.guessBindingForTypeReference(node);
 		ITypeBinding simpleBinding= null;
-		if (binding != null && !binding.getQualifiedName().equals("java.lang.Object")) { //$NON-NLS-1$
+		if (binding != null &&
+				(!binding.getQualifiedName().equals("java.lang.Object") || elements.length == 0)) { //$NON-NLS-1$
 			simpleBinding= binding;
 			if (simpleBinding.isArray()) {
 				simpleBinding= simpleBinding.getElementType();


### PR DESCRIPTION
- add check in UnresolvedElementsBaseSubProcessor.addSimilarTypeProposal method to ignore a guessed binding of Object for unresolved type if there is a list of possible types to check
- fix relevance when importing and adding to module so it will be offered first
- for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5039

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See referenced issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See referenced issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
