### PR TITLE
Add icons to Navigate menu actions for Type Hierarchy, Call Hierarchy, Javadoc, Go To Package and Go To Type

### DIFF
--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -2443,6 +2443,7 @@
             id="org.eclipse.jdt.ui.JavaActionSet">
          <action
                definitionId="org.eclipse.jdt.ui.navigate.open.type.in.hierarchy"
+               icon="$nl$/icons/full/eview16/class_hi.svg"
                label="%OpenTypeInHierarchyAction.label"
                helpContextId="org.eclipse.jdt.ui.open_type_in_hierarchy_action"
                tooltip="%OpenTypeInHierarchyAction.tooltip"
@@ -2542,6 +2543,7 @@
          </action>
          <action
                definitionId="org.eclipse.jdt.ui.edit.text.java.open.call.hierarchy"
+               icon="$nl$/icons/full/eview16/call_hierarchy.svg"
                label="%OpenCallHierarchyAction.label"
                retarget="true"
                menubarPath="navigate/open.ext"
@@ -2549,6 +2551,7 @@
          </action>
          <action
                definitionId="org.eclipse.jdt.ui.edit.text.java.open.type.hierarchy"
+               icon="$nl$/icons/full/eview16/class_hi.svg"
                label="%OpenTypeHierarchyAction.label"
                retarget="true"
                menubarPath="navigate/open.ext"
@@ -2641,6 +2644,7 @@
 <!-- =========================================================================== -->
          <action
                definitionId="org.eclipse.jdt.ui.edit.text.java.open.external.javadoc"
+               icon="$nl$/icons/full/eview16/javadoc.svg"
                label="%OpenAttachedJavadocAction.label"
                retarget="true"
                allowLabelUpdate="true"
@@ -2665,6 +2669,7 @@
          </action>
          <action
                definitionId="org.eclipse.jdt.ui.navigate.gotopackage"
+               icon="$nl$/icons/full/eview16/package.svg"
                label="%GoToPackageAction.label"
                retarget="true"
                menubarPath="navigate/goTo/"
@@ -2672,6 +2677,7 @@
          </action>
          <action
                definitionId="org.eclipse.jdt.ui.navigate.gototype"
+               icon="$nl$/icons/full/eview16/types.svg"
                label="%GoToTypeAction.label"
                retarget="true"
                menubarPath="navigate/goTo/"


### PR DESCRIPTION
This change adds icons to six Navigate menu actions that were previously displayed without any visual indicator. These blank entries created an inconsistent experience alongside neighboring menu items that already carry icons.

All icons referenced are pre-existing assets within `org.eclipse.jdt.ui`  - no new files were introduced. The only file changed is `plugin.xml`.

- Open Type Hierarchy      → eview16/class_hi.svg
  (consistent with the Type Hierarchy view tab icon)
- Open Type in Hierarchy  → eview16/class_hi.svg
  (same view is opened)
- Open Call Hierarchy        → eview16/call_hierarchy.svg
  (matches the Call Hierarchy view tab icon)
- Open Attached Javadoc  → eview16/javadoc.svg
  (represents Javadoc as a concept)
- Go To Package                → eview16/package.svg
  (direct match - package icon used consistently throughout the IDE)
- Go To Type                      → eview16/types.svg
  (best available match for navigating to a type)

In Summary 
All icons are pre-existing assets within `org.eclipse.jdt.ui`.
No new icon files were added; only plugin.xml was updated.
