### PR TITLE
Add auto-closing support for Markdown fenced code blocks - enhancement

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/MarkdownTypingTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/MarkdownTypingTest.java
@@ -188,9 +188,10 @@ public class MarkdownTypingTest extends TestCase {
 
 	public void testEnableFencedCodeBlockTypingInMarkdown_supported_java_version() throws Exception {
 		String customContent = """
-					///
-					public class Test {}
-				""";
+							 ///
+							 public class Test {}
+							 """;
+
 		ICompilationUnit cu= createCompilationUnit(customContent);
 
 		IJavaProject project = cu.getJavaProject();
@@ -209,13 +210,16 @@ public class MarkdownTypingTest extends TestCase {
 		typeCharacter(editor, '`', offset);
 		typeCharacter(editor, '`', offset + 1);
 		typeCharacter(editor, '`', offset + 2);
+		typeCharacter(editor, '\r', offset + 3);
 
 		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
 
 		String expected = """
-					///``````
-					public class Test {}
-				""";
+							///```
+							///\s
+							/// ```
+							public class Test {}
+							""";
 		assertEquals(expected, doc.get());
 	}
 
@@ -242,21 +246,24 @@ public class MarkdownTypingTest extends TestCase {
 		typeCharacter(editor, '`', offset);
 		typeCharacter(editor, '`', offset + 1);
 		typeCharacter(editor, '`', offset + 2);
+		typeCharacter(editor, '\r', offset + 3);
 
 		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
 
 		String expected = """
 					///```
+					///\s
 					public class Test {}
 				""";
 		assertEquals(expected, doc.get());
 	}
 
-	public void testDiableFencedCodeBlockTypingInMarkdown() throws Exception {
+	public void testDisableFencedCodeBlockTypingInMarkdown() throws Exception {
 		String customContent = """
-					///
-					public class Test {}
-				""";
+				///
+				public class Test {}
+				 """;
+
 		ICompilationUnit cu= createCompilationUnit(customContent);
 
 		IJavaProject project = cu.getJavaProject();
@@ -275,45 +282,14 @@ public class MarkdownTypingTest extends TestCase {
 		typeCharacter(editor, '`', offset);
 		typeCharacter(editor, '`', offset + 1);
 		typeCharacter(editor, '`', offset + 2);
+		typeCharacter(editor, '\r', offset + 3);
 
 		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
 
 		String expected = """
-					///```
-					public class Test {}
-				""";
-		assertEquals(expected, doc.get());
-	}
-
-	public void testEnableFencedCodeBlockInsideDoubleQuote_supported_java_version() throws Exception {
-		String customContent = """
-					/// int x = "";
-					public class Test {}
-				""";
-		ICompilationUnit cu= createCompilationUnit(customContent);
-
-		IJavaProject project = cu.getJavaProject();
-		Map<String, String> options = project.getOptions(true);
-		JavaCore.setComplianceOptions(JavaCore.VERSION_26, options);
-		project.setOptions(options);
-
-		assertEquals(JavaCore.VERSION_26, project.getOption(JavaCore.COMPILER_COMPLIANCE, true));
-
-		editor = openEditor(cu);
-
-		PreferenceConstants.getPreferenceStore()
-        .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
-
-		int offset = customContent.indexOf("\"\"") + 1;
-		typeCharacter(editor, '`', offset);
-		typeCharacter(editor, '`', offset + 1);
-		typeCharacter(editor, '`', offset + 2);
-
-		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
-
-		String expected = """
-					/// int x = "```";
-					public class Test {}
+				///```
+				///\s
+				public class Test {}
 				""";
 		assertEquals(expected, doc.get());
 	}
@@ -351,13 +327,12 @@ public class MarkdownTypingTest extends TestCase {
 		assertEquals(expected, doc.get());
 	}
 
-	public void testEnableFencedCodeBlockInsideJavadoc_supported_java_version() throws Exception {
+	public void testNoFenceAutoCloseAfterTextInMarkdown() throws Exception {
 		String customContent = """
-					/**
-					 *
-					 */
-					public class Test {}
+				/// s
+				public class Test {}
 				""";
+
 		ICompilationUnit cu= createCompilationUnit(customContent);
 
 		IJavaProject project = cu.getJavaProject();
@@ -372,19 +347,19 @@ public class MarkdownTypingTest extends TestCase {
 		PreferenceConstants.getPreferenceStore()
         .setValue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, true);
 
-		int offset = customContent.indexOf("\n", customContent.indexOf("\n") + 1);
+		int offset = customContent.indexOf("///") + 5;
 		typeCharacter(editor, '`', offset);
 		typeCharacter(editor, '`', offset + 1);
 		typeCharacter(editor, '`', offset + 2);
+		typeCharacter(editor, '\r', offset + 3);
 
 		IDocument doc= editor.getDocumentProvider().getDocument(editor.getEditorInput());
 
 		String expected = """
-					/**
-					 *```
-					 */
-					public class Test {}
+				/// s```
+				///\s
+				public class Test {}
 				""";
-		assertEquals(expected, doc.get());
+	assertEquals(expected, doc.get());
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/CompilationUnitEditor.java
@@ -453,7 +453,6 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 				case '[':
 				case '\'':
 				case '\"':
-				case '`':
 					break;
 				default:
 					return;
@@ -481,7 +480,6 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 				IJavaProject project= cu.getJavaProject();
 				boolean textBlockSupported= JavaModelUtil.is15OrHigher(project);
 
-				ITypedRegion partition= TextUtilities.getPartition(document, IJavaPartitions.JAVA_PARTITIONING, offset, true);
 				switch (event.character) {
 					case '(':
 						if (!fCloseBrackets
@@ -523,47 +521,12 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 								|| textBlockSupported && previous == null && offset > 2 && document.get(offset - 2, 2).equals("\"\"")) //$NON-NLS-1$
 							return;
 						break;
-					case '`':
-						String compliance = project != null
-				        ? project.getOption(JavaCore.COMPILER_COMPLIANCE, true)
-				        : JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE);
-						if (validateEditorInputState()
-						        && IJavaPartitions.JAVA_MARKDOWN_COMMENT.equals(partition.getType())
-						        && JavaCore.compareJavaVersions(
-						        		compliance,
-					                    JavaCore.VERSION_23) >= 0) {
-							IDocument doc = sourceViewer.getDocument();
-						    int backtickOffset = selection.x;
-
-						    if (backtickOffset >= 2) {
-						        String prev = doc.get(backtickOffset - 2, 2);
-
-						        if ("``".equals(prev) //$NON-NLS-1$
-						        		&& isPreferenceTrue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK)
-						        		&& !shouldSuppressFenceAutoClose(doc, backtickOffset)) {
-
-						            String delimiter = TextUtilities.getDefaultLineDelimiter(doc);
-						            String insertion = "```" + "```"; //$NON-NLS-1$ //$NON-NLS-2$
-
-						            doc.replace(backtickOffset - 2, 2, insertion);
-
-						            sourceViewer.setSelectedRange(
-						            		backtickOffset + delimiter.length(),
-						                0
-						            );
-
-						            event.doit = false;
-						            return;
-						        }
-						    }
-					    } else {
-					    	return;
-					    }
-					    break;
 
 					default:
 						return;
 				}
+
+				ITypedRegion partition= TextUtilities.getPartition(document, IJavaPartitions.JAVA_PARTITIONING, offset, true);
 
 				// Markdown checking is not required since Markdown should behave the same as Javadoc
 				if (!IDocument.DEFAULT_CONTENT_TYPE.equals(partition.getType()))
@@ -617,59 +580,6 @@ public class CompilationUnitEditor extends JavaEditor implements IJavaReconcilin
 			} catch (BadLocationException | BadPositionCategoryException e) {
 				JavaPlugin.log(e);
 			}
-		}
-
-		private boolean shouldSuppressFenceAutoClose(IDocument doc, int offset) throws BadLocationException {
-		    IRegion lineInfo = doc.getLineInformationOfOffset(offset);
-		    int lineStart = lineInfo.getOffset();
-
-		    String text = doc.get(lineStart, offset - lineStart);
-
-		    // Optional: only for markdown doc comment lines
-		    String trimmed = text.trim();
-		    if (!trimmed.startsWith("///")) { //$NON-NLS-1$
-		        return false;
-		    }
-		    return hasUnclosedQuote(text) || hasUnclosedParen(text);
-		}
-
-		// handles int x = "
-		private boolean hasUnclosedQuote(String s) {
-		    boolean escaped = false;
-		    int quotes = 0;
-
-		    for (char c : s.toCharArray()) {
-		        if (escaped) {
-		            escaped = false;
-		            continue;
-		        }
-		        if (c == '\\') {
-		            escaped = true;
-		        } else if (c == '"') {
-		            quotes++;
-		        }
-		    }
-		    return (quotes % 2) == 1;
-		}
-
-		// handles abc(
-		private boolean hasUnclosedParen(String s) {
-		    int count = 0;
-		    for (char c : s.toCharArray()) {
-		        if (c == '(') count++;
-		        else if (c == ')' && count > 0) count--;
-		    }
-		    return count > 0;
-		}
-
-		/**
-		 * Returns the value of the given boolean-typed preference.
-		 *
-		 * @param preference the preference to look up
-		 * @return the value of the given preference in the Java plug-in's default preference store
-		 */
-		private boolean isPreferenceTrue(String preference) {
-			return JavaPlugin.getDefault().getPreferenceStore().getBoolean(preference);
 		}
 
 		/*

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/SmartTypingConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/SmartTypingConfigurationBlock.java
@@ -33,8 +33,12 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
@@ -42,6 +46,7 @@ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.corext.util.CodeFormatterUtil;
 import org.eclipse.jdt.internal.corext.util.Messages;
 
+import org.eclipse.jdt.ui.IWorkingCopyManager;
 import org.eclipse.jdt.ui.PreferenceConstants;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
@@ -226,11 +231,42 @@ class SmartTypingConfigurationBlock extends AbstractConfigurationBlock {
 		slave= addCheckBox(composite, label, PreferenceConstants.EDITOR_ADD_JAVADOC_TAGS, 0);
 		createDependency(master, slave);
 
-		if (JavaCore.compareJavaVersions(
-				JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE), JavaCore.VERSION_23) >= 0) {
+		ICompilationUnit cu= getCompilationUnit();
+		IJavaProject project= cu.getJavaProject();
+		String compliance= project != null
+				? project.getOption(JavaCore.COMPILER_COMPLIANCE, true)
+				: JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE);
+		if (JavaCore.compareJavaVersions(compliance, JavaCore.VERSION_23) >= 0) {
 			label= PreferencesMessages.JavaEditorPreferencePage_closeMarkdownThreeBacktick;
 			master= addCheckBox(composite, label, PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK, 0);
 		}
+	}
+
+	/**
+	 * Returns the compilation unit of the compilation unit editor invoking the <code>AutoIndentStrategy</code>,
+	 * might return <code>null</code> on error.
+	 * @return the compilation unit represented by the document
+	 */
+	private static ICompilationUnit getCompilationUnit() {
+
+		IWorkbenchWindow window= JavaPlugin.getActiveWorkbenchWindow();
+		if (window == null)
+			return null;
+
+		IWorkbenchPage page= window.getActivePage();
+		if (page == null)
+			return null;
+
+		IEditorPart editor= page.getActiveEditor();
+		if (editor == null)
+			return null;
+
+		IWorkingCopyManager manager= JavaPlugin.getDefault().getWorkingCopyManager();
+		ICompilationUnit unit= manager.getWorkingCopy(editor.getEditorInput());
+		if (unit == null)
+			return null;
+
+		return unit;
 	}
 
 	private void createMessage(final Composite composite) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocAutoIndentStrategy.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocAutoIndentStrategy.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IModuleDescription;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.manipulation.CodeGeneration;
 
@@ -106,6 +107,8 @@ public class JavaDocAutoIndentStrategy extends DefaultIndentLineAutoEditStrategy
 					// Javadoc/markdown started on this line
 					if (d.getChar(firstNonWS+1) == '/') {
 						buf.append("/// "); //$NON-NLS-1$
+						if (handleMarkdownCodeFence(d, c, lineOffset, offset, indentation, buf))
+							return;
 					} else {
 						buf.append(" * "); //$NON-NLS-1$
 					}
@@ -158,6 +161,48 @@ public class JavaDocAutoIndentStrategy extends DefaultIndentLineAutoEditStrategy
 		} catch (BadLocationException excp) {
 			// stop work
 		}
+	}
+
+	private boolean handleMarkdownCodeFence(IDocument d, DocumentCommand c, int lineOffset, int offset, String indentation, StringBuilder buf) {
+		try {
+			if (!isPreferenceTrue(PreferenceConstants.EDITOR_CLOSE_FENCED_CODE_BLOCK))
+				return false;
+			ICompilationUnit cu= getCompilationUnit();
+			if (cu == null)
+				return false;
+
+			IJavaProject project= cu.getJavaProject();
+			String compliance= project != null
+					? project.getOption(JavaCore.COMPILER_COMPLIANCE, true)
+					: JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE);
+
+			if (JavaCore.compareJavaVersions(compliance, JavaCore.VERSION_23) < 0)
+				return false;
+
+			String prefix= d.get(lineOffset, offset - lineOffset).trim();
+
+			// CommonMark allows up to 3 spaces of indentation before the opening code fence.
+			if (!("///```".equals(prefix) || "/// ```".equals(prefix) || "///  ```".equals(prefix) || "///   ```".equals(prefix))) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+				return false;
+
+			String delimiter= TextUtilities.getDefaultLineDelimiter(d);
+
+			c.shiftsCaret= false;
+			c.caretOffset= c.offset + buf.length();
+
+			buf.append(delimiter);
+			buf.append(indentation);
+			buf.append("/// ```"); //$NON-NLS-1$
+
+			c.text= buf.toString();
+
+			return true;
+
+		} catch (BadLocationException e) {
+			JavaPlugin.log(e);
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Enhances Markdown comment editing by automatically inserting a closing triple backtick when Enter is pressed after an opening code fence. A new preference has been added to allow users to configure this behavior.

Ref: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2529

In light of the [discussion](https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2529#issuecomment-4499801360) from #2529, the functionality has changes in a way that, the auto closing of the three backtick happens when the user presses the enter key.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
