### PR TITLE
Remove com.ibm.icu.source from not-loaded bundle allowlists

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
@@ -148,7 +148,6 @@ public class PluginsNotLoadedTest {
 			"org.junit",
 			"org.junit4",
 			"org.mortbay.jetty",
-			"com.ibm.icu.source",
 			"javax.servlet.jsp-api.source",
 			"javax.servlet.source",
 			"org.apache.ant.source",

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/activation/JavaActivationTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/activation/JavaActivationTest.java
@@ -130,7 +130,6 @@ public class JavaActivationTest {
 			"org.junit",
 			"org.junit4",
 			"org.mortbay.jetty",
-			"com.ibm.icu.source",
 			"javax.servlet.jsp-api.source",
 			"javax.servlet.source",
 			"org.apache.ant.source",


### PR DESCRIPTION
ICU is no longer a dependency of this repo, so the `com.ibm.icu.source` entries in the not-loaded bundle allowlists in JavaActivationTest and PluginsNotLoadedTest are dead. The tests guard that certain bundles are never activated by the Java editor; without ICU on the classpath the entries can never match anything.