### PR TITLE
Avoid ForkJoinPool common pool deadlock in code mining

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
@@ -116,6 +116,7 @@ import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitDocumentProvider;
 import org.eclipse.jdt.internal.ui.javaeditor.DocumentAdapter;
 import org.eclipse.jdt.internal.ui.javaeditor.ICompilationUnitDocumentProvider;
 import org.eclipse.jdt.internal.ui.javaeditor.WorkingCopyManager;
+import org.eclipse.jdt.internal.ui.javaeditor.codemining.JavaCodeMiningExecutor;
 import org.eclipse.jdt.internal.ui.javaeditor.saveparticipant.SaveParticipantRegistry;
 import org.eclipse.jdt.internal.ui.preferences.MembersOrderPreferenceCache;
 import org.eclipse.jdt.internal.ui.preferences.formatter.FormatterProfileStore;
@@ -542,6 +543,8 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 			SpellCheckEngine.shutdownInstance();
 
 			QualifiedTypeNameHistory.getDefault().save();
+
+			JavaCodeMiningExecutor.shutdown();
 
 			// must add here to guarantee that it is the first in the listener list
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaCodeMiningExecutor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaCodeMiningExecutor.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2026 SAP SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.javaeditor.codemining;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Provides a dedicated {@link Executor} for Java code mining resolution.
+ * <p>
+ * Code mining resolve tasks issue blocking JDT search calls. Running them on
+ * {@link java.util.concurrent.ForkJoinPool#commonPool()} can starve the JDT indexer (which itself
+ * submits work to the common pool), leading to a deadlock between code mining workers and the
+ * indexer. Routing these tasks through a separate, fixed-size pool keeps them off the common pool.
+ * <p>
+ * The pool's thread count is capped (2-4 threads); the work queue itself is unbounded. This is
+ * acceptable because the number of in-flight code mining tasks is naturally limited by the visible
+ * minings in open editors, and superseded resolutions are cancelled by the platform.
+ */
+public final class JavaCodeMiningExecutor {
+
+	private static ExecutorService instance;
+
+	private JavaCodeMiningExecutor() {
+	}
+
+	public static synchronized Executor get() {
+		if (instance == null || instance.isShutdown()) {
+			instance= createExecutor();
+		}
+		return instance;
+	}
+
+	/**
+	 * Shuts down the executor. Called from {@code JavaPlugin#stop} so that worker threads do not
+	 * outlive the plug-in across bundle restarts/updates. A subsequent {@link #get()} call will
+	 * create a fresh executor, so the bundle can be restarted within the same JVM.
+	 */
+	public static synchronized void shutdown() {
+		if (instance != null) {
+			instance.shutdownNow();
+			instance= null;
+		}
+	}
+
+	private static ExecutorService createExecutor() {
+		int parallelism= Math.max(2, Math.min(4, Runtime.getRuntime().availableProcessors() / 2));
+		ThreadFactory factory= new ThreadFactory() {
+			private final AtomicInteger counter= new AtomicInteger(1);
+
+			@Override
+			public Thread newThread(Runnable r) {
+				Thread t= new Thread(r, "Java Code Mining Worker-" + counter.getAndIncrement()); //$NON-NLS-1$
+				t.setDaemon(true);
+				t.setPriority(Thread.NORM_PRIORITY - 1);
+				return t;
+			}
+		};
+		return Executors.newFixedThreadPool(parallelism, factory);
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaImplementationCodeMining.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaImplementationCodeMining.java
@@ -125,7 +125,7 @@ public class JavaImplementationCodeMining extends AbstractJavaElementLineHeaderC
 			} catch (CoreException e1) {
 				// Should never occur
 			}
-		});
+		}, JavaCodeMiningExecutor.get());
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaReferenceCodeMining.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/codemining/JavaReferenceCodeMining.java
@@ -115,7 +115,7 @@ public class JavaReferenceCodeMining extends AbstractJavaElementLineHeaderCodeMi
 			} catch (CoreException e) {
 				// Should never occur
 			}
-		});
+		}, JavaCodeMiningExecutor.get());
 	}
 
 	@Override


### PR DESCRIPTION
JavaReferenceCodeMining and JavaImplementationCodeMining ran their blocking JDT search calls via CompletableFuture.runAsync on ForkJoinPool.commonPool(). The JDT indexer also uses the common pool for parallel search and holds the IndexManager monitor while waiting for results, so a busy editor could deadlock: every common pool worker held the IndexManager monitor in JobManager.performConcurrentJob while the indexer waited on ForkJoinTask.get. Route code mining resolution through a dedicated bounded executor (JavaCodeMiningExecutor) instead.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2994

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
