### PR TITLE
Fix Run/Debug configuration dialog when project is closed

### DIFF
--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
@@ -130,6 +130,8 @@ public final class JUnitMessages extends NLS {
 
 	public static String JUnitLaunchConfigurationTab_error_mixedJUnitJupiterVersions;
 
+	public static String JUnitLaunchConfigurationTab_error_projectnotopen;
+
 	public static String JUnitLaunchConfigurationTab_error_testcasenotonpath;
 
 	public static String JUnitLaunchConfigurationTab_error_testnotdefined;
@@ -386,4 +388,5 @@ public final class JUnitMessages extends NLS {
 	public static String TestRunnerViewPart_layout_menu;
 
 	public static String TestSearchEngine_search_message_progress_monitor;
+
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
@@ -169,6 +169,7 @@ JUnitLaunchConfigurationTab_folderdialog_title=Folder Selection
 JUnitLaunchConfigurationTab_folderdialog_message=Choose a Project, Source Folder or Package:
 JUnitLaunchConfigurationTab_error_projectnotdefined=Project not specified
 JUnitLaunchConfigurationTab_error_projectnotexists=Project does not exist
+JUnitLaunchConfigurationTab_error_projectnotopen=Project is closed
 JUnitLaunchConfigurationTab_error_notJavaProject=Specified project is not a Java project
 JUnitLaunchConfigurationTab_error_operation_canceled=(Operation canceled by the user)
 JUnitLaunchConfigurationTab_error_testnotdefined=Test not specified

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationTab.java
@@ -746,7 +746,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 	}
 
 	private Set<String> getMethodsForType(IJavaProject javaProject, IType type, TestKind testKind) {
-		if (javaProject == null || type == null || testKind == null)
+		if (javaProject == null || !javaProject.isOpen() || type == null || testKind == null)
 			return Collections.emptySet();
 
 		String testKindId= testKind.getId();
@@ -768,7 +768,7 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 		try {
 			IJavaProject javaProject= getJavaProject();
 
-			if (javaProject == null) {
+			if (javaProject == null || !javaProject.isOpen()) {
 				// can't find methods if the project
 				return;
 			}
@@ -967,6 +967,11 @@ public class JUnitLaunchConfigurationTab extends AbstractLaunchConfigurationTab 
 				setErrorMessage(JUnitMessages.JUnitLaunchConfigurationTab_error_projectnotexists);
 				return;
 			}
+			if (!project.isOpen()) {
+				setErrorMessage(JUnitMessages.JUnitLaunchConfigurationTab_error_projectnotopen);
+				return;
+			}
+
 			IJavaProject javaProject= JavaCore.create(project);
 			validateJavaProject(javaProject);
 


### PR DESCRIPTION
- fix JUnitLaunchConfigurationTab to check for the project being closed to avoid causing exceptions when closed projects are not filtered out and instead issue error message for the configuration
- fixes #2969

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
