### PR TITLE
NPE in SmartTypingConfigurationBlock when no Java editor is active

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/SmartTypingConfigurationBlock.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/SmartTypingConfigurationBlock.java
@@ -232,7 +232,7 @@ class SmartTypingConfigurationBlock extends AbstractConfigurationBlock {
 		createDependency(master, slave);
 
 		ICompilationUnit cu= getCompilationUnit();
-		IJavaProject project= cu.getJavaProject();
+		IJavaProject project= cu != null ? cu.getJavaProject() : null;
 		String compliance= project != null
 				? project.getOption(JavaCore.COMPILER_COMPLIANCE, true)
 				: JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE);


### PR DESCRIPTION
The Typing preference page threw an NPE when opened with no active Java editor, since a null compilation unit was dereferenced without a check; this adds the missing null guard, consistent with the existing null-safe handling right below it.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3068

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
