### PR TITLE
Fix for replace qualified name bug (#3060)

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ReplaceQualifiedTypeFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ReplaceQualifiedTypeFixCore.java
@@ -40,6 +40,7 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
 import org.eclipse.jdt.internal.corext.dom.AbortSearchException;
 import org.eclipse.jdt.internal.corext.refactoring.structure.CompilationUnitRewrite;
+import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
 
 import org.eclipse.jdt.internal.ui.text.correction.CorrectionMessages;
 
@@ -212,13 +213,14 @@ public class ReplaceQualifiedTypeFixCore extends CompilationUnitRewriteOperation
 			TextEditGroup group= createTextEditGroup(CorrectionMessages.QuickAssistProcessor_replaceQualifiedName_description, cuRewrite);
 			ASTRewrite rewrite= cuRewrite.getASTRewrite();
 			AST ast= cuRewrite.getRoot().getAST();
+			ImportRemover iRemover= cuRewrite.getImportRemover();
 			for (QualifiedName itemToModify : itemsToModify) {
 				SimpleName newItem= ast.newSimpleName(className.getFullyQualifiedName());
+				iRemover.registerRemovedNode(itemToModify);
 				ASTNodes.replaceButKeepComment(rewrite, itemToModify, newItem, group);
 			}
 			if (needImport) {
 				ImportRewrite iRewrite= cuRewrite.getImportRewrite();
-
 				if (isImportStatic) {
 					QualifiedName itemToModify = itemsToModify.get(0);
 					if (itemToModify.resolveBinding() instanceof ITypeBinding) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ReplaceQualifiedTypeFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/ReplaceQualifiedTypeFixCore.java
@@ -126,7 +126,8 @@ public class ReplaceQualifiedTypeFixCore extends CompilationUnitRewriteOperation
 
 		@Override
 		public boolean visit(QualifiedName qname) {
-			if (qname.getFullyQualifiedName().equals(fullQualifiedName)) {
+			if (qname.getFullyQualifiedName().equals(fullQualifiedName) && !(qname.getParent() instanceof ImportDeclaration)) {
+				// I will add the qname if and only if is not an instance of an ImportDeclaration
 				searchResults.add(qname);
 			}
 			return false;
@@ -219,7 +220,17 @@ public class ReplaceQualifiedTypeFixCore extends CompilationUnitRewriteOperation
 				ImportRewrite iRewrite= cuRewrite.getImportRewrite();
 
 				if (isImportStatic) {
-					iRewrite.addStaticImport(itemsToModify.get(0).resolveBinding());
+					QualifiedName itemToModify = itemsToModify.get(0);
+					if (itemToModify.resolveBinding() instanceof ITypeBinding) {
+						// When an static class is used within another, we don't need to use import static
+						// but we still need to import it.
+						String itemToImport = itemToModify.resolveTypeBinding().getQualifiedName();
+						if(itemToImport != null) {
+							iRewrite.addImport(itemToImport);
+						}
+					} else {
+						iRewrite.addStaticImport(itemsToModify.get(0).resolveBinding());
+					}
 				} else {
 					iRewrite.addImport(itemsToModify.get(0).getFullyQualifiedName());
 				}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -7931,6 +7931,7 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		assertExpectedExistInProposals(proposals, new String[] { expected });
 	}
 
+	@Test
 	public void test_refactorQualifiedName_bug_3060() throws Exception {
 		// If the classes share the same package the import will not be added
 		IPackageFragment pack1= fSourceFolder.createPackageFragment("test3", false, null);
@@ -7966,7 +7967,6 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 		String expected= """
 				package test2;
 
-				import test3.Test;
 				import test3.Test.Test2;
 
 				public class TestStaticImport {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/AssistQuickFixTest1d8.java
@@ -7930,5 +7930,111 @@ public class AssistQuickFixTest1d8 extends QuickFixTest {
 				""";
 		assertExpectedExistInProposals(proposals, new String[] { expected });
 	}
+
+	public void test_refactorQualifiedName_bug_3060() throws Exception {
+		// If the classes share the same package the import will not be added
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test3", false, null);
+		String classToImport= """
+				package test3;
+
+				public class Test {
+
+					public static class Test2 {
+						public static int x;
+						public static int getX() {
+							return x;
+						}
+					}
+				}
+				""";
+		pack1.createCompilationUnit("Test.java", classToImport, false, null);
+		IPackageFragment pack2= fSourceFolder.createPackageFragment("test2", false, null);
+		String importingClass= """
+				package test2;
+
+				import test3.Test;
+
+				public class TestStaticImport {
+
+					public int foo3() {
+						return Test.Test2.getX();
+					}
+
+				}
+				""";
+
+		String expected= """
+				package test2;
+
+				import test3.Test;
+				import test3.Test.Test2;
+
+				public class TestStaticImport {
+
+					public int foo3() {
+						return Test2.getX();
+					}
+
+				}
+				""";
+		ICompilationUnit cu1= pack2.createCompilationUnit("TestStaticImport.java", importingClass, false, null);
+		int offset= importingClass.indexOf("Test.Test2");
+		AssistContext context= getCorrectionContext(cu1, offset+2, 0);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertNumberOfProposals(proposals, 1);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
+
+	@Test
+	public void test_refactorQualifiedName_bug_3060_2() throws Exception {
+		// If the classes share the same package the import will not be added
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test3", false, null);
+		String classToImport= """
+				package test3;
+
+				public class Test {
+
+					public static class Test2 {
+						public static int x;
+						public static int getX() {
+							return x;
+						}
+					}
+				}
+				""";
+		pack1.createCompilationUnit("Test.java", classToImport, false, null);
+		IPackageFragment pack2= fSourceFolder.createPackageFragment("test2", false, null);
+		String importingClass= """
+				package test2;
+
+				public class TestStaticImport {
+
+					public int foo4() {
+						return test3.Test.Test2.getX();
+					}
+
+				}
+				""";
+
+		String expected= """
+				package test2;
+
+				import test3.Test.Test2;
+
+				public class TestStaticImport {
+
+					public int foo4() {
+						return Test2.getX();
+					}
+
+				}
+				""";
+		ICompilationUnit cu1= pack2.createCompilationUnit("TestStaticImport.java", importingClass, false, null);
+		int offset= importingClass.indexOf("Test.Test2");
+		AssistContext context= getCorrectionContext(cu1, offset, 0);
+		List<IJavaCompletionProposal> proposals= collectAssists(context, false);
+		assertNumberOfProposals(proposals, 1);
+		assertExpectedExistInProposals(proposals, new String[] { expected });
+	}
 }
 


### PR DESCRIPTION
## What it does
It fix #3060 

## How to test
Try follow the steps in the example provided in the issue above. Now it should add the correct imports, and remove the fqn. 

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
