### PR TITLE
Wait on quick diff initialize before editing CU in test

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
@@ -35,6 +35,8 @@ import org.eclipse.jface.internal.text.reconciler.ReconcilerJobFamilies;
 
 import org.eclipse.jface.text.CopyOnWriteTextStore;
 
+import org.eclipse.ui.internal.texteditor.quickdiff.DocumentLineDiffer;
+
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
@@ -105,6 +107,7 @@ public class SaveParticipantTest extends CleanUpTestCase {
 	private static void editCUInEditor(ICompilationUnit cu, String newContent) throws Exception {
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
 		Job.getJobManager().join(ReconcilerJobFamilies.FAMILY_RECONCILER, null);
+		Job.getJobManager().join(DocumentLineDiffer.QUICKDIFF_INITIALIZE_FAMILY, null);
 		TestUtils.cancelDecorationJob();
 
 		cu.getBuffer().setContents(newContent);


### PR DESCRIPTION
Tracings of recent `SaveParticipantTest` fail show the quick diff initialize job, accessing `GapTextStore` in parallel to the tests. This change joins this initialize job, prior to editing CUs from the tests - to avoid potential race conditions.

See: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/79
