### PR TITLE
Asynchronously open internal browser for javadoc hover

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/OpenBrowserUtil.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/actions/OpenBrowserUtil.java
@@ -29,7 +29,7 @@ import org.eclipse.jdt.internal.ui.JavaPlugin;
 public class OpenBrowserUtil {
 
 	/**
-	 * Opens the given url in the browser as choosen in the preferences.
+	 * Opens the given url in the browser as chosen in the preferences.
 	 *
 	 * @param url the URL
 	 * @param display the display
@@ -37,6 +37,16 @@ public class OpenBrowserUtil {
 	 */
 	public static void open(final URL url, Display display) {
 		display.syncExec(() -> internalOpen(url, false));
+	}
+
+	/**
+	 * Asynchronously opens the given url in the browser as chosen in the preferences.
+	 *
+	 * @param url the URL
+	 * @param display the display
+	 */
+	public static void openAsync(final URL url, Display display) {
+		display.asyncExec(() -> internalOpen(url, false));
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/hover/JavadocHover.java
@@ -676,7 +676,7 @@ public class JavadocHover extends AbstractJavaEditorTextHover {
 				control.dispose(); //FIXME: should have protocol to hide, rather than dispose
 
 				// Open attached Javadoc links
-				OpenBrowserUtil.open(url, display);
+				OpenBrowserUtil.openAsync(url, display);
 
 				return true;
 			}


### PR DESCRIPTION
Currently, when opening an external link in a javadoc hover in the internal browser under Windows, the user interface permanently freezes.

This is caused by a deadlock within the Edge/WebView2 browser runtime which occurs if a new browser instance is being created from within a (navigation) callback of another browser instance.

Adapting `handleExternalLink(URL, Display)` in the link handler used by the `JavadocHover` to open the new browser instance asynchronously fixes the problem as the browser creation is now moved out of the (navigation) callback.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3105

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
