### PR TITLE
Fix inline method to not inline a super call to another type

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.24.100.qualifier
+Bundle-Version: 1.24.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -57,6 +57,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String CallInliner_simple_functions;
 
+	public static String CallInliner_super_into_other_type;
+
 	public static String CallInliner_super_into_this_expression;
 
 	public static String CallInliner_unexpected_model_exception;
@@ -2546,6 +2548,7 @@ public final class RefactoringCoreMessages extends NLS {
 	public static String ConvertToRecordRefactoring_has_initializer;
 
 	public static String ConvertToRecordRefactoring_member_types_not_supported;
+
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, RefactoringCoreMessages.class);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -54,6 +54,7 @@ import org.eclipse.jdt.core.NamingConventions;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.ArrayInitializer;
 import org.eclipse.jdt.core.dom.Assignment;
 import org.eclipse.jdt.core.dom.Block;
@@ -341,6 +342,22 @@ public class CallInliner {
 					severity,
 					RefactoringCoreMessages.CallInliner_super_into_this_expression,
 					JavaStatusContext.create(fCUnit, fInvocation)));
+			} else {
+				AbstractTypeDeclaration sourceTypeDecl= ASTNodes.getFirstAncestorOrNull(fSourceProvider.getDeclaration(), AbstractTypeDeclaration.class);
+				AbstractTypeDeclaration targetTypeDecl= ASTNodes.getFirstAncestorOrNull(fInvocation, AbstractTypeDeclaration.class);
+				if (sourceTypeDecl != null && targetTypeDecl != null) {
+					ITypeBinding sourceTypeBinding= sourceTypeDecl.resolveBinding();
+					ITypeBinding targetTypeBinding= targetTypeDecl.resolveBinding();
+					if (sourceTypeBinding != null && targetTypeBinding != null) {
+						if (!sourceTypeBinding.getQualifiedName().equals(targetTypeBinding.getQualifiedName())) {
+							result.addEntry(new RefactoringStatusEntry(
+									severity,
+									RefactoringCoreMessages.CallInliner_super_into_other_type,
+									JavaStatusContext.create(fCUnit, fInvocation)));
+						}
+					}
+				}
+
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -219,6 +219,7 @@ CallInliner_field_initializer_simple=In field initializers inlining is only supp
 CallInliner_field_initialize_new_local=Cannot inline field initializer because new local variable is required.
 CallInliner_incompatible_super_call_for_static_method=Cannot inline super class reference into a static method.
 CallInliner_super_into_this_expression=Cannot inline a super invocation into a this expression.
+CallInliner_super_into_other_type=Cannot inline a super invocation into a method of a different type.
 CallInliner_field_initialize_write_parameter=Cannot inline field initializer because one of the method parameters is used as an assignment target and will require new local variable.
 CallInliner_field_initialize_self_reference=Cannot inline method. Method references the field to be initialized.
 CallInliner_constructors=Cannot inline a constructor invocation that is used as a class instance creation.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/TestSuperCallInOtherType.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/TestSuperCallInOtherType.java
@@ -1,0 +1,28 @@
+package invalid;
+
+class B extends A {
+	int toInline() {
+		return super.g();
+	}
+}
+
+public class TestSuperCallInOtherType {
+	public static void main(String[] args) {
+		B b = new B();
+		new C().test(b);
+	}
+}
+
+class A {
+	int g() {
+		return 1;
+	}
+}
+
+
+class C {
+	void test(B b) {
+		int x = /*[*/b.toInline()/*]*/; // inline method 'f()'
+		System.out.println(x);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -215,6 +215,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void testSuperCallInOtherType() throws Exception {
+		performInvalidTestInlineMethod();
+	}
+
+	@Test
 	public void testNotMethodName() throws Exception {
 		ICompilationUnit unit= createCU(fgTestSetup.getInvalidPackage(), getName());
 		int[] selection= getSelection();


### PR DESCRIPTION
- modify CallInliner.checkMethodDeclaration() to check if the source contains a super call and the type declaration of the source and target are not the same
- add new test to InlineMethodTests
- fixes #3007

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
