### PR TITLE
Add Wizard support for creating Compact Source Files

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/NewTypeWizardTest25.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/wizardapi/NewTypeWizardTest25.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.ui.tests.wizardapi;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Hashtable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.testplugin.StringAsserts;
+import org.eclipse.jdt.testplugin.TestOptions;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+
+import org.eclipse.jdt.internal.core.manipulation.CodeTemplateContextType;
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+
+import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.core.rules.Java25ProjectTestSetup;
+import org.eclipse.jdt.ui.wizards.NewCompactWizardPage;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+
+public class NewTypeWizardTest25 {
+
+	private IJavaProject fJProject1;
+
+	private IPackageFragmentRoot fSourceFolder;
+
+	private IPackageFragment fpack1;
+
+	@Rule
+	public Java25ProjectTestSetup projectSetup= new Java25ProjectTestSetup();
+
+	@Before
+	public void setUp() throws Exception {
+		Hashtable<String, String> options= TestOptions.getDefaultOptions();
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, "4");
+		JavaCore.setOptions(options);
+
+		IPreferenceStore store= JavaPlugin.getDefault().getPreferenceStore();
+		store.setValue(PreferenceConstants.CODEGEN_ADD_COMMENTS, false);
+
+		StubUtility.setCodeTemplate(CodeTemplateContextType.METHODCOMMENT_ID, "/**\n * Method\n */", null);
+
+		fJProject1= projectSetup.getProject();
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+		fpack1= fSourceFolder.createPackageFragment("test1", false, null);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		JavaProjectHelper.clear(fJProject1, projectSetup.getDefaultClasspath());
+	}
+
+	@Test
+	public void testCreateCompactType() throws Exception {
+		NewCompactWizardPage wizardPage= new NewCompactWizardPage();
+		wizardPage.setPackageFragmentRoot(fSourceFolder, true);
+		wizardPage.setPackageFragment(fpack1, true);
+		wizardPage.setTypeName("Hello", true);
+		wizardPage.setModifiers(Flags.AccPublic, true);
+
+		assertEquals(Flags.AccPublic, wizardPage.getModifiers());
+
+		wizardPage.createType(null);
+
+		String actual= wizardPage.getCreatedType().getCompilationUnit().getSource();
+		assertFalse("Source must not start with a blank line", actual.startsWith("\n"));
+		String expected= """
+			public void main() {
+			    // TODO Auto-generated method stub
+
+			}
+			""";
+		String cuName= wizardPage.getCreatedType().getCompilationUnit().getElementName();
+		assertEquals("Hello.java", cuName);
+		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
+	}
+
+	@Test
+	public void testCreateCompactTypeWithComments() throws Exception {
+		NewCompactWizardPage wizardPage= new NewCompactWizardPage();
+		wizardPage.setPackageFragmentRoot(fSourceFolder, true);
+		wizardPage.setPackageFragment(fpack1, true);
+		wizardPage.setTypeName("Hello", true);
+		wizardPage.setModifiers(Flags.AccPublic, true);
+		wizardPage.setAddComments(true, true);
+		wizardPage.enableCommentControl(true);
+
+		assertEquals(Flags.AccPublic, wizardPage.getModifiers());
+
+		wizardPage.createType(null);
+
+		String actual= wizardPage.getCreatedType().getCompilationUnit().getSource();
+		assertFalse("Source must not start with a blank line", actual.startsWith("\n"));
+		String expected= """
+			/**
+			 * Method
+			 */
+			public void main() {
+			    // TODO Auto-generated method stub
+
+			}
+			""";
+		String cuName= wizardPage.getCreatedType().getCompilationUnit().getElementName();
+		assertEquals("Hello.java", cuName);
+		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
+	}
+}

--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -185,4 +185,12 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java" type="org.eclipse.jdt.ui.wizards.NewTypeWizardPage">
+        <filter id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.ui.wizards.NewTypeWizardPage"/>
+                <message_argument value="COMPACT_TYPE"/>
+            </message_arguments>
+        </filter>
+    </resource>
 </component>

--- a/org.eclipse.jdt.ui/icons/full/etool16/newcompact_wiz.svg
+++ b/org.eclipse.jdt.ui/icons/full/etool16/newcompact_wiz.svg
@@ -1,0 +1,40 @@
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+	<defs>
+		<radialGradient id="g1" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-4.555,-4.555,4.555,-4.555,12.505,5.634)">
+			<stop offset="0" stop-color="#e0c576"/>
+			<stop offset="1" stop-color="#9e7916"/>
+		</radialGradient>
+		<linearGradient id="g2" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,6.277,-6.238,0,11.893,2.194)">
+			<stop offset="0" stop-color="#f7f9fb"/>
+			<stop offset="1" stop-color="#ffd680"/>
+		</linearGradient>
+	</defs>
+	<style>
+		.s0 { fill: #571919;stroke: #14733c;stroke-linecap: round;stroke-linejoin: round;stroke-width: 1 } 
+		.s1 { fill: #ffffff } 
+		.s2 { fill: url(#g1);stroke: #a27d18;stroke-width: 1 } 
+		.s3 { fill: url(#g2) } 
+	</style>
+	<g id="layer1">
+		<g id="g6124-3">
+			<g id="g6438">
+				<g id="g4193">
+					<g id="g6124-3-3">
+						<g id="g6438-8">
+							<path id="path10796-2-6-2" fill-rule="evenodd" class="s0" d="m8.54 14.51c-3.31 0-5.99-2.69-5.99-6.01 0-3.33 2.68-6.02 5.99-6.02 3.32 0 5.99 2.69 5.99 6.02 0 3.32-2.67 6.01-5.99 6.01z"/>
+						</g>
+					</g>
+					<path id="path3817" class="s1" d="m9.96 7.09c-0.29-0.4-0.23-0.32-0.47-0.53q-0.36-0.32-0.95-0.32-0.77 0-1.23 0.56c-0.31 0.36-0.46 0.6-0.46 1.46 0 0.96 0.16 1.39 0.46 1.78 0.32 0.4 0.8 0.59 1.26 0.59 0.46 0 0.71-0.14 0.97-0.34 0.26-0.2 0.28-0.2 0.53-0.73l2.03-0.01c-0.21 0.96-0.62 1.6-1.21 2.09q-0.9 0.74-2.41 0.74-1.72 0-2.74-1.12c-0.68-0.75-1.02-1.53-1.02-2.85 0-1.33 0.34-1.99 1.03-2.73q1.02-1.12 2.76-1.12 1.43 0 2.27 0.64c0.57 0.42 1.04 0.99 1.28 1.85z"/>
+				</g>
+			</g>
+			<g id="g6432">
+				<g id="g4514">
+					<g id="g4522">
+						<path id="rect3910" fill-rule="evenodd" class="s2" d="m12.54 7.89l-3.24-3.24 3.15-3.15 3.24 3.24z"/>
+						<path id="path5581-5-5" class="s3" d="m11.99 2.08h1v1.95h1.99v1.01h-1.99v2.05h-1v-2.05h-1.99v-1.01h1.99z"/>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</svg>

--- a/org.eclipse.jdt.ui/icons/full/wizban/newcomp_wiz.svg
+++ b/org.eclipse.jdt.ui/icons/full/wizban/newcomp_wiz.svg
@@ -1,0 +1,57 @@
+<svg version="1.2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 75 66" width="75" height="66">
+	<defs>
+		<linearGradient id="g1" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(75,0,0,66,0,33)">
+			<stop offset="0" stop-color="#b8ccf1" stop-opacity=".1"/>
+			<stop offset="1" stop-color="#6e97e2" stop-opacity=".1"/>
+		</linearGradient>
+		<linearGradient id="g2" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(75,0,0,44.939,0,43.53)">
+			<stop offset="0" stop-color="#fcfdfe" stop-opacity=".26"/>
+			<stop offset="1" stop-color="#98aae7" stop-opacity=".4"/>
+		</linearGradient>
+		<linearGradient id="g3" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(44.834,.083,-0.122,65.84,30.166,32.917)">
+			<stop offset="0" stop-color="#ffffff" stop-opacity=".35"/>
+			<stop offset="1" stop-color="#91ade6" stop-opacity="1"/>
+		</linearGradient>
+		<filter x="-50%" y="-50%" width="200%" height="200%" id="f1"> <feGaussianBlur stdDeviation="1.5"/> </filter>
+		<filter x="-50%" y="-50%" width="200%" height="200%" id="f2"> <feGaussianBlur stdDeviation="5.3"/> </filter>
+		<filter x="-50%" y="-50%" width="200%" height="200%" id="f3"> <feGaussianBlur stdDeviation="1.2"/> </filter>
+		<filter x="-50%" y="-50%" width="200%" height="200%" id="f4"> <feGaussianBlur stdDeviation=".9"/> </filter>
+		<filter x="-50%" y="-50%" width="200%" height="200%" id="f5"> <feGaussianBlur stdDeviation=".4"/> </filter>
+		<linearGradient id="g4" x2="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-20.777,.189,-0.233,-25.682,31.581,34.01)">
+			<stop offset="0" stop-color="#4aa118"/>
+			<stop offset=".798" stop-color="#4aa118"/>
+			<stop offset="1" stop-color="#9edc70"/>
+		</linearGradient>
+	</defs>
+	<style>
+		.s0 { fill: url(#g1) } 
+		.s1 { opacity: .4;fill: url(#g2) } 
+		.s2 { opacity: .18;fill: url(#g3) } 
+		.s3 { opacity: .75;filter: url(#f1);fill: #cacaca } 
+		.s4 { fill: #770000 } 
+		.s5 { filter: url(#f2);fill: #ffffff } 
+		.s6 { filter: url(#f3);fill: #770000 } 
+		.s7 { filter: url(#f4);fill: #770000 } 
+		.s8 { filter: url(#f5);fill: #770000 } 
+		.s9 { fill: #ffffff;stroke: url(#g4) } 
+		.s10 { filter: url(#f3);fill: #d7f1c6 } 
+		.s11 { fill: none;stroke: #657a32;stroke-linecap: round;stroke-linejoin: round;stroke-width: 1.3 } 
+	</style>
+	<g id="layer2">
+		<path id="rect4113-1" class="s0" d="m75 0v66h-75c0-24.8 50.01-66 75-66z"/>
+		<path id="rect4113-1-0" class="s1" d="m75 21.06v44.94h-75c10.63-18.2 43.51-40.56 75-44.94z"/>
+		<path id="rect4113-1-7" class="s2" d="m75 0v66h-45c0-19.85 17.71-56.75 45-66z"/>
+	</g>
+	<g id="layer1">
+		<path id="path3007-0" class="s3" d="m42.01 53.51l0.11 0.9 3.11 0.74-0.86 0.99-3.63 0.44-7.04 0.38-8.33 0.15-10.35-0.34c0 0-8.43-1.05-8.43-1.11 0-0.07 1.6-1.59 2.14-1.61 0.53-0.02 2.84-0.52 2.84-0.52l4.04-0.25 5.88-0.22 5.71-0.05 6.17 0.07c0 0 4.38 0.24 5.02 0.24 0.64 0 2.95 0.18 2.95 0.18z"/>
+		<path id="path10796-2-6-2" fill-rule="evenodd" class="s4" d="m24.42 54.5c-11.02 0-19.92-8.94-19.92-20 0-11.06 8.9-20 19.92-20 11.02 0 19.93 8.94 19.93 20 0 11.06-8.91 20-19.93 20z"/>
+		<path id="path5381-3" class="s5" d="m24.3 14.83q-2.46 0-4.84 0.6-2.39 0.61-4.55 1.77-2.17 1.17-3.99 2.82-1.82 1.66-3.18 3.72-0.03 0.16-0.04 0.33-0.02 0.16-0.03 0.33-0.01 0.16-0.02 0.33 0 0.17 0 0.33c0 1.57 0.33 3.12 0.99 4.56 0.65 1.45 1.61 2.76 2.82 3.87 1.21 1.11 2.65 1.99 4.23 2.58 1.58 0.6 3.27 0.91 4.99 0.91 1.71 0 3.4-0.31 4.98-0.91 1.58-0.59 3.02-1.47 4.23-2.58 1.21-1.11 2.16-2.42 2.82-3.87 0.65-1.44 0.99-2.99 0.99-4.56q0-1.46-0.39-2.88-0.39-1.42-1.14-2.71-0.75-1.29-1.82-2.38-1.07-1.09-2.39-1.91-0.46-0.08-0.91-0.15-0.46-0.06-0.91-0.11-0.46-0.04-0.92-0.07-0.46-0.02-0.92-0.02z"/>
+		<path id="path5137-8" fill-rule="evenodd" class="s6" d="m28.37 22.96c-27.62-7.11-25.85 32.41 1.06 25.38-25.68-0.29-23.19-26.82-1.06-25.38z"/>
+		<path id="path4955" fill-rule="evenodd" class="s7" d="m22.92 52.59c13.14 1.35 26.21-13.25 15.68-30.04 4.27 11.66-2.6 28.13-15.68 30.04z"/>
+		<path id="path4955-4" fill-rule="evenodd" class="s8" d="m11.47 21.08c-7.21 7.5-9.59 17.63 0.97 27.42-5.04-8.25-5.93-18.61-0.97-27.42z"/>
+		<path id="path4955-4-7" fill-rule="evenodd" class="s8" d="m32.3 17.32c-4-1.95-14.91-3.15-19 3.12 5.48-4.28 12.27-3.76 19-3.12z"/>
+		<path id="path3817-0" class="s9" d="m30.68 26.38c-0.12 0.01-12.22-2.99-12.28 7.34-0.29 9.78 11.19 6.57 12.48 5.93l1.55 5c1 0.66-12.1 4.85-18.02-1.34-2.26-2.47-3.51-5.2-3.51-9.58 0-4.43 0.91-6.85 3.18-9.31 5.73-6.62 18.09-3.92 17.83-3.08z"/>
+		<path id="path5137" fill-rule="evenodd" class="s10" d="m31.61 21.71c-26.33-7.08-26.11 31.45-0.75 23.04-24.82 0.19-20.69-24.08 0.75-23.04z"/>
+		<path id="path10796-2-6-2-2" fill-rule="evenodd" class="s11" d="m24.42 54.5c-11.02 0-19.92-8.94-19.92-20 0-11.06 8.9-20 19.92-20 11.02 0 19.93 8.94 19.93 20 0 11.06-8.91 20-19.93 20z"/>
+	</g>
+</svg>

--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -375,6 +375,9 @@ NewJavaPackage.description=Create a Java package
 NewJavaClass.label= Class
 NewJavaClass.description=Create a Java class
 
+NewCompact.label= Compact
+NewCompact.description=Create a Compact Source file
+
 NewJavaInterface.label= Interface
 NewJavaInterface.description= Create a Java interface
 

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -763,6 +763,19 @@
          <keywordReference id="org.eclipse.jdt.ui.wizards.java"/>
       </wizard>
       <wizard
+            name="%NewCompact.label"
+            icon="$nl$/icons/full/etool16/newcompact_wiz.svg"
+            category="org.eclipse.jdt.ui.java"
+            id="org.eclipse.jdt.ui.wizards.NewCompactCreationWizard">
+         <class class="org.eclipse.jdt.internal.ui.wizards.NewCompactCreationWizard">
+            <parameter name="javatype" value="true"/>
+         </class>
+         <description>
+            %NewCompact.description
+         </description>
+         <keywordReference id="org.eclipse.jdt.ui.wizards.java"/>
+      </wizard>
+      <wizard
             name="%NewJavaInterface.label"
             icon="$nl$/icons/full/etool16/newint_wiz.svg"
             category="org.eclipse.jdt.ui.java"
@@ -6318,6 +6331,22 @@
 		        menuGroupId="org.eclipse.jdt.ui.java"
 		        type="new"
 		        wizardId="org.eclipse.jdt.ui.wizards.NewClassCreationWizard">
+		     <enablement>
+		        <or>
+		           <instanceof value="org.eclipse.jdt.core.IPackageFragment"/>
+		           <instanceof value="org.eclipse.jdt.core.IPackageFragmentRoot"/>
+		           <instanceof value="org.eclipse.jdt.core.ICompilationUnit"/>
+		           <adapt type="org.eclipse.core.resources.IProject">
+		              <test property="org.eclipse.core.resources.projectNature" value="org.eclipse.jdt.core.javanature"/>
+		           </adapt>
+		        </or>
+		     </enablement>
+		  </commonWizard>
+
+		  <commonWizard
+		        menuGroupId="org.eclipse.jdt.ui.java"
+		        type="new"
+		        wizardId="org.eclipse.jdt.ui.wizards.NewCompactCreationWizard">
 		     <enablement>
 		        <or>
 		           <instanceof value="org.eclipse.jdt.core.IPackageFragment"/>

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/IJavaHelpContextIds.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/IJavaHelpContextIds.java
@@ -373,6 +373,8 @@ public interface IJavaHelpContextIds {
 	String NEW_JAVAPROJECT_WIZARD_PAGE= 								PREFIX + "new_javaproject_wizard_page_context"; //$NON-NLS-1$
 	String NEW_PACKAGE_WIZARD_PAGE= 									PREFIX + "new_package_wizard_page_context"; //$NON-NLS-1$
 	String NEW_CLASS_WIZARD_PAGE= 										PREFIX + "new_class_wizard_page_context"; //$NON-NLS-1$
+
+	String NEW_COMPACT_WIZARD_PAGE= 									PREFIX + "new_compact_wizard_page_context"; //$NON-NLS-1$
 	String NEW_INTERFACE_WIZARD_PAGE= 									PREFIX + "new_interface_wizard_page_context"; //$NON-NLS-1$
 
 	// since 3.1

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaHierarchyPerspectiveFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaHierarchyPerspectiveFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -82,6 +82,7 @@ public class JavaHierarchyPerspectiveFactory implements IPerspectiveFactory {
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.JavaProjectWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewPackageCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewClassCreationWizard"); //$NON-NLS-1$
+		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewCompactCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewInterfaceCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewEnumCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewAnnotationCreationWizard"); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPerspectiveFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPerspectiveFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -93,6 +93,7 @@ public class JavaPerspectiveFactory implements IPerspectiveFactory {
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.JavaProjectWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewPackageCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewClassCreationWizard"); //$NON-NLS-1$
+		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewCompactCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewInterfaceCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewEnumCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewRecordCreationWizard"); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPluginImages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPluginImages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -452,7 +452,9 @@ public class JavaPluginImages {
 
 	public static final ImageDescriptor DESC_WIZBAN_NEWCLASS= createUnManaged(T_WIZBAN, "newclass_wiz.svg"); 			//$NON-NLS-1$
 	public static final ImageDescriptor DESC_WIZBAN_NEWINT= createUnManaged(T_WIZBAN, "newint_wiz.svg"); 				//$NON-NLS-1$
-	public static final ImageDescriptor DESC_WIZBAN_NEWENUM= createUnManaged(T_WIZBAN, "newenum_wiz.svg"); 				//$NON-NLS-1$
+	public static final ImageDescriptor DESC_WIZBAN_NEWENUM= createUnManaged(T_WIZBAN, "newenum_wiz.svg"); //$NON-NLS-1$
+
+	public static final ImageDescriptor DESC_WIZBAN_NEWCOMP= createUnManaged(T_WIZBAN, "newcomp_wiz.svg"); //$NON-NLS-1$
 	public static final ImageDescriptor DESC_WIZBAN_NEWRECORD= createUnManaged(T_WIZBAN, "newrecord_wiz.svg"); 				//$NON-NLS-1$
 	public static final ImageDescriptor DESC_WIZBAN_NEWANNOT= createUnManaged(T_WIZBAN, "newannotation_wiz.svg"); 				//$NON-NLS-1$
 	public static final ImageDescriptor DESC_WIZBAN_NEWJPRJ= createUnManaged(T_WIZBAN, "newjprj_wiz.svg"); 			//$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/JavaBrowsingPerspectiveFactory.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/JavaBrowsingPerspectiveFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2010 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -90,6 +90,7 @@ public class JavaBrowsingPerspectiveFactory implements IPerspectiveFactory {
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.JavaProjectWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewPackageCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewClassCreationWizard"); //$NON-NLS-1$
+		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewCompactCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewInterfaceCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewEnumCreationWizard"); //$NON-NLS-1$
 		layout.addNewWizardShortcut("org.eclipse.jdt.ui.wizards.NewAnnotationCreationWizard"); //$NON-NLS-1$

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewCompactCreationWizard.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewCompactCreationWizard.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.ui.wizards;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+
+import org.eclipse.jdt.core.IJavaElement;
+
+import org.eclipse.jdt.ui.wizards.NewCompactWizardPage;
+
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.JavaPluginImages;
+
+public class NewCompactCreationWizard extends NewElementWizard {
+
+	private NewCompactWizardPage fPage;
+    private boolean fOpenEditorOnFinish;
+
+	public NewCompactCreationWizard(NewCompactWizardPage page, boolean openEditorOnFinish) {
+		setDefaultPageImageDescriptor(JavaPluginImages.DESC_WIZBAN_NEWCOMP);
+		setDialogSettings(JavaPlugin.getDefault().getDialogSettings());
+		setWindowTitle(NewWizardMessages.NewCompactCreationWizard_title);
+
+		fPage= page;
+		fOpenEditorOnFinish= openEditorOnFinish;
+	}
+
+	public NewCompactCreationWizard() {
+		this(null, true);
+	}
+
+	/*
+	 * @see Wizard#createPages
+	 */
+	@Override
+	public void addPages() {
+		super.addPages();
+		if (fPage == null) {
+			fPage= new NewCompactWizardPage();
+			fPage.setWizard(this);
+			fPage.init(getSelection());
+		}
+		addPage(fPage);
+	}
+
+	@Override
+	protected boolean canRunForked() {
+		return !fPage.isEnclosingTypeSelected();
+	}
+
+	@Override
+	protected void finishPage(IProgressMonitor monitor) throws InterruptedException, CoreException {
+		fPage.createType(monitor); // use the full progress monitor
+	}
+
+	@Override
+	public boolean performFinish() {
+		warnAboutTypeCommentDeprecation();
+		boolean res= super.performFinish();
+		if (res) {
+			IResource resource= fPage.getModifiedResource();
+			if (resource != null) {
+				selectAndReveal(resource);
+				if (fOpenEditorOnFinish) {
+					openResource((IFile) resource);
+				}
+			}
+		}
+		return res;
+	}
+
+	@Override
+	public IJavaElement getCreatedElement() {
+		return fPage.getCreatedType();
+	}
+
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -974,6 +974,9 @@ public final class NewWizardMessages extends NLS {
 	public static String ReleaseAttributeConfiguration_nameLabel;
 	public static String ReleaseAttributeConfiguration_path;
 	public static String ReleaseAttributeConfiguration_warning;
+	public static String NewCompactCreationWizard_title;
+	public static String NewCompactWizardPage_description;
+	public static String NewCompactWizardModuleError;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, NewWizardMessages.class);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/wizards/NewWizardMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2024 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -193,6 +193,12 @@ NewClassWizardPage_methods_main=public static &void main(String[] args)
 NewClassWizardPage_methods_constructors=Constr&uctors from superclass
 NewClassWizardPage_methods_inherited=In&herited abstract methods
 
+
+# ------- NewCompactSourceWizardPage -------
+
+NewCompactCreationWizard_title=New Compact Source
+NewCompactWizardPage_description=Create a new Compact File Source.
+NewCompactWizardModuleError=Compact source files are not allowed in a project with a named module
 
 # ------- NewRecordWizardPage -------
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewCompactWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewCompactWizardPage.java
@@ -1,0 +1,226 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.ui.wizards;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.ScrolledComposite;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.viewers.IStructuredSelection;
+
+import org.eclipse.jface.text.ITextSelection;
+
+import org.eclipse.ui.PlatformUI;
+
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IModuleDescription;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.manipulation.CodeGeneration;
+
+import org.eclipse.jdt.internal.core.manipulation.StubUtility;
+
+import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
+import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.dialogs.StatusInfo;
+import org.eclipse.jdt.internal.ui.wizards.NewWizardMessages;
+
+/**
+ * Wizard page to  create a new compact source file.
+ * <p>
+ * Note: This class is not intended to be subclassed, but clients can instantiate.
+ * To implement a different kind of a new compact wizard page, extend <code>NewTypeWizardPage</code>.
+ * </p>
+ *
+ * @noextend This class is not intended to be subclassed by clients.
+ * @since 3.39
+ */
+public class NewCompactWizardPage extends NewTypeWizardPage {
+
+	private final static String PAGE_NAME= "NewCompactWizardPage"; //$NON-NLS-1$
+
+	  private final static int TYPE = NewTypeWizardPage.COMPACT_TYPE;
+	/**
+	 * Creates a new <code>NewCompactWizardPage</code>
+	 */
+	public NewCompactWizardPage() {
+		super(TYPE, PAGE_NAME);
+		setTitle(NewWizardMessages.NewCompactCreationWizard_title);
+		setDescription(NewWizardMessages.NewCompactWizardPage_description);
+	}
+
+	public void init(IStructuredSelection selection) {
+		IJavaElement jelem= getInitialJavaElement(selection);
+		initContainerPage(jelem);
+		initTypePage(jelem);
+		doStatusUpdate();
+	}
+
+	@Override
+	protected void initTypePage(IJavaElement elem) {
+		IJavaProject project= null;
+		IPackageFragment pack= null;
+
+		if (elem != null) {
+			project= elem.getJavaProject();
+			pack= (IPackageFragment) elem.getAncestor(IJavaElement.PACKAGE_FRAGMENT);
+		}
+
+		String typeName= ""; //$NON-NLS-1$
+
+		ITextSelection selection= getCurrentTextSelection();
+		if (selection != null) {
+			String text= selection.getText();
+			if (text != null ) {
+				typeName= getUniqueJavaTypeName (pack, text);
+			}
+		}
+
+		setTypeName(typeName, true);
+
+		setAddComments(StubUtility.doAddComments(project), true);
+	}
+
+	private void doStatusUpdate() {
+		// status of all used components
+		IStatus[] status= new IStatus[] {
+			fTypeNameStatus,
+			fModifierStatus,
+			fContainerStatus,
+			moduleStatus()
+		};
+		updateStatus(status);
+	}
+
+	private IStatus moduleStatus() {
+		StatusInfo status= new StatusInfo();
+		IJavaProject project= getJavaProject();
+		if (project != null) {
+			try {
+				IModuleDescription module= project.getModuleDescription();
+				if (module != null && module.exists()) {
+					status.setError(NewWizardMessages.NewCompactWizardModuleError);
+					return status;
+				}
+			} catch (JavaModelException e) {
+				JavaPlugin.log(e);
+			}
+		}
+
+		return status;
+	}
+
+	@Override
+	protected void handleFieldChanged(String fieldName) {
+		super.handleFieldChanged(fieldName);
+		doStatusUpdate();
+	}
+
+
+	@Override
+	public void createControl(Composite parent) {
+		initializeDialogUnits(parent);
+
+		Composite composite= createScrollableContainer(parent);
+		composite.setFont(parent.getFont());
+
+		int nColumns= 4;
+
+		GridLayout layout= new GridLayout();
+		layout.numColumns= nColumns;
+		composite.setLayout(layout);
+
+
+		createContainerControls(composite, nColumns);
+
+		createSeparator(composite, nColumns);
+
+		createTypeNameControls(composite, nColumns);
+		createModifierControls(composite, nColumns);
+
+
+		createSeparator(composite, nColumns);
+
+		createCommentControls(composite, nColumns);
+		enableCommentControl(true);
+		ScrolledComposite sc= (ScrolledComposite) composite.getParent();
+		setControl(sc);
+
+		Dialog.applyDialogFont(composite);
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite, IJavaHelpContextIds.NEW_COMPACT_WIZARD_PAGE);
+		sc.setMinSize(composite.computeSize(SWT.DEFAULT, SWT.DEFAULT));
+	}
+
+	/*
+	 * @see WizardPage#becomesVisible
+	 */
+	@Override
+	public void setVisible(boolean visible) {
+		super.setVisible(visible);
+		if (visible) {
+			setFocus();
+			doStatusUpdate();
+		}
+	}
+
+	@Override
+	protected void createTypeMembers(IType type, ImportsManager imports, IProgressMonitor monitor) throws CoreException {
+		createMainMethod(type, imports);
+	}
+
+	@Override
+	protected IMethod createMainMethod(IType type, ImportsManager imports) throws CoreException{
+		if (type != null ) {
+			StringBuilder buf= new StringBuilder();
+
+			final String lineDelim= "\n"; //$NON-NLS-1$
+			if (isAddComments()) {
+				String comment= CodeGeneration.getMethodComment(type.getCompilationUnit(), type.getTypeQualifiedName('.'), "main", new String[] { }, new String[0], Signature.createTypeSignature("void", true), null, lineDelim); //$NON-NLS-1$ //$NON-NLS-2$
+				if (comment != null) {
+					buf.append(comment);
+					buf.append(lineDelim);
+				}
+			}
+			int modifiers= getModifiers();
+			buf.append(Flags.toString(modifiers));
+			if (modifiers != 0) {
+				buf.append(' ');
+			}
+
+			buf.append("void main() {"); //$NON-NLS-1$
+			buf.append(lineDelim);
+			final String content= CodeGeneration.getMethodBodyContent(type.getCompilationUnit(), type.getTypeQualifiedName('.'), "main", false, "", lineDelim); //$NON-NLS-1$ //$NON-NLS-2$
+			if (content != null && content.length() != 0)
+				buf.append(content);
+			buf.append(lineDelim);
+			buf.append("}"); //$NON-NLS-1$
+			ICompilationUnit cu= type.getCompilationUnit();
+			cu.getBuffer().setContents(buf.toString());
+			return type.getMethod("main", new String[0]); //$NON-NLS-1$
+		}
+		return null;
+	}
+}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -513,6 +513,12 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 	 * @noreference This field is not intended to be referenced by clients.
 	 */
 	public static final int RECORD_TYPE = 5;
+
+	/**
+	 * Constant to signal that the created type is an compact file source.
+	 * @since 3.39
+	 */
+	public static final int COMPACT_TYPE = 6;
 
 	/**
 	 * Creates a new <code>NewTypeWizardPage</code>.
@@ -1090,6 +1096,14 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 			}
 
 			DialogField.createEmptySpace(composite);
+		}
+		if (fTypeKind == COMPACT_TYPE) {
+			fAccMdfButtons.enableSelectionButton(PRIVATE_INDEX, false);
+			fAccMdfButtons.enableSelectionButton(PROTECTED_INDEX, true);
+			fAccMdfButtons.enableSelectionButton(DEFAULT_INDEX, true);
+			fAccMdfButtons.enableSelectionButton(PUBLIC_INDEX, true);
+			fAccMdfButtons.setSelection(DEFAULT_INDEX, true);
+			fAccMdfButtons.setSelection(PUBLIC_INDEX, false);
 		}
 	}
 
@@ -1884,6 +1898,13 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 		    	}
 	    	} else {
 	    		return new StatusInfo(IStatus.WARNING, NewWizardMessages.NewTypeWizardPage_warning_RecordClassNotFound);
+	    	}
+	    }
+		if (fTypeKind == COMPACT_TYPE && !status.matches(IStatus.ERROR)) {
+	    	if (root != null) {
+	    		if (!JavaModelUtil.is25OrHigher(root.getJavaProject())) {
+	    			return new StatusInfo(IStatus.ERROR, Messages.format(NewWizardMessages.NewTypeWizardPage_warning_NotJDKCompliant2, new String[] {BasicElementLabels.getJavaElementName(root.getJavaProject().getElementName()), "25" })); //$NON-NLS-1$
+	    		}
 	    	}
 	    }
 
@@ -2780,10 +2801,15 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 				connectedCU= parentCU;
 
 				IBuffer buffer= parentCU.getBuffer();
-
 				String simpleTypeStub= constructSimpleTypeStub();
-				String cuContent= constructCUContent(parentCU, simpleTypeStub, lineDelimiter);
-				buffer.setContents(cuContent);
+				String cuContent;
+				if (fTypeKind == COMPACT_TYPE) {
+					cuContent= simpleTypeStub;
+					buffer.setContents(cuContent);
+				} else {
+					cuContent= constructCUContent(parentCU, simpleTypeStub, lineDelimiter);
+					buffer.setContents(cuContent);
+				}
 
 				CompilationUnit astRoot= createASTForImports(parentCU);
 				existingImports= getExistingImports(astRoot);
@@ -2884,7 +2910,6 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 			JavaModelUtil.reconcile(cu);
 
 			ISourceRange range= createdType.getSourceRange();
-
 			IBuffer buf= cu.getBuffer();
 			String originalContent= buf.getText(range.getOffset(), range.getLength());
 
@@ -2898,6 +2923,7 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 					buf.replace(0, 0, fileComment + lineDelimiter);
 				}
 			}
+
 			fCreatedType= createdType;
 
 			if (needsSave) {
@@ -3081,10 +3107,15 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 
 
 	private String constructSimpleTypeStub() {
+		if (fTypeKind == COMPACT_TYPE) {
+			return ""; //$NON-NLS-1$
+		}
 		StringBuilder buf= new StringBuilder("public class "); //$NON-NLS-1$
 		buf.append(getTypeName());
 		buf.append("{ }"); //$NON-NLS-1$
 		return buf.toString();
+
+
 	}
 
 	/*
@@ -3092,6 +3123,9 @@ public abstract class NewTypeWizardPage extends NewContainerWizardPage {
 	 */
 	private String constructTypeStub(ICompilationUnit parentCU, ImportsManager imports, String lineDelimiter) throws CoreException {
 		StringBuffer buf= new StringBuffer();
+		if(fTypeKind == COMPACT_TYPE) {
+			return buf.toString();
+		}
 
 		int modifiers= getModifiers();
 		buf.append(Flags.toString(modifiers));


### PR DESCRIPTION
Introduces a new "Compact" entry in the New Java wizard to create implicit class source files (JEP 463, Java 25+). The wizard generates a file with a top-level void main() method, similar to what other IDEs have.
<img width="775" height="290" alt="image" src="https://github.com/user-attachments/assets/3d976f9a-f9b8-4baa-ab85-b50a602748b9" />


<img width="724" height="461" alt="Screenshot 2026-07-22 at 5 15 31 PM" src="https://github.com/user-attachments/assets/9c3da1b8-1249-415e-bac2-2ade8e04ec75" />

<img width="429" height="161" alt="Screenshot 2026-07-22 at 5 16 10 PM" src="https://github.com/user-attachments/assets/9bd4a198-18e0-4354-9bc6-577809173aa7" />


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
