### PR TITLE
Remove obsolete ICU references from surrogate-handling comments

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestCaseWizardPageOne.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestCaseWizardPageOne.java
@@ -1107,19 +1107,8 @@ public class NewTestCaseWizardPageOne extends NewTypeWizardPage {
 				buffer.replace(index, index + 1, OF_TAG);
 			else if (character == '?')
 				buffer.replace(index, index + 1, QUESTION_MARK_TAG);
-			else if (!Character.isJavaIdentifierPart(character)) {
-				// Check for surrogates
-				if (!Character.isSurrogate(character)) {
-					/*
-					 * XXX: Here we should create the code point and test whether
-					 * it is a Java identifier part. Currently this is not possible
-					 * because java.lang.Character in 1.4 does not support surrogates
-					 * and because com.ibm.icu.lang.UCharacter.isJavaIdentifierPart(int)
-					 * is not correctly implemented.
-					 */
-					buffer.deleteCharAt(index);
-				}
-
+			else if (!Character.isJavaIdentifierPart(character) && !Character.isSurrogate(character)) {
+				buffer.deleteCharAt(index);
 			}
 		}
 	}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaWordFinder.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaWordFinder.java
@@ -32,19 +32,8 @@ public class JavaWordFinder {
 
 			while (pos >= 0) {
 				c= document.getChar(pos);
-				if (!Character.isJavaIdentifierPart(c)) {
-					// Check for surrogates
-					if (Character.isSurrogate(c)) {
-						/*
-						 * XXX: Here we should create the code point and test whether
-						 * it is a Java identifier part. Currently this is not possible
-						 * because java.lang.Character in 1.4 does not support surrogates
-						 * and because com.ibm.icu.lang.UCharacter.isJavaIdentifierPart(int)
-						 * is not correctly implemented.
-						 */
-					} else {
-						break;
-					}
+				if (!Character.isJavaIdentifierPart(c) && !Character.isSurrogate(c)) {
+					break;
 				}
 				--pos;
 			}
@@ -55,19 +44,8 @@ public class JavaWordFinder {
 
 			while (pos < length) {
 				c= document.getChar(pos);
-				if (!Character.isJavaIdentifierPart(c)) {
-					if (Character.isSurrogate(c)) {
-						/*
-						 * XXX: Here we should create the code point and test whether
-						 * it is a Java identifier part. Currently this is not possible
-						 * because java.lang.Character in 1.4 does not support surrogates
-						 * and because com.ibm.icu.lang.UCharacter.isJavaIdentifierPart(int)
-						 * is not correctly implemented.
-						 */
-					} else {
-						break;
-					}
-
+				if (!Character.isJavaIdentifierPart(c) && !Character.isSurrogate(c)) {
+					break;
 				}
 				++pos;
 			}


### PR DESCRIPTION
The XXX comments in JavaWordFinder and NewTestCaseWizardPageOne referenced com.ibm.icu.lang.UCharacter and java.lang.Character behavior on Java 1.4. ICU is no longer a dependency of this repo, and the surrogate branches in those if/else blocks contained no actual logic beyond the comment, so I folded the surrogate check into the outer condition and dropped the stale comments. Behavior is unchanged.