### PR TITLE
Use ILog API for logging in org.eclipse.jdt.junit.core

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.14.200.qualifier
+Bundle-Version: 3.14.300.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitCorePlugin.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/JUnitCorePlugin.java
@@ -30,12 +30,12 @@ import org.eclipse.jdt.junit.TestRunListener;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Plugin;
-import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 
 import org.eclipse.jdt.internal.junit.model.JUnitModel;
@@ -119,14 +119,6 @@ public class JUnitCorePlugin extends Plugin {
 		return CORE_PLUGIN_ID;
 	}
 
-	public static void log(Throwable e) {
-		log(new Status(IStatus.ERROR, getPluginId(), IStatus.ERROR, "Error", e)); //$NON-NLS-1$
-	}
-
-	public static void log(IStatus status) {
-		getDefault().getLog().log(status);
-	}
-
 	/**
 	 * @see Plugin#start(BundleContext)
 	 */
@@ -199,7 +191,7 @@ public class JUnitCorePlugin extends Plugin {
 			}
 		}
 		if (!status.isOK()) {
-			JUnitCorePlugin.log(status);
+			ILog.of(JUnitCorePlugin.class).log(status);
 		}
 	}
 

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/BuildPathSupport.java
@@ -33,11 +33,10 @@ import org.eclipse.equinox.frameworkadmin.BundleInfo;
 import org.eclipse.jdt.junit.JUnitCore;
 
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
-import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jdt.core.IAccessRule;
 import org.eclipse.jdt.core.IClasspathAttribute;
@@ -49,6 +48,8 @@ import org.eclipse.jdt.internal.junit.JUnitPreferencesConstants;
 
 
 public class BuildPathSupport {
+
+	private static final ILog LOG = ILog.of(BuildPathSupport.class);
 
 	public static final String JUNIT_JUPITER_VERSION= "[5.0.0,6.0.0)"; //$NON-NLS-1$
 	public static final String JUNIT_PLATFORM_VERSION= "[1.0.0,2.0.0)"; //$NON-NLS-1$
@@ -130,7 +131,7 @@ public class BuildPathSupport {
 						URL fileRootUrl= FileLocator.toFileURL(rootUrl);
 						return new Path(fileRootUrl.getPath());
 					} catch (IOException ex) {
-						JUnitCorePlugin.log(ex);
+						LOG.error(ex.getMessage(), ex);
 					}
 				}
 			}
@@ -172,7 +173,7 @@ public class BuildPathSupport {
 							return new Path(fileRootUrl.getPath());
 						}
 					} catch (IOException ex) {
-						JUnitCorePlugin.log(ex);
+						LOG.error(ex.getMessage(), ex);
 					}
 				}
 			}
@@ -199,7 +200,7 @@ public class BuildPathSupport {
 				ZipEntry entry= jar.getEntry(filePath);
 				if (entry != null) {
 					if (!container.toFile().exists() && !container.toFile().mkdirs()) {
-						JUnitCorePlugin.log(new Status(IStatus.ERROR, JUnitCorePlugin.CORE_PLUGIN_ID, "Unable to create directory to hold " + filePath)); //$NON-NLS-1$
+						LOG.error("Unable to create directory to hold " + filePath); //$NON-NLS-1$
 						return null;
 					}
 					try (InputStream input= jar.getInputStream(entry);
@@ -213,7 +214,7 @@ public class BuildPathSupport {
 					return extractedPath;
 				}
 			} catch (IOException ex) {
-				JUnitCorePlugin.log(ex);
+				LOG.error(ex.getMessage(), ex);
 			}
 			return null;
 		}
@@ -248,7 +249,7 @@ public class BuildPathSupport {
 				return JavaCore.newLibraryEntry(bundleRootLocation, srcLocation, null, getAccessRules(), attributes, false);
 			}
 			String message = "Unable to compute bundle location for '" + bundleId + "' with range " + versionRange;  //$NON-NLS-1$//$NON-NLS-2$
-			JUnitCorePlugin.log(Status.error(message, new IllegalStateException(message)));
+			LOG.error(message, new IllegalStateException(message));
 			return null;
 		}
 

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/P2Utils.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/buildpath/P2Utils.java
@@ -28,6 +28,7 @@ import org.eclipse.equinox.simpleconfigurator.manipulator.SimpleConfiguratorMani
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.URIUtil;
@@ -41,6 +42,8 @@ import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
  * @since 3.5
  */
 class P2Utils {
+
+	private static final ILog LOG = ILog.of(P2Utils.class);
 
 	/**
 	 * Finds the bundle info for the given arguments.
@@ -92,7 +95,7 @@ class P2Utils {
 		try {
 			bundles= manipulator.loadConfiguration(context, bundleInfoPath);
 		} catch (IOException e) {
-			JUnitCorePlugin.log(e);
+			LOG.error(e.getMessage(), e);
 		}
 
 		if (bundles != null) {
@@ -132,7 +135,7 @@ class P2Utils {
 			URI localFileURI= new URI(localFileURL.toExternalForm());
 			return new Path(localFileURI.getPath());
 		} catch (IOException | URISyntaxException e) {
-			JUnitCorePlugin.log(e);
+			LOG.error(e.getMessage(), e);
 			return null;
 		}
 	}

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/TestKind.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/TestKind.java
@@ -18,8 +18,7 @@ package org.eclipse.jdt.internal.junit.launcher;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
-
-import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.core.runtime.ILog;
 
 
 public class TestKind implements ITestKind {
@@ -41,7 +40,7 @@ public class TestKind implements ITestKind {
 			try {
 				fFinder= (ITestFinder) fElement.createExecutableExtension(FINDER_CLASS_NAME);
 			} catch (CoreException e1) {
-				JUnitCorePlugin.log(e1);
+				ILog.of(TestKind.class).error(e1.getMessage(), e1);
 				fFinder= ITestFinder.NULL;
 			}
 		}

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
@@ -26,6 +26,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.SafeRunner;
 
@@ -41,10 +42,12 @@ import org.eclipse.jdt.internal.junit.runner.RemoteTestRunner;
  */
 public class RemoteTestRunnerClient {
 
+	private static final ILog LOG = ILog.of(RemoteTestRunnerClient.class);
+
 	public abstract static class ListenerSafeRunnable implements ISafeRunnable {
 		@Override
 		public void handleException(Throwable exception) {
-			JUnitCorePlugin.log(exception);
+			LOG.error(exception.getMessage(), exception);
 		}
 	}
 	/**
@@ -293,7 +296,7 @@ public class RemoteTestRunnerClient {
 			} catch (SocketException e) {
 				notifyTestRunTerminated();
 			} catch (IOException e) {
-				JUnitCorePlugin.log(e);
+				LOG.error(e.getMessage(), e);
 				// fall through
 			}
 			shutDown();

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.junit.model.ITestRunSession;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ListenerList;
 
 import org.eclipse.debug.core.DebugPlugin;
@@ -99,6 +100,8 @@ public class TestRunSession implements ITestRunSession {
 	 * Suite for unrooted test case elements, or <code>null</code>.
 	 */
 	private TestSuiteElement fUnrootedSuite;
+
+	private static final ILog LOG = ILog.of(TestRunSession.class);
 
 	private static final String EMPTY_STRING= ""; //$NON-NLS-1$
 
@@ -380,7 +383,7 @@ public class TestRunSession implements ITestRunSession {
 			fUnrootedSuite= null;
 
 		} catch (IllegalStateException | CoreException e) {
-			JUnitCorePlugin.log(e);
+			LOG.error(e.getMessage(), e);
 		}
 	}
 
@@ -410,7 +413,7 @@ public class TestRunSession implements ITestRunSession {
 		try {
 			JUnitModel.importIntoTestRunSession(getSwapFile(), this);
 		} catch (IllegalStateException | CoreException e) {
-			JUnitCorePlugin.log(e);
+			LOG.error(e.getMessage(), e);
 			fTestRoot= new TestRoot(this);
 			fTestResult= null;
 		}
@@ -798,7 +801,7 @@ public class TestRunSession implements ITestRunSession {
 		}
 
 		private void logUnexpectedTest(String testId, TestElement testElement) {
-			JUnitCorePlugin.log(new Exception("Unexpected TestElement type for testId '" + testId + "': " + testElement)); //$NON-NLS-1$ //$NON-NLS-2$
+			LOG.error("Unexpected TestElement type for testId '" + testId + "': " + testElement); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -24,9 +24,9 @@ import org.osgi.framework.Version;
 import org.eclipse.jdt.junit.JUnitCore;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Status;
 
 import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IClassFile;
@@ -230,7 +230,7 @@ public class CoreTestSearchEngine {
 								}
 							}
 						} catch (Throwable e) {
-							JUnitCorePlugin.log(Status.warning("Failed to determine JUnit version", e)); //$NON-NLS-1$
+							ILog.of(CoreTestSearchEngine.class).warn("Failed to determine JUnit version", e); //$NON-NLS-1$
 						}
 					}
 					if (version != null && version.getMajor() != junitMajorVersion) {


### PR DESCRIPTION
Replace the JUnitCorePlugin.log() wrapper methods with direct use of the Eclipse ILog API. Files with multiple logging call sites get a private static final ILog field via ILog.of(MyClass.class); single-call sites use ILog.of(MyClass.class) inline. This removes the indirection through the plugin activator and stamps each log entry with the bundle that actually owns the code, rather than always attributing it to the UI plugin.