### PR TITLE
Add additional logic to CallHierarchyCore.getCompilationUnitNode()

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchyCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/callhierarchy/CallHierarchyCore.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 
+import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
@@ -308,7 +309,7 @@ public class CallHierarchyCore {
         ITypeRoot typeRoot= member.getTypeRoot();
         try {
             if (typeRoot != null && typeRoot.exists() && typeRoot.getBuffer() != null
-                    && JavaCore.isJavaLikeFileName(typeRoot.getElementName())) {
+                    && (typeRoot instanceof IClassFile || JavaCore.isJavaLikeFileName(typeRoot.getElementName()))) {
 				ASTParser parser= ASTParser.newParser(IASTSharedValues.SHARED_AST_LEVEL);
 				parser.setSource(typeRoot);
 				parser.setResolveBindings(resolveBindings);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/CallHierarchyParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/CallHierarchyParticipantTest.java
@@ -24,6 +24,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
@@ -47,8 +49,6 @@ import org.eclipse.jdt.internal.corext.callhierarchy.CallHierarchyCore;
 import org.eclipse.jdt.internal.corext.callhierarchy.MethodWrapper;
 
 import org.eclipse.jdt.ui.tests.callhierarchy.TestCallHierarchyParticipant;
-
-import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 /**
  * Tests for call hierarchy integration with contributed search participants.
@@ -398,4 +398,68 @@ public class CallHierarchyParticipantTest {
 		assertTrue("Should find firstCaller", foundFirst);
 		assertTrue("Should find secondCaller", foundSecond);
 	}
+
+	/**
+	 * Regression test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3015
+	 *
+	 * Verifies that outgoing call hierarchy works for methods in class files
+	 * from a JAR/class folder with attached source. The {@code isJavaLikeFileName}
+	 * guard must not reject {@code IClassFile} members whose element name ends
+	 * in {@code .class}.
+	 */
+	@Test
+	public void outgoingCallsWorkForClassFileWithAttachedSource() throws Exception {
+		JavaProjectHelper.addRTJar9(fSourceProject);
+		IPackageFragmentRoot src = JavaProjectHelper.addSourceContainer(fSourceProject, "src");
+		IPackageFragment pkg = src.createPackageFragment("testpkg", true, null);
+		pkg.createCompilationUnit("Lib.java",
+				"""
+				package testpkg;
+				public class Lib {
+				    public void targetMethod() {}
+				    public void anotherTarget() {}
+				    public void callerMethod() { targetMethod(); anotherTarget(); }
+				}
+				""",
+				true, null);
+		fSourceProject.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
+
+		// Add source project's output as a class folder WITH source attachment
+		JavaProjectHelper.addRTJar9(fBinaryProject);
+		IPath outputPath = fSourceProject.getOutputLocation();
+		IFolder outputFolder = fSourceProject.getProject()
+				.getFolder(outputPath.removeFirstSegments(1));
+		JavaProjectHelper.addLibrary(fBinaryProject, outputFolder.getFullPath(),
+				src.getPath(), null);
+
+		IType binaryType = fBinaryProject.findType("testpkg.Lib");
+		assertNotNull("Binary type should be found", binaryType);
+		IMethod binaryCallerMethod = binaryType.getMethod("callerMethod", new String[0]);
+		assertTrue("Binary callerMethod should exist", binaryCallerMethod.exists());
+
+		// Verify preconditions: this is a class file with source attached
+		ITypeRoot typeRoot = binaryCallerMethod.getTypeRoot();
+		assertTrue("Should be a class file", typeRoot instanceof IClassFile);
+		assertNotNull("Class file with source attachment should have a buffer",
+				typeRoot.getBuffer());
+
+		MethodWrapper[] roots = CallHierarchyCore.getDefault().getCalleeRoots(
+				new IMember[] { binaryCallerMethod });
+		assertEquals(1, roots.length);
+		MethodWrapper[] callees = roots[0].getCalls(new NullProgressMonitor());
+
+		assertEquals("Should find 2 callees via Java AST from attached source",
+				2, callees.length);
+
+		boolean foundTarget = false;
+		boolean foundAnother = false;
+		for (MethodWrapper callee : callees) {
+			String name = callee.getMember().getElementName();
+			if ("targetMethod".equals(name)) foundTarget = true;
+			if ("anotherTarget".equals(name)) foundAnother = true;
+		}
+		assertTrue("Should find targetMethod as callee", foundTarget);
+		assertTrue("Should find anotherTarget as callee", foundAnother);
+	}
+
 }


### PR DESCRIPTION
- add check for class file to avoid checking for a java file name which won't find the .java extension and will return false
- fixes #3015

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run jdt.ls test mentioned in issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
