### PR TITLE
Fix Package Explorer View filter not filtering non-archive plug-ins

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filters/LibraryFilter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filters/LibraryFilter.java
@@ -32,18 +32,15 @@ public class LibraryFilter extends ViewerFilter {
 
 	@Override
 	public boolean select(Viewer viewer, Object parentElement, Object element) {
-		if (element instanceof IPackageFragmentRoot) {
-			IPackageFragmentRoot root= (IPackageFragmentRoot)element;
-			if (root.isArchive()) {
-				// don't filter out JARs contained in the project itself
-				IResource resource= root.getResource();
-				if (resource != null) {
-					IProject jarProject= resource.getProject();
-					IProject container= root.getJavaProject().getProject();
-					return container.equals(jarProject);
-				}
-				return false;
+		if (element instanceof IPackageFragmentRoot root) {
+			// don't filter out libraries contained in the project itself
+			IResource resource= root.getResource();
+			if (resource != null) {
+				IProject project= resource.getProject();
+				IProject container= root.getJavaProject().getProject();
+				return container.equals(project);
 			}
+			return false;
 		} else if (element instanceof ClassPathContainer.RequiredProjectWrapper) {
 			return false;
 		}


### PR DESCRIPTION
## What it does
When "Libraries from External" is filtering in Package Explorer it should also filter plug-ins that are not in archive format. This is not happening. This fixes the condition to return false for the filter if the package is a folder so that it is not shown in Package Explorer.

## How to test
See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3029 for steps to reproduce

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
