### PR TITLE
Add support for completing a method that returns a type

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/CodeCompletionTest1d8.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/CodeCompletionTest1d8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2025 GK Software AG, IBM Corporation and others.
+ * Copyright (c) 2014, 2026 GK Software AG, IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1280,6 +1280,331 @@ public class CodeCompletionTest1d8 extends AbstractCompletionTest {
 				    }
 				}
 				""";
+			assertEquals(str1, doc.get());
+		} finally {
+			part.getSite().getPage().closeAllEditors(false);
+		}
+	}
+
+	@Test
+	public void testIssue832a() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		String contents= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        K k = new K(3);
+			        k.getThis()
+			    }
+			}
+			""";
+
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", contents, false, null);
+
+		IEditorPart part= JavaUI.openInEditor(cu);
+		try {
+			String str= "k.getThis()";
+
+			int offset= contents.indexOf(str) + str.length();
+
+			CompletionProposalCollector collector= createCollector(cu, offset);
+			collector.setReplacementLength(0);
+
+			codeComplete(cu, offset, collector);
+
+			IJavaCompletionProposal proposal= null;
+
+			for (IJavaCompletionProposal p : collector.getJavaCompletionProposals()) {
+				if (p.getDisplayString().startsWith("l")) {
+					proposal= p;
+				}
+			}
+			assertNotNull("no proposal for l", proposal);
+
+			IDocument doc= JavaUI.getDocumentProvider().getDocument(part.getEditorInput());
+			proposal.apply(doc);
+
+			String str1= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        K k = new K(3);
+			        k.getThis().l
+			    }
+			}
+			""";
+			assertEquals(str1, doc.get());
+		} finally {
+			part.getSite().getPage().closeAllEditors(false);
+		}
+	}
+	@Test
+	public void testIssue832b() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		String contents= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        K k = new K(3);
+			        k.getThis()
+			    }
+			}
+			""";
+
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", contents, false, null);
+
+		IEditorPart part= JavaUI.openInEditor(cu);
+		try {
+			String str= "k.getThis()";
+
+			int offset= contents.indexOf(str) + str.length();
+
+			CompletionProposalCollector collector= createCollector(cu, offset);
+			collector.setReplacementLength(0);
+
+			codeComplete(cu, offset, collector);
+
+			IJavaCompletionProposal proposal= null;
+
+			for (IJavaCompletionProposal p : collector.getJavaCompletionProposals()) {
+				if (p.getDisplayString().startsWith("getString")) {
+					proposal= p;
+				}
+			}
+			assertNotNull("no proposal for getString", proposal);
+
+			IDocument doc= JavaUI.getDocumentProvider().getDocument(part.getEditorInput());
+			proposal.apply(doc);
+
+			String str1= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        K k = new K(3);
+			        k.getThis().getString()
+			    }
+			}
+			""";
+			assertEquals(str1, doc.get());
+		} finally {
+			part.getSite().getPage().closeAllEditors(false);
+		}
+	}
+	@Test
+	public void testIssue832c() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		String contents= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        new K(3)
+			    }
+			}
+			""";
+
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", contents, false, null);
+
+		IEditorPart part= JavaUI.openInEditor(cu);
+		try {
+			String str= "new K(3)";
+
+			int offset= contents.indexOf(str) + str.length();
+
+			CompletionProposalCollector collector= createCollector(cu, offset);
+			collector.setReplacementLength(0);
+
+			codeComplete(cu, offset, collector);
+
+			IJavaCompletionProposal proposal= null;
+
+			for (IJavaCompletionProposal p : collector.getJavaCompletionProposals()) {
+				if (p.getDisplayString().startsWith("getString")) {
+					proposal= p;
+				}
+			}
+			assertNotNull("no proposal for getString", proposal);
+
+			IDocument doc= JavaUI.getDocumentProvider().getDocument(part.getEditorInput());
+			proposal.apply(doc);
+
+			String str1= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        new K(3).getString()
+			    }
+			}
+			""";
+			assertEquals(str1, doc.get());
+		} finally {
+			part.getSite().getPage().closeAllEditors(false);
+		}
+	}
+	@Test
+	public void testIssue832d() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= sourceFolder.createPackageFragment("test1", false, null);
+		String contents= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        new K(3)
+			    }
+			}
+			""";
+
+		ICompilationUnit cu= pack1.createCompilationUnit("A.java", contents, false, null);
+
+		IEditorPart part= JavaUI.openInEditor(cu);
+		try {
+			String str= "new K(3)";
+
+			int offset= contents.indexOf(str) + str.length();
+
+			CompletionProposalCollector collector= createCollector(cu, offset);
+			collector.setReplacementLength(0);
+
+			codeComplete(cu, offset, collector);
+
+			IJavaCompletionProposal proposal= null;
+
+			for (IJavaCompletionProposal p : collector.getJavaCompletionProposals()) {
+				if (p.getDisplayString().startsWith("l")) {
+					proposal= p;
+				}
+			}
+			assertNotNull("no proposal for l", proposal);
+
+			IDocument doc= JavaUI.getDocumentProvider().getDocument(part.getEditorInput());
+			proposal.apply(doc);
+
+			String str1= """
+			package test1;
+
+			class K {
+			   int l;
+			   public K(int val) {
+			       l = val;
+			   }
+			   public K getThis() {
+			       return this;
+			   }
+			   public String getString() {
+			       return "abc";
+			   }
+			}
+
+			public class A {
+			    public void foo() {
+			        new K(3).l
+			    }
+			}
+			""";
 			assertEquals(str1, doc.get());
 		} finally {
 			part.getSite().getPage().closeAllEditors(false);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMethodCompletionProposal.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/JavaMethodCompletionProposal.java
@@ -349,8 +349,13 @@ public class JavaMethodCompletionProposal extends LazyJavaCompletionProposal {
 			buffer.append(replacement.substring(0, replacement.lastIndexOf('.') + 1));
 		}
 
-		if (fProposal.getKind() != CompletionProposal.CONSTRUCTOR_INVOCATION)
-			buffer.append(fProposal.getName());
+		if (fProposal.getKind() != CompletionProposal.CONSTRUCTOR_INVOCATION) {
+			if (fProposal.getCompletion().length > 0 && fProposal.getCompletion()[0] == '.') {
+				buffer.append(".").append(fProposal.getName()); //$NON-NLS-1$
+			} else {
+				buffer.append(fProposal.getName());
+			}
+		}
 
 		FormatterPrefs prefs= getFormatterPrefs();
 		if (prefs.beforeOpeningParen)


### PR DESCRIPTION
- add logic to JavaMethodCompletionProposal() to add a dot operator in the case where we have a dot in the proposal
- add new tests to CodeCompletionTest1d8
- fixes #832

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.  Adds method and field proposals that add a dot operator automatically.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
