### PR TITLE
When referring to record constructor use type Javadoc if none exists

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -44,6 +44,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
@@ -368,6 +369,99 @@ public class JavadocHoverTests extends CoreTests {
 			int index= actualHtmlContent.indexOf(member.getElementName().equals("foo") ? "The foo." : "The bar.");
 			assertNotEquals("Expected HTML not found, instead found : " + actualHtmlContent,  -1, index);
 		}
+	}
+
+	@Test
+	public void testRecordConstructor1() throws Exception {
+		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/931
+		String source=
+				"""
+			package p;
+			public class X {}
+			/**
+			 * A foo bar.
+			 * @param foo The foo.
+			 * @param bar The bar.
+			 */
+			record FooBar(String foo, String bar) {
+				public FooBar {
+					if (foo == null) {
+						foo = "abc";
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/X.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		IType recordType= cu.getType("FooBar");
+		boolean found= false;
+		for (IJavaElement member : recordType.getChildren()) {
+			if (member.getElementName().equals("FooBar")) {
+				assertTrue("not a constructor", member instanceof IMethod method && method.isConstructor());
+				found= true;
+				IJavaElement[] elements= { member };
+				ISourceRange range= ((ISourceReference) member).getNameRange();
+				// copy logic from JavadocHover
+				if (elements.length == 1 && elements[0] instanceof IMethod method && method.isConstructor()
+						&& method.getJavadocRange() == null && method.getParent() instanceof IType type && type.isRecord()) {
+					elements[0]= method.getParent();
+				}
+				JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(elements, cu, new Region(range.getOffset(), range.getLength()), null);
+				String actualHtmlContent= hoverInfo.getHtml();
+				int index= actualHtmlContent.indexOf("A foo bar.");
+				assertNotEquals("Expected HTML not found, instead found : " + actualHtmlContent,  -1, index);
+			}
+		}
+		assertTrue("constructor not found", found);
+	}
+
+	@Test
+	public void testRecordConstructor2() throws Exception {
+		// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/931
+		String source=
+				"""
+			package p;
+			public class X {}
+			/**
+			 * A foo bar.
+			 * @param foo The foo.
+			 * @param bar The bar.
+			 */
+			record FooBar(String foo, String bar) {
+				/**
+				 * Foobar constructor
+				 */
+				public FooBar {
+					if (foo == null) {
+						foo = "abc";
+					}
+				}
+			}
+			""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/X.java", source, null);
+		assertNotNull("TestClass.java", cu);
+
+		IType recordType= cu.getType("FooBar");
+		boolean found= false;
+		for (IJavaElement member : recordType.getChildren()) {
+			if (member.getElementName().equals("FooBar")) {
+				assertTrue("not a constructor", member instanceof IMethod method && method.isConstructor());
+				found= true;
+				IJavaElement[] elements= { member };
+				ISourceRange range= ((ISourceReference) member).getNameRange();
+				// copy logic from JavadocHover
+				if (elements.length == 1 && elements[0] instanceof IMethod method && method.isConstructor()
+						&& method.getJavadocRange() == null && method.getParent() instanceof IType type && type.isRecord()) {
+					elements[0]= method.getParent();
+				}
+				JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(elements, cu, new Region(range.getOffset(), range.getLength()), null);
+				String actualHtmlContent= hoverInfo.getHtml();
+				int index= actualHtmlContent.indexOf("Foobar constructor");
+				assertNotEquals("Expected HTML not found, instead found : " + actualHtmlContent,  -1, index);
+			}
+		}
+		assertTrue("constructor not found", found);
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -89,6 +89,7 @@ import org.eclipse.jdt.core.IPackageDeclaration;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.ISourceReference;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaCore;
@@ -708,7 +709,14 @@ public class JavadocHover extends AbstractJavaEditorTextHover {
 		IJavaElement[] elements= JavaCore.callReadOnly(() -> getJavaElementsAt(textViewer, hoverRegion));
 		if (elements == null || elements.length == 0)
 			return null;
-
+		try {
+			if (elements.length == 1 && elements[0] instanceof IMethod method && method.isConstructor()
+					&& method.getJavadocRange() == null && method.getParent() instanceof IType type && type.isRecord()) {
+				elements[0]= method.getParent();
+			}
+		} catch (JavaModelException e) {
+			// do nothing
+		}
 		return getHoverInfo(elements, getEditorInputJavaElement(), hoverRegion, null);
 	}
 


### PR DESCRIPTION
- modify JavadocHover.internalGetHoverInfo() to check when there is a single JavaElement that is a record constructor that has no Javadoc and in that case get hover info for the parent record type
- add new tests to JavadocHoverTests
- fixes #2832

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
