### PR TITLE
Fix access checking for inlined code to include constructor calls

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -382,6 +382,16 @@ class SourceAnalyzer  {
 		@Override
 		public boolean visit(SimpleName node) {
 			IBinding binding= node.resolveBinding();
+			return checkBindingAccess(binding);
+		}
+
+		@Override
+		public boolean visit(ClassInstanceCreation node) {
+			IBinding binding= node.resolveConstructorBinding();
+			return checkBindingAccess(binding);
+		}
+
+		private boolean checkBindingAccess(IBinding binding) {
 			if (binding != null) {
 				int modifiers= binding.getModifiers();
 				boolean isPublic= Modifier.isPublic(modifiers);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/TestPrivateConstructor.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/invalid/TestPrivateConstructor.java
@@ -1,0 +1,17 @@
+package invalid;
+
+class A1 {
+	private A1() {
+	}
+
+	public static A1 /*]*/create/*[*/() { // inline this method
+		return new A1();
+	}
+}
+
+
+public class TestPrivateConstructor {
+	public static void main(String[] args) {
+		A1 a1 = A1.create();
+	}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -195,6 +195,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void testPrivateConstructor() throws Exception {
+		performInvalidTest();
+	}
+
+	@Test
 	public void testCompileError1() throws Exception {
 		performInvalidTest();
 	}


### PR DESCRIPTION
- modify SourceAnalyzer.AccessAnalyzer class to also check for constructor calls
- add new test to InlineMethodTests
- fixes #3018

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
