### PR TITLE
Use ProjectionRegion in folding tests

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/CustomFoldingRegionTest.java
@@ -37,7 +37,6 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
@@ -101,7 +100,7 @@ public class CustomFoldingRegionTest {
 				package org.example.test;
 				public class Test { }
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		assertEquals(0, projectionRanges.size());
 	}
 
@@ -118,7 +117,7 @@ public class CustomFoldingRegionTest {
 					// endregion
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 3); // region 1
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 7); // region 2
 	}
@@ -136,7 +135,7 @@ public class CustomFoldingRegionTest {
 					// endregion inner
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		assertEquals(3, projectionRanges.size());
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 8);//class Test
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 7);//outer
@@ -157,7 +156,7 @@ public class CustomFoldingRegionTest {
 					// endregion inner
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);//outer
 	}
 
@@ -173,7 +172,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5); // region 1
 	}
 
@@ -184,7 +183,7 @@ public class CustomFoldingRegionTest {
 
 				import java.util.List;
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		assertEquals(0, projectionRanges.size());
 	}
 
@@ -197,7 +196,7 @@ public class CustomFoldingRegionTest {
 				import java.util.List;
 				// endregion
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 4); // imports
 	}
 
@@ -225,7 +224,7 @@ public class CustomFoldingRegionTest {
 
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 15); // region 1
 	}
 
@@ -247,7 +246,7 @@ public class CustomFoldingRegionTest {
 				}
 				// endregion outside class
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		assertEquals(5, projectionRanges.size());
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 12);//class Test
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 1, 13);//outside class
@@ -269,7 +268,7 @@ public class CustomFoldingRegionTest {
 				}
 				// endregion outside class
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 4);//region inside method
 	}
 
@@ -289,7 +288,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		if (extendedFoldingActive) {
 			assertEquals(5, projectionRanges.size());
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 2, 11);//class SpecialCommentTypes
@@ -323,7 +322,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 7);//region 1
 	}
 
@@ -348,7 +347,7 @@ public class CustomFoldingRegionTest {
 
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);// region outside
 	}
 
@@ -367,7 +366,7 @@ public class CustomFoldingRegionTest {
 					// endregion
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 9);//region 1
 	}
 
@@ -387,7 +386,7 @@ public class CustomFoldingRegionTest {
 					// endregion should be ignored
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4); // this is the region
 	}
 
@@ -403,7 +402,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5);//region 1
 	}
 
@@ -419,7 +418,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);
 	}
 
@@ -435,7 +434,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);
 	}
 
@@ -451,7 +450,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 5);//region 1
 	}
 
@@ -468,7 +467,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//region 1
 	}
 
@@ -485,7 +484,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 6);//region 1
 	}
 
@@ -501,7 +500,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//region 1
 	}
 
@@ -515,7 +514,7 @@ public class CustomFoldingRegionTest {
 					/* endregion */
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 2);
 	}
 
@@ -529,7 +528,7 @@ public class CustomFoldingRegionTest {
 					void a(){/* endregion*/}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 2);
 	}
 
@@ -549,7 +548,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//region 1
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//region 1
 	}
@@ -574,7 +573,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 3);// region 1
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 6);// region 2
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(projectionRanges, str, 9);// region 3
@@ -591,7 +590,7 @@ public class CustomFoldingRegionTest {
 					/* endregion */ void test(){}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4); // region 1
 	}
 
@@ -611,7 +610,7 @@ public class CustomFoldingRegionTest {
 
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 4);//first start
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//second start
 	}
@@ -641,7 +640,7 @@ public class CustomFoldingRegionTest {
 					// ----
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 7);//variables
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 8, 13);//methods
 	}
@@ -675,7 +674,7 @@ public class CustomFoldingRegionTest {
 					}
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 9);//inner
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 12);//inner 2
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 15, 19);//outer 2
@@ -699,7 +698,7 @@ public class CustomFoldingRegionTest {
 
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 3, 8);//no end marker
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 5, 6);//first
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 7, 8);//second
@@ -721,7 +720,7 @@ public class CustomFoldingRegionTest {
 
 				// regend second
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionWithOffsetAndLength(projectionRanges, 2, 7, //no end marker
 		FoldingTestUtils.findLineStartIndex(str, 2), str.length() - 1);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 5);//first
@@ -751,7 +750,7 @@ public class CustomFoldingRegionTest {
 					// reg end
 				}
 		""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 6, 7);//first
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 10, 11);//second
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 12, 13);//third
@@ -767,7 +766,7 @@ public class CustomFoldingRegionTest {
 		// reg my region
 
 		// some comment without line break""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 0, 2);
 	}
 
@@ -782,7 +781,7 @@ public class CustomFoldingRegionTest {
 
 
 		""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 0, 3);
 	}
 
@@ -809,7 +808,7 @@ public class CustomFoldingRegionTest {
 
 				}
 				""";
-		List<IRegion> projectionRanges= getProjectionRangesOfFile(str);
+		List<FoldingTestUtils.ProjectionRegion> projectionRanges= getProjectionRangesOfFile(str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(projectionRanges, str, 4, 12);//custom region
 	}
 
@@ -838,7 +837,7 @@ public class CustomFoldingRegionTest {
 		try {
 			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
 
-			List<IRegion> initialRegions= FoldingTestUtils.extractRegions(model);
+			List<FoldingTestUtils.ProjectionRegion> initialRegions= FoldingTestUtils.extractRegions(model);
 
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 2, 15);//outer
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(initialRegions, code, 5, 12);//middle
@@ -856,8 +855,8 @@ public class CustomFoldingRegionTest {
 
 			// check that regions are in the same order as before and not modified in another way
 			for(int i= 0; i < positions.size(); i++) {
-				assertEquals(initialRegions.get(i).getOffset(), positions.get(i).getOffset());
-				assertEquals(initialRegions.get(i).getLength() + additionalText.length(), positions.get(i).getLength());
+				assertEquals(initialRegions.get(i).offset(), positions.get(i).getOffset());
+				assertEquals(initialRegions.get(i).length() + additionalText.length(), positions.get(i).getLength());
 			}
 		} finally {
 			editor.close(false);
@@ -946,8 +945,9 @@ public class CustomFoldingRegionTest {
 		return positions;
 	}
 
-	private List<IRegion> getProjectionRangesOfFile(String str) throws Exception {
+	private List<FoldingTestUtils.ProjectionRegion> getProjectionRangesOfFile(String str) throws Exception {
 		return FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
 	}
 
 }
+

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingIncludeClosingBracketTests.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingIncludeClosingBracketTests.java
@@ -27,7 +27,6 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import org.eclipse.jface.text.IRegion;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -95,7 +94,7 @@ public class FoldingIncludeClosingBracketTests {
 				    };
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // if
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 6, 8); // for
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 11); // while
@@ -119,7 +118,7 @@ public class FoldingIncludeClosingBracketTests {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 11); // x()
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // s
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 8, 9); // s2
@@ -148,10 +147,11 @@ public class FoldingIncludeClosingBracketTests {
 				@interface SomeAnnotation {}
 				@interface OtherAnnotation {}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3); // A
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // B
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 8, 9); // C
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 11, 14); // someMethod
 	}
 }
+

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -31,7 +31,6 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import org.eclipse.jface.text.IRegion;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -88,7 +87,7 @@ public class FoldingTest {
 				class A {		//here should be an annotation
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 2); // class
 	}
 
@@ -118,7 +117,7 @@ public class FoldingTest {
 				class A {		//here should be an annotation
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 2); // class
 	}
 
@@ -133,7 +132,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // Javadoc
 	}
 
@@ -149,7 +148,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 3); // Imports
 	}
 
@@ -167,7 +166,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // foo Methode
 	}
@@ -184,7 +183,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // method
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 3);
 	}
@@ -203,7 +202,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // foo Methode
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // bar Methode
 	}
@@ -221,7 +220,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // InnerClass
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // bar Methode
 	}
@@ -245,7 +244,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // OuterWithDocs Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 12); // InnerWithDocs Klasse
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 6, 8); // InnerWithDocs Javadoc
@@ -268,7 +267,7 @@ public class FoldingTest {
 				    class Example {}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // 1. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // 2. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 9); // 3. Javadoc
@@ -301,7 +300,7 @@ public class FoldingTest {
 				}
 				""";
 
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // 1. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // 2. Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 9); // 3. Javadoc
@@ -322,7 +321,7 @@ public class FoldingTest {
 
 				class SomeClass {}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 0, 2);
 	}
 
@@ -341,7 +340,7 @@ public class FoldingTest {
 					}
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // JavaDoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 7, 9); // 2. Method
@@ -360,7 +359,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // if
 	}
@@ -380,7 +379,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 8); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // try
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // catch
@@ -399,7 +398,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // while
 	}
@@ -417,7 +416,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // for
 	}
@@ -435,7 +434,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // for
 	}
@@ -453,7 +452,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 4); // do
 	}
@@ -471,7 +470,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // synchronized
 	}
@@ -490,7 +489,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 7); // 1. Method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // Supplier
 	}
@@ -507,7 +506,7 @@ public class FoldingTest {
 				    };
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // Object
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // Method
 	}
@@ -530,7 +529,7 @@ public class FoldingTest {
 					}
 				}
 							""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 8); // method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 7); // Runnable (anonymous class)
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 6); // run
@@ -548,7 +547,7 @@ public class FoldingTest {
 				    B
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 4); // enum
 	}
 
@@ -562,7 +561,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // static
 	}
 
@@ -585,7 +584,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 12); // method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 11); // if
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 10); // for
@@ -605,7 +604,7 @@ public class FoldingTest {
 					}
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // method
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 3, 5); // inner class
 	}
@@ -641,7 +640,7 @@ public class FoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 21); // x()
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 22, 23); // bar()
 		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 3); // do-while
@@ -688,7 +687,7 @@ public class FoldingTest {
 					}
 				}
 								""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 24); // switch expression
 	}
 
@@ -715,7 +714,7 @@ public class FoldingTest {
 					}
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 4, 15); // switch
 	}
 
@@ -732,7 +731,7 @@ public class FoldingTest {
 
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 5); // @Deprecated
 	}
 
@@ -752,7 +751,7 @@ public class FoldingTest {
 				}
 
 								""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // array
 	}
 
@@ -778,7 +777,7 @@ public class FoldingTest {
 
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // predicate
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // ArrayList
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 9, 10); // if
@@ -817,7 +816,7 @@ public class FoldingTest {
 					}
 				}
 				""";
-		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRegionsOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsExpandedRegionUsingStartAndEndLine(regions, str, 0, 4); // class B
 		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 1, 3); // class B1
 		FoldingTestUtils.assertContainsExpandedRegionUsingStartAndEndLine(regions, str, 6, 21); // class A
@@ -828,3 +827,4 @@ public class FoldingTest {
 
 	}
 }
+

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
@@ -24,11 +24,8 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Position;
-import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
@@ -40,14 +37,16 @@ import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 
 public final class FoldingTestUtils {
-	private record StartEnd(int start, int end) {}
+	private record StartEnd(int start, int end) {
+	}
 
-	public record ProjectionRegion(IRegion region, boolean collapsed) {}
+	public record ProjectionRegion(int offset, int length, boolean collapsed) {
+	}
 
 	private FoldingTestUtils() {
 	}
 
-	public static List<IRegion> getProjectionRangesOfPackage(IPackageFragment packageFragment, String code) throws Exception {
+	public static List<ProjectionRegion> getProjectionRangesOfPackage(IPackageFragment packageFragment, String code) throws Exception {
 		ICompilationUnit cu= packageFragment.createCompilationUnit("A.java", code, true, null);
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
 		try {
@@ -59,26 +58,14 @@ public final class FoldingTestUtils {
 		}
 	}
 
-	public static List<ProjectionRegion> getProjectionRegionsOfPackage(IPackageFragment packageFragment, String code) throws Exception {
-		ICompilationUnit cu= packageFragment.createCompilationUnit("A.java", code, true, null);
-		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
-		try {
-			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
-
-			return extractProjectionRegions(model);
-		} finally {
-			editor.close(false);
-		}
-	}
-
-	public static List<IRegion> extractRegions(ProjectionAnnotationModel model) {
-		List<IRegion> regions= new ArrayList<>();
+	public static List<ProjectionRegion> extractRegions(ProjectionAnnotationModel model) {
+		List<ProjectionRegion> regions= new ArrayList<>();
 		Iterator<Annotation> it= model.getAnnotationIterator();
 		while (it.hasNext()) {
 			Annotation a= it.next();
-			if (a instanceof ProjectionAnnotation) {
+			if (a instanceof ProjectionAnnotation projectionAnnotation) {
 				Position p= model.getPosition(a);
-				regions.add(new Region(p.getOffset(), p.getLength()));
+				regions.add(new ProjectionRegion(p.getOffset(), p.getLength(), projectionAnnotation.isCollapsed()));
 			}
 		}
 		assertNoDuplicatedRegions(regions);
@@ -86,34 +73,18 @@ public final class FoldingTestUtils {
 		return regions;
 	}
 
-	public static List<ProjectionRegion> extractProjectionRegions(ProjectionAnnotationModel model) {
-		List<ProjectionRegion> regions= new ArrayList<>();
-		Iterator<Annotation> it= model.getAnnotationIterator();
-		while (it.hasNext()) {
-			Annotation a= it.next();
-			if (a instanceof ProjectionAnnotation projectionAnnotation) {
-				Position p= model.getPosition(a);
-				regions.add(new ProjectionRegion(new Region(p.getOffset(), p.getLength()), projectionAnnotation.isCollapsed()));
-			}
-		}
-		List<IRegion> projectionRanges= regions.stream().map(ProjectionRegion::region).collect(Collectors.toList());
-		assertNoDuplicatedRegions(projectionRanges);
-		assertNoRegionsStartInTheSameOffset(projectionRanges);
-		return regions;
-	}
-
-	private static void assertNoDuplicatedRegions(List<IRegion> regions) {
+	private static void assertNoDuplicatedRegions(List<ProjectionRegion> regions) {
 		long distinctRegions= regions.stream()
-				.map(r -> Map.entry(r.getOffset(), r.getLength())) // map to offset-length pairs
+				.map(r -> Map.entry(r.offset(), r.length())) // map to offset-length pairs
 				.distinct()
 				.count();
 		assertEquals(regions.size(), distinctRegions,
 				"Some regions are duplicated: " + sorted(regions));
 	}
 
-	private static void assertNoRegionsStartInTheSameOffset(Collection<IRegion> regions) {
+	private static void assertNoRegionsStartInTheSameOffset(Collection<ProjectionRegion> regions) {
 		long distinctOffsets= regions.stream()
-				.map(IRegion::getOffset)
+				.map(ProjectionRegion::offset)
 				.distinct()
 				.count();
 
@@ -122,27 +93,27 @@ public final class FoldingTestUtils {
 	}
 
 	public static void assertCodeHasRegions(IPackageFragment packageFragment, String code, int regionsCount) throws Exception {
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, code);
+		List<ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, code);
 		assertEquals(regionsCount, regions.size(), String.format("Expected %d regions but saw %d.", regionsCount, regions.size()));
 	}
 
-	public static void assertDoesNotContainRegionUsingStartLine(List<IRegion> projectionRanges, String input, int startLine) {
+	public static void assertDoesNotContainRegionUsingStartLine(List<ProjectionRegion> projectionRanges, String input, int startLine) {
 		int startLineBegin= findLineStartIndex(input, startLine);
-		for (IRegion region : projectionRanges) {
-			if (region.getOffset() == startLineBegin) {
-				fail("found unexpected region at offset=" + region.getOffset() + ", length=" + region.getLength() +
+		for (ProjectionRegion region : projectionRanges) {
+			if (region.offset() == startLineBegin) {
+				fail("found unexpected region at offset=" + region.offset() + ", length=" + region.length() +
 						" starting at line " + startLine + " (line offset: " + startLineBegin + ")");
 			}
 		}
 	}
 
-	public static void assertDoesNotContainRegionUsingStartAndEndLine(List<IRegion> projectionRanges, String input, int startLine, int endLine) {
-		StartEnd startEnd = getStartEnd(input, startLine, endLine);
+	public static void assertDoesNotContainRegionUsingStartAndEndLine(List<ProjectionRegion> projectionRanges, String input, int startLine, int endLine) {
+		StartEnd startEnd= getStartEnd(input, startLine, endLine);
 		assertDoesNotContainRegionWithOffsetAndLength(projectionRanges, startLine, endLine, startEnd.start(), startEnd.end());
 	}
 
-	public static void assertContainsRegionUsingStartAndEndLine(List<IRegion> projectionRanges, String input, int startLine, int endLine) {
-		StartEnd startEnd = getStartEnd(input, startLine, endLine);
+	public static void assertContainsRegionUsingStartAndEndLine(List<ProjectionRegion> projectionRanges, String input, int startLine, int endLine) {
+		StartEnd startEnd= getStartEnd(input, startLine, endLine);
 		assertContainsRegionWithOffsetAndLength(projectionRanges, startLine, endLine, startEnd.start(), startEnd.end());
 	}
 
@@ -160,8 +131,7 @@ public final class FoldingTestUtils {
 		int expectedRegionLength= startEnd.end() - startEnd.start() + 1;
 
 		for (ProjectionRegion projectionRegion : projectionRanges) {
-			IRegion region= projectionRegion.region();
-			if (region.getOffset() == expectedRegionBegin && region.getLength() == expectedRegionLength) {
+			if (projectionRegion.offset() == expectedRegionBegin && projectionRegion.length() == expectedRegionLength) {
 				assertEquals(collapsed, projectionRegion.collapsed(),
 						"incorrect collapsed state for region from line " + startLine + " to line " + endLine + " (offset: " + expectedRegionBegin
 								+ ", length: " + expectedRegionLength + ")");
@@ -172,7 +142,7 @@ public final class FoldingTestUtils {
 		fail(
 				"missing region from line " + startLine + " to line " + endLine + " (offset: " + expectedRegionBegin
 						+ ", length: " + expectedRegionLength + ")" +
-						", actual regions: " + sorted(projectionRanges.stream().map(ProjectionRegion::region).collect(Collectors.toList())));
+						", actual regions: " + sorted(projectionRanges));
 	}
 
 	private static StartEnd getStartEnd(String input, int startLine, int endLine) {
@@ -186,11 +156,11 @@ public final class FoldingTestUtils {
 		return new StartEnd(expectedRegionBegin, expectedRegionEnd);
 	}
 
-	static void assertDoesNotContainRegionWithOffsetAndLength(List<IRegion> projectionRanges, int startLine, int endLine, int expectedRegionBegin, int expectedRegionEnd) {
+	static void assertDoesNotContainRegionWithOffsetAndLength(List<ProjectionRegion> projectionRanges, int startLine, int endLine, int expectedRegionBegin, int expectedRegionEnd) {
 		int expectedRegionLength= expectedRegionEnd - expectedRegionBegin + 1;
 
-		for (IRegion region : projectionRanges) {
-			if (region.getOffset() == expectedRegionBegin && region.getLength() == expectedRegionLength) {
+		for (ProjectionRegion region : projectionRanges) {
+			if (region.offset() == expectedRegionBegin && region.length() == expectedRegionLength) {
 				fail(
 						"The region from line " + startLine + " to line " + endLine + " (offset: " + expectedRegionBegin
 								+ ", length: " + expectedRegionLength + ")" +
@@ -199,11 +169,11 @@ public final class FoldingTestUtils {
 		}
 	}
 
-	static void assertContainsRegionWithOffsetAndLength(List<IRegion> projectionRanges, int startLine, int endLine, int expectedRegionBegin, int expectedRegionEnd) {
+	static void assertContainsRegionWithOffsetAndLength(List<ProjectionRegion> projectionRanges, int startLine, int endLine, int expectedRegionBegin, int expectedRegionEnd) {
 		int expectedRegionLength= expectedRegionEnd - expectedRegionBegin + 1;
 
-		for (IRegion region : projectionRanges) {
-			if (region.getOffset() == expectedRegionBegin && region.getLength() == expectedRegionLength) {
+		for (ProjectionRegion region : projectionRanges) {
+			if (region.offset() == expectedRegionBegin && region.length() == expectedRegionLength) {
 				return;
 			}
 		}
@@ -221,9 +191,9 @@ public final class FoldingTestUtils {
 	 *         <li>Then by length (descending i.e. longer regions first)</li>
 	 *         </ul>
 	 */
-	private static Collection<IRegion> sorted(Collection<IRegion> regions) {
-		List<IRegion> sortedRegions= new ArrayList<>(regions);
-		sortedRegions.sort(Comparator.comparingInt(IRegion::getOffset).thenComparing(Comparator.comparingInt(IRegion::getLength).reversed()));
+	private static Collection<ProjectionRegion> sorted(Collection<ProjectionRegion> regions) {
+		List<ProjectionRegion> sortedRegions= new ArrayList<>(regions);
+		sortedRegions.sort(Comparator.comparingInt(ProjectionRegion::offset).thenComparing(Comparator.comparingInt(ProjectionRegion::length).reversed()));
 		return sortedRegions;
 	}
 

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingWithShowSelectedElementTests.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingWithShowSelectedElementTests.java
@@ -29,7 +29,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -82,7 +81,7 @@ public class FoldingWithShowSelectedElementTests {
 					}
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4);
 	}
 
@@ -115,7 +114,7 @@ public class FoldingWithShowSelectedElementTests {
 						}
 					""", editor.getViewer().getTextWidget().getText());
 
-			List<IRegion> regions= FoldingTestUtils.extractRegions(model);
+			List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.extractRegions(model);
 
 			IDocument document= editor.getViewer().getDocument();
 			FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 6); // region (custom)
@@ -162,3 +161,4 @@ public class FoldingWithShowSelectedElementTests {
 		}
 	}
 }
+

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/MarkdownJavadocFoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/MarkdownJavadocFoldingTest.java
@@ -29,7 +29,6 @@ import org.eclipse.core.runtime.CoreException;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import org.eclipse.jface.text.IRegion;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -88,7 +87,7 @@ public class MarkdownJavadocFoldingTest {
 				class HeaderCommentTest {
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // Javadoc
 	}
 
@@ -105,8 +104,9 @@ public class MarkdownJavadocFoldingTest {
 				    }
 				}
 				""";
-		List<IRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(fPackageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // foo method
 	}
 }
+


### PR DESCRIPTION
Follow-up of (and also **contains**):
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/3052

I am drafting this PR until #3052 is merged so that the reviewer can focus on the changes of the 2nd commit only.

## What it does
Replaces all usages of `IRegion` in `FoldingTestUtils` for usages of `ProjectionRegion` (internal **record**). This makes the API of the utility class easier to use and avoids functionality duplication.

`ProjectionRegion` not only contains the length and offset of a region but also its state: collapsed/expanded. 

## How to test
Run the tests in `org.eclipse.jdt.text.tests.folding.FoldingTestSuite`, they should pass.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
