### PR TITLE
Add preference for using wildcards between open type camel case segments

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/FilteredTypesSelectionDialog.java
@@ -50,6 +50,7 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.operation.IRunnableContext;
 import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.resource.LocalResourceManager;
@@ -104,6 +105,7 @@ import org.eclipse.jdt.launching.LibraryLocation;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
 import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.dialogs.ITypeInfoFilterExtension;
 import org.eclipse.jdt.ui.dialogs.ITypeInfoImageProvider;
 import org.eclipse.jdt.ui.dialogs.ITypeSelectionComponent;
@@ -942,7 +944,9 @@ public class FilteredTypesSelectionDialog extends FilteredItemsSelectionDialog i
 			 */
 			super(new TypeSearchPattern());
 			fOriginalPattern= patternMatcher.getPattern();
-			String pattern= getModifiedPatternText(fOriginalPattern);
+			IPreferenceStore preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
+			boolean inferWildcards= preferenceStore.getBoolean(PreferenceConstants.OPEN_TYPES_INFER_WILDCARDS);
+			String pattern= inferWildcards ? getModifiedPatternText(fOriginalPattern) : fOriginalPattern;
 			fTypeInfoFilter= new TypeInfoFilter(pattern, scope, elementKind, extension);
 		}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/OpenTypeSelectionDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/dialogs/OpenTypeSelectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,9 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.ui.dialogs;
 
+
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.Clipboard;
 import org.eclipse.swt.dnd.TextTransfer;
 import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -27,6 +31,7 @@ import org.eclipse.jface.commands.ActionHandler;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.operation.IRunnableContext;
+import org.eclipse.jface.preference.IPreferenceStore;
 
 import org.eclipse.ui.ActiveShellExpression;
 import org.eclipse.ui.IWorkbenchCommandConstants;
@@ -38,11 +43,16 @@ import org.eclipse.jdt.core.search.IJavaSearchScope;
 
 import org.eclipse.jdt.internal.corext.util.TypeInfoFilter;
 
+import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.dialogs.TypeSelectionExtension;
 
 import org.eclipse.jdt.internal.ui.IJavaHelpContextIds;
 import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.ui.JavaUIMessages;
+import org.eclipse.jdt.internal.ui.preferences.PreferencesMessages;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.DialogField;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.IDialogFieldListener;
+import org.eclipse.jdt.internal.ui.wizards.dialogfields.SelectionButtonDialogField;
 
 /**
  * A type selection dialog used for opening types.
@@ -50,6 +60,8 @@ import org.eclipse.jdt.internal.ui.JavaUIMessages;
 public class OpenTypeSelectionDialog extends FilteredTypesSelectionDialog {
 
 	private static final String DIALOG_SETTINGS= "org.eclipse.jdt.internal.ui.dialogs.OpenTypeSelectionDialog2"; //$NON-NLS-1$
+
+	private SelectionButtonDialogField fOpenTypesInferWildcards;
 
 	public OpenTypeSelectionDialog(Shell parent, boolean multi, IRunnableContext context, IJavaSearchScope scope, int elementKinds) {
 		this(parent, multi, context, scope, elementKinds, null);
@@ -74,6 +86,36 @@ public class OpenTypeSelectionDialog extends FilteredTypesSelectionDialog {
 		}
 
 		return settings;
+	}
+
+	private void doDialogFieldChanged(DialogField field) {
+		IPreferenceStore preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
+
+		if (field == fOpenTypesInferWildcards)
+			preferenceStore.setValue(PreferenceConstants.OPEN_TYPES_INFER_WILDCARDS, fOpenTypesInferWildcards.isSelected());
+		applyFilter();
+	}
+
+	@Override
+	protected Control createButtonBar(Composite parent) {
+		IPreferenceStore preferenceStore= JavaPlugin.getDefault().getPreferenceStore();
+		IDialogFieldListener listener= this::doDialogFieldChanged;
+
+		Composite newComposite= new Composite(parent, NONE);
+		GridLayout layout= new GridLayout();
+		layout.numColumns= 1;
+		layout.marginLeft= 5;
+		newComposite.setLayout(layout);
+		GridData gd= new GridData();
+		gd.horizontalIndent= 5;
+		newComposite.setLayoutData(gd);
+		fOpenTypesInferWildcards= new SelectionButtonDialogField(SWT.CHECK);
+		fOpenTypesInferWildcards.setDialogFieldListener(listener);
+		fOpenTypesInferWildcards.setLabelText(PreferencesMessages.OpenTypesDialog_default_wildcard_between_camel_case_parts_label);
+		fOpenTypesInferWildcards.doFillIntoGrid(newComposite, 1);
+		fOpenTypesInferWildcards.setSelection(preferenceStore.getBoolean(PreferenceConstants.OPEN_TYPES_INFER_WILDCARDS));
+
+		return super.createButtonBar(parent);
 	}
 
 	@Override

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.java
@@ -938,6 +938,5 @@ public final class PreferencesMessages extends NLS {
 	public static String JavaLaunchingConfigurationBlock_junit_name_fully_qualified_label;
 	public static String JavaLaunchingConfigurationBlock_name_description;
 
-	public static String MiscellaneousConfigurationBlock_open_type_name;
-	public static String MiscellaneousConfigurationBlock_default_wildcard_between_camel_case_parts_label;
+	public static String OpenTypesDialog_default_wildcard_between_camel_case_parts_label;
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/PreferencesMessages.properties
@@ -1064,5 +1064,4 @@ JavaLaunchingConfigurationBlock_applet_name_fully_qualified_label=Use fully qual
 JavaLaunchingConfigurationBlock_junit_name_fully_qualified_label=Use fully qualified name for new JUnit test
 JavaLaunchingConfigurationBlock_name_description=Launch Configuration Names
 
-MiscellaneousConfigurationBlock_open_type_name=Open Type Preferences
-MiscellaneousConfigurationBlock_default_wildcard_between_camel_case_parts_label=Default wildcard (*) between camel case sections
+OpenTypesDialog_default_wildcard_between_camel_case_parts_label=Default wildcard (*) between camel case sections

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2880,6 +2880,19 @@ public class PreferenceConstants {
 	public final static String SPELLING_ENABLE_CONTENTASSIST= "spelling_enable_contentassist"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that specifies whether the open types dialog should infer wildcards before
+	 * upper-case characters in a camel-case specificier.  The option does not apply when there are
+	 * only upper-case characters in the string.
+	 *
+	 * <p>
+	 * Value is of type <code>Boolean</code>.
+	 * </p>
+	 *
+	 * @since 3.39
+	 */
+	public final static String OPEN_TYPES_INFER_WILDCARDS= "open_types_infer_wildcards"; //$NON-NLS-1$
+
+	/**
 	 * A named preference that controls whether code snippets are formatted
 	 * in Javadoc comments.
 	 * <p>
@@ -4438,6 +4451,8 @@ public class PreferenceConstants {
 
 		store.setToDefault(PreferenceConstants.EDITOR_SHOW_TEXT_HOVER_AFFORDANCE); // global
 
+		// Open types dialog
+		store.setDefault(PreferenceConstants.OPEN_TYPES_INFER_WILDCARDS, true);
 
 		//Code Clean Up
 		CleanUpConstantsOptions.initDefaults(store);


### PR DESCRIPTION
- add new preference to PreferenceConstants
- modify OpenTypeSelectionDialog to add createButtonBar() override that adds a new preference checkbox to the dialog for the new preference
- modify FilteredTypesSelectionDialog.TypeItemsFilter to only modify the pattern if the new preference is set (default is true)
- for #3102

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds new preference for inferred wildcards for camel-case segments in the open types dialog.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
