### PR TITLE
Skip organize imports on save while the type indexer is busy

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.24.200.qualifier
+Bundle-Version: 1.25.0.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
@@ -235,6 +235,8 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 
 		private boolean fDoIgnoreLowerCaseNames;
 
+		private boolean fSkipWhenIndexerBusy;
+
 		private final UnresolvableImportMatcher fUnresolvableImportMatcher;
 
 		private IPackageFragment fCurrPackage;
@@ -250,12 +252,13 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 
 
 		public TypeReferenceProcessor(Set<String> oldSingleImports, Set<String> oldDemandImports, Map<String, Set<String>> oldModuleImports,
-				CompilationUnit root, ImportRewrite impStructure, boolean ignoreLowerCaseNames, UnresolvableImportMatcher unresolvableImportMatcher) {
+				CompilationUnit root, ImportRewrite impStructure, boolean ignoreLowerCaseNames, boolean skipWhenIndexerBusy, UnresolvableImportMatcher unresolvableImportMatcher) {
 			fOldSingleImports= oldSingleImports;
 			fOldDemandImports= oldDemandImports;
 			fOldModuleImports= oldModuleImports;
 			fImpStructure= impStructure;
 			fDoIgnoreLowerCaseNames= ignoreLowerCaseNames;
+			fSkipWhenIndexerBusy= skipWhenIndexerBusy;
 			fUnresolvableImportMatcher= unresolvableImportMatcher;
 			fRoot= root;
 
@@ -435,7 +438,8 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 				boolean excludeTestCode= !((IPackageFragmentRoot)fCurrPackage.getParent()).getResolvedClasspathEntry().isTest();
 				IJavaSearchScope scope= SearchEngine.createJavaSearchScope(excludeTestCode, new IJavaElement[] { project }, true);
 				TypeNameMatchCollector collector= new TypeNameMatchCollector(typesFound);
-				new SearchEngine().searchAllTypeNames(null, allTypes, scope, collector, IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH, monitor);
+				int waitingPolicy= fSkipWhenIndexerBusy ? IJavaSearchConstants.CANCEL_IF_NOT_READY_TO_SEARCH : IJavaSearchConstants.WAIT_UNTIL_READY_TO_SEARCH;
+				new SearchEngine().searchAllTypeNames(null, allTypes, scope, collector, waitingPolicy, monitor);
 
 				for (TypeNameMatch curr : typesFound) {
 					UnresolvedTypeData data= fUnresolvedTypes.get(curr.getSimpleTypeName());
@@ -598,6 +602,7 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 
 	private boolean fIgnoreLowerCaseNames;
 	private boolean fRestoreExistingImports;
+	private boolean fSkipWhenIndexerBusy;
 
 	private IChooseImportQuery fChooseImportQuery;
 
@@ -657,6 +662,17 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 	}
 
 	/**
+	 * Sets whether the operation is skipped instead of waiting for the type indexer when missing
+	 * imports can only be found through an index search. Default is <code>false</code>.
+	 *
+	 * @param skipWhenIndexerBusy if set, no text edit is created while the indexer is busy
+	 * @since 1.25
+	 */
+	public void setSkipWhenIndexerBusy(boolean skipWhenIndexerBusy) {
+		fSkipWhenIndexerBusy= skipWhenIndexerBusy;
+	}
+
+	/**
 	 * Runs the operation.
 	 * @param monitor the progress monitor
 	 * @throws CoreException thrown when the operation failed
@@ -708,6 +724,7 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 				astRoot,
 				importsRewrite,
 				fIgnoreLowerCaseNames,
+				fSkipWhenIndexerBusy,
 				unresolvableImportMatcher);
 
 		Iterator<SimpleName> refIterator= typeReferences.iterator();
@@ -716,7 +733,15 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 			processor.add(typeRef);
 		}
 
-		boolean hasOpenChoices= processor.process(subMonitor.split(3));
+		boolean hasOpenChoices;
+		try {
+			hasOpenChoices= processor.process(subMonitor.split(3));
+		} catch (OperationCanceledException e) {
+			if (fSkipWhenIndexerBusy && !subMonitor.isCanceled()) {
+				return null; // the indexer is busy: skip organizing imports instead of waiting
+			}
+			throw e;
+		}
 		addStaticImports(staticReferences, importsRewrite, unresolvableImportMatcher);
 
 		if (hasOpenChoices && fChooseImportQuery != null) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.jdt.internal.ui.javaeditor.saveparticipant.SavePartici
 import static org.eclipse.jdt.internal.ui.javaeditor.saveparticipant.SaveParticipantPreferenceConfigurationConstants.POSTSAVELISTENER_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -70,6 +71,8 @@ import org.eclipse.jdt.core.search.TypeNameMatch;
 
 import org.eclipse.jdt.internal.core.CompilationUnit;
 import org.eclipse.jdt.internal.core.CompilationUnitElementInfo;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
 
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.PreferenceConstants;
@@ -357,6 +360,47 @@ public class ImportOrganizeTest extends CoreTests {
 			"test.IB",
 			"test.IC",
 			"test.ID",
+		});
+	}
+
+	@Test
+	public void testSkipWhenIndexerBusy() throws Exception {
+		IPackageFragmentRoot sourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack= sourceFolder.createPackageFragment("test1", false, null);
+		String str= """
+			package test1;
+
+			public class C {
+				ArrayList list;
+			}
+			""";
+		ICompilationUnit cu= pack.createCompilationUnit("C.java", str, false, null);
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("C", new String[] {}, new int[] {});
+
+		IndexManager indexManager= JavaModelManager.getIndexManager();
+		indexManager.disable();
+		try {
+			// enqueue indexing work that the disabled indexer cannot process
+			indexManager.indexAll(fJProject1.getProject());
+
+			OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+			op.setSkipWhenIndexerBusy(true);
+			assertNull("expected no edit while the indexer is busy", op.createTextEdit(null));
+		} finally {
+			indexManager.enable();
+		}
+
+		TestUtils.waitForIndexer();
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.setSkipWhenIndexerBusy(true);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+			"java.util.ArrayList"
 		});
 	}
 

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -119,7 +119,7 @@ Require-Bundle:
  org.eclipse.ui.forms;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.ui.navigator;bundle-version="[3.3.200,4.0.0)",
  org.eclipse.ui.navigator.resources;bundle-version="[3.4.0,4.0.0)",
- org.eclipse.jdt.core.manipulation;bundle-version="[1.22.0,2.0.0)",
+ org.eclipse.jdt.core.manipulation;bundle-version="[1.25.0,2.0.0)",
  org.eclipse.equinox.bidi;bundle-version="[0.10.0,2.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Capability: eclipse.swt;filter:="(image.format=svg)"

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpPostSaveListener.java
@@ -104,6 +104,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.actions.ActionUtil;
 import org.eclipse.jdt.internal.ui.dialogs.OptionalMessageDialog;
 import org.eclipse.jdt.internal.ui.fix.IMultiLineCleanUp.MultiLineCleanUpContext;
+import org.eclipse.jdt.internal.ui.fix.ImportsCleanUp;
 import org.eclipse.jdt.internal.ui.fix.MapCleanUpOptions;
 import org.eclipse.jdt.internal.ui.javaeditor.saveparticipant.IPostSaveListener;
 import org.eclipse.jdt.internal.ui.javaeditor.saveparticipant.SaveParticipantPreferenceConfigurationConstants;
@@ -455,6 +456,10 @@ public class CleanUpPostSaveListener implements IPostSaveListener {
 
 		for (ICleanUp cleanUp : result) {
 			cleanUp.setOptions(new MapCleanUpOptions(settings));
+			if (cleanUp instanceof ImportsCleanUp importsCleanUp) {
+				// saving must not block on background indexing
+				importsCleanUp.setSkipWhenIndexerBusy(true);
+			}
 		}
 
 		return result;

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ImportsFix.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/ImportsFix.java
@@ -47,7 +47,7 @@ import org.eclipse.jdt.internal.ui.actions.ActionMessages;
 
 public class ImportsFix extends TextEditFix {
 
-	public static ICleanUpFix createCleanUp(final CompilationUnit cu, CodeGenerationSettings settings, boolean organizeImports, RefactoringStatus status) throws CoreException {
+	public static ICleanUpFix createCleanUp(final CompilationUnit cu, CodeGenerationSettings settings, boolean organizeImports, RefactoringStatus status, boolean skipWhenIndexerBusy) throws CoreException {
 		if (!organizeImports)
 			return null;
 
@@ -59,6 +59,7 @@ public class ImportsFix extends TextEditFix {
 
 		final ICompilationUnit unit= (ICompilationUnit)cu.getJavaElement();
 		OrganizeImportsOperation op= new OrganizeImportsOperation(unit, cu, settings.importIgnoreLowercase, false, false, query);
+		op.setSkipWhenIndexerBusy(skipWhenIndexerBusy);
 
 		TextEdit edit= runUsingProgressService(op);
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ImportsCleanUp.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/fix/ImportsCleanUp.java
@@ -38,6 +38,7 @@ public class ImportsCleanUp extends AbstractCleanUp {
 
 	private CodeGenerationSettings fCodeGeneratorSettings;
 	private RefactoringStatus fStatus;
+	private boolean fSkipWhenIndexerBusy;
 
 	public ImportsCleanUp(Map<String, String> options) {
 		super(options);
@@ -60,7 +61,16 @@ public class ImportsCleanUp extends AbstractCleanUp {
     		return null;
 
 		return ImportsFix.createCleanUp(compilationUnit, fCodeGeneratorSettings,
-				isEnabled(CleanUpConstants.ORGANIZE_IMPORTS), fStatus);
+				isEnabled(CleanUpConstants.ORGANIZE_IMPORTS), fStatus, fSkipWhenIndexerBusy);
+	}
+
+	/**
+	 * Sets whether organize imports is skipped instead of waiting when the type indexer is busy.
+	 *
+	 * @param skipWhenIndexerBusy if set, no fix is created while the indexer is busy
+	 */
+	public void setSkipWhenIndexerBusy(boolean skipWhenIndexerBusy) {
+		fSkipWhenIndexerBusy= skipWhenIndexerBusy;
 	}
 
     @Override


### PR DESCRIPTION
When Organize Imports is enabled as a save action, resolving missing imports searches the type index with WAIT_UNTIL_READY_TO_SEARCH. Saving right after startup, a branch switch or a large build therefore blocks until indexing finishes, which regularly exceeds the 2 second threshold and greets the user with the "Slow Save Actions" warning dialog.

This adds OrganizeImportsOperation#setSkipWhenIndexerBusy, which makes the type search use CANCEL_IF_NOT_READY_TO_SEARCH and produce no edit while the indexer is busy. The save actions enable it, so saving stays fast and a missing import is simply added on the next save once the index is ready. The Clean Up wizard and the manual Organize Imports action are unchanged and still wait for the index.