### PR TITLE
Synchronize access to AnnoationModel while computing folding structure

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.38.0.qualifier
+Bundle-Version: 3.38.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.38.0-SNAPSHOT</version>
+  <version>3.38.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1901,8 +1901,21 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	}
 
 	private Map<IJavaElement, List<Tuple>> computeCurrentStructure(FoldingStructureComputationContext ctx) {
-		Map<IJavaElement, List<Tuple>> map= new HashMap<>();
+		Map<IJavaElement, List<Tuple>> map;
 		ProjectionAnnotationModel model= ctx.getModel();
+		synchronized (model.getLockObject()) {
+			map = mapAnnotationPositions(model);
+		}
+
+		Comparator<Tuple> comparator= (o1, o2) -> o1.position.getOffset() - o2.position.getOffset();
+		for (List<Tuple> list : map.values()) {
+			Collections.sort(list, comparator);
+		}
+		return map;
+	}
+
+	private Map<IJavaElement, List<Tuple>> mapAnnotationPositions(ProjectionAnnotationModel model) {
+		Map<IJavaElement, List<Tuple>> map= new HashMap<>();
 		Iterator<Annotation> e= model.getAnnotationIterator();
 		while (e.hasNext()) {
 			Object annotation= e.next();
@@ -1917,11 +1930,6 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				}
 				list.add(new Tuple(java, position));
 			}
-		}
-
-		Comparator<Tuple> comparator= (o1, o2) -> o1.position.getOffset() - o2.position.getOffset();
-		for (List<Tuple> list : map.values()) {
-			Collections.sort(list, comparator);
 		}
 		return map;
 	}


### PR DESCRIPTION
`DefaultJavaFoldingStructureProvider.computeCurrentStructure()` iterates over annotations in an `AnnotationModel` without using the respective lock. Since the `AnnotationModel` can change concurrently, this can lead to NPEs and CMEs.

This change adjusts `computeCurrentStructure()` to use `AnnotationModel.getLockObject()` while iterating over the annotations of the model.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2990
