### PR TITLE
Support compact record constructors in StubUtility2Core

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/StubUtility2Core.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2025 IBM Corporation and others.
+ * Copyright (c) 2018, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -272,6 +272,10 @@ public final class StubUtility2Core {
 		decl.modifiers().addAll(ASTNodeFactory.newModifiers(ast, modifiers & ~Modifier.ABSTRACT & ~Modifier.NATIVE));
 		decl.setName(ast.newSimpleName(typeBinding.getName()));
 		decl.setConstructor(true);
+		if(typeBinding.isRecord()) {
+			decl.setCompactConstructor(true);
+		}
+
 
 		List<SingleVariableDeclaration> parameters= decl.parameters();
 		if (superConstructor != null) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateConstructorUsingFieldsTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateConstructorUsingFieldsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -97,7 +97,7 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 		runOperation(type, fields, superConstructor, null, true, false, Modifier.PUBLIC);
 	}
 
-	private IMethodBinding getObjectConstructor(CompilationUnit compilationUnit) {
+	public static IMethodBinding getObjectConstructor(CompilationUnit compilationUnit) {
 		final ITypeBinding binding= compilationUnit.getAST().resolveWellKnownType("java.lang.Object"); //$NON-NLS-1$
 		return Bindings.findMethodInType(binding, "Object", new ITypeBinding[0]); //$NON-NLS-1$
 	}
@@ -729,7 +729,7 @@ public class GenerateConstructorUsingFieldsTest extends SourceTestCase {
 	public void insertAt1() throws Exception {
 		String originalContent= """
 			package p;
-			
+
 			public class A  {
 				int x;
 			\t

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateRecordConstructorTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GenerateRecordConstructorTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.core.source;
+
+import java.lang.reflect.Modifier;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+
+import org.eclipse.jdt.internal.corext.codemanipulation.AddCustomConstructorOperation;
+import org.eclipse.jdt.internal.corext.dom.ASTNodes;
+import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
+import org.eclipse.jdt.internal.corext.refactoring.util.RefactoringASTParser;
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
+
+public class GenerateRecordConstructorTest extends SourceTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws CoreException {
+		super.setUp();
+		JavaProjectHelper.set17CompilerOptions(fJavaProject, false);
+	}
+
+	public void runOperation(IType type, boolean createComments, boolean omitSuper, int visibility) throws CoreException {
+
+		RefactoringASTParser parser= new RefactoringASTParser(IASTSharedValues.SHARED_AST_LEVEL);
+		CompilationUnit unit= parser.parse(type.getCompilationUnit(), true);
+		ITypeBinding typeBinding= ASTNodes.getTypeBinding(unit, type);
+		IMethodBinding constructorToInvoke= GenerateConstructorUsingFieldsTest.getObjectConstructor(unit);
+
+		fSettings.createComments= createComments;
+
+		AddCustomConstructorOperation op= new AddCustomConstructorOperation(unit, typeBinding, new IVariableBinding[] {}, constructorToInvoke, null, fSettings, true, true);
+		op.setOmitSuper(omitSuper);
+		op.setVisibility(visibility);
+
+		op.run(new NullProgressMonitor());
+		JavaModelUtil.reconcile(type.getCompilationUnit());
+	}
+
+	@Test
+	public void testGenerateCompactConstructorForRecord() throws Exception {
+
+		ICompilationUnit cu= fPackageP.createCompilationUnit(
+				"InnerApp4.java",
+				"""
+						package p;
+
+						public record InnerApp4(int p) {
+						}
+						""",
+				true,
+				null);
+
+		IType type= cu.getType("InnerApp4");
+
+		runOperation(type, true, true, Modifier.PUBLIC);
+
+		compareSource("""
+				package p;
+
+				public record InnerApp4(int p) {
+
+					/**
+					 *\s
+					 */
+					public InnerApp4 {
+					}
+				}
+				""", cu.getSource());
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -31,7 +31,8 @@ GenerateDelegateMethodsTest16.class,
 AddUnimplementedConstructorsTest.class,
 GenerateConstructorUsingFieldsTest.class,
 GenerateHashCodeEqualsTest.class,
-GenerateToStringTest.class
+GenerateToStringTest.class,
+GenerateRecordConstructorTest.class
 })
 public class SourceActionTests {
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceTestCase.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceTestCase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -48,7 +48,7 @@ public class SourceTestCase {
 	@Rule
 	public TestName tn=new TestName();
 
-	private IJavaProject fJavaProject;
+	protected IJavaProject fJavaProject;
 
 	protected IPackageFragment fPackageP;
 


### PR DESCRIPTION
Add support for generating compact constructors for Java records in StubUtility2Core#createConstructorStub

part of https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3813

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
