### PR TITLE
feat(junit.runtime): support multi-method launches in a single JVM

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -696,6 +696,20 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 						String testName= type.getFullyQualifiedName();
 						bw.write(testName);
 						bw.newLine();
+					} else if (testElement instanceof IMethod) {
+						// Extended -testNameFile format: "fully.qualified.ClassName:methodName".
+						// Allows running an arbitrary set of methods (potentially across
+						// multiple classes) within a single launch. The remote runner falls
+						// back to legacy class-only behavior when no ':' is present, so older
+						// runtime jars remain compatible.
+						IMethod method= (IMethod) testElement;
+						IType declaringType= method.getDeclaringType();
+						if (declaringType == null) {
+							abort(JUnitMessages.JUnitLaunchConfigurationDelegate_error_wrong_input, null, IJavaLaunchConfigurationConstants.ERR_UNSPECIFIED_MAIN_TYPE);
+						} else {
+							bw.write(declaringType.getFullyQualifiedName() + ':' + method.getElementName());
+							bw.newLine();
+						}
 					} else {
 						abort(JUnitMessages.JUnitLaunchConfigurationDelegate_error_wrong_input, null, IJavaLaunchConfigurationConstants.ERR_UNSPECIFIED_MAIN_TYPE);
 					}

--- a/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.runtime/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.runtime
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.runtime;singleton:=true
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 3.8.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: 

--- a/org.eclipse.jdt.junit.runtime/pom.xml
+++ b/org.eclipse.jdt.junit.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit.runtime</artifactId>
-  <version>3.8.0-SNAPSHOT</version>
+  <version>3.8.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/ITestLoader.java
+++ b/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/ITestLoader.java
@@ -16,6 +16,11 @@
 
 package org.eclipse.jdt.internal.junit.runner;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 public interface ITestLoader {
 	/**
 	 * @param testClasses classes to be run
@@ -28,5 +33,58 @@ public interface ITestLoader {
 	 * @return the loaded test references
 	 */
 	ITestReference[] loadTests(Class<?>[] testClasses, String testName, String[] failureNames, String[] packages, String[][] includeExcludeTags, String uniqueId, RemoteTestRunner listener);
+
+	/**
+	 * Loads tests for an arbitrary collection of (class, method) pairs in a single launch.
+	 * <p>
+	 * The default implementation delegates to {@link #loadTests(Class[], String, String[], String[], String[][], String, RemoteTestRunner)}
+	 * for each pair, preserving the legacy behavior of one filtered request per method.
+	 * Loaders that can express multi-method discovery natively (e.g. JUnit Platform via multiple
+	 * {@code selectMethod} selectors, JUnit 4 via a multi-method filter) are encouraged to override
+	 * this method so that the entire selection runs inside a single launch.
+	 * </p>
+	 *
+	 * @param classToMethods ordered map from test class to the set of methods to run within that class
+	 * @param failureNames may want to run these first, since they failed
+	 * @param packages packages containing tests to run
+	 * @param includeExcludeTags tags to be included and excluded in the test run
+	 * @param uniqueId unique ID of the test to run
+	 * @param listener to be notified if tests could not be loaded
+	 * @return the loaded test references
+	 */
+	default ITestReference[] loadTests(LinkedHashMap<Class<?>, List<String>> classToMethods, String[] failureNames, String[] packages, String[][] includeExcludeTags, String uniqueId, RemoteTestRunner listener) {
+		List<ITestReference> refs= new ArrayList<>();
+		for (Map.Entry<Class<?>, List<String>> entry : classToMethods.entrySet()) {
+			Class<?>[] singleClass= { entry.getKey() };
+			List<String> methods= entry.getValue();
+			if (methods == null || methods.isEmpty()) {
+				// An empty / null method list represents an unfiltered class run, which
+				// the legacy single-method overload models by passing testName == null.
+				// This lets callers (e.g. RemoteTestRunner) mix class-only and
+				// Class:method entries from the same -testNameFile without losing the
+				// class-only selections.
+				ITestReference[] wholeClass= loadTests(singleClass, null, failureNames, packages, includeExcludeTags, uniqueId, listener);
+				if (wholeClass != null) {
+					for (ITestReference r : wholeClass) {
+						if (r != null) {
+							refs.add(r);
+						}
+					}
+				}
+				continue;
+			}
+			for (String methodName : methods) {
+				ITestReference[] perMethod= loadTests(singleClass, methodName, failureNames, packages, includeExcludeTags, uniqueId, listener);
+				if (perMethod != null) {
+					for (ITestReference r : perMethod) {
+						if (r != null) {
+							refs.add(r);
+						}
+					}
+				}
+			}
+		}
+		return refs.toArray(new ITestReference[0]);
+	}
 }
 

--- a/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RemoteTestRunner.java
+++ b/org.eclipse.jdt.junit.runtime/src/org/eclipse/jdt/internal/junit/runner/RemoteTestRunner.java
@@ -26,6 +26,11 @@ import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Vector;
 
 import org.eclipse.jdt.internal.junit.runner.junit3.JUnit3TestLoader;
@@ -65,6 +70,15 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 	 * The name of the test (argument -test)
 	 */
 	private String fTestName;
+	/**
+	 * Optional mapping from test class name to the list of method names to execute
+	 * within that class. Populated when {@code -testNameFile} contains lines of the
+	 * form {@code ClassName:methodName}. When non-empty, multi-method dispatch is
+	 * used so that the entire selection runs in a single launch. When empty, the
+	 * legacy single-method ({@link #fTestName}) path is used and behavior is
+	 * unchanged.
+	 */
+	private LinkedHashMap<String, List<String>> fMethodsByClass= new LinkedHashMap<>();
 	/**
 	 * The names of the packages containing tests to run
 	 */
@@ -408,11 +422,48 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 	}
 
 	private void readTestNames(String testNameFile) throws IOException {
-		fTestClassNames= readLines(testNameFile);
+		String[] lines= readLines(testNameFile);
+		fMethodsByClass.clear();
+		// LinkedHashSet keeps insertion order (so test execution follows the order in
+		// the file) while giving O(1) deduplication. The previous ArrayList#contains
+		// approach was O(n^2) for files with many Class:method lines.
+		LinkedHashSet<String> classNames= new LinkedHashSet<>();
+		for (String line : lines) {
+			if (line == null) {
+				continue;
+			}
+			line= line.trim();
+			if (line.isEmpty()) {
+				continue;
+			}
+			int colonIdx= line.indexOf(':');
+			if (colonIdx <= 0 || colonIdx == line.length() - 1) {
+				// Legacy line: a fully-qualified class name.
+				classNames.add(line);
+			} else {
+				// Extended format: "fully.qualified.ClassName:methodName" — selects a
+				// specific method. Multiple methods of the same class may appear on
+				// separate lines and will be dispatched in a single launch via
+				// ITestLoader#loadTests(LinkedHashMap, ...).
+				String className= line.substring(0, colonIdx);
+				String methodName= line.substring(colonIdx + 1);
+				List<String> methods= fMethodsByClass.computeIfAbsent(className, k -> new ArrayList<>());
+				methods.add(methodName);
+				classNames.add(className);
+			}
+		}
+		fTestClassNames= classNames.toArray(new String[0]);
 		if (fDebugMode) {
 			System.out.println("Tests:"); //$NON-NLS-1$
 			for (String fTestClassName : fTestClassNames) {
-				System.out.println("    "+fTestClassName); //$NON-NLS-1$
+				List<String> methods= fMethodsByClass.get(fTestClassName);
+				if (methods == null || methods.isEmpty()) {
+					System.out.println("    "+fTestClassName); //$NON-NLS-1$
+				} else {
+					for (String m : methods) {
+						System.out.println("    "+fTestClassName+":"+m); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}
 			}
 		}
 	}
@@ -501,7 +552,32 @@ public class RemoteTestRunner implements MessageSender, IVisitsTestTrees {
 	 * @param execution executor
 	 */
 	private void runTests(String[] testClassNames, String testName, TestExecution execution) {
-		ITestReference[] suites= fLoader.loadTests(loadClasses(testClassNames), testName, fFailureNames, fPackageNames, fIncludeExcludeTags, fUniqueId, this);
+		ITestReference[] suites;
+		if (!fMethodsByClass.isEmpty()) {
+			// Multi-method launch: each entry maps a loaded Class<?> to the list of
+			// methods that should be discovered for it. Class-only entries from the
+			// same -testNameFile are kept and represented by an empty method list,
+			// which loaders interpret as "run the whole class" — this lets a single
+			// file mix legacy class lines with Class:method lines and still execute
+			// the whole selection inside one test JVM (sharing per-class
+			// @BeforeAll / @AfterAll / Spring ApplicationContext lifecycle).
+			Class<?>[] classes= loadClasses(testClassNames);
+			LinkedHashMap<Class<?>, List<String>> classToMethods= new LinkedHashMap<>();
+			for (Class<?> clazz : classes) {
+				if (clazz == null) {
+					continue;
+				}
+				List<String> methods= fMethodsByClass.get(clazz.getName());
+				classToMethods.put(clazz, methods != null ? methods : Collections.emptyList());
+			}
+			if (!classToMethods.isEmpty()) {
+				suites= fLoader.loadTests(classToMethods, fFailureNames, fPackageNames, fIncludeExcludeTags, fUniqueId, this);
+			} else {
+				suites= new ITestReference[0];
+			}
+		} else {
+			suites= fLoader.loadTests(loadClasses(testClassNames), testName, fFailureNames, fPackageNames, fIncludeExcludeTags, fUniqueId, this);
+		}
 
 		// count all testMethods and inform ITestRunListeners
 		int count= countTests(suites);

--- a/org.eclipse.jdt.junit4.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit4.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit4.runtime;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit4.runner;x-internal:=true
 Require-Bundle: org.junit;bundle-version="[4.13.0,5.0.0)",

--- a/org.eclipse.jdt.junit4.runtime/pom.xml
+++ b/org.eclipse.jdt.junit4.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit4.runtime</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit4.runtime/src/org/eclipse/jdt/internal/junit4/runner/JUnit4TestLoader.java
+++ b/org.eclipse.jdt.junit4.runtime/src/org/eclipse/jdt/internal/junit4/runner/JUnit4TestLoader.java
@@ -17,11 +17,17 @@ package org.eclipse.jdt.internal.junit4.runner;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.runner.Description;
 import org.junit.runner.Request;
 import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
 
 import org.eclipse.jdt.internal.junit.runner.ITestLoader;
 import org.eclipse.jdt.internal.junit.runner.ITestReference;
@@ -50,6 +56,102 @@ public class JUnit4TestLoader implements ITestLoader {
 			refs[i]= ref;
 		}
 		return refs;
+	}
+
+	@Override
+	public ITestReference[] loadTests(
+			LinkedHashMap<Class<?>, List<String>> classToMethods,
+			String[] failureNames,
+			String[] packages,
+			String[][] includeExcludeTags,
+			String uniqueId,
+			RemoteTestRunner listener) {
+
+		if (classToMethods == null || classToMethods.isEmpty()) {
+			return new ITestReference[0];
+		}
+		// JUnit 4 has no native multi-method selector, but a single class can be
+		// filtered down to an arbitrary set of methods via Request#filterWith. We
+		// therefore create one ITestReference per class (each running in the same JVM)
+		// instead of one per (class, method) pair.
+		List<ITestReference> refs= new ArrayList<>(classToMethods.size());
+		for (Map.Entry<Class<?>, List<String>> entry : classToMethods.entrySet()) {
+			Class<?> clazz= entry.getKey();
+			if (clazz == null) {
+				continue;
+			}
+			List<String> methods= entry.getValue();
+			if (methods == null || methods.isEmpty()) {
+				ITestReference unfiltered= createUnfilteredTest(clazz, failureNames);
+				if (unfiltered != null) {
+					refs.add(unfiltered);
+				}
+				continue;
+			}
+			ITestReference ref= createMultiMethodTest(clazz, methods, failureNames, listener);
+			if (ref != null) {
+				refs.add(ref);
+			}
+		}
+		return refs.toArray(new ITestReference[0]);
+	}
+
+	private ITestReference createMultiMethodTest(Class<?> clazz, List<String> methodNames, String[] failureNames, RemoteTestRunner listener) {
+		// Fast path: a single method behaves exactly like the legacy -test path so we
+		// preserve identical behavior (incl. JUnit 3 setUpTest detection).
+		if (methodNames.size() == 1) {
+			return createTest(clazz, methodNames.get(0), failureNames, listener);
+		}
+		Set<String> distinct= new HashSet<>(methodNames);
+		Request request= sortByFailures(Request.classWithoutSuiteMethod(clazz).filterWith(new MultiMethodFilter(distinct)), failureNames);
+		Runner runner= request.getRunner();
+		Description description= runner.getDescription();
+		return new JUnit4TestReference(runner, description);
+	}
+
+	/**
+	 * Filter that accepts any test {@link Description} whose method name (with the
+	 * trailing parameter list, if present, stripped) matches one of the requested
+	 * method names. Suites and parent descriptions are accepted when at least one
+	 * descendant matches.
+	 */
+	private static final class MultiMethodFilter extends Filter {
+		private final Set<String> fMethodNames;
+
+		MultiMethodFilter(Set<String> methodNames) {
+			fMethodNames= methodNames;
+		}
+
+		@Override
+		public boolean shouldRun(Description description) {
+			if (description.isTest()) {
+				String name= description.getMethodName();
+				if (name == null) {
+					return false;
+				}
+				int paren= name.indexOf('(');
+				if (paren > 0) {
+					name= name.substring(0, paren);
+				}
+				int bracket= name.indexOf('[');
+				if (bracket > 0) {
+					// strip parameterized invocation index, e.g. "myTest[0]" -> "myTest"
+					name= name.substring(0, bracket);
+				}
+				return fMethodNames.contains(name);
+			}
+			for (Description child : description.getChildren()) {
+				if (shouldRun(child)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public String describe() {
+			return "matches any of " + fMethodNames; //$NON-NLS-1$
+		}
 	}
 
 	private Description getRootDescription(Runner runner, DescriptionMatcher matcher) {

--- a/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit5.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit5.runtime;singleton:=true
-Bundle-Version: 1.2.0.qualifier
+Bundle-Version: 1.2.100.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit5.runner;x-internal:=true
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.jdt.junit5.runtime/pom.xml
+++ b/org.eclipse.jdt.junit5.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit5.runtime</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
 	<plugins>

--- a/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestLoader.java
+++ b/org.eclipse.jdt.junit5.runtime/src/org/eclipse/jdt/internal/junit5/runner/JUnit5TestLoader.java
@@ -15,8 +15,11 @@
 package org.eclipse.jdt.internal.junit5.runner;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
@@ -57,6 +60,53 @@ public class JUnit5TestLoader implements ITestLoader {
 			}
 		}
 		return refs;
+	}
+
+	@Override
+	public ITestReference[] loadTests(LinkedHashMap<Class<?>, List<String>> classToMethods, String[] failureNames, String[] packages, String[][] includeExcludeTags, String uniqueId, RemoteTestRunner listener) {
+		fRemoteTestRunner= listener;
+		if (classToMethods == null || classToMethods.isEmpty()) {
+			return new ITestReference[0];
+		}
+		// Build a single LauncherDiscoveryRequest covering every selected method across
+		// every selected class. JUnit Platform supports multiple selectors natively, so
+		// the resulting test plan is executed in one launch, sharing per-class
+		// @BeforeAll / @AfterAll lifecycle and any cached fixture (e.g. a Spring
+		// ApplicationContext). A null/empty method list represents an unfiltered class
+		// run, which lets a single -testNameFile mix legacy class lines with
+		// Class:method lines without losing the class-only selections.
+		List<DiscoverySelector> selectors= new ArrayList<>();
+		for (Map.Entry<Class<?>, List<String>> entry : classToMethods.entrySet()) {
+			Class<?> clazz= entry.getKey();
+			if (clazz == null) {
+				continue;
+			}
+			List<String> methods= entry.getValue();
+			if (methods == null || methods.isEmpty()) {
+				selectors.add(DiscoverySelectors.selectClass(clazz.getName()));
+			} else {
+				for (String method : methods) {
+					if (method == null || method.isEmpty()) {
+						continue;
+					}
+					// Note: the protocol carries only the method name (no parameter
+					// signature), so a name like "Class#test" matches every method
+					// declared with that name. For parameterized/repeated tests this
+					// is the desired behaviour; for genuinely overloaded test
+					// methods all overloads will be discovered, which mirrors the
+					// behaviour of the single-method ATTR_TEST_NAME path.
+					selectors.add(DiscoverySelectors.selectMethod(clazz.getName() + '#' + method));
+				}
+			}
+		}
+		if (selectors.isEmpty()) {
+			return new ITestReference[0];
+		}
+		LauncherDiscoveryRequest request= LauncherDiscoveryRequestBuilder.request()
+				.selectors(selectors)
+				.filters(getTagFilters(includeExcludeTags))
+				.build();
+		return new ITestReference[] { new JUnit5TestReference(request, fLauncher, fRemoteTestRunner) };
 	}
 
 	private ITestReference createTest(Class<?> clazz, String testName, String[][] includeExcludeTags, String[] failureNames) {

--- a/org.eclipse.jdt.junit6.runtime/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit6.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-SymbolicName: org.eclipse.jdt.junit6.runtime;singleton:=true
-Bundle-Version: 1.0.100.qualifier
+Bundle-Version: 1.0.200.qualifier
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.internal.junit6.runner;x-internal:=true
 Require-Bundle: org.eclipse.jdt.junit.runtime;bundle-version="[3.5.0,4.0.0)",

--- a/org.eclipse.jdt.junit6.runtime/pom.xml
+++ b/org.eclipse.jdt.junit6.runtime/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.junit6.runtime</artifactId>
-  <version>1.0.100-SNAPSHOT</version>
+  <version>1.0.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   
   <properties>

--- a/org.eclipse.jdt.junit6.runtime/src/org/eclipse/jdt/internal/junit6/runner/JUnit6TestLoader.java
+++ b/org.eclipse.jdt.junit6.runtime/src/org/eclipse/jdt/internal/junit6/runner/JUnit6TestLoader.java
@@ -15,8 +15,11 @@
 package org.eclipse.jdt.internal.junit6.runner;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.Filter;
 import org.junit.platform.engine.discovery.ClassNameFilter;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
@@ -57,6 +60,53 @@ public class JUnit6TestLoader implements ITestLoader {
 			}
 		}
 		return refs;
+	}
+
+	@Override
+	public ITestReference[] loadTests(LinkedHashMap<Class<?>, List<String>> classToMethods, String[] failureNames, String[] packages, String[][] includeExcludeTags, String uniqueId, RemoteTestRunner listener) {
+		fRemoteTestRunner= listener;
+		if (classToMethods == null || classToMethods.isEmpty()) {
+			return new ITestReference[0];
+		}
+		// Build a single LauncherDiscoveryRequest covering every selected method across
+		// every selected class. JUnit Platform supports multiple selectors natively, so
+		// the resulting test plan is executed in one launch, sharing per-class
+		// @BeforeAll / @AfterAll lifecycle and any cached fixture (e.g. a Spring
+		// ApplicationContext). A null/empty method list represents an unfiltered class
+		// run, which lets a single -testNameFile mix legacy class lines with
+		// Class:method lines without losing the class-only selections.
+		List<DiscoverySelector> selectors= new ArrayList<>();
+		for (Map.Entry<Class<?>, List<String>> entry : classToMethods.entrySet()) {
+			Class<?> clazz= entry.getKey();
+			if (clazz == null) {
+				continue;
+			}
+			List<String> methods= entry.getValue();
+			if (methods == null || methods.isEmpty()) {
+				selectors.add(DiscoverySelectors.selectClass(clazz.getName()));
+			} else {
+				for (String method : methods) {
+					if (method == null || method.isEmpty()) {
+						continue;
+					}
+					// Note: the protocol carries only the method name (no parameter
+					// signature), so a name like "Class#test" matches every method
+					// declared with that name. For parameterized/repeated tests this
+					// is the desired behaviour; for genuinely overloaded test
+					// methods all overloads will be discovered, which mirrors the
+					// behaviour of the single-method ATTR_TEST_NAME path.
+					selectors.add(DiscoverySelectors.selectMethod(clazz.getName() + '#' + method));
+				}
+			}
+		}
+		if (selectors.isEmpty()) {
+			return new ITestReference[0];
+		}
+		LauncherDiscoveryRequest request= LauncherDiscoveryRequestBuilder.request()
+				.selectors(selectors)
+				.filters(getTagFilters(includeExcludeTags))
+				.build();
+		return new ITestReference[] { new JUnit6TestReference(request, fLauncher, fRemoteTestRunner) };
 	}
 
 	private ITestReference createTest(Class<?> clazz, String testName, String[][] includeExcludeTags, String[] failureNames) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/JUnitLauncherTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/JUnitLauncherTests.java
@@ -20,6 +20,7 @@ import org.junit.platform.suite.api.Suite;
 @Suite
 @SelectClasses({
 AdvancedJUnitLaunchConfigurationDelegateTest.class,
+MultiMethodLaunchConfigurationDelegateTest.class,
 })
 public class JUnitLauncherTests {
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/MultiMethodLaunchConfigurationDelegateTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/launcher/MultiMethodLaunchConfigurationDelegateTest.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Microsoft Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.junit.launcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Platform;
+
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.Launch;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+
+/**
+ * Tests for the multi-method extension to {@code -testNameFile} introduced to allow
+ * an arbitrary set of methods (potentially across multiple classes) to be executed
+ * inside a single launch.
+ *
+ * <p>The change lives in the private {@code createTestNamesFile(IJavaElement[])}
+ * helper of {@link JUnitLaunchConfigurationDelegate}, reached through
+ * {@code collectExecutionArguments(...)} when {@code fTestElements.length > 1}.
+ * The default {@code evaluateTests(...)} in the delegate never produces multiple
+ * {@code IMethod} entries, so each test below subclasses the delegate and feeds a
+ * synthetic {@code IMember[]} via an override, then asserts on the file emitted
+ * after {@code showCommandLine(...)}.</p>
+ */
+public class MultiMethodLaunchConfigurationDelegateTest {
+
+	private IJavaProject fJavaProject;
+
+	@AfterEach
+	public void deleteProject() throws CoreException {
+		if (fJavaProject != null) {
+			JavaProjectHelper.delete(fJavaProject);
+		}
+	}
+
+	@Test
+	public void multipleMethodsInSameClassEmitClassColonMethodLines() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-MultiMethod-SameClass";
+		fJavaProject= createJUnit5Project(projectName);
+		IPackageFragmentRoot src= JavaProjectHelper.addSourceContainer(fJavaProject, "src");
+		IPackageFragment p1= src.createPackageFragment("p1", true, null);
+		ICompilationUnit cu= p1.createCompilationUnit("FooTest.java", """
+				package p1;
+				public class FooTest {
+					@org.junit.jupiter.api.Test public void a() { }
+					@org.junit.jupiter.api.Test public void b() { }
+					@org.junit.jupiter.api.Test public void c() { }
+				}
+				""", true, null);
+		IType fooType= cu.getType("FooTest");
+		IMember[] members= {
+				fooType.getMethod("a", new String[0]),
+				fooType.getMethod("b", new String[0]),
+				fooType.getMethod("c", new String[0])
+		};
+
+		List<String> lines= showCommandLineAndReadTestNamesFile(fJavaProject, fooType, members);
+
+		assertThat(lines).containsExactlyInAnyOrder("p1.FooTest:a", "p1.FooTest:b", "p1.FooTest:c");
+	}
+
+	@Test
+	public void methodsAcrossMultipleClassesEmitClassColonMethodLines() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-MultiMethod-CrossClass";
+		fJavaProject= createJUnit5Project(projectName);
+		IPackageFragmentRoot src= JavaProjectHelper.addSourceContainer(fJavaProject, "src");
+		IPackageFragment p1= src.createPackageFragment("p1", true, null);
+		ICompilationUnit fooCu= p1.createCompilationUnit("FooTest.java", """
+				package p1;
+				public class FooTest {
+					@org.junit.jupiter.api.Test public void a() { }
+				}
+				""", true, null);
+		ICompilationUnit barCu= p1.createCompilationUnit("BarTest.java", """
+				package p1;
+				public class BarTest {
+					@org.junit.jupiter.api.Test public void b() { }
+				}
+				""", true, null);
+		IType fooType= fooCu.getType("FooTest");
+		IType barType= barCu.getType("BarTest");
+		IMember[] members= {
+				fooType.getMethod("a", new String[0]),
+				barType.getMethod("b", new String[0])
+		};
+
+		List<String> lines= showCommandLineAndReadTestNamesFile(fJavaProject, fooType, members);
+
+		assertThat(lines).containsExactlyInAnyOrder("p1.FooTest:a", "p1.BarTest:b");
+	}
+
+	@Test
+	public void mixedTypeAndMethodEmitLegacyAndExtendedLines() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-MultiMethod-Mixed";
+		fJavaProject= createJUnit5Project(projectName);
+		IPackageFragmentRoot src= JavaProjectHelper.addSourceContainer(fJavaProject, "src");
+		IPackageFragment p1= src.createPackageFragment("p1", true, null);
+		ICompilationUnit fooCu= p1.createCompilationUnit("FooTest.java", """
+				package p1;
+				public class FooTest {
+					@org.junit.jupiter.api.Test public void a() { }
+				}
+				""", true, null);
+		ICompilationUnit barCu= p1.createCompilationUnit("BarTest.java", """
+				package p1;
+				public class BarTest {
+					@org.junit.jupiter.api.Test public void onlyOne() { }
+				}
+				""", true, null);
+		IType fooType= fooCu.getType("FooTest");
+		IType barType= barCu.getType("BarTest");
+		IMember[] members= {
+				fooType.getMethod("a", new String[0]),
+				barType
+		};
+
+		List<String> lines= showCommandLineAndReadTestNamesFile(fJavaProject, fooType, members);
+
+		assertThat(lines).containsExactlyInAnyOrder("p1.FooTest:a", "p1.BarTest");
+	}
+
+	@Test
+	public void multipleTypesStillEmitLegacyClassOnlyLines() throws Exception {
+		String projectName= "JUnitLaunchConfigurationDelegate-MultiMethod-LegacyClassOnly";
+		fJavaProject= createJUnit5Project(projectName);
+		IPackageFragmentRoot src= JavaProjectHelper.addSourceContainer(fJavaProject, "src");
+		IPackageFragment p1= src.createPackageFragment("p1", true, null);
+		ICompilationUnit fooCu= p1.createCompilationUnit("FooTest.java", """
+				package p1;
+				public class FooTest {
+					@org.junit.jupiter.api.Test public void a() { }
+				}
+				""", true, null);
+		ICompilationUnit barCu= p1.createCompilationUnit("BarTest.java", """
+				package p1;
+				public class BarTest {
+					@org.junit.jupiter.api.Test public void b() { }
+				}
+				""", true, null);
+		IType fooType= fooCu.getType("FooTest");
+		IType barType= barCu.getType("BarTest");
+		IMember[] members= { fooType, barType };
+
+		List<String> lines= showCommandLineAndReadTestNamesFile(fJavaProject, fooType, members);
+
+		assertThat(lines).containsExactlyInAnyOrder("p1.FooTest", "p1.BarTest");
+	}
+
+	private IJavaProject createJUnit5Project(String projectName) throws CoreException {
+		IJavaProject javaProject= JavaProjectHelper.createJavaProject(projectName, "bin");
+		JavaProjectHelper.addRTJar18(javaProject);
+		IClasspathEntry cpe= JavaCore.newContainerEntry(JUnitCore.JUNIT5_CONTAINER_PATH);
+		JavaProjectHelper.addToClasspath(javaProject, cpe);
+		JavaProjectHelper.set18CompilerOptions(javaProject);
+		return javaProject;
+	}
+
+	private List<String> showCommandLineAndReadTestNamesFile(IJavaProject project, IType anchorType, IMember[] testMembers)
+			throws CoreException, IOException {
+		AdvancedJUnitLaunchConfigurationDelegate delegate= new AdvancedJUnitLaunchConfigurationDelegate() {
+			@Override
+			protected IMember[] evaluateTests(ILaunchConfiguration configuration, IProgressMonitor monitor) {
+				return testMembers;
+			}
+		};
+		MockLaunchConfig configuration= new MockLaunchConfig();
+		configuration.setProjectName(project.getElementName());
+		configuration.setTestRunnerKind(TestKindRegistry.JUNIT5_TEST_KIND_ID);
+		configuration.setContainerHandle(anchorType.getHandleIdentifier());
+		String mode= ILaunchManager.DEBUG_MODE;
+		ILaunch launch= new Launch(configuration, mode, null);
+		String showCommandLine= delegate.showCommandLine(configuration, mode, launch, new NullProgressMonitor());
+		int idx= showCommandLine.indexOf("-testNameFile");
+		assertThat(idx).overridingErrorMessage("-testNameFile argument not found in: %s", showCommandLine).isGreaterThan(-1);
+		String filePath= showCommandLine.substring(idx + "-testNameFile".length() + 1);
+		if (Platform.OS.isWindows()) {
+			filePath= filePath.substring(1, filePath.length() - 1);
+		}
+		return Files.readAllLines(Paths.get(filePath));
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/AbstractTestRunListenerTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/AbstractTestRunListenerTest.java
@@ -18,13 +18,19 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.After;
 import org.junit.Before;
 
 import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.junit.launcher.AdvancedJUnitLaunchConfigurationDelegate;
 import org.eclipse.jdt.junit.launcher.JUnitLaunchShortcut;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.util.DisplayHelper;
@@ -32,6 +38,8 @@ import org.eclipse.jdt.testplugin.util.DisplayHelper;
 import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -44,10 +52,12 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.ILaunchesListener2;
+import org.eclipse.debug.core.Launch;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
@@ -186,6 +196,77 @@ public class AbstractTestRunListenerTest {
 		return log.getLog();
 	}
 
+	/**
+	 * Launches a JUnit test session with an arbitrary set of {@link IMember} test elements,
+	 * possibly spanning multiple types. Used to verify the multi-method extension to the
+	 * {@code -testNameFile} dispatch (see {@code JUnitLaunchConfigurationDelegate#createTestNamesFile(IJavaElement[])}).
+	 *
+	 * <p>The default {@code evaluateTests} in the production delegate never returns multiple
+	 * {@code IMethod} entries, so this helper installs an inline subclass of
+	 * {@link AdvancedJUnitLaunchConfigurationDelegate} that returns the supplied members,
+	 * then bypasses the launch registry and directly invokes {@code delegate.launch(...)}.
+	 * The launch is registered with the launch manager beforehand so that {@code JUnitModel}
+	 * picks up the test events through the standard {@code ATTR_PORT} change notification.</p>
+	 *
+	 * @param testMembers the test members (types or methods) to run in a single VM
+	 * @param anchor      anchor type used to materialize a launch configuration; typically
+	 *                    the declaring type of the first member
+	 * @param testKindId  one of the {@code TestKindRegistry.JUNIT*_TEST_KIND_ID} constants
+	 * @param log         log that the caller's {@link org.eclipse.jdt.junit.TestRunListener}
+	 *                    writes into; used to wait for {@code sessionFinished}
+	 */
+	protected String[] launchJUnitMultiMethod(final IMember[] testMembers, IType anchor, String testKindId, final TestRunLog log) throws CoreException {
+		buildTestCase(anchor);
+
+		ILaunchManager lm= DebugPlugin.getDefault().getLaunchManager();
+		lm.removeLaunches(lm.getLaunches());
+		LaunchesListener listener= new LaunchesListener();
+		lm.addLaunchListener(listener);
+
+		ILaunchConfigurationWorkingCopy configuration= TestJUnitLaunchShortcut.createConfiguration(anchor, null);
+		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, testKindId);
+		configuration.removeAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME);
+
+		AdvancedJUnitLaunchConfigurationDelegate delegate= new AdvancedJUnitLaunchConfigurationDelegate() {
+			@Override
+			protected IMember[] evaluateTests(ILaunchConfiguration cfg, IProgressMonitor monitor) {
+				return testMembers;
+			}
+		};
+
+		Launch launch= new Launch(configuration, ILaunchManager.RUN_MODE, null);
+		try {
+			lm.addLaunch(launch);
+			delegate.launch(configuration, ILaunchManager.RUN_MODE, launch, new NullProgressMonitor());
+			waitForCondition(listener.fLaunchHasTerminated::get, 60 * 1000, 1000);
+			boolean success= waitForCondition(log::isDone, 15 * 1000, 100);
+			if (!success) {
+				log.add("AbstractTestRunListenerTest#launchJUnitMultiMethod timed out");
+			}
+		} finally {
+			try {
+				if (!launch.isTerminated()) {
+					launch.terminate();
+				}
+				// Wait briefly so the listener can observe the termination event
+				// before we unregister it; otherwise the launchesTerminated callback
+				// may fire on a removed listener and the next run can mistake any
+				// stale launch state for the current one.
+				waitForCondition(listener.fLaunchHasTerminated::get, 5 * 1000, 200);
+			} catch (Exception ignore) {
+				// best-effort cleanup
+			}
+			lm.removeLaunchListener(listener);
+			lm.removeLaunches(lm.getLaunches());
+			try {
+				configuration.delete();
+			} catch (CoreException ignore) {
+				// best-effort cleanup
+			}
+		}
+		return log.getLog();
+	}
+
 	protected static boolean waitForCondition(Supplier<Boolean> condition, long timeout, long interval) {
 		DisplayHelper displayHelper= new DisplayHelper() {
 			@Override
@@ -234,6 +315,43 @@ public class AbstractTestRunListenerTest {
 			expected.append(sequence).append('\n');
 		}
 		assertEquals(expected.toString(), actual.toString());
+	}
+
+	/**
+	 * Asserts that the {@link TestRunListeners.SequenceTest} log records exactly one
+	 * {@code sessionStarted}/{@code sessionFinished} pair plus a {@code testCaseStarted}
+	 * and {@code testCaseFinished} event for each of the supplied {@code class#method}
+	 * identifiers (in any order). Used by the multi-method launch tests because the
+	 * dispatch order across classes is implementation-defined.
+	 */
+	protected static void assertMultiMethodRun(String[] log, String... expectedClassHashMethod) {
+		Pattern p= Pattern.compile("testCaseMethod: (.+?)\\s*[\\r\\n]+\\s*class: (\\S+)");
+		int sessionStartedCount= 0;
+		int sessionFinishedCount= 0;
+		Set<String> started= new TreeSet<>();
+		Set<String> finished= new TreeSet<>();
+		for (String entry : log) {
+			if (entry.startsWith("sessionStarted-")) {
+				sessionStartedCount++;
+			} else if (entry.startsWith("sessionFinished-")) {
+				sessionFinishedCount++;
+			} else if (entry.startsWith("testCaseStarted-")) {
+				Matcher m= p.matcher(entry);
+				if (m.find()) {
+					started.add(m.group(2) + "#" + m.group(1));
+				}
+			} else if (entry.startsWith("testCaseFinished-")) {
+				Matcher m= p.matcher(entry);
+				if (m.find()) {
+					finished.add(m.group(2) + "#" + m.group(1));
+				}
+			}
+		}
+		Set<String> expected= new TreeSet<>(Arrays.asList(expectedClassHashMethod));
+		assertEquals("Expected exactly one sessionStarted event in log: " + Arrays.toString(log), 1, sessionStartedCount);
+		assertEquals("Expected exactly one sessionFinished event in log: " + Arrays.toString(log), 1, sessionFinishedCount);
+		assertEquals("Started test cases differ", expected, started);
+		assertEquals("Finished test cases differ", expected, finished);
 	}
 
 	protected static class LaunchesListener implements ILaunchesListener2 {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest4.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest4.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.junit.model.ITestElement.ProgressState;
 import org.eclipse.jdt.junit.model.ITestElement.Result;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
+import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 
@@ -348,5 +349,49 @@ public class TestRunListenerTest4 extends AbstractTestRunListenerTest {
 		};
 		String[] actual= runTreeTest(aTestCase, 12);
 		assertEqualLog(expectedSequence, actual);
+	}
+
+	/**
+	 * Verifies that selecting individual methods across multiple test classes runs all
+	 * of them in a single VM via the multi-method {@code -testNameFile} extension.
+	 */
+	@Test
+	public void testMultiMethodAcrossClasses() throws Exception {
+		String fooSource=
+				"""
+			package pack;
+			import org.junit.Test;
+			public class FooTest {
+			    @Test public void a() { }
+			    @Test public void unused() { }
+			}""";
+		String barSource=
+				"""
+			package pack;
+			import org.junit.Test;
+			public class BarTest {
+			    @Test public void b() { }
+			    @Test public void c() { }
+			}""";
+		IType fooType= createType(fooSource, "pack", "FooTest.java");
+		IType barType= createType(barSource, "pack", "BarTest.java");
+
+		IMember[] members= {
+				fooType.getMethod("a", new String[0]),
+				barType.getMethod("b", new String[0]),
+				barType.getMethod("c", new String[0]),
+		};
+
+		TestRunLog log= new TestRunLog();
+		final TestRunListener testRunListener= new TestRunListeners.SequenceTest(log);
+		JUnitCore.addTestRunListener(testRunListener);
+		String[] actual;
+		try {
+			actual= launchJUnitMultiMethod(members, fooType, TestKindRegistry.JUNIT4_TEST_KIND_ID, log);
+		} finally {
+			JUnitCore.removeTestRunListener(testRunListener);
+		}
+
+		assertMultiMethodRun(actual, "pack.FooTest#a", "pack.BarTest#b", "pack.BarTest#c");
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest5.java
@@ -51,6 +51,7 @@ import org.eclipse.debug.core.ILaunchManager;
 
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 
@@ -264,6 +265,49 @@ public class TestRunListenerTest5 extends AbstractTestRunListenerTest {
 		doTestTerminateLaunch(fProject, TestKindRegistry.JUNIT5_TEST_KIND_ID);
 	}
 
+	/**
+	 * Verifies that selecting individual methods across multiple JUnit Jupiter test classes
+	 * runs all of them in a single VM via the multi-method {@code -testNameFile} extension.
+	 */
+	@Test
+	public void testMultiMethodAcrossClasses() throws Exception {
+		String fooSource=
+				"""
+			package pack;
+			import org.junit.jupiter.api.Test;
+			public class FooTest {
+			    @Test public void a() { }
+			    @Test public void unused() { }
+			}""";
+		String barSource=
+				"""
+			package pack;
+			import org.junit.jupiter.api.Test;
+			public class BarTest {
+			    @Test public void b() { }
+			    @Test public void c() { }
+			}""";
+		IType fooType= createType(fooSource, "pack", "FooTest.java");
+		IType barType= createType(barSource, "pack", "BarTest.java");
+
+		IMember[] members= {
+				fooType.getMethod("a", new String[0]),
+				barType.getMethod("b", new String[0]),
+				barType.getMethod("c", new String[0]),
+		};
+
+		TestRunLog log= new TestRunLog();
+		final TestRunListener testRunListener= new TestRunListeners.SequenceTest(log);
+		JUnitCore.addTestRunListener(testRunListener);
+		String[] actual;
+		try {
+			actual= launchJUnitMultiMethod(members, fooType, TestKindRegistry.JUNIT5_TEST_KIND_ID, log);
+		} finally {
+			JUnitCore.removeTestRunListener(testRunListener);
+		}
+
+		assertMultiMethodRun(actual, "pack.FooTest#a", "pack.BarTest#b", "pack.BarTest#c");
+	}
 	protected static void doTestTerminateLaunch(IJavaProject project, String testKindId) throws CoreException {
 		String source=
 				"""

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest6.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest6.java
@@ -34,6 +34,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 
 import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
 
@@ -237,5 +238,49 @@ public class TestRunListenerTest6 extends AbstractTestRunListenerTest {
 	@Test
 	public void testTerminateLaunch() throws Exception {
 		TestRunListenerTest5.doTestTerminateLaunch(fProject, TestKindRegistry.JUNIT6_TEST_KIND_ID);
+	}
+
+	/**
+	 * Verifies that selecting individual methods across multiple JUnit Jupiter test classes
+	 * runs all of them in a single VM via the multi-method {@code -testNameFile} extension.
+	 */
+	@Test
+	public void testMultiMethodAcrossClasses() throws Exception {
+		String fooSource=
+				"""
+			package pack;
+			import org.junit.jupiter.api.Test;
+			public class FooTest {
+			    @Test public void a() { }
+			    @Test public void unused() { }
+			}""";
+		String barSource=
+				"""
+			package pack;
+			import org.junit.jupiter.api.Test;
+			public class BarTest {
+			    @Test public void b() { }
+			    @Test public void c() { }
+			}""";
+		IType fooType= createType(fooSource, "pack", "FooTest.java");
+		IType barType= createType(barSource, "pack", "BarTest.java");
+
+		IMember[] members= {
+				fooType.getMethod("a", new String[0]),
+				barType.getMethod("b", new String[0]),
+				barType.getMethod("c", new String[0]),
+		};
+
+		TestRunLog log= new TestRunLog();
+		final TestRunListener testRunListener= new TestRunListeners.SequenceTest(log);
+		JUnitCore.addTestRunListener(testRunListener);
+		String[] actual;
+		try {
+			actual= launchJUnitMultiMethod(members, fooType, TestKindRegistry.JUNIT6_TEST_KIND_ID, log);
+		} finally {
+			JUnitCore.removeTestRunListener(testRunListener);
+		}
+
+		assertMultiMethodRun(actual, "pack.FooTest#a", "pack.BarTest#b", "pack.BarTest#c");
 	}
 }

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -723,6 +723,21 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 						String testName = type.getFullyQualifiedName();
 						bw.write(testName);
 						bw.newLine();
+					} else if (testElement instanceof IMethod) {
+						// Extended -testNameFile format: "fully.qualified.ClassName:methodName".
+						// Allows running an arbitrary set of methods (potentially across
+						// multiple classes) within a single launch. The remote runner falls
+						// back to legacy class-only behavior when no ':' is present, so older
+						// runtime jars remain compatible.
+						IMethod method = (IMethod) testElement;
+						IType declaringType = method.getDeclaringType();
+						if (declaringType == null) {
+							abort(Messages.JUnitLaunchConfigurationDelegate_error_wrong_input, null,
+									IJavaLaunchConfigurationConstants.ERR_UNSPECIFIED_MAIN_TYPE);
+						} else {
+							bw.write(declaringType.getFullyQualifiedName() + ':' + method.getElementName());
+							bw.newLine();
+						}
 					} else {
 						abort(Messages.JUnitLaunchConfigurationDelegate_error_wrong_input, null,
 								IJavaLaunchConfigurationConstants.ERR_UNSPECIFIED_MAIN_TYPE);


### PR DESCRIPTION
Allow a `-testNameFile` to contain lines of the form `ClassName:methodName` so that an arbitrary set of methods (potentially across multiple classes) can be discovered and executed inside a single test JVM. This avoids the per-method setup/teardown cycles that currently 
occur when a user runs more than one method via Eclipse's Test Explorer (or via `vscode-java-test`, which sits on top of this protocol).
 
 * `ITestLoader` gains a default `loadTests(LinkedHashMap<Class<?>, List<String>>, ...)` method that pair-wise delegates to the legacy single-method overload, so every existing loader keeps working unchanged.
 * `RemoteTestRunner.readTestNames()` recognises `:`-separated lines and routes through the new dispatch when present; class-only lines keep their previous semantics so older clients are unaffected.
 * `JUnit5TestLoader` builds one `LauncherDiscoveryRequest` with multiple `selectMethod` selectors, letting JUnit Platform run the entire selection natively within a single test JVM.
 * `JUnit4TestLoader` composes a `Request.classWithoutSuiteMethod(c).filterWith(...)` using a new `MultiMethodFilter` to express the same selection on JUnit 4.
 * Both `JUnitLaunchConfigurationDelegate` variants (in `org.eclipse.jdt.junit.core` and `org.eclipse.jdt.ui.unittest.junit`) relax `createTestNamesFile()` to also write `IMethod` elements as `Class:method` lines, allowing the new behaviour to be reached via the existing 
`-testNameFile` path without any new protocol parameters.
 
 ## What it does
 
 When a user selects multiple test methods in Eclipse's Test Explorer (or via clients such as `vscode-java-test`), each method is currently launched in its own JVM, because the existing protocol can carry at most one `(class, method)` pair per launch. For tests with expensive
 per-class setup (e.g. Spring `@SpringBootTest`, Testcontainers), this means the fixture is rebuilt N times.
 
 This change extends the existing `-testNameFile` protocol with a fully backwards-compatible `Class:method` line format and lets every test loader opt-in to multi-method discovery:
 
 - `ITestLoader` gains a default `loadTests(LinkedHashMap<Class<?>, List<String>>, ...)` that pair-wise delegates to the legacy overload, so loaders that don't override it keep behaving exactly as before.
 - `RemoteTestRunner.readTestNames()` recognises `:`-separated lines and routes through the new dispatch only when at least one such line is present. Class-only lines keep their previous semantics, so older clients (and old `-testNameFile` files) are unaffected.
 - `JUnit5TestLoader` builds a single `LauncherDiscoveryRequest` with multiple `selectMethod` selectors, letting JUnit Platform discover the whole selection in one JVM.
 - `JUnit4TestLoader` composes per class `Request.classWithoutSuiteMethod(c).filterWith(new MultiMethodFilter(...))` to express the same selection on JUnit 4. The filter strips both the parameter list `(...)` and the `[idx]` suffix added by `Parameterized` before matching.
 - Both `JUnitLaunchConfigurationDelegate` variants (`org.eclipse.jdt.junit.core` and `org.eclipse.jdt.ui.unittest.junit`) relax `createTestNamesFile` to also accept `IMethod` elements and emit the new `Class:method` lines.
 
 JUnit 3 needs no changes — it inherits the default `ITestLoader` impl which still loops per `(class, method)`.
 
 ## How to test
 
 1. Open an Eclipse workspace with a JUnit 5 test class that has multiple `@Test` methods and a non-trivial `@BeforeAll` (e.g. starting an embedded server, or a Spring `@SpringBootTest`).
 2. In the JUnit view / Project Explorer, multi-select two or more methods inside the same class and **Run As → JUnit Test**.
 3. Observe that:
    - There is a single test JVM (one entry in the Console view, one `RemoteTestRunner` process).
    - `@BeforeAll` runs once and `@AfterAll` runs once for the whole selection.
    - All selected methods report Pass/Fail individually in the JUnit view.
 4. Repeat with methods spread across two different classes — both should still execute inside one JVM, with each class's own `@BeforeAll` / `@AfterAll` firing once.
 5. Repeat with a JUnit 4 class (including a `@RunWith(Parameterized.class)` test) to verify the JUnit 4 path and the `[idx]` / `(params)` stripping.
 6. Sanity check backwards compatibility: a launch from an older client that still writes only class FQNs to `-testNameFile` continues to run as before (whole class executed).
 
 ## Author checklist
 
 - [x] I have thoroughly tested my changes
 - [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
 - [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
