### PR TITLE
Issue #3080 Improve phonetic distance algorithm

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/JdtTextTestSuite.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.text.tests.contentassist.ContentAssistTestSuite;
 import org.eclipse.jdt.text.tests.folding.FoldingTestSuite;
 import org.eclipse.jdt.text.tests.semantictokens.SemanticTokensProviderErrorTest;
 import org.eclipse.jdt.text.tests.semantictokens.SemanticTokensProviderTest;
+import org.eclipse.jdt.text.tests.spelling.DefaultPhoneticDistanceAlgorithmTest;
 import org.eclipse.jdt.text.tests.spelling.SpellCheckEngineTestCase;
 import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
 
@@ -55,6 +56,7 @@ import org.eclipse.jdt.text.tests.templates.TemplatesTestSuite;
 	MarkOccurrenceTest1d8.class,
 	BracketInserterTest.class,
 	SpellCheckEngineTestCase.class,
+	DefaultPhoneticDistanceAlgorithmTest.class,
 	SemanticHighlightingTest.class,
 	SemanticTokensProviderTest.class,
 	SemanticTokensProviderErrorTest.class,

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/spelling/DefaultPhoneticDistanceAlgorithmTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/spelling/DefaultPhoneticDistanceAlgorithmTest.java
@@ -1,0 +1,114 @@
+package org.eclipse.jdt.text.tests.spelling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.jdt.internal.ui.text.spelling.engine.DefaultPhoneticDistanceAlgorithm;
+
+
+public class DefaultPhoneticDistanceAlgorithmTest {
+
+	private static final DefaultPhoneticDistanceAlgorithm ALGO= new DefaultPhoneticDistanceAlgorithm();
+
+	/** {@code AbstractSpellDictionary.DISTANCE_THRESHOLD} */
+	private static final int DISTANCE_THRESHOLD= 160;
+
+
+	@Test
+	void testThresholdMaxValueMatchesUnbounded() {
+		String[] words= { "cat", "cats", "catch", "kitten", "sitting", "algorithm" };
+		for (String a : words) {
+			for (String b : words) {
+				int unbounded= ALGO.getDistance(a, b);
+				int bounded= ALGO.getDistance(a, b, Integer.MAX_VALUE);
+				assertEquals(unbounded, bounded,
+						"getDistance with MAX threshold must equal unbounded result for (" + a + ", " + b + ")");
+			}
+		}
+	}
+
+	@Test
+	void testThresholdJustAboveTrueDistanceReturnsCorrectResult() {
+		int real= ALGO.getDistance("kitten", "sitting");
+		int result= ALGO.getDistance("kitten", "sitting", real + 1);
+		assertEquals(real, result, "Threshold just above true distance must not truncate result");
+	}
+
+	@Test
+	void testIdenticalStringsHaveZeroDistance() {
+		assertEquals(0, ALGO.getDistance("hello", "hello", DISTANCE_THRESHOLD));
+		assertEquals(0, ALGO.getDistance("hello", "hello"));
+	}
+
+	@Test
+	void testEmptyStringDistance() {
+		int expected= ALGO.getDistance("", "abc");
+		assertEquals(expected, ALGO.getDistance("", "abc", Integer.MAX_VALUE));
+	}
+	
+	@Test
+	void testEmptyString2Distance() {
+		int expected= ALGO.getDistance("abc", "");
+		assertEquals(expected, ALGO.getDistance("abc", "", Integer.MAX_VALUE));
+	}
+
+	@Test
+	void testLengthDiffTwoReturnsLowerBound() {
+		int minCost= Math.min(DefaultPhoneticDistanceAlgorithm.COST_INSERT,
+				DefaultPhoneticDistanceAlgorithm.COST_REMOVE);
+		int result= ALGO.getDistance("cat", "catch", DISTANCE_THRESHOLD);
+
+		assertTrue(result >= DISTANCE_THRESHOLD,
+				"Length-diff-2 pair must be rejected (got " + result + ")");
+		assertEquals(2 * minCost, result,
+				"Must return the length-difference lower bound " + (2 * minCost));
+	}
+
+	@Test
+	void testLengthDiffLargeReturnsLowerBound() {
+		int minCost= Math.min(DefaultPhoneticDistanceAlgorithm.COST_INSERT,
+				DefaultPhoneticDistanceAlgorithm.COST_REMOVE);
+
+		int diff= "algorithm".length() - "a".length();
+		int result= ALGO.getDistance("a", "algorithm", DISTANCE_THRESHOLD);
+		assertTrue(result >= DISTANCE_THRESHOLD);
+		assertEquals(diff * minCost, result);
+	}
+
+
+	@Test
+	void testLengthDiffOneIsNotRejectedByLengthBound() {
+		int result= ALGO.getDistance("cat", "cats", DISTANCE_THRESHOLD);
+		assertTrue(result < DISTANCE_THRESHOLD,
+				"Length-diff-1 must not be rejected by length bound; got " + result);
+		assertEquals(ALGO.getDistance("cat", "cats"), result,
+				"Result must match unbounded overload");
+	}
+
+	@Test
+	void testEqualLengthWordsNotAffectedByLengthBound() {
+		assertEquals(ALGO.getDistance("kitten", "bitten"),
+				ALGO.getDistance("kitten", "bitten", DISTANCE_THRESHOLD));
+	}
+
+	@Test
+	void testEqualLengthWordsWithBigDistanceExitsEarlier() {
+		int exact= ALGO.getDistance("Elephant", "Sunshine");
+		int bounded= ALGO.getDistance("Elephant", "Sunshine", DISTANCE_THRESHOLD);
+
+		assertTrue(exact > DISTANCE_THRESHOLD);
+
+		assertTrue(bounded > DISTANCE_THRESHOLD, "Truncated distance must be >= threshold");
+		assertTrue(bounded < exact, "Distance must be smaller than unbounded distance");
+	}
+	
+ 	@Test
+ 	void testSwapBelowThresholdIsNotTruncated() {
+ 		int threshold= DefaultPhoneticDistanceAlgorithm.COST_INSERT;
+ 
+ 		assertEquals(DefaultPhoneticDistanceAlgorithm.COST_SWAP, ALGO.getDistance("ab", "ba"));
+ 		assertEquals(DefaultPhoneticDistanceAlgorithm.COST_SWAP, ALGO.getDistance("ab", "ba", threshold));
+ 	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/AbstractSpellDictionary.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/AbstractSpellDictionary.java
@@ -198,7 +198,7 @@ public abstract class AbstractSpellDictionary implements ISpellDictionary {
 						JavaPlugin.log(e);
 						return result;
 					}
-					distance= fDistanceAlgorithm.getDistance(word, candidate);
+					distance= fDistanceAlgorithm.getDistance(word, candidate, DISTANCE_THRESHOLD);
 					if (distance < DISTANCE_THRESHOLD) {
 						buffer.setLength(0);
 						buffer.append(candidate);
@@ -220,7 +220,7 @@ public abstract class AbstractSpellDictionary implements ISpellDictionary {
 					JavaPlugin.log(e);
 					return result;
 				}
-				distance= fDistanceAlgorithm.getDistance(word, candidate);
+				distance= fDistanceAlgorithm.getDistance(word, candidate, DISTANCE_THRESHOLD);
 
 				if (distance < DISTANCE_THRESHOLD) {
 
@@ -290,7 +290,7 @@ public abstract class AbstractSpellDictionary implements ISpellDictionary {
 				JavaPlugin.log(e);
 				return;
 			}
-			distance= fDistanceAlgorithm.getDistance(word, candidate);
+			distance= fDistanceAlgorithm.getDistance(word, candidate, minimum);
 
 			if (distance <= minimum) {
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/DefaultPhoneticDistanceAlgorithm.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/DefaultPhoneticDistanceAlgorithm.java
@@ -42,35 +42,55 @@ public final class DefaultPhoneticDistanceAlgorithm implements IPhoneticDistance
 	@Override
 	public int getDistance(final String from, final String to) {
 
+		return getDistance(from, to, Integer.MAX_VALUE);
+	}
+
+	@Override
+	public int getDistance(final String from, final String to, final int threshold) {
+
+		// If this already meets or exceeds the threshold we can skip the full
+		// computation entirely.  With DISTANCE_THRESHOLD=160 and min-cost=95 this
+		// rejects every candidate whose length differs by two or more characters
+		int lengthDiff= Math.abs(from.length() - to.length());
+		if (lengthDiff > 0) {
+			int lowerBound= lengthDiff * Math.min(COST_INSERT, COST_REMOVE);
+			if (lowerBound >= threshold)
+				return lowerBound;
+		}
+
 		final char[] first= (" " + from).toCharArray(); //$NON-NLS-1$
 		final char[] second= (" " + to).toCharArray(); //$NON-NLS-1$
 
 		final int rows= first.length;
 		final int columns= second.length;
 
-		final int[][] metric= new int[rows][columns];
-		for (int column= 1; column < columns; column++)
-			metric[0][column]= metric[0][column - 1] + COST_REMOVE;
+		// Use three rolling 1-D arrays instead of a full n×m matrix
+		int[] prev2= new int[columns]; // row - 2  (needed for swap cost)
+		int[] prev1= new int[columns]; // row - 1
+		int[] curr=  new int[columns]; // row  (current)
 
-		for (int row= 1; row < rows; row++)
-			metric[row][0]= metric[row - 1][0] + COST_INSERT;
+		// Initialise row 0: only COST_REMOVE accumulates along columns.
+		for (int column= 1; column < columns; column++)
+			prev1[column]= prev1[column - 1] + COST_REMOVE;
 
 		char source, target;
+		int swap, change, minimum, diagonal, insert, remove;
 
-		int swap= Integer.MAX_VALUE;
-		int change= Integer.MAX_VALUE;
-
-		int minimum, diagonal, insert, remove;
 		for (int row= 1; row < rows; row++) {
 
 			source= first[row];
+			curr[0]= prev1[0] + COST_INSERT;
+			int rowMin= curr[0];
+
 			for (int column= 1; column < columns; column++) {
 
 				target= second[column];
-				diagonal= metric[row - 1][column - 1];
+				diagonal= prev1[column - 1];
 
 				if (source == target) {
-					metric[row][column]= diagonal;
+					curr[column]= diagonal;
+					if (diagonal < rowMin)
+						rowMin= diagonal;
 					continue;
 				}
 
@@ -80,25 +100,46 @@ public final class DefaultPhoneticDistanceAlgorithm implements IPhoneticDistance
 
 				swap= Integer.MAX_VALUE;
 				if (row != 1 && column != 1 && source == second[column - 1] && first[row - 1] == target)
-					swap= COST_SWAP + metric[row - 2][column - 2];
+					swap= COST_SWAP + prev2[column - 2];
 
 				minimum= COST_SUBSTITUTE + diagonal;
 				if (swap < minimum)
 					minimum= swap;
 
-				remove= metric[row][column - 1];
+				remove= curr[column - 1];
 				if (COST_REMOVE + remove < minimum)
 					minimum= COST_REMOVE + remove;
 
-				insert= metric[row - 1][column];
+				insert= prev1[column];
 				if (COST_INSERT + insert < minimum)
 					minimum= COST_INSERT + insert;
 				if (change < minimum)
 					minimum= change;
 
-				metric[row][column]= minimum;
+				curr[column]= minimum;
+
+				if (minimum < rowMin)
+					rowMin= minimum;
 			}
+
+ 			// Abort only when both this row and the previous row are already >= threshold.
+ 			// Otherwise a later row can still drop below threshold (e.g. due to swap).
+ 			if (rowMin >= threshold) {
+ 				int prevRowMin= Integer.MAX_VALUE;
+ 				for (int c= 0; c < columns; c++) {
+ 					if (prev1[c] < prevRowMin)
+ 						prevRowMin= prev1[c];
+ 				}
+ 				if (prevRowMin >= threshold)
+ 					return rowMin;
+ 			}
+
+			// Rotate the three row references without allocating new arrays
+			int[] tmp= prev2;
+			prev2= prev1;
+			prev1= curr;
+			curr= tmp;
 		}
-		return metric[rows - 1][columns - 1];
+		return prev1[columns - 1];
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/IPhoneticDistanceAlgorithm.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/spelling/engine/IPhoneticDistanceAlgorithm.java
@@ -31,4 +31,30 @@ public interface IPhoneticDistanceAlgorithm {
 	 * @return The non-negative phonetic distance between the words.
 	 */
 	int getDistance(String from, String to);
+
+	/**
+	 * Returns the non-negative phonetic distance between two words.
+ 	 * <p>
+ 	 * Implementations may use {@code threshold} to abort early and return a value
+ 	 * {@code >= threshold} as soon as it is determined that the distance cannot be
+ 	 * below the threshold.
+ 	 * </p>
+ 	 * <p>
+ 	 * The default implementation ignores {@code threshold} and delegates to
+ 	 * {@link #getDistance(String, String)}.
+ 	 * </p>
+	 *
+	 * @param from
+	 *                  The first word
+	 * @param to
+	 *                  The second word
+	 * @param threshold
+	 *                  The distance threshold above which computation can be aborted
+	 * @return The non-negative phonetic distance between the words, or a value
+	 *         &gt;= <code>threshold</code> if the distance meets or exceeds it.
+	 * @since 3.20
+	 */
+	default int getDistance(String from, String to, int threshold) {
+		return getDistance(from, to);
+	}
 }


### PR DESCRIPTION
See Issue #3080 

## What it does
Improve phonetic distance algorithm. It now uses less memory because of creating a matrix full n x m matric it uses only 3 arrays.
Also added a new Interface to pass the threshold. So the calculation can stop earlier when the a value already meets or exceeds the threshold. The final distance cannot be below it because all remaining edit costs are non-negative.

## How to test
See Issue #3080. Create a very long String and trigger the spell corrections.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
