### PR TITLE
Fix overridden method inherited javadoc when markdown is used

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccess.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccess.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2023 IBM Corporation and others.
+ * Copyright (c) 2008, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -433,7 +433,39 @@ public class CoreJavadocAccess {
 		}
 
 		if (CoreJavadocContentAccessUtility.canInheritJavadoc(member)) {
-			IMethod method= (IMethod) member;
+			IMethod method= (IMethod)member;
+			IType declaringType= method.getDeclaringType();
+
+			IMethod overridden= null;
+			if (rawJavadoc.equals("/***/")) { //$NON-NLS-1$
+				try {
+					// we have assumed we have old-style Javadoc...check if
+					// we have an overridden method with Javadoc where we can check if
+					// it is markdown in which case, update rawJavadoc string and
+					// recalculate javadoc based on using a markdown processor
+					if (!method.isConstructor()) {
+						ITypeHierarchy hierarchy= SuperTypeHierarchyCache.getTypeHierarchy(declaringType);
+						MethodOverrideTester tester= new MethodOverrideTester(declaringType, hierarchy);
+						overridden= tester.findOverriddenMethod(method, true);
+					}
+					if (overridden != null) {
+						IBuffer buf= overridden.getOpenable().getBuffer();
+						if (buf != null) {
+							ISourceRange javadocRange= overridden.getJavadocRange();
+							if (javadocRange != null) {
+								String javadocStart= buf.getText(javadocRange.getOffset(), 3);
+								if (javadocStart.equals("///")) { //$NON-NLS-1$
+									rawJavadoc= "///\n"; //$NON-NLS-1$
+									javadoc= CoreJavadocContentAccessUtility.getJavadocNode(member, rawJavadoc);
+								}
+							}
+						}
+					}
+				} catch (JavaModelException e2) {
+					JavaManipulationPlugin.log(e2);
+				}
+			}
+
 			return this.fFactory.createJavadocAccess(element, javadoc, rawJavadoc, new JavadocLookup(method.getDeclaringType(), this.fFactory)).toHTML();
 		}
 		return this.fFactory.createJavadocAccess(element, javadoc, rawJavadoc, null).toHTML();

--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
@@ -578,7 +578,7 @@ public class CoreJavadocAccessImpl implements IJavadocAccess {
 
 			fBuf= null;
 		}
-		return fMainDescription.length() > 0 ? fMainDescription : null;
+		return fMainDescription.length() > 0 ? fMainDescription.append("\n") : null; //$NON-NLS-1$
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.ui.tests.hover;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.net.URI;
@@ -505,8 +506,8 @@ public class MarkdownCommentTests extends CoreTests {
 		String superURI= makeEncodedClassUri("p", "Spec03Tags", "Super");
 		String superMURI= makeEncodedMethodUri(true, "p", "Spec03Tags", "Super","m", "I");
 		String expectedContent= """
-				<p>super doc
-				In addition, this methods calls <code><a href='METHOD_URI'>wait()</a></code>.<div><b>Overrides:</b> <a href='SUPER_M_URI'>m(...)</a> in <a href='SUPER_URI'>Super</a></div></p>
+				<p>super doc</p>
+				<p>In addition, this methods calls <code><a href='METHOD_URI'>wait()</a></code>.<div><b>Overrides:</b> <a href='SUPER_M_URI'>m(...)</a> in <a href='SUPER_URI'>Super</a></div></p>
 				<dl><dt>Parameters:</dt><dd><b>i</b> the index</dd></dl>
 				"""
 				.replace("METHOD_URI", waitURI)
@@ -1112,6 +1113,41 @@ public class MarkdownCommentTests extends CoreTests {
 		assertNotEquals(-1, index);
 		String actualSnippet= actualHtmlContent.substring(index, index + expectedContent.length());
 		assertEquals("sequence doesn't match", expectedContent, actualSnippet);
+	}
+
+	@Test
+	public void testInheritedMethod() throws CoreException {
+		String source= """
+				public class Base {
+				    /// ## Title
+				    /// *Some* `formatted` {@code text}
+				    /// ```
+				    /// block
+				    /// ```
+				    ///
+				    void m() {}
+
+				    class A1 extends Base {
+				        @Override
+				        void m() {}
+				    }
+				}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Base.java", source, null);
+		assertNotNull("Base.java", cu);
+
+		String expectedContent= """
+				<p><em>Some</em> <code>formatted</code> <code>text
+				</code></p>
+				<pre><code>block
+				</code></pre>
+				<div><b>Overrides:</b> <a href='eclipse-javadoc:%E2%98%82=TestSetupProject/src%3Cp%7BBase.java%E2%98%83Base~m'>m()</a> in <a href='eclipse-javadoc:%E2%98%82=TestSetupProject/src%3Cp%7BBase.java%E2%98%83Base'>Base</a></div>
+				""";
+		IType type0= cu.getType("Base");
+		IType type= type0.getType("A1");
+		IMethod method= type.getMethods()[0];
+		String actualHtmlContent= getHoverHtmlContent(cu, method);
+		assertTrue("Doesn't contain expected content", actualHtmlContent.contains(expectedContent));
 	}
 
 }


### PR DESCRIPTION
- fix CoreJavadocAccess.javadoc2HTML to check if we have the default rawjavadoc string and if we can inherit javadoc, if the overridden method has markdown javadoc, then reset the rawjavadoc to the default markdown string so that the markdown processors will be used
- add newline after fetching main description in case we have a markdown code block
- add new test to MarkdownCommentTests
- fixes #3101

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
