### PR TITLE
Fix inline of method with instantiation of local class

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -268,7 +268,7 @@ class SourceAnalyzer  {
 			if (fTypeCounter == 0) {
 				Expression receiver= node.getExpression();
 				if (receiver == null) {
-					if (node.resolveTypeBinding().isLocal() && !node.resolveTypeBinding().isAnonymous())
+					if (node.resolveTypeBinding().isMember())
 						fImplicitReceivers.add(node);
 				}
 			}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_3070_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_3070_1.java
@@ -1,0 +1,19 @@
+package bugs_in;
+
+public class Test_issue_3070_1 {
+    public static void main(String[] args) {
+        Test_issue_3070_1 obj = new Test_issue_3070_1();
+        int result = obj.f();
+        System.out.println(result);
+    }
+
+    class H {
+        int g() {
+            return 7;
+        }
+    }
+ 
+    int /*]*/f()/*[*/ {
+        return new H().g();
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_3070_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_3070_2.java
@@ -1,0 +1,18 @@
+package bugs_in;
+
+public class Test_issue_3070_2 {
+    public static void main(String[] args) {
+        Test_issue_3070_2 obj = new Test_issue_3070_2();
+        int result = obj.f();
+        System.out.println(result);
+    }
+
+    int /*]*/f()/*[*/ {
+    	class H {
+    		int g() {
+    			return 7;
+    		}
+    	}
+        return new H().g();
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_3070_1.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_3070_1.java
@@ -1,0 +1,15 @@
+package bugs_in;
+
+public class Test_issue_3070_1 {
+    public static void main(String[] args) {
+        Test_issue_3070_1 obj = new Test_issue_3070_1();
+        int result = obj.new H().g();
+        System.out.println(result);
+    }
+
+    class H {
+        int g() {
+            return 7;
+        }
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_3070_2.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_3070_2.java
@@ -1,0 +1,14 @@
+package bugs_in;
+
+public class Test_issue_3070_2 {
+    public static void main(String[] args) {
+        Test_issue_3070_2 obj = new Test_issue_3070_2();
+		class H {
+			int g() {
+				return 7;
+			}
+		}
+        int result = new H().g();
+        System.out.println(result);
+    }
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -572,6 +572,16 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 		performBugTest();
 	}
 
+	@Test
+	public void test_issue_3070_1() throws Exception {
+		performBugTest();
+	}
+
+	@Test
+	public void test_issue_3070_2() throws Exception {
+		performBugTest();
+	}
+
 	/* *********************** Argument Tests ******************************* */
 
 	private void performArgumentTest() throws Exception {


### PR DESCRIPTION
- modify SourceAnalyzer.visit(ClassInstanceCreation) to only mark a member class as a receiver
- add new tests to InlineMethodTests
- fixes #3070

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
