### PR TITLE
Fix inline method to handle local classes referencing receivers

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -61,6 +61,7 @@ import org.eclipse.jdt.core.dom.SuperFieldAccess;
 import org.eclipse.jdt.core.dom.SuperMethodInvocation;
 import org.eclipse.jdt.core.dom.ThisExpression;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclarationStatement;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.manipulation.ImportReferencesCollector;
 
@@ -175,6 +176,7 @@ class SourceAnalyzer  {
 
 	private class UpdateCollector extends ASTVisitor {
 		private int fTypeCounter;
+		private int fLocalTypeCounter;
 		@Override
 		public boolean visit(TypeDeclaration node) {
 			return visitType(node);
@@ -190,6 +192,15 @@ class SourceAnalyzer  {
 		@Override
 		public void endVisit(EnumDeclaration node) {
 			fTypeCounter--;
+		}
+		@Override
+		public boolean visit(TypeDeclarationStatement node) {
+			fLocalTypeCounter++;
+			return true;
+		}
+		@Override
+		public void endVisit(TypeDeclarationStatement node) {
+			fLocalTypeCounter--;
 		}
 		@Override
 		public boolean visit(AnnotationTypeDeclaration node) {
@@ -234,10 +245,21 @@ class SourceAnalyzer  {
 		}
 		@Override
 		public boolean visit(MethodInvocation node) {
-			if (fTypeCounter == 0) {
-				Expression receiver= node.getExpression();
-				if (receiver == null && !isStaticallyImported(node.getName())) {
+			Expression receiver= node.getExpression();
+			if (receiver == null && !isStaticallyImported(node.getName())) {
+				if (fTypeCounter == 0) {
 					fImplicitReceivers.add(node);
+				} else if (fLocalTypeCounter > 0) {
+					IMethodBinding methodBinding= node.resolveMethodBinding();
+					if (methodBinding != null) {
+						ITypeBinding typeBinding= methodBinding.getDeclaringClass();
+						while (typeBinding != null && typeBinding.isMember()) {
+							typeBinding= typeBinding.getDeclaringClass();
+						}
+						if (typeBinding != null && !typeBinding.isLocal()) {
+							fImplicitReceivers.add(node);
+						}
+					}
 				}
 			}
 			return true;
@@ -265,11 +287,21 @@ class SourceAnalyzer  {
 		}
 		@Override
 		public boolean visit(ClassInstanceCreation node) {
-			if (fTypeCounter == 0) {
-				Expression receiver= node.getExpression();
-				if (receiver == null) {
-					if (node.resolveTypeBinding().isMember())
-						fImplicitReceivers.add(node);
+			Expression receiver= node.getExpression();
+			if (receiver == null && !isStaticallyImported(node.getName())) {
+				if (fTypeCounter == 0) {
+					fImplicitReceivers.add(node);
+				} else if (fLocalTypeCounter > 0) {
+					IMethodBinding methodBinding= node.resolveConstructorBinding();
+					if (methodBinding != null) {
+						ITypeBinding typeBinding= methodBinding.getDeclaringClass();
+						while (typeBinding != null && typeBinding.isMember()) {
+							typeBinding= typeBinding.getDeclaringClass();
+						}
+						if (typeBinding != null && !typeBinding.isLocal()) {
+							fImplicitReceivers.add(node);
+						}
+					}
 				}
 			}
 			return true;
@@ -303,7 +335,17 @@ class SourceAnalyzer  {
 						StructuralPropertyDescriptor location= node.getLocationInParent();
 						if (location != SingleVariableDeclaration.NAME_PROPERTY
 							&& location != VariableDeclarationFragment.NAME_PROPERTY) {
-							fImplicitReceivers.add(node);
+							if (fTypeCounter == 0) {
+								fImplicitReceivers.add(node);
+							} else if (fLocalTypeCounter > 0) {
+								ITypeBinding typeBinding= vb.getDeclaringClass();
+								while (typeBinding != null && typeBinding.isMember()) {
+									typeBinding= typeBinding.getDeclaringClass();
+								}
+								if (typeBinding != null && !typeBinding.isLocal()) {
+									fImplicitReceivers.add(node);
+								}
+							}
 						}
 					}
 				} else if (!vb.isField()) {

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/code/SourceAnalyzer.java
@@ -288,21 +288,9 @@ class SourceAnalyzer  {
 		@Override
 		public boolean visit(ClassInstanceCreation node) {
 			Expression receiver= node.getExpression();
-			if (receiver == null && !isStaticallyImported(node.getName())) {
-				if (fTypeCounter == 0) {
+			if (receiver == null) {
+				if (node.resolveTypeBinding().isMember())
 					fImplicitReceivers.add(node);
-				} else if (fLocalTypeCounter > 0) {
-					IMethodBinding methodBinding= node.resolveConstructorBinding();
-					if (methodBinding != null) {
-						ITypeBinding typeBinding= methodBinding.getDeclaringClass();
-						while (typeBinding != null && typeBinding.isMember()) {
-							typeBinding= typeBinding.getDeclaringClass();
-						}
-						if (typeBinding != null && !typeBinding.isLocal()) {
-							fImplicitReceivers.add(node);
-						}
-					}
-				}
 			}
 			return true;
 		}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_3069.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_in/Test_issue_3069.java
@@ -1,0 +1,34 @@
+package bugs_in;
+
+public class Test_issue_3069 {
+
+	int x;
+
+	public static void main(String[] args) {
+		Test_issue_3069 obj= new Test_issue_3069();
+		int result= obj.f();
+	}
+
+	int helper() {
+		return 7;
+	}
+
+	int /*]*/ f()/*[*/ {
+		class H {
+			int y;
+			int j() {
+				return helper();
+			}
+			class K {
+				int g() {
+					return helper();
+				}
+				int h() {
+					return g() + x + y;
+				}
+			}
+		}
+		return H.class.getSimpleName().length() + helper();
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_3069.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/InlineMethodWorkspace/TestCases/bugs_out/Test_issue_3069.java
@@ -1,0 +1,30 @@
+package bugs_in;
+
+public class Test_issue_3069 {
+
+	int x;
+
+	public static void main(String[] args) {
+		Test_issue_3069 obj= new Test_issue_3069();
+		class H {
+			int y;
+			int j() {
+				return obj.helper();
+			}
+			class K {
+				int g() {
+					return obj.helper();
+				}
+				int h() {
+					return g() + obj.x + y;
+				}
+			}
+		}
+		int result= H.class.getSimpleName().length() + obj.helper();
+	}
+
+	int helper() {
+		return 7;
+	}
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/InlineMethodTests.java
@@ -573,6 +573,11 @@ public class InlineMethodTests extends AbstractJunit4SelectionTestCase {
 	}
 
 	@Test
+	public void test_issue_3069() throws Exception {
+		performBugTest();
+	}
+
+	@Test
 	public void test_issue_3070_1() throws Exception {
 		performBugTest();
 	}


### PR DESCRIPTION
- modify SourceAnalyzer.UpdateCollector to recognize when method invocations, constructor instantiations, and field references are within a local class but are referring to methods, constructors, and fields in the receiver class instead of the local one
- add new test to InlineMethodTests
- fixes #3069

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
