### PR TITLE
Fix inlining lambda logic into lambda body

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -821,16 +821,37 @@ public class CallInliner {
 				allblocks += blocks[i];
 			}
 			StringBuilder builder= new StringBuilder();
-			builder.append("{"); //$NON-NLS-1$
 			String[] lines= allblocks.split("\n"); //$NON-NLS-1$
+			if (fSourceProvider.getMarkerMode() == SourceProvider.EXPRESSION_MODE) {
+				String[] lastLines= lines[lines.length - 1].split(";"); //$NON-NLS-1$
+				if (lastLines.length > 1) {
+					lines= Arrays.copyOf(lines, lines.length + 1);
+					lines[lines.length - 2]= lastLines[0] + ";"; //$NON-NLS-1$
+					lines[lines.length - 1]= lastLines[1];
+				}
+			}
+			if (lines.length != 1) {
+				builder.append("{"); //$NON-NLS-1$
+			}
 			String separator= lines.length == 1 ? "" : "\n\t"; //$NON-NLS-1$ //$NON-NLS-2$
-			for (int i= 0; i < lines.length; ++i) {
+			boolean expressionMode= fSourceProvider.getMarkerMode() == SourceProvider.EXPRESSION_MODE;
+			for (int i= 0; i < lines.length - (expressionMode ? 1 : 0); ++i) {
 				builder.append(separator);
 				builder.append(lines[i]);
 				separator= "\n\t"; //$NON-NLS-1$
 			}
+			if (expressionMode) {
+				if (lines.length == 1) {
+					builder.append(lines[0]);
+				} else {
+					builder.append(separator);
+					builder.append("return " + lines[lines.length - 1] + ";"); //$NON-NLS-1$ //$NON-NLS-2$
+				}
+			}
 			separator= lines.length == 1 ? "" : "\n"; //$NON-NLS-1$ //$NON-NLS-2$
-			builder.append(separator + "}"); //$NON-NLS-1$
+			if (lines.length != 1 || !expressionMode) {
+				builder.append(separator + "}"); //$NON-NLS-1$
+			}
 			ASTNode newNode= fRewrite.createStringPlaceholder(builder.toString(), ASTNode.BLOCK);
 			fRewrite.replace(fTargetNode, newNode, textEditGroup);
 		} else {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
@@ -127,9 +127,9 @@ public class SourceProvider {
 	private List<Expression> fReturnExpressions;
 	private IDocument fSource;
 
-	private static final int EXPRESSION_MODE= 1;
-	private static final int STATEMENT_MODE= 2;
-	private static final int RETURN_STATEMENT_MODE= 3;
+	public static final int EXPRESSION_MODE= 1;
+	public static final int STATEMENT_MODE= 2;
+	public static final int RETURN_STATEMENT_MODE= 3;
 	private int fMarkerMode;
 
 
@@ -328,6 +328,10 @@ public class SourceProvider {
 			}
 		}
 		return false;
+	}
+
+	public int getMarkerMode() {
+		return fMarkerMode;
 	}
 
 	public String getMethodName() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_in/TestLambdaBody1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_in/TestLambdaBody1.java
@@ -1,0 +1,20 @@
+package call_in;
+
+interface Supplier<T> {
+	T supply();
+}
+
+public class TestLambdaBody1 {
+
+	// Refactoring operation: Inline method
+	static String toInline() {
+		return "lambda";
+	}
+
+	public static void main(String[] args) {
+		Supplier<String> s= () -> /*]*/toInline()/*[*/; // inline here
+		System.out.println(s.get());
+		System.out.println("done");
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_in/TestLambdaBody2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_in/TestLambdaBody2.java
@@ -1,0 +1,21 @@
+package call_in;
+
+interface Supplier<T> {
+	T supply();
+}
+
+public class TestLambdaBody1 {
+
+	// Refactoring operation: Inline method
+	static String toInline() {
+		int i = 0;
+		return "lambda";
+	}
+
+	public static void main(String[] args) {
+		Supplier<String> s= () -> /*]*/toInline()/*[*/; // inline here
+		System.out.println(s.get());
+		System.out.println("done");
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_in/TestLambdaBody3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_in/TestLambdaBody3.java
@@ -1,0 +1,22 @@
+package call_in;
+
+interface Supplier<T> {
+	T supply();
+}
+
+public class TestLambdaBody1 {
+
+	// Refactoring operation: Inline method
+	static String toInline() {
+		return "lambda";
+	}
+
+	public static void main(String[] args) {
+		Supplier<String> s= () -> {
+			return /*]*/toInline()/*[*/; // inline here
+		};
+		System.out.println(s.get());
+		System.out.println("done");
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_out/TestLambdaBody1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_out/TestLambdaBody1.java
@@ -1,0 +1,20 @@
+package call_in;
+
+interface Supplier<T> {
+	T supply();
+}
+
+public class TestLambdaBody1 {
+
+	// Refactoring operation: Inline method
+	static String toInline() {
+		return "lambda";
+	}
+
+	public static void main(String[] args) {
+		Supplier<String> s= () -> /*]*/"lambda"/*[*/; // inline here
+		System.out.println(s.get());
+		System.out.println("done");
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_out/TestLambdaBody2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_out/TestLambdaBody2.java
@@ -1,0 +1,24 @@
+package call_in;
+
+interface Supplier<T> {
+	T supply();
+}
+
+public class TestLambdaBody1 {
+
+	// Refactoring operation: Inline method
+	static String toInline() {
+		int i = 0;
+		return "lambda";
+	}
+
+	public static void main(String[] args) {
+		Supplier<String> s= () -> /*]*/{
+			int i = 0;
+			return "lambda";
+		}/*[*/; // inline here
+		System.out.println(s.get());
+		System.out.println("done");
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_out/TestLambdaBody3.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/call_out/TestLambdaBody3.java
@@ -1,0 +1,22 @@
+package call_in;
+
+interface Supplier<T> {
+	T supply();
+}
+
+public class TestLambdaBody1 {
+
+	// Refactoring operation: Inline method
+	static String toInline() {
+		return "lambda";
+	}
+
+	public static void main(String[] args) {
+		Supplier<String> s= () -> {
+			/*]*/return "lambda"/*[*/; // inline here
+		};
+		System.out.println(s.get());
+		System.out.println("done");
+	}
+}
+

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -823,7 +823,22 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performCallTest();
 	}
 
-	/* *********************** Expression Tests ******************************* */
+	@Test
+	public void testLambdaBody1() throws Exception {
+		performCallTest();
+	}
+
+	@Test
+	public void testLambdaBody2() throws Exception {
+		performCallTest();
+	}
+
+	@Test
+	public void testLambdaBody3() throws Exception {
+		performCallTest();
+	}
+
+/* *********************** Expression Tests ******************************* */
 
 	private void performExpressionTest() throws Exception {
 		performTestInlineCall(fgTestSetup.getExpressionPackage(), getName(), COMPARE_WITH_OUTPUT, "expression_out");


### PR DESCRIPTION
- add new API to SourceProvider to get the marker mode
- modify CallInliner.replaceCall() logic for lambda body to look for a marker mode of EXPRESSION_MODE which indicates a return statement has been replaced with just its expression and in which case either put the expression directly in or surround with block and restore the return statement
- add new tests to InlineMethodTests
- fixes #3008

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue and new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
