### PR TITLE
Detect renamed junit-platform-console-standalone JARs via the Engine-Version-junit-jupiter manifest attribute

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/util/CoreTestSearchEngine.java
@@ -80,7 +80,6 @@ public class CoreTestSearchEngine {
 	private static final String JUNIT_PLATFORM_SUITE_API_PREFIX= BuildPathSupport.JUNIT_PLATFORM_SUITE_API;
 	private static final String JUNIT_PLATFORM_COMMONS_PREFIX= BuildPathSupport.JUNIT_PLATFORM_COMMONS;
 	private static final String JUNIT_JUPITER_API_PREFIX= BuildPathSupport.JUNIT_JUPITER_API;
-	private static final String JUNIT_PLATFORM_CONSOLE_STANDALONE_PREFIX= "junit-platform-console-standalone"; //$NON-NLS-1$
 	private static final String ENGINE_VERSION_JUNIT_JUPITER= "Engine-Version-junit-jupiter"; //$NON-NLS-1$
 	private static final String SPECIFICATION_VERSION= "Specification-Version"; //$NON-NLS-1$
 	private static final String JAR_EXTENSION= ".jar"; //$NON-NLS-1$
@@ -224,7 +223,7 @@ public class CoreTestSearchEngine {
 							}
 							if (manifest != null) {
 								Attributes attributes= manifest.getMainAttributes();
-								String versionString= getJUnitVersionFromManifest(filename, attributes);
+								String versionString= getJUnitVersionFromManifest(attributes);
 								if (versionString != null) {
 									version= Version.parseVersion(versionString);
 								}
@@ -252,12 +251,17 @@ public class CoreTestSearchEngine {
 		return false;
 	}
 
-	private static String getJUnitVersionFromManifest(String filename, Attributes attributes) {
-		if (filename.startsWith(JUNIT_PLATFORM_CONSOLE_STANDALONE_PREFIX + "_") || filename.startsWith(JUNIT_PLATFORM_CONSOLE_STANDALONE_PREFIX + "-")) { //$NON-NLS-1$ //$NON-NLS-2$
-			String versionString= attributes.getValue(ENGINE_VERSION_JUNIT_JUPITER);
-			if (versionString != null) {
-				return versionString;
-			}
+	/*
+	 * The junit-platform-console-standalone fat JAR bundles a JUnit Jupiter engine whose version differs from the JUnit
+	 * Platform version reported by {@code Specification-Version}. It is the only JUnit artifact that advertises the bundled
+	 * Jupiter version through the {@code Engine-Version-junit-jupiter} manifest attribute, so prefer that attribute when it
+	 * is present. This works regardless of how the JAR file has been renamed. See
+	 * https://github.com/redhat-developer/vscode-java/issues/4396
+	 */
+	private static String getJUnitVersionFromManifest(Attributes attributes) {
+		String jupiterEngineVersion= attributes.getValue(ENGINE_VERSION_JUNIT_JUPITER);
+		if (jupiterEngineVersion != null) {
+			return jupiterEngineVersion;
 		}
 		return attributes.getValue(SPECIFICATION_VERSION);
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitStandaloneDetectionTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitStandaloneDetectionTest.java
@@ -87,6 +87,34 @@ public class JUnitStandaloneDetectionTest {
 		assertThat(CoreTestSearchEngine.hasJUnit6TestAnnotation(javaProject)).isTrue();
 	}
 
+	@Test
+	public void testDetectJUnit5FromRenamedModuleStyleStandaloneJar() throws Exception {
+		// The standalone JAR is identified through its manifest even when the file is renamed to the
+		// OSGi/module style name, see https://github.com/redhat-developer/vscode-java/issues/4396
+		javaProject= createProjectWithStandaloneJar("org.junit.platform.console.standalone-1.13.4.jar", "1.13.4", "5.13.4");
+
+		assertThat(CoreTestSearchEngine.hasJUnit5TestAnnotation(javaProject)).isTrue();
+		assertThat(CoreTestSearchEngine.hasJUnit6TestAnnotation(javaProject)).isFalse();
+	}
+
+	@Test
+	public void testDetectJUnit6FromRenamedModuleStyleStandaloneJar() throws Exception {
+		javaProject= createProjectWithStandaloneJar("org.junit.platform.console.standalone-6.0.3.jar", "6.0.3", "6.0.3");
+
+		assertThat(CoreTestSearchEngine.hasJUnit5TestAnnotation(javaProject)).isFalse();
+		assertThat(CoreTestSearchEngine.hasJUnit6TestAnnotation(javaProject)).isTrue();
+	}
+
+	@Test
+	public void testDetectJUnit5FromArbitrarilyRenamedStandaloneJar() throws Exception {
+		// Detection must not depend on the file name at all; some users rename the JAR to e.g. junit4.jar,
+		// see https://github.com/redhat-developer/vscode-java/issues/4396
+		javaProject= createProjectWithStandaloneJar("junit4.jar", "1.13.4", "5.13.4");
+
+		assertThat(CoreTestSearchEngine.hasJUnit5TestAnnotation(javaProject)).isTrue();
+		assertThat(CoreTestSearchEngine.hasJUnit6TestAnnotation(javaProject)).isFalse();
+	}
+
 	private static IJavaProject createProjectWithStandaloneJar(String jarName, String specificationVersion, String jupiterVersion) throws Exception {
 		IJavaProject project= JavaProjectHelper.createJavaProject("JUnitStandaloneDetectionTest", "bin");
 		JavaProjectHelper.addRTJar_17(project, false);


### PR DESCRIPTION
## Summary

Follow-up to #2960. The `junit-platform-console-standalone` detection still fails when the standalone fat JAR is **renamed** (which is common, e.g. companies rename it to `junit4.jar`, or it ends up with the OSGi/module-style name `org.junit.platform.console.standalone-1.13.4.jar`).

## Problem

`CoreTestSearchEngine.getJUnitVersionFromManifest()` only reads the bundled `Engine-Version-junit-jupiter` attribute when the **file name** starts with `junit-platform-console-standalone`. For a renamed JAR the check misses and detection falls back to `Specification-Version`, which is the JUnit **Platform** version (e.g. `1.13.4`), not the bundled Jupiter version (e.g. `5.13.4`). The major version is then computed as `1` and the JAR is not recognized as JUnit 5, producing:

> Cannot find 'org.junit.platform.commons.annotation.Testable' on project build path. JUnit 5 tests can only be run if JUnit 5 is on the build path.

This was verified end-to-end against a plain Eclipse project using `org.junit.platform.console.standalone-1.13.4.jar` (the JAR is the official Maven Central artifact, only renamed).

## Fix

Stop relying on the file name entirely. The standalone fat JAR is the only JUnit artifact whose manifest declares `Engine-Version-junit-jupiter`, so that attribute is itself the reliable discriminator: when it is present, use it as the (Jupiter) version; otherwise fall back to `Specification-Version` exactly as before.

```java
private static String getJUnitVersionFromManifest(Attributes attributes) {
    String jupiterEngineVersion= attributes.getValue(ENGINE_VERSION_JUNIT_JUPITER);
    if (jupiterEngineVersion != null) {
        return jupiterEngineVersion;
    }
    return attributes.getValue(SPECIFICATION_VERSION);
}
```

This is robust to any rename and removes the file-name/module/symbolic-name guessing. Non-standalone JARs (e.g. `junit-jupiter-api-*.jar`) do not declare `Engine-Version-junit-jupiter`, so their behavior is unchanged.

## Behavior Matrix

| Scenario | Before | After |
|----------|--------|-------|
| `junit-platform-console-standalone-1.13.4.jar` (Jupiter 5.13.4) | JUnit 5 | JUnit 5 |
| `org.junit.platform.console.standalone-1.13.4.jar` (renamed) | Detected as Platform `1.x`, not JUnit 5 | JUnit 5 |
| `org.junit.platform.console.standalone-6.0.3.jar` (renamed) | not JUnit 6 | JUnit 6 |
| `junit4.jar` (arbitrarily renamed standalone) | not JUnit 5 | JUnit 5 |
| Direct `junit-jupiter-api-*.jar` | Works | Works |

## Tests

Extends `JUnitStandaloneDetectionTest` with renamed-JAR cases: module-style names for both JUnit 5 and JUnit 6, plus an arbitrarily renamed `junit4.jar`.

## Related

- Follow-up of #2960
- Downstream: https://github.com/redhat-developer/vscode-java/issues/4396
