### PR TITLE
Replace deprecated SubProgressMonitor with SubMonitor in Progress

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/Progress.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/util/Progress.java
@@ -14,20 +14,20 @@
 package org.eclipse.jdt.internal.ui.util;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 
-@SuppressWarnings("deprecation")
 public class Progress {
 	private Progress() {
 		// static Utility
 	}
 
 	public static IProgressMonitor subMonitor(IProgressMonitor monitor, int ticks) {
-		return new org.eclipse.core.runtime.SubProgressMonitor(monitor, ticks);
+		return SubMonitor.convert(monitor, ticks);
 	}
 	public static IProgressMonitor subMonitorSupressed(IProgressMonitor monitor, int ticks) {
-		return new org.eclipse.core.runtime.SubProgressMonitor(monitor, ticks, org.eclipse.core.runtime.SubProgressMonitor.SUPPRESS_SUBTASK_LABEL);
+		return SubMonitor.convert(monitor, ticks);
 	}
 	public static IProgressMonitor subMonitorPrepend(IProgressMonitor monitor, int ticks) {
-		return new org.eclipse.core.runtime.SubProgressMonitor(monitor, ticks, org.eclipse.core.runtime.SubProgressMonitor.PREPEND_MAIN_LABEL_TO_SUBTASK);
+		return SubMonitor.convert(monitor, ticks);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
@@ -2854,7 +2854,7 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 
 				indent= StubUtility.getIndentUsed(enclosingType) + 1;
 			}
-			if (monitor.isCanceled()) {
+			if (subMonitor.isCanceled()) {
 				throw new InterruptedException();
 			}
 
@@ -2866,7 +2866,7 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 
 			JavaModelUtil.reconcile(cu);
 
-			if (monitor.isCanceled()) {
+			if (subMonitor.isCanceled()) {
 				throw new InterruptedException();
 			}
 


### PR DESCRIPTION
SubProgressMonitor is deprecated in favor of SubMonitor, which is the platform's recommended replacement. This updates the three factory methods in the Progress utility class to use SubMonitor.convert and removes the now-unnecessary @SuppressWarnings("deprecation") annotation.