### PR TITLE
Fix JavaElementUtil.isForbiddenOnClassPath() method

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/util/JavaElementUtil.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/util/JavaElementUtil.java
@@ -269,7 +269,7 @@ public class JavaElementUtil {
 								case IAccessRule.K_DISCOURAGED:
 									return true;
 								default:
-									break;
+									return false;
 							}
 						}
 					}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest1d8.java
@@ -522,4 +522,110 @@ public class ImportOrganizeTest1d8 extends ImportOrganizeTest {
 				JavaProjectHelper.delete(referencing2);
 		}
 	}
+
+	@Test
+	public void testStaticImportFavorite_Issue2893_2() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2893
+		IPreferenceStore preferenceStore= PreferenceConstants.getPreferenceStore();
+		preferenceStore.setValue(PreferenceConstants.CODEASSIST_FAVORITE_STATIC_MEMBERS, "test.Assertions.*;test1.Assertions.*");
+		IJavaProject p1= null;
+		IJavaProject referencing1= null;
+		IJavaProject referencing2= null;
+		try {
+			p1= JavaProjectHelper.createJavaProject("p1", "bin");
+			referencing1= JavaProjectHelper.createJavaProject("p2", "bin");
+			referencing2= JavaProjectHelper.createJavaProject("p3", "bin");
+
+			JavaProjectHelper.addRTJar(p1);
+			IPackageFragmentRoot p1SourceFolder= JavaProjectHelper.addSourceContainer(p1, "src");
+			IPackageFragment pack= p1SourceFolder.createPackageFragment("test", false, null);
+
+			String str= """
+					package test;
+
+					public class Assertions {
+						public static boolean assertEquals(Object obj1, Object obj2) throws Exception {
+							if (Object.equals(obj1, obj2)) {
+								throw new Exception();
+							}
+						}
+					}
+					""";
+			pack.createCompilationUnit("Assertions.java", str, false, null);
+
+			JavaProjectHelper.addRTJar(referencing1);
+			IPackageFragmentRoot ref1SourceFolder= JavaProjectHelper.addSourceContainer(referencing1, "src");
+			IPackageFragment pack1= ref1SourceFolder.createPackageFragment("test1", false, null);
+			String str1= """
+					package test1;
+
+					public class Assertions {
+						public static boolean assertEquals(Object obj1, Object obj2) throws Exception {
+							if (Object.equals(obj1, obj2)) {
+								throw new Exception();
+							}
+						}
+					}
+					""";
+			pack1.createCompilationUnit("Assertions.java", str1, false, null);
+
+			JavaProjectHelper.addRTJar(referencing2);
+			JavaProjectHelper.addRequiredProject(referencing2, referencing1);
+
+			IPackageFragmentRoot ref2SourceFolder= JavaProjectHelper.addSourceContainer(referencing2, "src");
+			IPackageFragment pack2= ref2SourceFolder.createPackageFragment("test2", false, null);
+			String str2= """
+					package test2;
+
+					public class E2 {
+						public boolean foo2(Object obj1, Object obj2) throws Exception {
+							assertEquals(obj1, obj2);
+						}
+					}
+					""";
+			ICompilationUnit cu2= pack2.createCompilationUnit("E2.java", str2, false, null);
+
+
+			IAccessRule[] accessRules2= new IAccessRule[] {
+					JavaCore.newAccessRule(new Path("test/Assertions/**"), IAccessRule.K_ACCESSIBLE),
+					JavaCore.newAccessRule(new Path("**/*"), IAccessRule.K_NON_ACCESSIBLE)
+			};
+			IClasspathAttribute[] extraAttributes2= new IClasspathAttribute[] {
+					JavaCore.newClasspathAttribute("myTestAttribute", "val")
+			};
+			IClasspathEntry cpe2= JavaCore.newProjectEntry(p1.getProject().getFullPath(), accessRules2, true, extraAttributes2, false);
+			JavaProjectHelper.addToClasspath(referencing2, cpe2);
+
+			String[] order= new String[] {};
+			IChooseImportQuery query= createQuery("StaticMethodReferenceImports_bug424172", new String[] {}, new int[] {});
+
+			OrganizeImportsOperation op= createOperation(cu2, order, 99, false, true, true, query);
+			op.run(null);
+
+			String expected= """
+					package test2;
+
+					import static test.Assertions.assertEquals;
+
+					public class E2 {
+						public boolean foo2(Object obj1, Object obj2) throws Exception {
+							assertEquals(obj1, obj2);
+						}
+					}
+					""";
+			assertEqualString(cu2.getSource(), expected);
+		} finally {
+			preferenceStore.setValue(PreferenceConstants.CODEASSIST_FAVORITE_STATIC_MEMBERS, "");
+			if (referencing1 != null && referencing1.exists())
+				JavaProjectHelper.removeSourceContainer(referencing1, "src");
+			if (referencing2 != null && referencing2.exists())
+				JavaProjectHelper.removeSourceContainer(referencing2, "src");
+
+			if (p1 != null && p1.exists())
+				JavaProjectHelper.delete(p1);
+			if (referencing1 != null && referencing1.exists())
+				JavaProjectHelper.delete(referencing1);
+			if (referencing2 != null && referencing2.exists())
+				JavaProjectHelper.delete(referencing2);
+		}
+	}
 }


### PR DESCRIPTION
- fix logic so that when a match is found that is accessible, return false instead of continuing to look through other access rules
- add new test to ImportOrganizeTest1d8
- fixes #2972

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
