### PR TITLE
Fix extract temp refactoring for a record accessor

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/util/SideEffectChecker.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/util/SideEffectChecker.java
@@ -123,7 +123,7 @@ public class SideEffectChecker extends ASTVisitor {
 			fSideEffect= true;
 			return null;
 		}
-		if (!(iTypeBinding.getJavaElement() instanceof IType))
+		if (!(iTypeBinding.getJavaElement() instanceof IType) || methodBinding.isSyntheticRecordMethod())
 			return null;
 		IType it= (IType) (iTypeBinding.getJavaElement());
 		try {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test160_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test160_in.java
@@ -1,0 +1,17 @@
+// 10, 24 -> 10, 36   AllowLoadtime == false
+package p;
+record User(String token) {
+}
+
+class A {
+	User user = new User("x");
+
+	void test() {
+		String a = use(user.token());
+		String b = use(user.token());
+	}
+
+	String use(String s) {
+		return s;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test160_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test160_out.java
@@ -1,0 +1,18 @@
+// 10, 24 -> 10, 36   AllowLoadtime == false
+package p;
+record User(String token) {
+}
+
+class A {
+	User user = new User("x");
+
+	void test() {
+		String token= user.token();
+		String a = use(token);
+		String b = use(token);
+	}
+
+	String use(String s) {
+		return s;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test161_in.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test161_in.java
@@ -1,0 +1,17 @@
+// 10, 24 -> 10, 36   AllowLoadtime == false
+package p;
+record User(String token) {
+}
+
+class A {
+	User user = new User("x");
+
+	void test() {
+		String a = use(user.token());
+		String b = use(user.token());
+	}
+
+	String use(String s) {
+		return s;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test161_out.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/canExtract16/A_test161_out.java
@@ -1,0 +1,18 @@
+// 10, 24 -> 10, 36   AllowLoadtime == false
+package p;
+record User(String token) {
+}
+
+class A {
+	User user = new User("x");
+
+	void test() {
+		String token= user.token();
+		String a = use(token);
+		String b = use(user.token());
+	}
+
+	String use(String s) {
+		return s;
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AllRefactoringTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/AllRefactoringTests.java
@@ -36,6 +36,7 @@ import org.junit.platform.suite.api.Suite;
 	ExtractTempTests.class,
 	ExtractTempTests1d7.class,
 	ExtractTempTests1d8.class,
+	ExtractTempTests16.class,
 	RenameTempTests.class,
 	ExtractConstantTests.class,
 	PromoteTempToFieldTests.class,

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests16.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests16.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.refactoring;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.eclipse.jdt.ui.tests.CustomBaseRunner;
+import org.eclipse.jdt.ui.tests.IgnoreInheritedTests;
+import org.eclipse.jdt.ui.tests.refactoring.rules.Java16Setup;
+
+@IgnoreInheritedTests
+@RunWith(CustomBaseRunner.class)
+public class ExtractTempTests16 extends ExtractTempTests {
+
+	public ExtractTempTests16() {
+		super(new Java16Setup());
+	}
+
+	@Override
+	protected String getTestFileName(boolean canExtract, boolean input) {
+		StringBuilder fileName= new StringBuilder(TEST_PATH_PREFIX).append(getRefactoringPath());
+		fileName.append(canExtract ? "canExtract16/" : "cannotExtract16/");
+		return fileName.append(getSimpleTestFileName(canExtract, input)).toString();
+	}
+
+	//--- TESTS
+
+	@Override
+	@Test
+	public void test160() throws Exception {
+		helper1(10, 24, 10, 36, true, false, "token", "token");
+	}
+
+	@Override
+	@Test
+	public void test161() throws Exception {
+		helper1(10, 24, 10, 36, false, false, "token", "token");
+	}
+}


### PR DESCRIPTION
- fix SideEffectChecker to not return side effects as true for a record accessor
- add new ExtractTempTests16 and add to AllRefactoringTests
- fixes #3004

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
