### PR TITLE
Add quick assist to unwrap a switch case block

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.java
@@ -189,6 +189,8 @@ public final class FixMessages extends NLS {
 	public static String InlineDeprecatedMethod_msg;
 	public static String ReplaceDeprecatedField_msg;
 
+	public static String SwitchCaseUnblockFix_unwrap_case_block;
+
 	static {
 		// initialize resource bundle
 		NLS.initializeMessages(BUNDLE_NAME, FixMessages.class);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/FixMessages.properties
@@ -151,6 +151,7 @@ LambdaExpressionsFix_convert_to_lambda_expression_removes_annotations=Convert to
 PatternMatchingForInstanceofFix_refactor=Use pattern matching for instanceof
 PatternInstanceof_convert_if_to_switch=Convert pattern instanceof if/else if/else chain to switch
 SwitchExpressionsFix_convert_to_switch_expression=Convert to switch expression
+SwitchCaseUnblockFix_unwrap_case_block=Unwrap switch expression case block
 SwitchFix_convert_if_to_switch=Convert if/else if/else chain to switch
 TypeParametersFix_insert_inferred_type_arguments_description=Insert inferred type arguments
 TypeParametersFix_insert_inferred_type_arguments_name=Insert inferred type arguments

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchCaseUnblockFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/SwitchCaseUnblockFixCore.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.corext.fix;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.SwitchCase;
+import org.eclipse.jdt.core.dom.SwitchExpression;
+import org.eclipse.jdt.core.dom.SwitchStatement;
+import org.eclipse.jdt.core.dom.YieldStatement;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+
+import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+
+public class SwitchCaseUnblockFixCore extends CompilationUnitRewriteOperationsFixCore {
+
+
+	public static class SwitchExpressionUnwrapBlockOperation extends CompilationUnitRewriteOperation {
+
+		private final Block block;
+
+		public SwitchExpressionUnwrapBlockOperation(Block block) {
+			this.block= block;
+		}
+
+		@Override
+		public void rewriteAST(CompilationUnitRewrite cuRewrite, LinkedProposalModelCore linkedModel) throws CoreException {
+
+			final ASTRewrite rewrite= cuRewrite.getASTRewrite();
+			final AST ast= rewrite.getAST();
+
+			Statement stmt= (Statement) block.statements().get(0);
+			Statement newStmt= null;
+			if (stmt instanceof YieldStatement yieldStmt) {
+				newStmt= ast.newExpressionStatement((Expression) rewrite.createCopyTarget(yieldStmt.getExpression()));
+			} else {
+				newStmt= (Statement)rewrite.createCopyTarget(stmt);
+			}
+			rewrite.replace(block, newStmt, null);
+		}
+
+
+	}
+
+	public static SwitchCaseUnblockFixCore createFix(Block block) {
+		CompilationUnit root= (CompilationUnit) block.getRoot();
+
+		ASTNode parent= block.getParent();
+		List<Statement> statements= new ArrayList<>();
+		if (parent instanceof SwitchStatement switchStatement) {
+			statements= switchStatement.statements();
+		} else if (parent instanceof SwitchExpression switchExpression) {
+			statements= switchExpression.statements();
+		}
+
+		if (statements.size() > 0 && statements.get(0) instanceof SwitchCase switchCase && switchCase.isSwitchLabeledRule()) {
+			SwitchExpressionUnwrapBlockOperation op= new SwitchExpressionUnwrapBlockOperation(block);
+			return new SwitchCaseUnblockFixCore(FixMessages.SwitchCaseUnblockFix_unwrap_case_block, root, new CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation[] { op });
+		}
+		return null;
+	}
+
+	protected SwitchCaseUnblockFixCore(String name, CompilationUnit compilationUnit, CompilationUnitRewriteOperationsFixCore.CompilationUnitRewriteOperation[] fixRewriteOperations) {
+		super(name, compilationUnit, fixRewriteOperations);
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest14.java
@@ -860,5 +860,295 @@ public class AssistQuickFixTest14 extends QuickFixTest {
 		assertProposalDoesNotExist(proposals, FixMessages.SwitchExpressionsFix_convert_to_switch_expression);
 	}
 
+	@Test
+	public void testUnwrapCaseBlock1() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					switch (k) {
+						case 0 -> {
+							i = 3;
+						}
+						default -> i = 22;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("i = 3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 5);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		String expected= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					switch (k) {
+						case 0 -> i = 3;
+						default -> i = 22;
+					}
+					return i;
+				}
+			}
+			""";
+
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testUnwrapCaseBlock2() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					switch (k) {
+						case 0 -> {
+							i = 3;
+						}
+						default -> i = 22;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("case 0");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 5);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		String expected= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					switch (k) {
+						case 0 -> i = 3;
+						default -> i = 22;
+					}
+					return i;
+				}
+			}
+			""";
+
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testUnwrapCaseBlock3() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					return switch (k) {
+						case 0 -> {
+							yield 3;
+						}
+						default -> 22;
+					};
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("yield 3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 5);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+
+		String expected= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					return switch (k) {
+						case 0 -> 3;
+						default -> 22;
+					};
+				}
+			}
+			""";
+
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void testDoNotUnwrapCaseBlock1() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					switch (k) {
+						case 0 -> {
+							return 3;
+						}
+						default -> i = 22;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("return 3");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 5);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+		assertProposalDoesNotExist(proposals, FixMessages.SwitchCaseUnblockFix_unwrap_case_block);
+	}
+
+	@Test
+	public void testDoNotUnwrapCaseBlock2() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					switch (k) {
+						case 0 -> {
+							i = 4;
+							System.out.println(i);
+						}
+						default -> i = 22;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("i = 4");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 5);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+		assertProposalDoesNotExist(proposals, FixMessages.SwitchCaseUnblockFix_unwrap_case_block);
+	}
+
+	@Test
+	public void testDoNotUnwrapCaseBlock3() throws Exception {
+		fJProject1= JavaProjectHelper.createJavaProject("TestProject1", "bin");
+		fJProject1.setRawClasspath(projectSetup.getDefaultClasspath(), null);
+		JavaProjectHelper.set14CompilerOptions(fJProject1, false);
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		String str= """
+			module test {
+			}
+			""";
+		IPackageFragment def= fSourceFolder.createPackageFragment("", false, null);
+		def.createCompilationUnit("module-info.java", str, false, null);
+
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test", false, null);
+		String str1= """
+			package test;
+			public class Cls {
+				public int foo(int k) {
+					int i;
+					// logic comment
+					switch (k) {
+						case 0: {
+							i = 4;
+						}
+						break;
+						default:
+							i = 22;
+						break;
+					}
+					return i;
+				}
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("Cls.java", str1, false, null);
+
+		int index= str1.indexOf("i = 4");
+		IInvocationContext ctx= getCorrectionContext(cu, index, 5);
+		assertNoErrors(ctx);
+		ArrayList<IJavaCompletionProposal> proposals= collectAssists(ctx, false);
+		assertProposalDoesNotExist(proposals, FixMessages.SwitchCaseUnblockFix_unwrap_case_block);
+	}
+
 }
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/correction/QuickAssistProcessor.java
@@ -111,6 +111,7 @@ import org.eclipse.jdt.core.dom.ParenthesizedExpression;
 import org.eclipse.jdt.core.dom.PostfixExpression;
 import org.eclipse.jdt.core.dom.PrimitiveType;
 import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.ReturnStatement;
 import org.eclipse.jdt.core.dom.SimpleName;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
@@ -175,6 +176,7 @@ import org.eclipse.jdt.internal.corext.fix.ReplaceQualifiedTypeFixCore;
 import org.eclipse.jdt.internal.corext.fix.SplitTryResourceFixCore;
 import org.eclipse.jdt.internal.corext.fix.SplitVariableFixCore;
 import org.eclipse.jdt.internal.corext.fix.StringConcatToTextBlockFixCore;
+import org.eclipse.jdt.internal.corext.fix.SwitchCaseUnblockFixCore;
 import org.eclipse.jdt.internal.corext.fix.SwitchExpressionsFixCore;
 import org.eclipse.jdt.internal.corext.fix.SwitchFixCore;
 import org.eclipse.jdt.internal.corext.fix.TypeParametersFixCore;
@@ -345,6 +347,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 					|| getDeprecatedFieldProposal(context, coveringNode, null, null)
 					|| getConvertToRecordProposals(context, coveringNode, null)
 					|| getConvertToSwitchProposals(context, coveringNode, null)
+					|| getUnblockSwitchExpressionCaseProposals(context, coveringNode, null)
 					|| getDeprecatedProposal(context, coveringNode, null, null)
 					|| getReplaceQualifiedNameProposals(context, coveringNode, null);
 		}
@@ -425,6 +428,7 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 				getAddStaticMemberFavoritesProposals(coveringNode, resultingCollections);
 				getConvertToSwitchExpressionProposals(context, coveringNode, resultingCollections);
 				getConvertToSwitchProposals(context, coveringNode, resultingCollections);
+				getUnblockSwitchExpressionCaseProposals(context, coveringNode, resultingCollections);
 				getDoWhileRatherThanWhileProposal(context, coveringNode, resultingCollections);
 				getStringConcatToTextBlockProposal(context, coveringNode, resultingCollections);
 				getSplitTryResourceProposal(context, coveringNode, resultingCollections);
@@ -1008,6 +1012,56 @@ public class QuickAssistProcessor implements IQuickAssistProcessor {
 		Block block= (Block)covering;
 
 		IProposableFix fix= SwitchFixCore.createSwitchFix(block, context.getSelectionOffset(), context.getSelectionLength());
+		if (fix == null)
+			return false;
+
+		if (resultingCollections == null)
+			return true;
+
+		// add correction proposal
+		Image image= JavaPluginImages.get(JavaPluginImages.IMG_CORRECTION_CHANGE);
+		FixCorrectionProposal proposal= new FixCorrectionProposal(fix, null, IProposalRelevance.CONVERT_TO_SWITCH, image, context);
+		resultingCollections.add(proposal);
+		return true;
+	}
+
+	private static boolean getUnblockSwitchExpressionCaseProposals(IInvocationContext context, ASTNode covering, Collection<ICommandAccess> resultingCollections) {
+		Block block= null;
+		if (covering instanceof Block coveringBlock) {
+			block= coveringBlock;
+		} else if (covering instanceof SwitchCase switchCase) {
+			ASTNode parent= switchCase.getParent();
+			List<Statement> statements= new ArrayList<>();
+			if (parent instanceof SwitchStatement switchStatement) {
+				statements= switchStatement.statements();
+			} else if (parent instanceof SwitchExpression switchExpression) {
+				statements= switchExpression.statements();
+			}
+			int i= 0;
+			for (i= 0; i < statements.size(); ++i) {
+				if (statements.get(i) == switchCase) {
+					break;
+				}
+			}
+			if (++i < statements.size() && statements.get(i) instanceof Block b) {
+				block= b;
+			}
+		} else {
+			while (!(covering instanceof Statement) && covering != null) {
+				covering= covering.getParent();
+			}
+			if (covering != null && covering.getParent() instanceof Block parentBlock) {
+				block= parentBlock;
+			}
+		}
+		if (block == null) {
+			return false;
+		}
+		if (block.statements().size() != 1 || block.statements().get(0) instanceof ReturnStatement) {
+			return false;
+		}
+
+		IProposableFix fix= SwitchCaseUnblockFixCore.createFix(block);
 		if (fix == null)
 			return false;
 


### PR DESCRIPTION
- add new SwitchCaseUnblockFixCore
- add new logic to QuickAssistProcessor
- add new tests to AssistQuickFixTest14
- fixes #3012

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
