### PR TITLE
Fix SubMonitor misuse in UndoablePackageDeleteChange

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/UndoablePackageDeleteChange.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/changes/UndoablePackageDeleteChange.java
@@ -39,19 +39,17 @@ public class UndoablePackageDeleteChange extends DynamicValidationStateChange {
 	@Override
 	public Change perform(IProgressMonitor pm) throws CoreException {
 		int count= fPackageDeletes.size();
-		pm.beginTask("", count * 3); //$NON-NLS-1$
+		SubMonitor subMonitor= SubMonitor.convert(pm, count * 3);
 		List<IResourceSnapshot<IResource>> snapshots = new ArrayList<>();
-		for (int i= 0; i < fPackageDeletes.size(); i++) {
-			IResource resource= fPackageDeletes.get(i);
+		for (IResource resource : fPackageDeletes) {
 			snapshots.add(ResourceSnapshotFactory.fromResource(resource));
-			pm.worked(1);
+			subMonitor.split(1);
 		}
 
-		DynamicValidationStateChange result= (DynamicValidationStateChange) super.perform(SubMonitor.convert(pm, count));
+		DynamicValidationStateChange result= (DynamicValidationStateChange) super.perform(subMonitor.split(count));
 
-		for (int i= 0; i < fPackageDeletes.size(); i++) {
-			IResourceSnapshot<IResource> resourceDescription= snapshots.get(i);
-			resourceDescription.recordStateFromHistory(SubMonitor.convert(pm, 1));
+		for (IResourceSnapshot<IResource> resourceDescription : snapshots) {
+			resourceDescription.recordStateFromHistory(subMonitor.split(1));
 			result.add(new UndoDeleteResourceChange(resourceDescription));
 		}
 		return result;


### PR DESCRIPTION
The `perform()` method mixed `pm.worked()` with `SubMonitor.convert()` on the same monitor, and called `SubMonitor.convert(pm, 1)` inside a loop. Both patterns corrupt progress reporting: `convert()` resets the monitor's remaining work, so repeated calls inside a loop or after `worked()` discard already-reported progress.

The fix replaces `beginTask`/`worked` and the in-loop `SubMonitor.convert()` calls with a single `SubMonitor.convert()` up front, then `split()` for each unit of work. The loops are also simplified to enhanced for-each since the index is no longer needed.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)