### PR TITLE
skip folding implicitly declared classes

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.text.tests.folding;
 
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -30,7 +31,6 @@ import org.junit.runners.Parameterized.Parameters;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.jface.preference.IPreferenceStore;
-
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
@@ -825,6 +825,25 @@ public class FoldingTest {
 		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 12, 17); // Runnable
 		JavaPlugin.getDefault().getPreferenceStore().setToDefault(PreferenceConstants.EDITOR_FOLDING_INNERTYPES);
 
+	}
+
+	@Test
+	public void testSimpleMainDoesNotContainRegionSurroundingImplicitClass() throws Exception {
+		String str = """
+				import module java.base;
+
+				int i;
+				int j;
+
+				void main() {
+					// main
+				}
+
+				""";
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // main
+		FoldingTestUtils.assertDoesNotContainRegionUsingStartLine(regions, str, 2); // int i
+		assertEquals(1, regions.size()); // no other unexpected regions anywhere else
 	}
 }
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1258,6 +1258,13 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			case IJavaElement.TYPE:
 				// only inner types may be collapsed
 				collapse= ctx.collapseInnerTypes() && isInnerType((IType) element);
+				try {
+					if (((IType) element).isImplicitlyDeclared()) {
+						return;
+					}
+				} catch (JavaModelException e) {
+					return;
+				}
 				break;
 			case IJavaElement.METHOD:
 			case IJavaElement.FIELD:


### PR DESCRIPTION
## What it does

[Compact Source Files](https://openjdk.org/jeps/512) contain an implicit class which not present in the source code However, this such a class may contain a folding region which can be collapsed.

As folding classes not present in the source code doesn't make sense, this PR skips them in the folding logic.

## How to test
Create the following simple main class in a project using JDK 25+ (the line break at the end is important):
```java
import module java.base;

int i;
int j;

void main() {
	// TODO Auto-generated method stub

}

```

There should be no folding region next to `int i`; that contains the entire class (the screenshot shows the folding region that shouldn't be there):
<img width="374" height="153" alt="image" src="https://github.com/user-attachments/assets/c678622d-5b54-4bbd-a520-bfc7d83aae7b" />

I hope the `ProjectTestSetup` will make sure JDK25+ is used in the test.

CC @HannesWell because you reported this in the devcall (by the way, the idea about skipping top level types on `Collapse All` may not be as easy as I thought because that logic is part of `ProjectionViewer`/Eclipse Platform while Java folding is JDT-UI so this might need adding new methods to the API)

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
