### PR TITLE
Suppress `Correct package declaration` quickfix for implicit classes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CorrectPackageDeclarationFixCore.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/fix/CorrectPackageDeclarationFixCore.java
@@ -62,8 +62,8 @@ public class CorrectPackageDeclarationFixCore implements IProposableFix {
 		IPackageFragment parentPack= (IPackageFragment) cu.getParent();
 		try {
 			IPackageDeclaration[] decls= cu.getPackageDeclarations();
+			IJavaProject jProject = parentPack.getJavaProject();
 			if (parentPack.isDefaultPackage() && decls.length > 0) {
-				IJavaProject jProject = parentPack.getJavaProject();
 				if (jProject != null && JavaModelUtil.is9OrHigher(jProject)) {
 					try {
 						IModuleDescription desc= jProject.getModuleDescription();
@@ -71,9 +71,13 @@ public class CorrectPackageDeclarationFixCore implements IProposableFix {
 							isValid= false;
 						}
 					} catch (JavaModelException e) {
-						// TODO Auto-generated catch block
-						e.printStackTrace();
+						JavaManipulationPlugin.log(e);
 					}
+				}
+			}
+			if (jProject != null && JavaModelUtil.is25OrHigher(jProject)) {
+				if(cu.getTypes()[0].isImplicitlyDeclared()) {
+					isValid= false;
 				}
 			}
 		} catch(JavaModelException e) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ReorgQuickFixTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/ReorgQuickFixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.ui.tests.quickfix;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -55,6 +56,7 @@ import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 
 import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.PreferenceConstants;
+import org.eclipse.jdt.ui.tests.core.rules.Java25ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 import org.eclipse.jdt.ui.text.java.ClasspathFixProcessor.ClasspathFixProposal;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
@@ -71,7 +73,10 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.FixCorrectionPropos
 public class ReorgQuickFixTest extends QuickFixTest {
 
 	@Rule
-    public ProjectTestSetup projectSetup = new ProjectTestSetup();
+	   public ProjectTestSetup projectSetup = new ProjectTestSetup();
+
+	@Rule
+	public ProjectTestSetup projectSetup25= new Java25ProjectTestSetup();
 
 	private IJavaProject fJProject1;
 	private IPackageFragmentRoot fSourceFolder;
@@ -95,6 +100,7 @@ public class ReorgQuickFixTest extends QuickFixTest {
 	@After
 	public void tearDown() throws Exception {
 		JavaProjectHelper.clear(fJProject1, projectSetup.getDefaultClasspath());
+		JavaProjectHelper.clear(projectSetup25.getProject(), projectSetup25.getDefaultClasspath());
 	}
 
 	@Test
@@ -1126,9 +1132,9 @@ public class ReorgQuickFixTest extends QuickFixTest {
 				}
 
 				@Override
-				public IPath getPath() {
-					return containerPath;
-				}
+					public IPath getPath() {
+						return containerPath;
+					}
 			};
 			ClasspathContainerInitializer initializer= JavaCore.getClasspathContainerInitializer(JavaCore.USER_LIBRARY_CONTAINER_ID);
 			initializer.requestClasspathContainerUpdate(containerPath, otherProject, newContainer);
@@ -1147,6 +1153,28 @@ public class ReorgQuickFixTest extends QuickFixTest {
 		}
 	}
 
+	@Test
+	public void testWrongPackageStatementImplicitClass() throws Exception {
+		fJProject1= projectSetup25.getProject();
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject1, "src");
+
+		IPackageFragment pack1= fSourceFolder.createPackageFragment("test1", false, null);
+		String str= """
+			void main() {
+			    System.out.println("implicit");
+			}
+			""";
+		ICompilationUnit cu= pack1.createCompilationUnit("Hello.java", str, false, null);
+
+		CompilationUnit astRoot= getASTRoot(cu);
+		ArrayList<IJavaCompletionProposal> proposals= collectCorrections(cu, astRoot);
+
+		for (IJavaCompletionProposal proposal : proposals) {
+			assertFalse(
+				"\"Correct package declaration\" must not be offered for implicit classes",
+				proposal instanceof FixCorrectionProposal);
+		}
+	}
 
 
 


### PR DESCRIPTION
Implicit classes always belong to the unnamed package, so correcting their package declaration will throw compilation error

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
