### PR TITLE
Add bounds check for end of file when aligning folding regions

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/codemining/ParameterNamesCodeMiningTest.java
@@ -27,6 +27,8 @@ import java.util.function.LongSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.util.DisplayHelper;
@@ -197,8 +199,9 @@ public class ParameterNamesCodeMiningTest {
 		assertEquals(2, fParameterNameCodeMiningProvider.provideCodeMinings(viewer, new NullProgressMonitor()).get().size());
 	}
 
-	@Test
-	public void testCollapsedFolding() throws Exception {
+	@ParameterizedTest
+	@ValueSource(ints= {ProjectionViewer.COLLAPSE, ProjectionViewer.COLLAPSE_ALL}) // ensure no error with both comment and everything collapsed
+	public void testCollapsedFolding(int collapseAction) throws Exception {
 		String contents= """
 			/**
 			 * aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -217,7 +220,7 @@ public class ParameterNamesCodeMiningTest {
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(compilationUnit);
 		fParameterNameCodeMiningProvider.setContext(editor);
 		JavaSourceViewer viewer= (JavaSourceViewer)editor.getViewer();
-		viewer.doOperation(ProjectionViewer.COLLAPSE_ALL);
+		viewer.doOperation(collapseAction);
 		viewer.setCodeMiningProviders(new ICodeMiningProvider[] {
 			fParameterNameCodeMiningProvider
 		});
@@ -265,7 +268,7 @@ public class ParameterNamesCodeMiningTest {
 			}
 		}.waitForCondition(widget.getDisplay(), 2000), "Code mining not available on expected chars");
 		//
-		viewer.doOperation(ProjectionViewer.COLLAPSE_ALL);
+		viewer.doOperation(ProjectionViewer.COLLAPSE); // collapse comment to check code mining/highlighting after folded region
 		assertTrue(new DisplayHelper() {
 			@Override
 			protected boolean condition() {

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -31,7 +31,6 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -119,6 +118,17 @@ public class FoldingTest {
 				""";
 		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 2); // class
+	}
+
+	@Test
+	public void testFoldClassEndingAtEOF() throws Exception {
+		String str= """
+				package org.example.test;
+				class A {		//here should be an annotation
+					// content
+				}""";
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 1, 3); // class
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -1130,7 +1130,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 			// Line numbers (0-based)
 			int start= document.getLineOfOffset(region.getOffset());
-			int end= document.getLineOfOffset(region.getOffset() + region.getLength());
+			int end= document.getLineOfOffset(Math.min(region.getOffset() + region.getLength(), ctx.getDocument().getLength()));
 
 			if (end >= document.getNumberOfLines()) {
 				end= document.getNumberOfLines() - 1;
@@ -1158,6 +1158,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 			return new Region(offset, endOffset - offset);
 		} catch (BadLocationException x) {
+			JavaPlugin.log(x);
 			return null;
 		}
 	}
@@ -1551,6 +1552,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 			regions.toArray(result);
 			return result;
 		} catch (JavaModelException | InvalidInputException e) {
+			JavaPlugin.log(e);
 		}
 
 		return new IRegion[0];


### PR DESCRIPTION
## What it does
When a folding region ends at an end of file (e.g. if the closing `}` of a class is the last character), the `alignRegon` method throws a `BadLocationException` at `int end= document.getLineOfOffset(region.getOffset() + region.getLength());`. This exception is caught resulting in no folding region being created.

This PR adds a bounds check to that method call to ensure it does not throw a `BadLocationException` and that the region is added properly.

I also added `JavaPlugin.log` calls in some places where exceptions are caught and ignored. Should I change these to use `IStatus.WARNING` instead of `IStatus.ERROR` as these only result in missing folding regions but the IDE continues working normally (I don't know the best practices for logging)?

I also thought about adding a check to ensure no errors are logged in the folding tests but that would would fail because of https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5286.

I found this when implementing #3116
CC @fedejeanne since you might be interested.

## How to test

Create a class like this with nothing (no line break etc) after the closing `}`:
```java
class A{
    // content
}
```

There should be a folding region corresponding to the class.

I also thought about adding `JavaPlugin.log(x)` to the place where the exception

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
