### PR TITLE
Make JUnit diff order consistent with the default compare diff order

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/CompareResultDialog.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/CompareResultDialog.java
@@ -254,9 +254,9 @@ public class CompareResultDialog extends TrayDialog {
 
 	private Control createPreviewer(Composite parent) {
 	    final CompareConfiguration compareConfiguration= new CompareConfiguration();
-	    compareConfiguration.setLeftLabel(JUnitMessages.CompareResultDialog_expectedLabel);
+	    compareConfiguration.setLeftLabel(JUnitMessages.CompareResultDialog_actualLabel);
 	    compareConfiguration.setLeftEditable(false);
-	    compareConfiguration.setRightLabel(JUnitMessages.CompareResultDialog_actualLabel);
+	    compareConfiguration.setRightLabel(JUnitMessages.CompareResultDialog_expectedLabel);
 	    compareConfiguration.setRightEditable(false);
 	    compareConfiguration.setProperty(CompareConfiguration.IGNORE_WHITESPACE, Boolean.FALSE);
 	    compareConfiguration.setProperty(PREFIX_SUFFIX_PROPERTY, fPrefixSuffix);
@@ -271,7 +271,7 @@ public class CompareResultDialog extends TrayDialog {
 
 	private void setCompareViewerInput() {
 		if (!fViewer.getControl().isDisposed()) {
-			fViewer.setInput(new DiffNode(new CompareElement(fExpected), new CompareElement(fActual)));
+			fViewer.setInput(new DiffNode(new CompareElement(fActual), new CompareElement(fExpected)));
 			fCompareViewerPane.setText(fTestName);
 		}
 	}


### PR DESCRIPTION
Similar to the refactoring wizard, JUnit diff order was always NOT following "traditional" Eclipse compare editor diff order (left is "new", right is "old"), so that "natural" order expected / actual was inconsistent with the compare editor preference, but it was based on this preference (via CompareConfiguration).

Now the "natural" order is default, swap the sides in JUNit diff pane to keep same order in as before left: expected, right: actual.

* See https://github.com/eclipse-platform/eclipse.platform/pull/2566 
* See https://github.com/eclipse-platform/eclipse.platform.ui/pull/3777 
* See https://github.com/eclipse-platform/eclipse.platform.ui/issues/3776#issuecomment-4382037847

