### PR TITLE
Force qualifier changes for org.org.eclipse.jdt.junit

### DIFF
--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.17.500.qualifier
+Bundle-Version: 3.17.600.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.junit/forceQualifierUpdate.txt
@@ -17,3 +17,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/17
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1923
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2595
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927


### PR DESCRIPTION
- It shares split packages with org.eclipse.jdt.junit.core.

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3927
