### PR TITLE
Add checks for type modifiers in SourceAnalyzer

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -398,7 +398,7 @@ class SourceAnalyzer  {
 						if (declClass == null || declClass.isLocal()) {
 							return true;
 						}
-					} else {
+					} else if (!(binding instanceof ITypeBinding)) {
 						return true;
 					}
 				}

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -200,9 +200,9 @@ InlineMethodRefactoring_checking_implements_error= Method to be inlined implemen
 
 InlineMethodRefactoring_SourceAnalyzer_recursive_call=Method declaration contains recursive call.
 InlineMethodRefactoring_SourceAnalyzer_native_methods=Cannot inline native methods
-InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_package_private=The method declaration references at least one package-private member that would be inaccessible after inlining.
-InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_private=The method declaration references at least one private member that would be inaccessible after inlining.
-InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_protected=The method declaration references at least one protected member that would be inaccessible after inlining.
+InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_package_private=The method declaration references at least one package-private member or class that would be inaccessible after inlining.
+InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_private=The method declaration references at least one private member or class that would be inaccessible after inlining.
+InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_accesses_protected=The method declaration references at least one protected member or class that would be inaccessible after inlining.
 InlineMethodRefactoring_SourceAnalyzer_declaration_has_errors=The method declaration contains compile errors. To perform the operation you will need to fix the errors.
 InlineMethodRefactoring_SourceAnalyzer_typedeclaration_has_errors=The type declaration contains compile errors. To perform the operation you will need to fix the errors.
 InlineMethodRefactoring_SourceAnalyzer_methoddeclaration_has_errors=The method declaration contains compile errors. To perform the operation you will need to fix the errors.

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/TestPrivateEnum.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/TestPrivateEnum.java
@@ -1,0 +1,18 @@
+package invalid;
+
+class A1 {
+	private enum Day {
+		MONDAY
+	}
+
+	int /*]*/getVal/*[*/() { // inline this method
+		return Day.MONDAY.ordinal();
+	}
+}
+
+
+public class TestPrivateEnum {
+	public static void main(String[] args) {
+		System.out.println(new A1().getVal()); // inline this call
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -190,6 +190,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void testPrivateEnum() throws Exception {
+		performInvalidTest();
+	}
+
+	@Test
 	public void testCompileError1() throws Exception {
 		performInvalidTest();
 	}


### PR DESCRIPTION
- modify SourceAnalyzer.AccessAnalyzer to also check access of type bindings
- add new test to InlineMethodTests
- fixes #3021

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
