### PR TITLE
Support newline formatting on text blocks created by quick assist

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -295,6 +295,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			});
 
 			IJavaElement root= cuRewrite.getRoot().getJavaElement();
+			boolean needNewLineTextBlock = false;
 			if (root != null) {
 				IJavaProject project= root.getJavaProject();
 				if (project != null) {
@@ -305,6 +306,8 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 							fIndent += " "; //$NON-NLS-1$
 						}
 					}
+					String newLineTextBlockStr = project.getOption(DefaultCodeFormatterConstants.FORMATTER_PUT_TEXT_BLOCK_QUOTES_ON_NEW_LINE, true);
+					needNewLineTextBlock = DefaultCodeFormatterConstants.TRUE.equals(newLineTextBlockStr);
 				}
 			}
 
@@ -325,12 +328,17 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 				}
 			});
 
+			if (needNewLineTextBlock) {
+				buf.append("\n" + fIndent); //$NON-NLS-1$
+			}
+
 			buf.append("\"\"\"\n"); //$NON-NLS-1$
 			boolean newLine= false;
 			boolean allWhiteSpaceStart= true;
 			boolean allEmpty= true;
+			int bufLength = (needNewLineTextBlock) ? 6 : 4;
 			for (String part : parts) {
-				if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
+				if (buf.length() > bufLength) {// the first part has been added after the text block delimiter and newline
 					if (!newLine) {
 						// no line terminator in this part: merge the line by emitting a line continuation escape
 						buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
@@ -373,6 +381,15 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 					buf.append("\\t"); //$NON-NLS-1$
 				}
 			}
+
+			if (needNewLineTextBlock) {
+				if (!newLine) {
+					buf.append("\\"); //$NON-NLS-1$
+					buf.append("\n");  //$NON-NLS-1$
+					buf.append(fIndent);
+				}
+			}
+
 			buf.append("\"\"\""); //$NON-NLS-1$
 			if (!isTagged) {
 				TextBlock textBlock= (TextBlock) rewrite.createStringPlaceholder(buf.toString(), ASTNode.TEXT_BLOCK);
@@ -852,7 +869,6 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 
 		@Override
 		public boolean visit(VariableDeclarationFragment node) {
-			// TODO Auto-generated method stub
 			VariableDeclarationStatement varDeclStmt= ASTNodes.getFirstAncestorOrNull(node, VariableDeclarationStatement.class);
 			if (varDeclStmt == null || varDeclStmt.fragments().size() != 1) {
 				return false;
@@ -1189,6 +1205,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 	private static StringBuilder createTextBlockBuffer(List<StringLiteral> literals, CompilationUnitRewrite cuRewrite) {
 		IJavaElement root= cuRewrite.getRoot().getJavaElement();
 		String fIndent= "\t"; //$NON-NLS-1$
+		boolean needNewLineTextBlock = false;
 		if (root != null) {
 			IJavaProject project= root.getJavaProject();
 			if (project != null) {
@@ -1199,20 +1216,24 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 						fIndent += " "; //$NON-NLS-1$
 					}
 				}
+				String newLineTextBlockStr = project.getOption(DefaultCodeFormatterConstants.FORMATTER_PUT_TEXT_BLOCK_QUOTES_ON_NEW_LINE, true);
+				needNewLineTextBlock = DefaultCodeFormatterConstants.TRUE.equals(newLineTextBlockStr);
 			}
 		}
-
 		StringBuilder buf= new StringBuilder();
 
 		List<String> parts= new ArrayList<>();
 		literals.stream().forEach((t) -> { String value= t.getEscapedValue(); parts.addAll(unescapeBlock(value.substring(1, value.length() - 1))); });
-
+		if(needNewLineTextBlock) {
+			buf.append("\n" + fIndent); //$NON-NLS-1$
+		}
 		buf.append("\"\"\"\n"); //$NON-NLS-1$
 		boolean newLine= false;
 		boolean allWhiteSpaceStart= true;
 		boolean allEmpty= true;
+		int bufLength = (needNewLineTextBlock) ? 6 : 4;
 		for (String part : parts) {
-			if (buf.length() > 4) {// the first part has been added after the text block delimiter and newline
+			if (buf.length() > bufLength) {// the first part has been added after the text block delimiter and newline
 				if (!newLine) {
 					// no line terminator in this part: merge the line by emitting a line continuation escape
 					buf.append("\\").append(System.lineSeparator()); //$NON-NLS-1$
@@ -1246,6 +1267,10 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 			for (int i= count; i > 0; --i) {
 				buf.append("\\\""); //$NON-NLS-1$
 			}
+		}
+		if(needNewLineTextBlock) {
+			if (!newLine)
+				buf.append("\\\\n" + fIndent); //$NON-NLS-1$
 		}
 		buf.append("\"\"\""); //$NON-NLS-1$
 		return buf;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/StringConcatToTextBlockFixCore.java
@@ -1270,7 +1270,7 @@ public class StringConcatToTextBlockFixCore extends CompilationUnitRewriteOperat
 		}
 		if(needNewLineTextBlock) {
 			if (!newLine)
-				buf.append("\\\\n" + fIndent); //$NON-NLS-1$
+				buf.append("\\").append(System.lineSeparator()).append(fIndent); //$NON-NLS-1$
 		}
 		buf.append("\"\"\""); //$NON-NLS-1$
 		return buf;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/CompilationUnitRewrite.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/CompilationUnitRewrite.java
@@ -311,8 +311,6 @@ public class CompilationUnitRewrite {
 					String importUpdateName= RefactoringCoreMessages.ASTData_update_imports;
 					cuChange.addTextEditGroup(new TextEditGroup(importUpdateName, importsEdit));
 				}
-			} else {
-
 			}
 			if (isEmptyEdit(multiEdit))
 				return null;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest15.java
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.testplugin.TestOptions;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -38,6 +39,8 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 import org.eclipse.jdt.ui.text.java.IInvocationContext;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 
+import org.eclipse.jdt.internal.ui.fix.MultiFixMessages;
+import org.eclipse.jdt.internal.ui.text.correction.AssistContext;
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
 public class AssistQuickFixTest15 extends QuickFixTest {
@@ -2075,4 +2078,143 @@ public class AssistQuickFixTest15 extends QuickFixTest {
 		assertExpectedExistInProposals(proposals, new String[] { expected });
 	}
 
+	@Test
+	public void testStringConcatToTextBlock() throws Exception {
+		//Testing new quick assist to place text block quotes on their own lines if option is enabled
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_PUT_TEXT_BLOCK_QUOTES_ON_NEW_LINE, DefaultCodeFormatterConstants.TRUE);
+		JavaCore.setOptions(options);
+
+		String example1 = """
+			package test1;
+			public class TestQuickAssistTextBlock {
+
+				String str1 = "asd" + "bsd\\n" + "cpp" + "osd";
+
+				public void foo1() {
+					System.out.println(str1);
+				}
+
+				public static void main(String[] args) {
+					TestQuickAssistTextBlock qatb = new TestQuickAssistTextBlock();
+					qatb.foo1();
+				}
+			}
+			""";
+		ICompilationUnit cu = pack1.createCompilationUnit("TestQuickAssistTextBlock.java", example1, false, null);
+		int offset= example1.indexOf("asd");
+		AssistContext context= getCorrectionContext(cu, offset, 0);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		assertProposalExists(proposals, MultiFixMessages.StringConcatToTextBlockCleanUp_description);
+		String expected = """
+				package test1;
+				public class TestQuickAssistTextBlock {
+
+					String str1 =\s
+						\"\"\"
+						asd\\
+						bsd
+						cpp\\
+						osd\\
+						\"\"\";
+
+					public void foo1() {
+						System.out.println(str1);
+					}
+
+					public static void main(String[] args) {
+						TestQuickAssistTextBlock qatb = new TestQuickAssistTextBlock();
+						qatb.foo1();
+					}
+				}
+				""";
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+		options.put(DefaultCodeFormatterConstants.FORMATTER_PUT_TEXT_BLOCK_QUOTES_ON_NEW_LINE, DefaultCodeFormatterConstants.FALSE);
+		JavaCore.setOptions(options);
+	}
+
+	@Test
+	public void testStringBufferToTextBlock() throws Exception {
+		//Testing new quick assist to place text block quotes on their own lines if option is enabled
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set15CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+
+		Hashtable<String, String> options = TestOptions.getDefaultOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_PUT_TEXT_BLOCK_QUOTES_ON_NEW_LINE, DefaultCodeFormatterConstants.TRUE);
+		JavaCore.setOptions(options);
+
+		String example1 = """
+			package test1;
+			public class TestQuickAssistTextBlock {
+
+				String str1 ="asd\\nbsd\\nasm\\n\\t\\tcpp\\n";
+
+				public void foo1() {
+					System.out.println(str1);
+				}
+
+				public static void main(String[] args) {
+					TestQuickAssistTextBlock qatb = new TestQuickAssistTextBlock();
+					qatb.foo1();
+				}
+			}
+			""";
+		ICompilationUnit cu = pack1.createCompilationUnit("TestQuickAssistTextBlock.java", example1, false, null);
+		int offset= example1.indexOf("asd");
+		AssistContext context= getCorrectionContext(cu, offset, 10);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertCorrectLabels(proposals);
+		assertProposalExists(proposals, MultiFixMessages.StringToTextBlock_description);
+		String expected = """
+				package test1;
+				public class TestQuickAssistTextBlock {
+
+					String str1 =
+						\"\"\"
+						asd
+						bsd
+						asm
+								cpp
+						\"\"\";
+
+					public void foo1() {
+						System.out.println(str1);
+					}
+
+					public static void main(String[] args) {
+						TestQuickAssistTextBlock qatb = new TestQuickAssistTextBlock();
+						qatb.foo1();
+					}
+				}
+				""";
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+		options.put(DefaultCodeFormatterConstants.FORMATTER_PUT_TEXT_BLOCK_QUOTES_ON_NEW_LINE, DefaultCodeFormatterConstants.FALSE);
+		JavaCore.setOptions(options);
+	}
 }


### PR DESCRIPTION
## What it does
Implement issue #2943 

## How to test
* Enable the java formatter option: `After and before opening and closing quotes of text block`
* Go on a string concatenation or a long string, and press `ctrl + 1`  select either `Convert String to text block` or `Convert string concatenation to text block`  it should change the string to a text block, with opening and closing quotes on their own line.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
