### PR TITLE
Remove now unused API-filters

### DIFF
--- a/org.eclipse.jdt.ui/.settings/.api_filters
+++ b/org.eclipse.jdt.ui/.settings/.api_filters
@@ -185,12 +185,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="ui/org/eclipse/jdt/ui/wizards/NewTypeWizardPage.java" type="org.eclipse.jdt.ui.wizards.NewTypeWizardPage">
-        <filter id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.ui.wizards.NewTypeWizardPage"/>
-                <message_argument value="COMPACT_TYPE"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.ui; singleton:=true
-Bundle-Version: 3.39.0.qualifier
+Bundle-Version: 3.39.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.ui.JavaPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.ui/pom.xml
+++ b/org.eclipse.jdt.ui/pom.xml
@@ -18,7 +18,7 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.ui</artifactId>
-  <version>3.39.0-SNAPSHOT</version>
+  <version>3.39.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 	<build>


### PR DESCRIPTION

## What it does
Remove now unused API-filters.

Follow-up on
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/3132

The now unused filter caused new API warnings in the jdt.ui build.


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
