### PR TITLE
Fix Simplify if/else to single return if possible clean-up

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SimplifyBooleanIfElseCleanUpCore.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/ui/fix/SimplifyBooleanIfElseCleanUpCore.java
@@ -108,6 +108,8 @@ public class SimplifyBooleanIfElseCleanUpCore extends AbstractMultiFix {
 		if (thenStatement instanceof ReturnStatement returnStatement) {
 			if (returnStatement.getExpression() instanceof BooleanLiteral literal) {
 				thenValue= literal.booleanValue();
+			} else {
+				return SimplifyStatus.INVALID;
 			}
 		} else if (thenStatement instanceof Block block && block.statements().size() == 1
 				&& block.statements().get(0) instanceof ReturnStatement returnStatement) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/CleanUpTest.java
@@ -16879,6 +16879,7 @@ public class CleanUpTest extends CleanUpTestCase {
 			package test1;
 
 			public class E {
+				String text;
 			    public boolean doNotSimplifyIfBooleanSame(int x) {
 			        if (x > 0 && x < 7) {
 			            return true;
@@ -16910,6 +16911,13 @@ public class CleanUpTest extends CleanUpTestCase {
 				    } else {
 				        return 2;
 				    }
+				}
+
+				public boolean doNotSimplifyInfixExpression(Integer x) {
+					if (text != null)
+						return text.length() > 43;
+					else
+						return false;
 				}
 			}
 		    """;


### PR DESCRIPTION
- do not perform clean-up if the then statement is not a boolean literal
- add new test to CleanUpTest
- fixes #3020

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
