### PR TITLE
Add check for Other Projects working set in JavaWorkingSetUpdater

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/JavaWorkingSetUpdater.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/workingsets/JavaWorkingSetUpdater.java
@@ -25,8 +25,10 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
 
+import org.eclipse.ui.ILocalWorkingSetManager;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.IWorkingSetUpdater;
+import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.jdt.core.ElementChangedEvent;
 import org.eclipse.jdt.core.IElementChangedListener;
@@ -118,7 +120,11 @@ public class JavaWorkingSetUpdater implements IWorkingSetUpdater, IElementChange
 		synchronized(fWorkingSets) {
 			workingSets= fWorkingSets.toArray(new IWorkingSet[fWorkingSets.size()]);
 		}
+		boolean otherFound= false;
 		for (IWorkingSet workingSet : workingSets) {
+			if (workingSet.getId() == IWorkingSetIDs.OTHERS) {
+				otherFound= true;
+			}
 			WorkingSetDelta workingSetDelta= new WorkingSetDelta(workingSet);
 			processJavaDelta(workingSetDelta, event.getDelta());
 			IResourceDelta[] resourceDeltas= event.getDelta().getResourceDeltas();
@@ -128,6 +134,21 @@ public class JavaWorkingSetUpdater implements IWorkingSetUpdater, IElementChange
 				}
 			}
 			workingSetDelta.process();
+		}
+		if (!otherFound) {
+			ILocalWorkingSetManager manager= PlatformUI.getWorkbench().createLocalWorkingSetManager();
+			IWorkingSet other= manager.getWorkingSet(WorkingSetMessages.WorkingSetModel_others_name);
+			if (other != null) {
+				WorkingSetDelta workingSetDelta= new WorkingSetDelta(other);
+				processJavaDelta(workingSetDelta, event.getDelta());
+				IResourceDelta[] resourceDeltas= event.getDelta().getResourceDeltas();
+				if (resourceDeltas != null) {
+					for (IResourceDelta resourceDelta : resourceDeltas) {
+						processResourceDelta(workingSetDelta, resourceDelta);
+					}
+				}
+				workingSetDelta.process();
+			}
 		}
 	}
 


### PR DESCRIPTION
- in JavaWorkingSetUpdater.elementChange() make sure that the Other Projects working set is processed either as part of the local list or by searching for it

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See https://github.com/eclipse-platform/eclipse.platform.ui/issues/2250#issuecomment-4407538174

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue above.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
