### PR TITLE
Force qualifier changes for org.eclipse.jdt.core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.manipulation/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/19
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2995
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927


### PR DESCRIPTION
- It shares split packages with org.eclipse.jdt.uu.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927