### PR TITLE
Expose JUnit VM runner configuration to subclasses

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.14.300.qualifier
+Bundle-Version: 3.15.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -124,7 +124,20 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 		}
 	}
 
-	private VMRunnerConfiguration getVMRunnerConfiguration(ILaunchConfiguration configuration, ILaunch launch, String mode, IProgressMonitor monitor) throws CoreException {
+	/**
+	 * Creates the VM runner configuration for the given JUnit launch configuration.
+	 * Subclasses can use this method to obtain the fully resolved launch configuration
+	 * while customizing the existing protected launch hooks.
+	 *
+	 * @param configuration the launch configuration
+	 * @param launch the launch
+	 * @param mode the launch mode
+	 * @param monitor the progress monitor
+	 * @return the VM runner configuration, or {@code null} if the operation was canceled
+	 * @throws CoreException if the launch configuration cannot be resolved
+	 * @since 3.15
+	 */
+	protected final VMRunnerConfiguration getVMRunnerConfiguration(ILaunchConfiguration configuration, ILaunch launch, String mode, IProgressMonitor monitor) throws CoreException {
 		SubMonitor subMon= SubMonitor.convert(monitor, JUnitMessages.JUnitLaunchConfigurationDelegate_verifying_attriburtes_description, 4);
 		// check for cancellation
 		if (subMon.isCanceled()) {

--- a/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
+++ b/org.eclipse.jdt.ui.unittest.junit.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.jdt.ui.unittest.junit.feature"
       label="%featureName"
-      version="1.2.200.qualifier"
+      version="1.2.300.qualifier"
       provider-name="%provider"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui.unittest.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui.unittest.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui.unittest.junit;singleton:=true
-Bundle-Version: 1.3.100.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Activator: org.eclipse.jdt.ui.unittest.junit.JUnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui.unittest.junit/pom.xml
+++ b/org.eclipse.jdt.ui.unittest.junit/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui.unittest.junit</artifactId>
-  <version>1.3.100-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.ui.unittest.junit/src/org/eclipse/jdt/ui/unittest/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -134,7 +134,20 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 		}
 	}
 
-	private VMRunnerConfiguration getVMRunnerConfiguration(ILaunchConfiguration configuration, ILaunch launch,
+	/**
+	 * Creates the VM runner configuration for the given JUnit launch configuration.
+	 * Subclasses can use this method to obtain the fully resolved launch configuration
+	 * while customizing the existing protected launch hooks.
+	 *
+	 * @param configuration the launch configuration
+	 * @param launch the launch
+	 * @param mode the launch mode
+	 * @param monitor the progress monitor
+	 * @return the VM runner configuration, or {@code null} if the operation was canceled
+	 * @throws CoreException if the launch configuration cannot be resolved
+	 * @since 1.4
+	 */
+	protected final VMRunnerConfiguration getVMRunnerConfiguration(ILaunchConfiguration configuration, ILaunch launch,
 			String mode, IProgressMonitor monitor) throws CoreException {
 		VMRunnerConfiguration runConfig = null;
 		monitor.beginTask(MessageFormat.format("{0}...", configuration.getName()), 5); //$NON-NLS-1$


### PR DESCRIPTION
## Motivation

`JUnitLaunchConfigurationDelegate` is public API intended to be extended, and exposes hooks such as `preLaunchCheck`, `evaluateTests`, and `collectExecutionArguments`. However, subclasses cannot obtain the fully resolved `VMRunnerConfiguration` without duplicating the launch orchestration because `getVMRunnerConfiguration` is private.

This has required consumers such as [Test Runner for Java](https://github.com/microsoft/vscode-java-test/blob/main/java-extension/com.microsoft.java.test.plugin/src/main/java/com/microsoft/java/test/plugin/launchers/JUnitLaunchConfigurationDelegate.java) to use reflection since 2019 (microsoft/vscode-java-test#828). The limitation is also relevant to microsoft/vscode-java-test#1883, where a subclass needs its `evaluateTests` override to participate before all VM arguments are resolved.

## Change

- Expose `getVMRunnerConfiguration` as `protected final` in both JUnit launch delegates.
- Keep the orchestration non-overridable while allowing subclasses to call it and customize the existing protected hooks.
- Bump both bundle minor versions for the new API and add `@since` documentation.

There is no launch behavior change for existing Eclipse clients.

## Validation

`mvn -Pbuild-individual-bundles -pl org.eclipse.jdt.junit.core,org.eclipse.jdt.ui.unittest.junit -am verify -DskipTests`