### PR TITLE
Fix extract temp refactoring to check assignment in conditional exp

### DIFF
--- a/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.manipulation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.core.manipulation
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.manipulation; singleton:=true
-Bundle-Version: 1.25.0.qualifier
+Bundle-Version: 1.25.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/code/ExtractTempRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -72,6 +72,7 @@ import org.eclipse.jdt.core.dom.CatchClause;
 import org.eclipse.jdt.core.dom.ChildListPropertyDescriptor;
 import org.eclipse.jdt.core.dom.ClassInstanceCreation;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ConditionalExpression;
 import org.eclipse.jdt.core.dom.ConstructorInvocation;
 import org.eclipse.jdt.core.dom.DoStatement;
 import org.eclipse.jdt.core.dom.EnhancedForStatement;
@@ -86,6 +87,7 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.IfStatement;
 import org.eclipse.jdt.core.dom.InfixExpression;
+import org.eclipse.jdt.core.dom.InfixExpression.Operator;
 import org.eclipse.jdt.core.dom.Initializer;
 import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
@@ -667,7 +669,7 @@ public class ExtractTempRefactoring extends Refactoring {
 	private RefactoringStatus checkExpression() throws JavaModelException {
 		Expression selectedExpression= getSelectedExpression().getAssociatedExpression();
 		if (selectedExpression != null) {
-			final ASTNode parent= selectedExpression.getParent();
+			ASTNode parent= selectedExpression.getParent();
 			if (selectedExpression instanceof NullLiteral) {
 				return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ExtractTempRefactoring_null_literals);
 			} else if (selectedExpression instanceof ArrayInitializer) {
@@ -675,8 +677,22 @@ public class ExtractTempRefactoring extends Refactoring {
 			} else if (selectedExpression instanceof Assignment) {
 				if (parent instanceof Expression && !(parent instanceof ParenthesizedExpression))
 					return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ExtractTempRefactoring_assignment);
-				else
+				else {
+					while (parent != null) {
+						parent= parent.getParent();
+						if (parent instanceof Statement) {
+							break;
+						} else if (parent instanceof InfixExpression infixExpression) {
+							if (infixExpression.getOperator() == Operator.CONDITIONAL_AND ||
+									infixExpression.getOperator() == Operator.CONDITIONAL_OR) {
+								return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ExtractTempRefactoring_side_effects_possible);
+							}
+						} else if (parent instanceof ConditionalExpression) {
+							return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ExtractTempRefactoring_side_effects_possible);
+						}
+					}
 					return null;
+				}
 			} else if (selectedExpression instanceof SimpleName) {
 				if ((((SimpleName) selectedExpression)).isDeclaration())
 					return RefactoringStatus.createFatalErrorStatus(RefactoringCoreMessages.ExtractTempRefactoring_names_in_declarations);

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/cannotExtract/A_testFail44.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/ExtractTemp/cannotExtract/A_testFail44.java
@@ -1,0 +1,13 @@
+package p; //10, 39, 10, 48
+
+public class A {
+	private Object elementName;
+	private Object parent;
+	
+    public void foo(boolean enabled) {
+        int value = 0;
+
+        boolean result = enabled && ((value = 1) > 0);
+    }
+
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/ExtractTempTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1411,6 +1411,12 @@ public class ExtractTempTests extends GenericRefactoringTest {
 	public void testFail43() throws Exception {
 		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1176
 		failHelper1(19, 9, 19, 88, true, false, "intValue", RefactoringStatus.FATAL);
+	}
+
+	@Test
+	public void testFail44() throws Exception {
+		//test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1176
+		failHelper1(10, 39, 10, 48, true, false, "intValue", RefactoringStatus.FATAL);
 	}
 
 }


### PR DESCRIPTION
- add logic to ExtractTempRefactoring.checkExpression() to not allow extraction if extracting an assignment that is part of a conditional expression or infix expression using conditional and or conditional or which means the assignment may not occur in regular logic
- add new test to ExtractTempTests
- fixes #3098

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
