### PR TITLE
Fix inlining to not cast to type variable type

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/CallInliner.java
@@ -1040,7 +1040,7 @@ public class CallInliner {
 			return ASTNodes.isTargetAmbiguous((Expression) fTargetNode, parameterType);
 		} else {
 			ITypeBinding explicitCast= ASTNodes.getExplicitCast(returnExprs.get(0), (Expression)fTargetNode);
-			return explicitCast != null;
+			return explicitCast != null && !explicitCast.isTypeVariable();
 		}
 	}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineConstantRefactoring.java
@@ -530,7 +530,7 @@ public class InlineConstantRefactoring extends Refactoring {
 
 			AST ast= fCuRewrite.getAST();
 			ITypeBinding explicitCast= ASTNodes.getExplicitCast(fInitializer, reference);
-			if (explicitCast != null) {
+			if (explicitCast != null && !explicitCast.isTypeVariable()) {
 				CastExpression cast= ast.newCastExpression();
 				Expression modifiedInitializerExpr= (Expression) fCuRewrite.getASTRewrite().createStringPlaceholder(modifiedInitializer, reference.getNodeType());
 				if (NecessaryParenthesesChecker.needsParentheses(fInitializer, cast, CastExpression.EXPRESSION_PROPERTY)) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/InlineTempRefactoring.java
@@ -524,7 +524,7 @@ public class InlineTempRefactoring extends Refactoring {
 		}
 
 		ITypeBinding explicitCast= ASTNodes.getExplicitCast(initializer, reference);
-		if (explicitCast != null) {
+		if (explicitCast != null && !explicitCast.isTypeVariable()) {
 			CastExpression cast= ast.newCastExpression();
 			if (NecessaryParenthesesChecker.needsParentheses(copy, cast, CastExpression.EXPRESSION_PROPERTY)) {
 				ParenthesizedExpression parenthesized= ast.newParenthesizedExpression();

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceProvider.java
@@ -495,7 +495,7 @@ public class SourceProvider {
 					Expression newExpression= (Expression)rewriter.createStringPlaceholder(expressionString, expression.getNodeType());
 					AST ast= rewriter.getAST();
 					ITypeBinding explicitCast= ASTNodes.getExplicitCast(expression, (Expression)element);
-					if (explicitCast != null) {
+					if (explicitCast != null && !explicitCast.isTypeVariable()) {
 						CastExpression cast= ast.newCastExpression();
 						if (NecessaryParenthesesChecker.needsParentheses(expression, cast, CastExpression.EXPRESSION_PROPERTY)) {
 							newExpression= createParenthesizedExpression(newExpression, ast);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/cast_in/TestNoCast2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/cast_in/TestNoCast2.java
@@ -1,0 +1,15 @@
+package cast_in;
+
+public class TestNoCast2 {
+	public static void main(String[] args) {
+		new TestNoCast2().test();
+	}
+
+	void test() {
+		/*]*/print/*[*/(1); // inline this call
+	}
+
+	<T> void print(T item) { // inline this method
+		System.out.println(item);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/cast_out/TestNoCast2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/cast_out/TestNoCast2.java
@@ -1,0 +1,15 @@
+package cast_in;
+
+public class TestNoCast2 {
+	public static void main(String[] args) {
+		new TestNoCast2().test();
+	}
+
+	void test() {
+		/*]*/System.out.println(1); // inline this call
+	}
+
+	<T> void print(T item) { // inline this method
+		System.out.println(item);
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -1177,6 +1177,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void testNoCast2() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3019
+		performCastTest();
+	}
+
+	@Test
 	public void testInfixExpression1() throws Exception {
 		performCastTest();
 	}


### PR DESCRIPTION
- modify CallInliner, InlineTempRefactoring and SourceProvider to check result of ASTNodes.getExplicitCast() method and do not use if it is a type variable casting
- add new test to InlineMethodTests
- fixes #3019

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
