### PR TITLE
Ensure markdown javadoc content processor initialized with auto-chars

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/ContentAssistPreference.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/ContentAssistPreference.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -96,6 +96,13 @@ public class ContentAssistPreference {
 		return null;
 	}
 
+	private static JavadocCompletionProcessor getJavaDocMarkdownProcessor(ContentAssistant assistant) {
+		IContentAssistProcessor p= assistant.getContentAssistProcessor(IJavaPartitions.JAVA_MARKDOWN_COMMENT);
+		if (p instanceof JavadocCompletionProcessor)
+			return (JavadocCompletionProcessor) p;
+		return null;
+	}
+
 	private static void configureJavaProcessor(ContentAssistant assistant, IPreferenceStore store) {
 		JavaCompletionProcessor jcp= getJavaProcessor(assistant);
 		if (jcp == null)
@@ -122,6 +129,15 @@ public class ContentAssistPreference {
 			jdcp.setCompletionProposalAutoActivationCharacters(triggers.toCharArray());
 
 		boolean enabled= store.getBoolean(CASE_SENSITIVITY);
+		jdcp.restrictProposalsToMatchingCases(enabled);
+
+		jdcp= getJavaDocMarkdownProcessor(assistant);
+		if (jdcp == null)
+			return;
+
+		if (triggers != null)
+			jdcp.setCompletionProposalAutoActivationCharacters(triggers.toCharArray());
+
 		jdcp.restrictProposalsToMatchingCases(enabled);
 	}
 
@@ -196,6 +212,18 @@ public class ContentAssistPreference {
 
 	private static void changeJavaDocProcessor(ContentAssistant assistant, IPreferenceStore store, String key) {
 		JavadocCompletionProcessor jdcp= getJavaDocProcessor(assistant);
+		if (jdcp == null)
+			return;
+
+		if (AUTOACTIVATION_TRIGGERS_JAVADOC.equals(key)) {
+			String triggers= store.getString(AUTOACTIVATION_TRIGGERS_JAVADOC);
+			if (triggers != null)
+				jdcp.setCompletionProposalAutoActivationCharacters(triggers.toCharArray());
+		} else if (CASE_SENSITIVITY.equals(key)) {
+			boolean enabled= store.getBoolean(CASE_SENSITIVITY);
+			jdcp.restrictProposalsToMatchingCases(enabled);
+		}
+		jdcp= getJavaDocMarkdownProcessor(assistant);
 		if (jdcp == null)
 			return;
 


### PR DESCRIPTION
- modify ContentsAssistPreference.configureJavaDocProcessor() to also make settings to the JavadocCompletionProcessor that is set up for markdown partitions
- same fo ContentAssistPreference.changeJavaDocProcessor() method
- fixes #2527

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
