### PR TITLE
Migrate code generation operations to SubMonitor

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddDelegateMethodsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddDelegateMethodsOperation.java
@@ -21,7 +21,7 @@ import java.util.List;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 import org.eclipse.core.resources.IWorkspaceRunnable;
@@ -48,7 +48,6 @@ import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.util.DelegateEntryComparator;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
-import org.eclipse.jdt.internal.ui.util.Progress;
 
 /**
  * Workspace runnable to add delegate methods.
@@ -153,57 +152,50 @@ public final class AddDelegateMethodsOperation implements IWorkspaceRunnable {
 	 */
 	@Override
 	public void run(IProgressMonitor monitor) throws CoreException {
-		if (monitor == null)
-			monitor= new NullProgressMonitor();
-		try {
-			monitor.beginTask("", 1); //$NON-NLS-1$
-			monitor.setTaskName(CodeGenerationMessages.AddDelegateMethodsOperation_monitor_message);
-			fCreated.clear();
-			ICompilationUnit cu= (ICompilationUnit) fASTRoot.getTypeRoot();
+		SubMonitor subMonitor= SubMonitor.convert(monitor, CodeGenerationMessages.AddDelegateMethodsOperation_monitor_message, 1);
+		fCreated.clear();
+		ICompilationUnit cu= (ICompilationUnit) fASTRoot.getTypeRoot();
 
-			ASTRewrite astRewrite= ASTRewrite.create(fASTRoot.getAST());
-			ImportRewrite importRewrite= StubUtility.createImportRewrite(fASTRoot, true);
+		ASTRewrite astRewrite= ASTRewrite.create(fASTRoot.getAST());
+		ImportRewrite importRewrite= StubUtility.createImportRewrite(fASTRoot, true);
 
-			ITypeBinding parentType= fDelegatesToCreate[0].field.getDeclaringClass();
+		ITypeBinding parentType= fDelegatesToCreate[0].field.getDeclaringClass();
 
-			ASTNode typeDecl= fASTRoot.findDeclaringNode(parentType);
+		ASTNode typeDecl= fASTRoot.findDeclaringNode(parentType);
 
-			ListRewrite listRewriter= null;
-			if (typeDecl instanceof AbstractTypeDeclaration) {
-				listRewriter= astRewrite.getListRewrite(typeDecl, ((AbstractTypeDeclaration) typeDecl).getBodyDeclarationsProperty());
-			} else if (typeDecl instanceof AnonymousClassDeclaration) {
-				listRewriter= astRewrite.getListRewrite(typeDecl, AnonymousClassDeclaration.BODY_DECLARATIONS_PROPERTY);
-			}
+		ListRewrite listRewriter= null;
+		if (typeDecl instanceof AbstractTypeDeclaration) {
+			listRewriter= astRewrite.getListRewrite(typeDecl, ((AbstractTypeDeclaration) typeDecl).getBodyDeclarationsProperty());
+		} else if (typeDecl instanceof AnonymousClassDeclaration) {
+			listRewriter= astRewrite.getListRewrite(typeDecl, AnonymousClassDeclaration.BODY_DECLARATIONS_PROPERTY);
+		}
 
-			if (listRewriter != null) {
-				ASTNode insertion= StubUtility2Core.getNodeToInsertBefore(listRewriter, fInsert);
+		if (listRewriter != null) {
+			ASTNode insertion= StubUtility2Core.getNodeToInsertBefore(listRewriter, fInsert);
 
-				ContextSensitiveImportRewriteContext context= new ContextSensitiveImportRewriteContext(fASTRoot, typeDecl.getStartPosition(), importRewrite);
+			ContextSensitiveImportRewriteContext context= new ContextSensitiveImportRewriteContext(fASTRoot, typeDecl.getStartPosition(), importRewrite);
 
-				Arrays.sort(fDelegatesToCreate, new DelegateEntryComparator());
+			Arrays.sort(fDelegatesToCreate, new DelegateEntryComparator());
 
-				for (DelegateEntry delegateEntry : fDelegatesToCreate) {
-					IMethodBinding delegateMethod= delegateEntry.delegateMethod;
-					IVariableBinding field= delegateEntry.field;
-					MethodDeclaration newMethod= StubUtility2Core.createDelegationStub(cu, astRewrite, importRewrite, context, delegateMethod, field, fSettings);
-					if (newMethod != null) {
-						fCreated.add(delegateMethod);
-						if (insertion != null && insertion.getParent() == typeDecl)
-							listRewriter.insertBefore(newMethod, insertion, null);
-						else
-							listRewriter.insertLast(newMethod, null);
-					}
-				}
-				fResultingEdit= new MultiTextEdit();
-				fResultingEdit.addChild(astRewrite.rewriteAST());
-				fResultingEdit.addChild(importRewrite.rewriteImports(Progress.subMonitor(monitor, 1)));
-
-				if (fApply) {
-					JavaModelUtil.applyEdit(cu, fResultingEdit, fSave, Progress.subMonitor(monitor, 1));
+			for (DelegateEntry delegateEntry : fDelegatesToCreate) {
+				IMethodBinding delegateMethod= delegateEntry.delegateMethod;
+				IVariableBinding field= delegateEntry.field;
+				MethodDeclaration newMethod= StubUtility2Core.createDelegationStub(cu, astRewrite, importRewrite, context, delegateMethod, field, fSettings);
+				if (newMethod != null) {
+					fCreated.add(delegateMethod);
+					if (insertion != null && insertion.getParent() == typeDecl)
+						listRewriter.insertBefore(newMethod, insertion, null);
+					else
+						listRewriter.insertLast(newMethod, null);
 				}
 			}
-		} finally {
-			monitor.done();
+			fResultingEdit= new MultiTextEdit();
+			fResultingEdit.addChild(astRewrite.rewriteAST());
+			fResultingEdit.addChild(importRewrite.rewriteImports(subMonitor.split(1)));
+
+			if (fApply) {
+				JavaModelUtil.applyEdit(cu, fResultingEdit, fSave, subMonitor.split(1));
+			}
 		}
 	}
 }

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddUnimplementedConstructorsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddUnimplementedConstructorsOperation.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 import org.eclipse.core.resources.IWorkspaceRunnable;
@@ -52,7 +52,6 @@ import org.eclipse.jdt.internal.core.manipulation.StubUtility;
 import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.internal.ui.preferences.JavaPreferencesSettings;
-import org.eclipse.jdt.internal.ui.util.Progress;
 
 /**
  * Workspace runnable to add unimplemented constructors.
@@ -210,77 +209,70 @@ public final class AddUnimplementedConstructorsOperation implements IWorkspaceRu
 	 */
 	@Override
 	public void run(IProgressMonitor monitor) throws CoreException {
-		if (monitor == null)
-			monitor= new NullProgressMonitor();
-		try {
-			monitor.beginTask("", 2); //$NON-NLS-1$
-			monitor.setTaskName(CodeGenerationMessages.AddUnimplementedMethodsOperation_description);
-			fCreatedMethods.clear();
-			ICompilationUnit cu= (ICompilationUnit) fASTRoot.getJavaElement();
+		SubMonitor subMonitor= SubMonitor.convert(monitor, CodeGenerationMessages.AddUnimplementedMethodsOperation_description, 2);
+		fCreatedMethods.clear();
+		ICompilationUnit cu= (ICompilationUnit) fASTRoot.getJavaElement();
 
-			AST ast= fASTRoot.getAST();
+		AST ast= fASTRoot.getAST();
 
-			ASTRewrite astRewrite= ASTRewrite.create(ast);
-			ImportRewrite importRewrite= StubUtility.createImportRewrite(fASTRoot, true);
+		ASTRewrite astRewrite= ASTRewrite.create(ast);
+		ImportRewrite importRewrite= StubUtility.createImportRewrite(fASTRoot, true);
 
-			ITypeBinding currTypeBinding= fType;
-			ListRewrite memberRewriter= null;
+		ITypeBinding currTypeBinding= fType;
+		ListRewrite memberRewriter= null;
 
-			ASTNode node= fASTRoot.findDeclaringNode(currTypeBinding);
-			if (node instanceof AnonymousClassDeclaration) {
-				memberRewriter= astRewrite.getListRewrite(node, AnonymousClassDeclaration.BODY_DECLARATIONS_PROPERTY);
-			} else if (node instanceof AbstractTypeDeclaration) {
-				ChildListPropertyDescriptor property= ((AbstractTypeDeclaration) node).getBodyDeclarationsProperty();
-				memberRewriter= astRewrite.getListRewrite(node, property);
-			} else {
-				throw new IllegalArgumentException();
-				// not possible, we checked this in the constructor
+		ASTNode node= fASTRoot.findDeclaringNode(currTypeBinding);
+		if (node instanceof AnonymousClassDeclaration) {
+			memberRewriter= astRewrite.getListRewrite(node, AnonymousClassDeclaration.BODY_DECLARATIONS_PROPERTY);
+		} else if (node instanceof AbstractTypeDeclaration) {
+			ChildListPropertyDescriptor property= ((AbstractTypeDeclaration) node).getBodyDeclarationsProperty();
+			memberRewriter= astRewrite.getListRewrite(node, property);
+		} else {
+			throw new IllegalArgumentException();
+			// not possible, we checked this in the constructor
+		}
+
+		final CodeGenerationSettings settings= JavaPreferencesSettings.getCodeGenerationSettings(cu);
+		settings.createComments= fCreateComments;
+
+		ASTNode insertion= getNodeToInsertBefore(memberRewriter);
+
+		IMethodBinding[] toImplement= fConstructorsToImplement;
+		if (toImplement == null) {
+			toImplement= StubUtility2Core.getVisibleConstructors(currTypeBinding, true, true);
+		}
+
+		int deprecationCount= 0;
+		for (IMethodBinding curr : toImplement) {
+			if (curr.isDeprecated()) {
+				deprecationCount++;
 			}
-
-			final CodeGenerationSettings settings= JavaPreferencesSettings.getCodeGenerationSettings(cu);
-			settings.createComments= fCreateComments;
-
-			ASTNode insertion= getNodeToInsertBefore(memberRewriter);
-
-			IMethodBinding[] toImplement= fConstructorsToImplement;
-			if (toImplement == null) {
-				toImplement= StubUtility2Core.getVisibleConstructors(currTypeBinding, true, true);
-			}
-
-			int deprecationCount= 0;
-			for (IMethodBinding curr : toImplement) {
-				if (curr.isDeprecated()) {
-					deprecationCount++;
+		}
+		boolean createDeprecated= deprecationCount == toImplement.length;
+		for (IMethodBinding curr : toImplement) {
+			if (!curr.isDeprecated() || createDeprecated) {
+				ImportRewriteContext context= new ContextSensitiveImportRewriteContext(node, importRewrite);
+				MethodDeclaration stub= StubUtility2Core.createConstructorStub(cu, astRewrite, importRewrite, context, curr, currTypeBinding.getName(), fVisibility, fOmitSuper, true, settings, fFormatSettings);
+				if (stub != null) {
+					fCreatedMethods.add(curr.getKey());
+					if (insertion != null)
+						memberRewriter.insertBefore(stub, insertion, null);
+					else
+						memberRewriter.insertLast(stub, null);
 				}
 			}
-			boolean createDeprecated= deprecationCount == toImplement.length;
-			for (IMethodBinding curr : toImplement) {
-				if (!curr.isDeprecated() || createDeprecated) {
-					ImportRewriteContext context= new ContextSensitiveImportRewriteContext(node, importRewrite);
-					MethodDeclaration stub= StubUtility2Core.createConstructorStub(cu, astRewrite, importRewrite, context, curr, currTypeBinding.getName(), fVisibility, fOmitSuper, true, settings, fFormatSettings);
-					if (stub != null) {
-						fCreatedMethods.add(curr.getKey());
-						if (insertion != null)
-							memberRewriter.insertBefore(stub, insertion, null);
-						else
-							memberRewriter.insertLast(stub, null);
-					}
-				}
-			}
-			fResultingEdit= new MultiTextEdit();
+		}
+		fResultingEdit= new MultiTextEdit();
 
-			TextEdit importEdits= importRewrite.rewriteImports(Progress.subMonitor(monitor, 1));
-			fCreatedImports= importRewrite.getCreatedImports();
-			if (fImports) {
-				fResultingEdit.addChild(importEdits);
-			}
-			fResultingEdit.addChild(astRewrite.rewriteAST());
+		TextEdit importEdits= importRewrite.rewriteImports(subMonitor.split(1));
+		fCreatedImports= importRewrite.getCreatedImports();
+		if (fImports) {
+			fResultingEdit.addChild(importEdits);
+		}
+		fResultingEdit.addChild(astRewrite.rewriteAST());
 
-			if (fApply) {
-				JavaModelUtil.applyEdit(cu, fResultingEdit, fSave, Progress.subMonitor(monitor, 1));
-			}
-		} finally {
-			monitor.done();
+		if (fApply) {
+			JavaModelUtil.applyEdit(cu, fResultingEdit, fSave, subMonitor.split(1));
 		}
 	}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/GenerateHashCodeEqualsOperation.java
@@ -26,8 +26,8 @@ import java.util.List;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 import org.eclipse.core.resources.IWorkspaceRunnable;
@@ -313,62 +313,55 @@ public final class GenerateHashCodeEqualsOperation implements IWorkspaceRunnable
 	 */
 	@Override
 	public void run(IProgressMonitor monitor) throws CoreException {
-		if (monitor == null)
-			monitor= new NullProgressMonitor();
-		try {
-			monitor.beginTask("", 1); //$NON-NLS-1$
-			monitor.setTaskName(CodeGenerationMessages.GenerateHashCodeEqualsOperation_description);
+		SubMonitor subMonitor= SubMonitor.convert(monitor, CodeGenerationMessages.GenerateHashCodeEqualsOperation_description, 1);
 
-			fCustomHashCodeTypes.clear();
+		fCustomHashCodeTypes.clear();
 
-			// get the declaration and the rewrite
-			AbstractTypeDeclaration declaration= (AbstractTypeDeclaration) ASTNodes.findDeclaration(fType, fRewrite.getRoot());
-			ListRewrite rewriter= fRewrite.getASTRewrite().getListRewrite(declaration, declaration.getBodyDeclarationsProperty());
-			List<BodyDeclaration> list= declaration.bodyDeclarations();
-			if (fType != null && rewriter != null) {
+		// get the declaration and the rewrite
+		AbstractTypeDeclaration declaration= (AbstractTypeDeclaration) ASTNodes.findDeclaration(fType, fRewrite.getRoot());
+		ListRewrite rewriter= fRewrite.getASTRewrite().getListRewrite(declaration, declaration.getBodyDeclarationsProperty());
+		List<BodyDeclaration> list= declaration.bodyDeclarations();
+		if (fType != null && rewriter != null) {
 
-				ICompilationUnit cu= (ICompilationUnit) fUnit.getJavaElement();
+			ICompilationUnit cu= (ICompilationUnit) fUnit.getJavaElement();
 
-				ASTNode insertion= StubUtility2Core.getNodeToInsertBefore(rewriter, fInsert);
+			ASTNode insertion= StubUtility2Core.getNodeToInsertBefore(rewriter, fInsert);
 
-				// equals(..)
-				ITypeBinding[] objectAsParam= { declaration.getAST().resolveWellKnownType(JAVA_LANG_OBJECT) };
-				BodyDeclaration oldEquals= fForce ? findMethodToReplace(list, METHODNAME_EQUALS, objectAsParam) : null;
+			// equals(..)
+			ITypeBinding[] objectAsParam= { declaration.getAST().resolveWellKnownType(JAVA_LANG_OBJECT) };
+			BodyDeclaration oldEquals= fForce ? findMethodToReplace(list, METHODNAME_EQUALS, objectAsParam) : null;
 
-				fImportRewriteContext= new ContextSensitiveImportRewriteContext(declaration, fRewrite.getImportRewrite());
-				MethodDeclaration equalsMethod= createEqualsMethod();
-				addMethod(rewriter, insertion, equalsMethod, oldEquals);
+			fImportRewriteContext= new ContextSensitiveImportRewriteContext(declaration, fRewrite.getImportRewrite());
+			MethodDeclaration equalsMethod= createEqualsMethod();
+			addMethod(rewriter, insertion, equalsMethod, oldEquals);
 
-				if (monitor.isCanceled())
-					throw new OperationCanceledException();
+			if (subMonitor.isCanceled())
+				throw new OperationCanceledException();
 
-				// hashCode()
-				BodyDeclaration oldHash= fForce ? findMethodToReplace(list, METHODNAME_HASH_CODE, new ITypeBinding[0]) : null;
+			// hashCode()
+			BodyDeclaration oldHash= fForce ? findMethodToReplace(list, METHODNAME_HASH_CODE, new ITypeBinding[0]) : null;
 
-				MethodDeclaration hashCodeMethod= createHashCodeMethod();
-				addMethod(rewriter, equalsMethod, hashCodeMethod, oldHash);
+			MethodDeclaration hashCodeMethod= createHashCodeMethod();
+			addMethod(rewriter, equalsMethod, hashCodeMethod, oldHash);
 
-				// helpers
-				for (ITypeBinding binding : fCustomHashCodeTypes) {
-					if (findMethodToReplace(list, METHODNAME_HASH_CODE, objectAsParam) == null) {
-						final MethodDeclaration helperDecl= createHashCodeHelper(binding);
-						addHelper(rewriter, null, helperDecl);
-					}
+			// helpers
+			for (ITypeBinding binding : fCustomHashCodeTypes) {
+				if (findMethodToReplace(list, METHODNAME_HASH_CODE, objectAsParam) == null) {
+					final MethodDeclaration helperDecl= createHashCodeHelper(binding);
+					addHelper(rewriter, null, helperDecl);
 				}
-
-				if (isMemberType()) {
-					if (findMethodToReplace(list, METHODNAME_GET_ENCLOSING_INSTANCE, new ITypeBinding[0]) == null) {
-						final MethodDeclaration helperDecl= createGetEnclosingInstanceHelper();
-						rewriter.insertLast(helperDecl, null);
-					}
-				}
-
-				fEdit= fRewrite.createChange(true).getEdit();
-				if (fApply)
-					JavaModelUtil.applyEdit(cu, fEdit, fSave, monitor);
 			}
-		} finally {
-			monitor.done();
+
+			if (isMemberType()) {
+				if (findMethodToReplace(list, METHODNAME_GET_ENCLOSING_INSTANCE, new ITypeBinding[0]) == null) {
+					final MethodDeclaration helperDecl= createGetEnclosingInstanceHelper();
+					rewriter.insertLast(helperDecl, null);
+				}
+			}
+
+			fEdit= fRewrite.createChange(true).getEdit();
+			if (fApply)
+				JavaModelUtil.applyEdit(cu, fEdit, fSave, subMonitor.split(1));
 		}
 	}
 

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/GenerateToStringOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/tostringgeneration/GenerateToStringOperation.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 
 import org.eclipse.core.resources.IWorkspaceRunnable;
@@ -88,39 +88,31 @@ public class GenerateToStringOperation implements IWorkspaceRunnable {
 
 	@Override
 	public void run(IProgressMonitor monitor) throws CoreException {
-		if (monitor == null)
-			monitor= new NullProgressMonitor();
-		try {
-			monitor.beginTask("", 1); //$NON-NLS-1$
-			monitor.setTaskName(CodeGenerationMessages.GenerateToStringOperation_description);
+		SubMonitor subMonitor= SubMonitor.convert(monitor, CodeGenerationMessages.GenerateToStringOperation_description, 1);
 
 
-			AbstractTypeDeclaration declaration= (AbstractTypeDeclaration)ASTNodes.findDeclaration(fContext.getTypeBinding(), fRewrite.getRoot());
-			ListRewrite rewriter= fRewrite.getASTRewrite().getListRewrite(declaration, declaration.getBodyDeclarationsProperty());
-			if (fContext.getTypeBinding() != null && rewriter != null) {
+		AbstractTypeDeclaration declaration= (AbstractTypeDeclaration)ASTNodes.findDeclaration(fContext.getTypeBinding(), fRewrite.getRoot());
+		ListRewrite rewriter= fRewrite.getASTRewrite().getListRewrite(declaration, declaration.getBodyDeclarationsProperty());
+		if (fContext.getTypeBinding() != null && rewriter != null) {
 
-				MethodDeclaration toStringMethod= fGenerator.generateToStringMethod();
+			MethodDeclaration toStringMethod= fGenerator.generateToStringMethod();
 
-				List<BodyDeclaration> list= declaration.bodyDeclarations();
-				BodyDeclaration replace= findMethodToReplace(list, toStringMethod);
-				if (replace == null || ((Boolean)toStringMethod.getProperty(AbstractToStringGenerator.OVERWRITE_METHOD_PROPERTY)).booleanValue())
-					insertMethod(toStringMethod, rewriter, replace);
+			List<BodyDeclaration> list= declaration.bodyDeclarations();
+			BodyDeclaration replace= findMethodToReplace(list, toStringMethod);
+			if (replace == null || ((Boolean)toStringMethod.getProperty(AbstractToStringGenerator.OVERWRITE_METHOD_PROPERTY)).booleanValue())
+				insertMethod(toStringMethod, rewriter, replace);
 
-				for (MethodDeclaration method : fGenerator.generateHelperMethods()) {
-					replace= findMethodToReplace(list, method);
-					if (replace == null || ((Boolean)method.getProperty(AbstractToStringGenerator.OVERWRITE_METHOD_PROPERTY)).booleanValue()) {
-						insertMethod(method, rewriter, replace);
-					}
-				}
-
-				fEdit= fRewrite.createChange(true).getEdit();
-				if (fApply) {
-					JavaModelUtil.applyEdit((ICompilationUnit)fUnit.getJavaElement(), fEdit, fSave, monitor);
+			for (MethodDeclaration method : fGenerator.generateHelperMethods()) {
+				replace= findMethodToReplace(list, method);
+				if (replace == null || ((Boolean)method.getProperty(AbstractToStringGenerator.OVERWRITE_METHOD_PROPERTY)).booleanValue()) {
+					insertMethod(method, rewriter, replace);
 				}
 			}
 
-		} finally {
-			monitor.done();
+			fEdit= fRewrite.createChange(true).getEdit();
+			if (fApply) {
+				JavaModelUtil.applyEdit((ICompilationUnit)fUnit.getJavaElement(), fEdit, fSave, subMonitor.split(1));
+			}
 		}
 	}
 


### PR DESCRIPTION
Replaces the raw `IProgressMonitor` begin/done lifecycle and the `Progress.subMonitor` helper with `SubMonitor.convert` and `split` in four code generation operations: `AddDelegateMethodsOperation`, `AddUnimplementedConstructorsOperation`, `GenerateHashCodeEqualsOperation` and `GenerateToStringOperation`.

`SubMonitor.convert` handles null monitors and cleanup, so the explicit null guards and `done()` calls are no longer needed. This follows the canonical pattern from the Eclipse Progress Monitors article and continues the SubProgressMonitor/SubMonitor cleanup.

Builds cleanly and the dedicated source-action test suites (GenerateHashCodeEquals, AddUnimplementedConstructors, GenerateDelegateMethods, GenerateToString; 114 tests) pass.