### PR TITLE
Remember the dialog size of the History dialog of the JUnit view

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/HistoryListAction.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/viewsupport/HistoryListAction.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.IStatus;
 
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.StatusDialog;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ISelection;
@@ -36,6 +37,7 @@ import org.eclipse.jface.window.Window;
 
 import org.eclipse.jdt.internal.corext.util.Messages;
 
+import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaUIMessages;
 import org.eclipse.jdt.internal.ui.dialogs.StatusInfo;
 import org.eclipse.jdt.internal.ui.wizards.dialogfields.DialogField;
@@ -194,6 +196,15 @@ import org.eclipse.jdt.internal.ui.wizards.dialogfields.StringDialogField;
 			return fMaxEntries;
 		}
 
+		@Override
+		protected IDialogSettings getDialogBoundsSettings() {
+			return JavaPlugin.getDefault().getDialogSettingsSection(getClass().getName());
+		}
+
+		@Override
+		protected int getDialogBoundsStrategy() {
+			return DIALOG_PERSISTSIZE;
+		}
 	}
 
 	private final class TestRunLabelProvider extends LabelProvider {


### PR DESCRIPTION
## What it does

I often increase the history size and have a launch group that runs all tests where there are more than a dozen.  Then I want to look at them in the history view, to ensure they all passed, but this view is always too small and I always need to increase the size to see all the tests.

## How to test

Just open an closed the History... of the Junit view.  Now when you resize it, it will come up with that size the next time you open it.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
