### PR TITLE
Honor record params on creating javadoc with "Generate Javadoc Element"

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/StubUtility.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/StubUtility.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -389,6 +389,14 @@ public class StubUtility {
 			typeParametersNames[i]= typeParameters[i].getElementName();
 		}
 		return typeParametersNames;
+	}
+
+	public static String[] getRecordParameterNames(IField[] recordParameters) {
+		String[] recordParametersNames= new String[recordParameters.length];
+		for (int i= 0; i < recordParameters.length; i++) {
+			recordParametersNames[i]= recordParameters[i].getElementName();
+		}
+		return recordParametersNames;
 	}
 
 	/**

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/AddJavaDocStubOperationTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/AddJavaDocStubOperationTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.core.source;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IType;
+
+import org.eclipse.jdt.internal.corext.codemanipulation.AddJavaDocStubOperation;
+
+
+public class AddJavaDocStubOperationTest extends SourceTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws CoreException {
+		super.setUp();
+		JavaProjectHelper.set17CompilerOptions(fJavaProject, false);
+	}
+
+
+	public void runOperation(IMember[] members) throws CoreException {
+		AddJavaDocStubOperation op= new AddJavaDocStubOperation(members);
+		op.run(new NullProgressMonitor());
+	}
+
+
+	@Test
+	public void testAddJavaDocToSimpleRecord() throws Exception {
+
+		ICompilationUnit cu= fPackageP.createCompilationUnit(
+				"InnerApp4.java",
+				"""
+						package p;
+
+						record InnerApp4<T>(int p) {}
+						""",
+				true,
+				null);
+		IType rec= cu.getTypes()[0];
+		cu.becomeWorkingCopy(new NullProgressMonitor());
+		try {
+			runOperation(new IMember[] { rec });
+			cu.commitWorkingCopy(true, new NullProgressMonitor());
+		} finally {
+			cu.discardWorkingCopy();
+		}
+
+		compareSource("""
+				package p;
+
+				/**
+				 * @param <T>
+				 * @param p
+				 */
+				record InnerApp4<T>(int p) {}
+				""", cu.getSource());
+	}
+
+	@Test
+	public void testAddJavaDocToSimpleRecord2() throws Exception {
+
+		ICompilationUnit cu= fPackageP.createCompilationUnit(
+				"InnerApp4.java",
+				"""
+						package p;
+
+						record InnerApp4<T>(int p, String x) {}
+						""",
+				true,
+				null);
+		IType rec= cu.getTypes()[0];
+		cu.becomeWorkingCopy(new NullProgressMonitor());
+		try {
+			runOperation(new IMember[] { rec });
+			cu.commitWorkingCopy(true, new NullProgressMonitor());
+		} finally {
+			cu.discardWorkingCopy();
+		}
+
+		compareSource("""
+				package p;
+
+				/**
+				 * @param <T>
+				 * @param p
+				 * @param x
+				 */
+				record InnerApp4<T>(int p, String x) {}
+				""", cu.getSource());
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
@@ -32,7 +32,8 @@ AddUnimplementedConstructorsTest.class,
 GenerateConstructorUsingFieldsTest.class,
 GenerateHashCodeEqualsTest.class,
 GenerateToStringTest.class,
-GenerateRecordConstructorTest.class
+GenerateRecordConstructorTest.class,
+AddJavaDocStubOperationTest.class
 })
 public class SourceActionTests {
 }

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddJavaDocStubOperation.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/codemanipulation/AddJavaDocStubOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -72,6 +72,10 @@ public class AddJavaDocStubOperation implements IWorkspaceRunnable {
 
 	private String createTypeComment(IType type, String lineDelimiter) throws CoreException {
 		String[] typeParameterNames= StubUtility.getTypeParameterNames(type.getTypeParameters());
+		if (type.isRecord() && type.getRecordComponents().length > 0) {
+			String[] recordParameterNames= StubUtility.getRecordParameterNames(type.getRecordComponents());
+			return CodeGeneration.getTypeComment(type.getCompilationUnit(), type.getTypeQualifiedName('.'), typeParameterNames,recordParameterNames, lineDelimiter);
+		}
 		return CodeGeneration.getTypeComment(type.getCompilationUnit(), type.getTypeQualifiedName('.'), typeParameterNames, lineDelimiter);
 	}
 


### PR DESCRIPTION
Fixed AddJavaDocStubOperation to properly generate @param tags for record components when creating Javadoc comments for record types.

Before :
<img width="1080" height="608" alt="befre" src="https://github.com/user-attachments/assets/4229b160-151d-4ac8-8316-9ed2d4fbb54d" />

After :
<img width="1080" height="608" alt="aftr" src="https://github.com/user-attachments/assets/4c9dd1d5-f5ce-45b6-b59a-a351f5622206" />



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
