### PR TITLE
Fix sort algorithm for open types dialog

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
@@ -1206,7 +1206,7 @@ public class FilteredTypesSelectionDialog extends FilteredItemsSelectionDialog i
 
 		@Override
 		public int compare(TypeNameMatch leftInfo, TypeNameMatch rightInfo) {
-			int result= compareOriginalTextMatchLength(leftInfo.getSimpleTypeName(), rightInfo.getSimpleTypeName());
+			int result= compareWithOriginalText(leftInfo.getSimpleTypeName(), rightInfo.getSimpleTypeName());
 			if (result != 0)
 				return result;
 			result= compareName(leftInfo.getSimpleTypeName(), rightInfo.getSimpleTypeName());
@@ -1231,15 +1231,63 @@ public class FilteredTypesSelectionDialog extends FilteredItemsSelectionDialog i
 			return compareContainerName(leftInfo, rightInfo);
 		}
 
-		private int compareOriginalTextMatchLength(String leftString, String rightString) {
+		private int compareWithOriginalText(String leftString, String rightString) {
 			if (fOriginalPrefix != null && !fOriginalPrefix.isEmpty()) {
 				int iLeft= 0;
-				while (iLeft < fOriginalPrefix.length() && iLeft < leftString.length() && leftString.charAt(iLeft) == fOriginalPrefix.charAt(iLeft)) {
+				int leftLength= leftString.length();
+				int prefixLength= fOriginalPrefix.length();
+				while (iLeft < prefixLength && iLeft < leftLength && leftString.charAt(iLeft) == fOriginalPrefix.charAt(iLeft)) {
 					++iLeft;
 				}
 				int iRight= 0;
-				while (iRight < fOriginalPrefix.length() && iRight < rightString.length() && rightString.charAt(iRight) == fOriginalPrefix.charAt(iRight)) {
+				int rightLength= rightString.length();
+				while (iRight < prefixLength && iRight < rightLength && rightString.charAt(iRight) == fOriginalPrefix.charAt(iRight)) {
 					++iRight;
+				}
+				int index= iLeft;
+				if (iRight == iLeft) {
+					while (index < prefixLength && (iLeft < leftLength || iRight < rightLength)) {
+						// Find next char in original prefix
+						char nextChar= fOriginalPrefix.charAt(index++);
+						if (Character.isUpperCase(nextChar)) {
+							int leftMatch= 0;
+							int rightMatch= 0;
+							do {
+								char leftChar= 0;
+								char rightChar= 0;
+								while (iLeft < leftLength && !Character.isUpperCase(leftChar= leftString.charAt(iLeft))) {
+									++iLeft;
+								}
+								if (leftChar == nextChar) {
+									leftMatch= 1;
+								}
+								while (iRight < rightLength && !Character.isUpperCase(rightChar= rightString.charAt(iRight))) {
+									++iRight;
+								}
+								if (rightChar == nextChar) {
+									rightMatch= 1;
+								}
+								if (rightMatch != leftMatch) {
+									return rightMatch - leftMatch;
+								}
+								++iLeft;
+								++iRight;
+							} while (leftMatch == 0 && rightMatch == 0 && (iLeft < leftLength || iRight < rightLength));
+						} else {
+							int originalLeft= iLeft;
+							int originalRight= iRight;
+							while (iLeft < leftLength && leftString.charAt(iLeft) != nextChar) {
+								++iLeft;
+							}
+							while (iRight < rightLength && rightString.charAt(iRight) != nextChar) {
+								++iRight;
+							}
+							int diffLeft= iLeft - originalLeft;
+							int diffRight= iRight - originalRight;
+							return diffLeft - diffRight;
+						}
+					}
+					return 0;
 				}
 				return iRight - iLeft;
 			}


### PR DESCRIPTION
- rename FilteredTypesSelectionDialog.compareOriginalTextMatchLength() method to compareWithOriginalText() and modify method to not only look for longest match of original text string but also when equal, look for next upper-case character and give precedence to match where it is found and more precedence if it is found earlier
- fixes #3102

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
