### PR TITLE
Use Hash Lookup in OutlineTreeViewer

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/AbstractInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/AbstractInformationControl.java
@@ -491,7 +491,10 @@ public abstract class AbstractInformationControl extends PopupDialog implements 
 	 * matches the current filter pattern.
 	 */
 	protected void selectFirstMatch() {
-		Object selectedElement= fTreeViewer.testFindItem(fInitiallySelectedType);
+		Object selectedElement = null;
+		if (fInitiallySelectedType != null) {
+			selectedElement= fTreeViewer.testFindItem(fInitiallySelectedType);
+		}
 		TreeItem element;
 		final Tree tree= fTreeViewer.getTree();
 		if (selectedElement instanceof TreeItem)

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
@@ -223,7 +223,7 @@ public class JavaOutlineInformationControl extends AbstractInformationControl {
 
 		private OutlineTreeViewer(Tree tree) {
 			super(tree);
-
+			setUseHashlookup(true);
 		}
 
 		@Override


### PR DESCRIPTION
When using the Quick Outline for large class hierarchies, UI slowdowns can occur when showing all inherited members of a class.

Sampling shows that a significant amount of time is spent finding the tree items shown in the OutlineTreeViewer.

Sample: [Uploading snapshot-quickOutline-noUseHashLookup-1780056752557.zip…]()

<img width="750" height="284" alt="image" src="https://github.com/user-attachments/assets/d5086c6f-29d2-4fb9-9610-392f78cd528a" />

This lookup can be speed up by enabling org.eclipse.jface.viewers.StructuredViewer.setUseHashlookup(boolean) on the viewer:

<img width="635" height="357" alt="image" src="https://github.com/user-attachments/assets/e07c728b-7047-4f07-b7b8-032d94f15dc4" />

## What it does
This PR improves the OutlineTreeViewer's performance by enabling the `org.eclipse.jface.viewers.StructuredViewer.setUseHashlookup(true)` optimization for faster lookups of tree items. The optimization is safe to use here since all `JavaElement`s override `equals()` and `hashCode()`.

This removes the time spent in `StructuredViewer.findItems()`, reducing the viewer's refresh time in this example from 1.4 sec to just 0.5 sec.

<img width="812" height="240" alt="image" src="https://github.com/user-attachments/assets/01880d37-0720-4799-8369-63186d30acf5" />


## How to test
- Unzip and import the test project and navigate to the class C0 [testProject.zip](https://github.com/user-attachments/files/28393539/testProject.zip)
- Select the class name of the C0 class and open the Quick Outline View (Ctrl-O)
- Press Ctrl-O again to show inherited members and type "C99"  into the search field -> The UI starts "stuttering", taking significant time to react to the user input 
<img width="1911" height="998" alt="QuickOutlineStuttering" src="https://github.com/user-attachments/assets/87d613f2-38c4-40c8-ab03-ae33eaeb5816" />

_Note:_ The reproduction uses a large generated class with many inner classes to produce enough work for the UI to start stuttering. The problem is however not bound to just inner classes, we can reproduce this problem consistently with very large "organic" class hierarchies in our code base.


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
