### PR TITLE
Ensure markdown links are colored the same as javadoc links

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocScanner.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/javadoc/JavaDocScanner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -47,7 +47,6 @@ import org.eclipse.jdt.internal.ui.text.JavaWhitespaceDetector;
  * A rule based JavaDoc scanner.
  */
 public final class JavaDocScanner extends JavaCommentScanner {
-
 
 	/**
 	 * Detector for HTML comment delimiters.
@@ -136,7 +135,7 @@ public final class JavaDocScanner extends JavaCommentScanner {
 	};
 
 
-	public JavaDocScanner(IColorManager manager, IPreferenceStore store, Preferences coreStore) {
+	public JavaDocScanner(IColorManager manager, IPreferenceStore store, @SuppressWarnings("deprecation") Preferences coreStore) {
 		super(manager, store, coreStore, IJavaColorConstants.JAVADOC_DEFAULT, fgTokenProperties);
 	}
 
@@ -180,11 +179,13 @@ public final class JavaDocScanner extends JavaCommentScanner {
 		list.add(new MultiLineRule("{@link", "}", token)); //$NON-NLS-2$ //$NON-NLS-1$
 		list.add(new MultiLineRule("{@value", "}", token)); //$NON-NLS-2$ //$NON-NLS-1$
 		list.add(new MultiLineRule("{@inheritDoc", "}", token)); //$NON-NLS-2$ //$NON-NLS-1$
+		list.add(new SingleLineRule(" [", "]", token)); //$NON-NLS-1$ //$NON-NLS-2$
 
 		// Add rules for @code and @literals
 		token= getToken(IJavaColorConstants.JAVADOC_DEFAULT);
 		list.add(new MultiLineRule("{@code", "}", token)); //$NON-NLS-2$ //$NON-NLS-1$
 		list.add(new MultiLineRule("{@literal", "}", token)); //$NON-NLS-2$ //$NON-NLS-1$
+		list.add(new MultiLineRule("```", "```", token)); //$NON-NLS-1$ //$NON-NLS-2$
 
 		// Add generic whitespace rule
 		token= getToken(IJavaColorConstants.JAVADOC_DEFAULT);


### PR DESCRIPTION
- modify JavaDocScanner.createRules() to add a rule for a markdown link
- also add a rule for a code block (``` block)
- fixes #3000

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
