### PR TITLE
Skip top level types in "Collapse All" editor actions

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -28,10 +28,13 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
+import org.eclipse.jdt.text.tests.folding.FoldingTestUtils.ProjectionRegion;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -41,6 +44,8 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 import org.eclipse.jdt.ui.tests.util.TestUtils;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
+import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
 
 @RunWith(Parameterized.class)
 public class FoldingTest {
@@ -169,6 +174,46 @@ public class FoldingTest {
 		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 2, 4); // Javadoc
 		FoldingTestUtils.assertContainsRegionUsingStartAndEndLine(regions, str, 5, 7); // foo Methode
+	}
+
+	@Test
+	public void testCollapseAll() throws Exception {
+		String str= """
+				package org.example.test;
+
+				import java.util.List;                  //here should be an annotation
+				import java.util.Set;
+
+				class A {                               //here should be an annotation
+				    /**									//here should be an annotation
+				     * Javadoc
+				     */
+				    public void foo() {					//here should be an annotation
+				        System.out.println("Hello");
+				    }
+
+				    class InnerClass {					//here should be an annotation
+
+				    }
+				}
+				""";
+
+		ICompilationUnit cu= packageFragment.createCompilationUnit("A.java", str, true, null);
+		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
+		try {
+
+			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
+			model.collapseAll(0, str.length());
+
+			List<ProjectionRegion> regions= FoldingTestUtils.extractRegions(model);
+			FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 2, 3); // imports
+			FoldingTestUtils.assertContainsExpandedRegionUsingStartAndEndLine(regions, str, 5, 16); // class A
+			FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 6, 8); // javadoc
+			FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 9, 11);// foo method
+			FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 13, 15);// class InnerClass
+		} finally {
+			editor.close(false);
+		}
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -48,6 +48,7 @@ import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.TypedRegion;
 import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModelListener;
 import org.eclipse.jface.text.source.projection.IProjectionListener;
 import org.eclipse.jface.text.source.projection.IProjectionPosition;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
@@ -361,6 +362,11 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 		void setIsComment(boolean isComment) {
 			fIsComment= isComment;
+		}
+
+		@Override
+		protected boolean includeInCollapseAll() {
+			return fJavaElement.getElementType() != IJavaElement.TYPE || isInnerType((IType) fJavaElement);
 		}
 
 		/*
@@ -939,6 +945,8 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		return createContext(true);
 	}
 
+	private IAnnotationModelListener annotationModelListener;
+
 	private FoldingStructureComputationContext createContext(boolean allowCollapse) {
 		if (!isInstalled())
 			return null;
@@ -948,6 +956,13 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 		IDocument doc= getDocument();
 		if (doc == null)
 			return null;
+
+		if (annotationModelListener == null) {
+			annotationModelListener = m -> {
+				// TODO if everything is being collapsed: uncollapse outer type?
+			};
+			model.addAnnotationModelListener(annotationModelListener);
+		}
 
 		IScanner scanner= null;
 		if (fUpdatingCount == 1)
@@ -1293,7 +1308,7 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 	 * @param type the type to test
 	 * @return <code>true</code> if <code>type</code> is an inner type
 	 */
-	private boolean isInnerType(IType type) {
+	private static boolean isInnerType(IType type) {
 		return type.getDeclaringType() != null;
 	}
 


### PR DESCRIPTION
## What it does


Currently, the `Collapse All` editor operation results in all elements including top level types being collapsed. So for most classes, the `Collapse All` operation results in a mostly empty class.

In some older Eclipse IDE releases (before extended folding was introduced), top level types were excluded from folding so this editor action only affected nested elements (and things like imports).

This PR disables the `Collapse All` operation on top level types.

## How to test

Create a class like this:
```java
class MyClass {
    void someMethod() {
        // does some work
    }
}
```

The "Collapse All" action should collapse `someMethod` but not `MyClass`.

[Screencast_20260823_115609.webm](https://github.com/user-attachments/assets/0d91bf4b-457a-4319-a4fa-fb769e4c2b5a)



~~This PR depends on https://github.com/eclipse-platform/eclipse.platform.ui/pull/4272.~~ This has been merged.

~~I know that we currently have a code freeze and I'm submitting it with the intention of ideally getting this into the release afterwards (4.42).~~

CC @HannesWell since you suggested this and @fedejeanne since you were involved in the folding changes.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
