### PR TITLE
Fix Missing Markdown Template contexts and MD Type comment generation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/CodeTemplateContextType.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/CodeTemplateContextType.java
@@ -66,6 +66,7 @@ public class CodeTemplateContextType extends TemplateContextType {
 	public static final String MARKDOWNGETTERCOMMENT_CONTEXTTYPE= "markdowngettercomment_context"; //$NON-NLS-1$
 	public static final String MARKDOWNSETTERCOMMENT_CONTEXTTYPE= "markdownsettercomment_context"; //$NON-NLS-1$
 	public static final String MARKDOWNMODULECOMMENT_CONTEXTTYPE= "markdownmodulecomment_context"; //$NON-NLS-1$
+	public static final String MARKDOWNOVERRIDECOMMENT_CONTEXTTYPE= "markdownoverridecomment_context"; //$NON-NLS-1$
 
 	/* templates */
 
@@ -104,6 +105,7 @@ public class CodeTemplateContextType extends TemplateContextType {
 	public static final String MARKDOWNGETTERCOMMENT_ID= CODETEMPLATES_PREFIX + "markdowngetter" + COMMENT_SUFFIX; //$NON-NLS-1$
 	public static final String MARKDOWNSETTERCOMMENT_ID= CODETEMPLATES_PREFIX + "markdownsetter" + COMMENT_SUFFIX; //$NON-NLS-1$
 	public static final String MARKDOWNMODULECOMMENT_ID= CODETEMPLATES_PREFIX + "markdownmodule" + COMMENT_SUFFIX; //$NON-NLS-1$
+	public static final String MARKDOWNOVERRIDECOMMENT_ID= CODETEMPLATES_PREFIX + "markdownoverride" + COMMENT_SUFFIX; //$NON-NLS-1$
 
 	/* resolver types */
 	public static final String EXCEPTION_TYPE= "exception_type"; //$NON-NLS-1$
@@ -285,6 +287,7 @@ public class CodeTemplateContextType extends TemplateContextType {
 			addCompilationUnitVariables();
 			fIsComment= true;
 			break;
+		case MARKDOWNOVERRIDECOMMENT_CONTEXTTYPE:
 		case OVERRIDECOMMENT_CONTEXTTYPE:
 			addResolver(new CodeTemplateVariableResolver(ENCLOSING_TYPE,  JavaManipulationMessages.CodeTemplateContextType_variable_description_enclosingtype));
 			addResolver(new CodeTemplateVariableResolver(ENCLOSING_METHOD,  JavaManipulationMessages.CodeTemplateContextType_variable_description_enclosingmethod));
@@ -403,6 +406,7 @@ public class CodeTemplateContextType extends TemplateContextType {
 		registry.addContextType(new CodeTemplateContextType(CodeTemplateContextType.MARKDOWNDELEGATECOMMENT_CONTEXTTYPE));
 		registry.addContextType(new CodeTemplateContextType(CodeTemplateContextType.MARKDOWNGETTERCOMMENT_CONTEXTTYPE));
 		registry.addContextType(new CodeTemplateContextType(CodeTemplateContextType.MARKDOWNSETTERCOMMENT_CONTEXTTYPE));
+		registry.addContextType(new CodeTemplateContextType(CodeTemplateContextType.MARKDOWNOVERRIDECOMMENT_CONTEXTTYPE));
 	}
 
 	/*

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/StubUtility.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/internal/core/manipulation/StubUtility.java
@@ -326,6 +326,11 @@ public class StubUtility {
 				throw new CoreException(new Status(IStatus.ERROR, JavaManipulation.ID_PLUGIN, IStatus.ERROR, e.getMessage(), e));
 			}
 		}
+		if (useMarkdown && typeParameterNames.length == 0 && params.length == 0 ) {
+			str = document.get();
+			str = str.replace("\n/// ", ""); //$NON-NLS-1$ //$NON-NLS-2$
+			return str;
+		}
 		return document.get();
 	}
 
@@ -444,7 +449,7 @@ public class StubUtility {
 			if (delegate)
 				templateName= useMarkdown ? CodeTemplateContextType.MARKDOWNDELEGATECOMMENT_ID : CodeTemplateContextType.DELEGATECOMMENT_ID;
 			else
-				templateName= CodeTemplateContextType.OVERRIDECOMMENT_ID;
+				templateName= useMarkdown ? CodeTemplateContextType.MARKDOWNOVERRIDECOMMENT_ID : CodeTemplateContextType.OVERRIDECOMMENT_ID;
 		}
 		Template template= getCodeTemplate(templateName, cu.getJavaProject());
 		if (template == null) {
@@ -720,7 +725,7 @@ public class StubUtility {
 			if (delegate)
 				templateName= useMarkdown ? CodeTemplateContextType.MARKDOWNDELEGATECOMMENT_ID : CodeTemplateContextType.DELEGATECOMMENT_ID;
 			else
-				templateName= CodeTemplateContextType.OVERRIDECOMMENT_ID;
+				templateName= useMarkdown ? CodeTemplateContextType.MARKDOWNOVERRIDECOMMENT_ID : CodeTemplateContextType.OVERRIDECOMMENT_ID;
 		}
 		Template template= getCodeTemplate(templateName, cu.getJavaProject());
 		if (template == null) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/TemplateStoreTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/TemplateStoreTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -73,6 +73,7 @@ public class TemplateStoreTest extends CoreTests {
 		CodeTemplateContextType.MARKDOWNGETTERCOMMENT_ID,
 		CodeTemplateContextType.MARKDOWNSETTERCOMMENT_ID,
 		CodeTemplateContextType.MARKDOWNMODULECOMMENT_ID,
+		CodeTemplateContextType.MARKDOWNOVERRIDECOMMENT_ID,
 	};
 
 	private TemplatePersistenceData find(String id, TemplatePersistenceData[] templateData) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GetTypeCommentMarkdownTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/GetTypeCommentMarkdownTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.core.source;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+
+import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.core.rules.Java23ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+public class GetTypeCommentMarkdownTest {
+
+	private static final String MARKDOWN_TYPECOMMENT_TEMPLATE= "/// ${type_name}" + "\n/// ${tags}";
+	@Rule
+	public ProjectTestSetup pts= new Java23ProjectTestSetup(false);
+
+	private IJavaProject fJavaProject;
+	private IPackageFragmentRoot fSourceFolder;
+	private IPackageFragment fPackageP;
+
+	@Before
+	public void setUp() throws CoreException {
+		fJavaProject= pts.getProject();
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJavaProject, "src");
+		fPackageP= fSourceFolder.createPackageFragment("p", true, null);
+
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.CODEGEN_USE_MARKDOWN, true);
+		store.setValue(PreferenceConstants.CODEGEN_ADD_COMMENTS, true);
+
+		StubUtility.setCodeTemplate(CodeTemplateContextType.MARKDOWNTYPECOMMENT_ID, MARKDOWN_TYPECOMMENT_TEMPLATE, null);
+	}
+
+	@After
+	public void tearDown() {
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.CODEGEN_USE_MARKDOWN, false);
+		store.setValue(PreferenceConstants.CODEGEN_ADD_COMMENTS, false);
+		fJavaProject= null;
+		fPackageP= null;
+	}
+
+	@Test
+	public void testNoTagsStripsTrailingMarkdownLine() throws Exception {
+		ICompilationUnit cu= fPackageP.createCompilationUnit("A.java",
+				"package p;\n\npublic class A {\n}\n", true, null);
+
+		String comment= StubUtility.getTypeComment(cu, "p.A", new String[0], new String[0], "\n");
+
+		assertEquals("/// A", comment);
+	}
+
+	@Test
+	public void testTypeParameterTagsNotStripped() throws Exception {
+		ICompilationUnit cu= fPackageP.createCompilationUnit("B.java",
+				"package p;\n\npublic class B<T> {\n}\n", true, null);
+
+		String comment= StubUtility.getTypeComment(cu, "p.B", new String[] { "T" }, new String[0], "\n");
+
+		assertTrue("expected type-name line", comment.startsWith("/// B\n"));
+		assertTrue("expected @param <T> tag to be preserved", comment.contains("@param <T>"));
+	}
+
+	@Test
+	public void testRecordComponentParamsNotStripped() throws Exception {
+		ICompilationUnit cu= fPackageP.createCompilationUnit("R.java",
+				"package p;\n\npublic record R(String x, int y) {\n}\n", true, null);
+
+		String comment= StubUtility.getTypeComment(cu, "p.R", new String[0], new String[] { "x", "y" }, "\n");
+
+		assertTrue("expected type-name line", comment.startsWith("/// R\n"));
+		assertTrue("missing @param tag for record component x", comment.contains("@param x"));
+		assertTrue("missing @param tag for record component y", comment.contains("@param y"));
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/source/SourceActionTests.java
@@ -33,7 +33,8 @@ GenerateConstructorUsingFieldsTest.class,
 GenerateHashCodeEqualsTest.class,
 GenerateToStringTest.class,
 GenerateRecordConstructorTest.class,
-AddJavaDocStubOperationTest.class
+AddJavaDocStubOperationTest.class,
+GetTypeCommentMarkdownTest.class
 })
 public class SourceActionTests {
 }

--- a/org.eclipse.jdt.ui/templates/default-codetemplates.xml
+++ b/org.eclipse.jdt.ui/templates/default-codetemplates.xml
@@ -76,6 +76,8 @@
 <template name="markdowndelegatecomment" id="org.eclipse.jdt.ui.text.codetemplates.markdowndelegatecomment" description="%CodeTemplates.markdowndelegatecomment" context="markdowndelegatecomment_context" enabled="true">/// ${tags}
 /// ${see_to_target}</template>
  
+ <template name="markdownoverridecomment" id="org.eclipse.jdt.ui.text.codetemplates.markdownoverridecomment" description="%CodeTemplates.markdownoverridecomment" context="markdownoverridecomment_context" enabled="true">/// ${see_to_overridden}</template>
+ 
  <template name="newtype" id="org.eclipse.jdt.ui.text.codetemplates.newtype" description="%CodeTemplates.newfile" context="newtype_context" enabled="true">${filecomment}
 ${package_declaration}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/CodeTemplateBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/CodeTemplateBlock.java
@@ -230,6 +230,8 @@ public class CodeTemplateBlock extends OptionsConfigurationBlock {
 						return 14;
 					case CodeTemplateContextType.MARKDOWNMETHODCOMMENT_ID:
 						return 15;
+					case CodeTemplateContextType.MARKDOWNOVERRIDECOMMENT_ID:
+						return 16;
 					case CodeTemplateContextType.MARKDOWNDELEGATECOMMENT_ID:
 						return 17;
 					case CodeTemplateContextType.MARKDOWNGETTERCOMMENT_ID:
@@ -298,6 +300,7 @@ public class CodeTemplateBlock extends OptionsConfigurationBlock {
 					case CodeTemplateContextType.MARKDOWNMETHODCOMMENT_ID:
 						return PreferencesMessages.CodeTemplateBlock_methodcomment_label;
 					case CodeTemplateContextType.OVERRIDECOMMENT_ID:
+					case CodeTemplateContextType.MARKDOWNOVERRIDECOMMENT_ID:
 						return PreferencesMessages.CodeTemplateBlock_overridecomment_label;
 					case CodeTemplateContextType.DELEGATECOMMENT_ID:
 					case CodeTemplateContextType.MARKDOWNDELEGATECOMMENT_ID:


### PR DESCRIPTION
This commit includes missing Markdown code templates and fixes unwanted "///" generating on types with empty params
Required for https://github.com/eclipse-jdtls/eclipse.jdt.ls/pull/3837
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
