### PR TITLE
Remove redundant ProblemsLabelDecorator

### DIFF
--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.38.0.qualifier
+Bundle-Version: 3.38.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.38.0-SNAPSHOT</version>
+  <version>3.38.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/JavaOutlineInformationControl.java
@@ -72,7 +72,6 @@ import org.eclipse.jdt.internal.corext.util.MethodOverrideTester;
 import org.eclipse.jdt.internal.corext.util.SuperTypeHierarchyCache;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
-import org.eclipse.jdt.ui.ProblemsLabelDecorator;
 import org.eclipse.jdt.ui.StandardJavaElementContentProvider;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
@@ -581,7 +580,6 @@ public class JavaOutlineInformationControl extends AbstractInformationControl {
 		treeViewer.addFilter(new MemberFilter());
 
 		fInnerLabelProvider= new OutlineLabelProvider();
-		fInnerLabelProvider.addLabelDecorator(new ProblemsLabelDecorator(null));
 		treeViewer.setLabelProvider(new DecoratingJavaLabelProvider(fInnerLabelProvider));
 
 		fLexicalSortingAction= new LexicalSortingAction(treeViewer);


### PR DESCRIPTION
The label provider of the `JavaOutlineInformationControl` currently registers the `ProblemsLabelDecorator` twice, once via `fInnerLabelProvider.addLabelDecorator(new ProblemsLabelDecorator(null))` and once via `treeViewer.setLabelProvider(new DecoratingJavaLabelProvider(fInnerLabelProvider))`.

See org.eclipse.jdt.internal.ui.text.JavaOutlineInformationControl.createTreeViewer(Composite, int)
<img width="837" height="73" alt="image" src="https://github.com/user-attachments/assets/060b11d8-4d16-4804-ae82-daf122376863" />

See org.eclipse.jdt.internal.ui.viewsupport.DecoratingJavaLabelProvider.DecoratingJavaLabelProvider(JavaUILabelProvider, boolean, boolean)
<img width="1187" height="310" alt="image" src="https://github.com/user-attachments/assets/ef252ad1-7908-4626-a664-86e8ab2b9643" />


## What it does
This PR removes the redundant second `ProblemsLabelDecorator`. This improves the performance of the quick outline by avoiding to calculate each problem decorator twice.

## How to test
1. Add debug outputs to `org.eclipse.jdt.ui.ProblemsLabelDecorator.decorateText(String, Object)` and `org.eclipse.jdt.ui.ProblemsLabelDecorator.decorateImage(Image, Object)`
```diff
diff --git a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/ProblemsLabelDecorator.java b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/ProblemsLabelDecorator.java
index 13f62a0..12bd53f 100644
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/ProblemsLabelDecorator.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/ProblemsLabelDecorator.java
@@ -183,11 +183,13 @@
 
 	@Override
 	public String decorateText(String text, Object element) {
+		System.out.println(String.format("Called decorateText(%s,%s)", text, element)); //$NON-NLS-1$
 		return text;
 	}
 
 	@Override
 	public Image decorateImage(Image image, Object obj) {
+		System.out.println(String.format("Called decorateImage(%s,%s)", image, obj)); //$NON-NLS-1$
 		if (image == null)
 			return null;
 
```

3. Inside the workspace, create a new project with an empty class
```java
public class TestClass {
	// Empty
}
```
4. Select the class name and open the quick outline (Crtl-O), observe the log output
```
Called decorateText(TestClass,class TestClass [in [Working copy] TestClass.java [in <default> [in src [in testProject]]]])
Called decorateText(TestClass,class TestClass [in [Working copy] TestClass.java [in <default> [in src [in testProject]]]])
Called decorateImage(Image {{125=org.eclipse.swt.graphics.Image$DestroyableImageHandle@434f15c9}},class TestClass [in [Working copy] TestClass.java [in <default> [in src [in testProject]]]])
Called decorateImage(Image {{125=org.eclipse.swt.graphics.Image$DestroyableImageHandle@434f15c9}},class TestClass [in [Working copy] TestClass.java [in <default> [in src [in testProject]]]])
```
The log shows that the problem decorations are calculated twice.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
