### PR TITLE
Fix Package Explorer View filter not filtering non-archive plug-ins part 2

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filters/ContainedLibraryFilter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filters/ContainedLibraryFilter.java
@@ -30,16 +30,13 @@ public class ContainedLibraryFilter extends ViewerFilter {
 
 	@Override
 	public boolean select(Viewer viewer, Object parentElement, Object element) {
-		if (element instanceof IPackageFragmentRoot) {
-			IPackageFragmentRoot root= (IPackageFragmentRoot)element;
-			if (root.isArchive()) {
-				// don't filter out JARs contained in the project itself
-				IResource resource= root.getResource();
-				if (resource != null) {
-					IProject jarProject= resource.getProject();
-					IProject container= root.getJavaProject().getProject();
-					return !container.equals(jarProject);
-				}
+		if (element instanceof IPackageFragmentRoot root) {
+			// don't filter out libraries contained in the project itself
+			IResource resource= root.getResource();
+			if (resource != null) {
+				IProject project= resource.getProject();
+				IProject container= root.getJavaProject().getProject();
+				return !container.equals(project);
 			}
 		}
 		return true;


### PR DESCRIPTION
## What it does
This is a follow up to https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/3032 but for the "Libraries in project" filter. When "Libraries in project" is filtering in Package Explorer it should also filter plug-ins that are not in archive format.

The fix is the same as for https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/3032

## How to test
See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3029 for steps to reproduce but use the filter "Libraries in project"

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
