### PR TITLE
Remove duplicate link with editor from menu bar in package explorer

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerActionGroup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerActionGroup.java
@@ -258,7 +258,6 @@ class PackageExplorerActionGroup extends CompositeActionGroup {
 
 	/* package */ void fillViewMenu(IMenuManager menu) {
 		menu.add(new Separator());
-		menu.add(fToggleLinkingAction);
 		menu.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS));
 		menu.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS+"-end"));//$NON-NLS-1$
 	}


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

This change removes the Link with Editor option from the view menu in package explorer.
The same action is already available in the toolbar, so having it in both places is unnecessary. This also makes the view consistent with the other toolbar actions, which do not have duplicate entries in the view menu.

Before :
<img width="277" height="280" alt="image" src="https://github.com/user-attachments/assets/35155f01-9cc5-48a8-8187-dc9b9c956372" />

After :
<img width="277" height="239" alt="image" src="https://github.com/user-attachments/assets/61190eaf-53c6-40de-bdbb-a6f8f9f56f8d" />


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
