### PR TITLE
Adjust test expectation after eclipse.jdt.core/pull/5054

### DIFF
--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuGetClass2/out/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InferTypeArguments/testCuGetClass2/out/A.java
@@ -5,7 +5,7 @@ class A {
 		someObject.getClass();
 	}
 	void m1(Object someObject) {
-		Class<? extends Object> c= someObject.getClass();
+		Class c= someObject.getClass();
 	}
 	void i(Integer someInt) {
 		someInt.getClass();


### PR DESCRIPTION
Since https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5054 ECJ avoids `? extends Object`, which requires the expectation of org.eclipse.jdt.ui.tests.refactoring.InferTypeArgumentsTests.testCuGetClass2() to be adjusted.
