### PR TITLE
Only fold inner types when preference is set #3031

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -784,4 +784,47 @@ public class FoldingTest {
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 10); // if
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 11, 13); // else
 	}
+
+	/**
+	 * See <a href="https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3031">GitHub Issue #3031</a>
+	 */
+	@Test
+	public void testFoldInnerTypesByDefault() throws Exception {
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.EDITOR_FOLDING_INNERTYPES, true);
+
+		String str= """
+				class B { // Should not be folded
+					static class B1 { // Should be folded
+
+					}
+				}
+
+				public class A { // Should not be folded
+					static class A1 { // Should be folded
+					}
+
+					static class A2 { // Should be folded
+						public static void main(String[] args) {
+							Runnable r = new Runnable() { // Should be folded
+								@Override
+								public void run() {
+
+								}
+							};
+						}
+
+					}
+				}
+				""";
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRegionsOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsExpandedRegionUsingStartAndEndLine(regions, str, 0, 4); // class B
+		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 1, 3); // class B1
+		FoldingTestUtils.assertContainsExpandedRegionUsingStartAndEndLine(regions, str, 6, 21); // class A
+		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 7, 8); // class A1
+		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 10, 20); // class A2
+		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 12, 17); // Runnable
+		JavaPlugin.getDefault().getPreferenceStore().setToDefault(PreferenceConstants.EDITOR_FOLDING_INNERTYPES);
+
+	}
 }

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
@@ -41,17 +42,33 @@ import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 public final class FoldingTestUtils {
 	private record StartEnd(int start, int end) {}
 
+	public record ProjectionRegion(IRegion region, boolean collapsed) {}
+
 	private FoldingTestUtils() {
 	}
 
 	public static List<IRegion> getProjectionRangesOfPackage(IPackageFragment packageFragment, String code) throws Exception {
 		ICompilationUnit cu= packageFragment.createCompilationUnit("A.java", code, true, null);
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
-		ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
+		try {
+			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
 
-		List<IRegion> regions= extractRegions(model);
-		editor.close(false);
-		return regions;
+			return extractRegions(model);
+		} finally {
+			editor.close(false);
+		}
+	}
+
+	public static List<ProjectionRegion> getProjectionRegionsOfPackage(IPackageFragment packageFragment, String code) throws Exception {
+		ICompilationUnit cu= packageFragment.createCompilationUnit("A.java", code, true, null);
+		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
+		try {
+			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
+
+			return extractProjectionRegions(model);
+		} finally {
+			editor.close(false);
+		}
 	}
 
 	public static List<IRegion> extractRegions(ProjectionAnnotationModel model) {
@@ -66,6 +83,22 @@ public final class FoldingTestUtils {
 		}
 		assertNoDuplicatedRegions(regions);
 		assertNoRegionsStartInTheSameOffset(regions);
+		return regions;
+	}
+
+	public static List<ProjectionRegion> extractProjectionRegions(ProjectionAnnotationModel model) {
+		List<ProjectionRegion> regions= new ArrayList<>();
+		Iterator<Annotation> it= model.getAnnotationIterator();
+		while (it.hasNext()) {
+			Annotation a= it.next();
+			if (a instanceof ProjectionAnnotation projectionAnnotation) {
+				Position p= model.getPosition(a);
+				regions.add(new ProjectionRegion(new Region(p.getOffset(), p.getLength()), projectionAnnotation.isCollapsed()));
+			}
+		}
+		List<IRegion> projectionRanges= regions.stream().map(ProjectionRegion::region).collect(Collectors.toList());
+		assertNoDuplicatedRegions(projectionRanges);
+		assertNoRegionsStartInTheSameOffset(projectionRanges);
 		return regions;
 	}
 
@@ -111,6 +144,35 @@ public final class FoldingTestUtils {
 	public static void assertContainsRegionUsingStartAndEndLine(List<IRegion> projectionRanges, String input, int startLine, int endLine) {
 		StartEnd startEnd = getStartEnd(input, startLine, endLine);
 		assertContainsRegionWithOffsetAndLength(projectionRanges, startLine, endLine, startEnd.start(), startEnd.end());
+	}
+
+	public static void assertContainsCollapsedRegionUsingStartAndEndLine(List<ProjectionRegion> projectionRanges, String input, int startLine, int endLine) {
+		assertContainsRegionWithCollapsedState(projectionRanges, input, startLine, endLine, true);
+	}
+
+	public static void assertContainsExpandedRegionUsingStartAndEndLine(List<ProjectionRegion> projectionRanges, String input, int startLine, int endLine) {
+		assertContainsRegionWithCollapsedState(projectionRanges, input, startLine, endLine, false);
+	}
+
+	private static void assertContainsRegionWithCollapsedState(List<ProjectionRegion> projectionRanges, String input, int startLine, int endLine, boolean collapsed) {
+		StartEnd startEnd= getStartEnd(input, startLine, endLine);
+		int expectedRegionBegin= startEnd.start();
+		int expectedRegionLength= startEnd.end() - startEnd.start() + 1;
+
+		for (ProjectionRegion projectionRegion : projectionRanges) {
+			IRegion region= projectionRegion.region();
+			if (region.getOffset() == expectedRegionBegin && region.getLength() == expectedRegionLength) {
+				assertEquals(collapsed, projectionRegion.collapsed(),
+						"incorrect collapsed state for region from line " + startLine + " to line " + endLine + " (offset: " + expectedRegionBegin
+								+ ", length: " + expectedRegionLength + ")");
+				return;
+			}
+		}
+
+		fail(
+				"missing region from line " + startLine + " to line " + endLine + " (offset: " + expectedRegionBegin
+						+ ", length: " + expectedRegionLength + ")" +
+						", actual regions: " + sorted(projectionRanges.stream().map(ProjectionRegion::region).collect(Collectors.toList())));
 	}
 
 	private static StartEnd getStartEnd(String input, int startLine, int endLine) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1256,7 +1256,8 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 				collapse= ctx.collapseImportContainer();
 				break;
 			case IJavaElement.TYPE:
-				collapse= ctx.collapseInnerTypes();
+				// only inner types may be collapsed
+				collapse= ctx.collapseInnerTypes() && isInnerType((IType) element);
 				break;
 			case IJavaElement.METHOD:
 			case IJavaElement.FIELD:


### PR DESCRIPTION
## What it does
Avoids folding outer types if the preference **Initially fold these elements > Inner Types** is checked.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3031

## How to test
Use this class:

```java
package plugin;

class B {
	static class B1 {

	}
}

public class A {
	static class A1 {
	}

	static class A2 {
		public static void main(String[] args) {
			Runnable r = new Runnable() {
				// Should be folded
				@Override
				public void run() {

				}
			};
		}

	}
}
``` 

Activate/Deactivate the preference, it should look like this

<img width="745" height="351" alt="image" src="https://github.com/user-attachments/assets/e334746e-39a2-42a7-842c-225e05c78320" />

---

<img width="697" height="415" alt="image" src="https://github.com/user-attachments/assets/03427fce-d59e-4695-a638-63c9638865e2" />


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
