### PR TITLE
Add ambiguous import checking for compact source

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/OrganizeImportsOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -56,6 +56,7 @@ import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IModuleBinding;
 import org.eclipse.jdt.core.dom.IPackageBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.ImplicitTypeDeclaration;
 import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.Modifier;
@@ -323,7 +324,8 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 			while (parent instanceof Type) {
 				parent= parent.getParent();
 			}
-			if (parent instanceof AbstractTypeDeclaration && parent.getParent() instanceof CompilationUnit) {
+			if ((parent instanceof AbstractTypeDeclaration && parent.getParent() instanceof CompilationUnit)
+					|| (parent instanceof ImplicitTypeDeclaration && parent.getParent() instanceof CompilationUnit)){
 				return true;
 			}
 
@@ -373,7 +375,7 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 							}
 							return;
 						}
-						if (fImplicitImports.contains(qualifier)) {
+						if (fImplicitImports.contains(qualifier) && !typeNameAmbiguousForImplicitModule(typeName)) {
 							return;
 						}
 					}
@@ -394,6 +396,25 @@ public class OrganizeImportsOperation implements IWorkspaceRunnable {
 
 			fImportsAdded.add(typeName);
 			fUnresolvedTypes.put(typeName, new UnresolvedTypeData(ref));
+		}
+
+		private boolean typeNameAmbiguousForImplicitModule(String typeName) {
+			IJavaProject project= fCurrPackage.getJavaProject();
+			IType foundType= null;
+			for (String packageName : fImplicitImports) {
+				try {
+					IType type= project.findType(packageName + "." + typeName); //$NON-NLS-1$
+					if (type != null) {
+						if (foundType != null) {
+							return true;
+						}
+						foundType= type;
+					}
+				} catch (JavaModelException e) {
+					return false;
+				}
+			}
+			return false;
 		}
 
 		private boolean typeNameAmbiguousForImportedModules(String typeName) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest25.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/core/ImportOrganizeTest25.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 IBM Corporation and others.
+ * Copyright (c) 2025, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -342,6 +342,40 @@ public class ImportOrganizeTest25 extends CoreTests {
 				"mod2",
 				"java.base",
 				"java.util.List",
+		});
+	}
+
+	@Test
+	public void testImplicitClass() throws Exception {
+		IPackageFragmentRoot sourceFolder2= JavaProjectHelper.addSourceContainer(fJProject2, "src");
+
+		IPackageFragment defaultPkg= sourceFolder2.createPackageFragment("", false, null);
+		String code= """
+			import java.security.cert.Certificate;
+			import java.util.List;
+
+			Certificate certificate;
+
+			public static void main(String[] args) {
+				Certificate certificate;
+				List<String> list;
+			}
+			""";
+		ICompilationUnit cu= defaultPkg.createCompilationUnit("MyClass.java", code, false, null);
+
+		Map<String, String> options= new HashMap<>();
+		options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_25);
+		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_25);
+		cu.setOptions(options);
+
+		String[] order= new String[0];
+		IChooseImportQuery query= createQuery("E", new String[] {}, new int[] {});
+
+		OrganizeImportsOperation op= createOperation(cu, order, 99, false, true, true, query);
+		op.run(null);
+
+		assertImports(cu, new String[] {
+				"java.security.cert.Certificate"
 		});
 	}
 }


### PR DESCRIPTION
- add a new OrganizeImportsOperation.typeNameAmbiguousForImplicitModule method
- if an import matches one of the implicit package names, verify it is not ambiguous for the implicit module using new method
- add new test to ImportOrganizeTest25
- fixes #3111

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Add ambiguity checking for imports in compact source.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
