### PR TITLE
Add highlight feature for resources in package explorer

### DIFF
--- a/org.eclipse.jdt.ui/plugin.properties
+++ b/org.eclipse.jdt.ui/plugin.properties
@@ -174,6 +174,8 @@ coloredLabels.writeaccess_highlight.description=The background color used to hig
 
 coloredLabels.inherited.label=Inherited members
 coloredLabels.inherited.description=The color used to render to inherited members. 
+packageExplorerHighlightColor.label=Highlight resource in Package Explorer
+packageExplorerHighlightColor.description=The foreground color used to highlight resources in the Package Explorer. Bold style is applied by default.
 
 javaPrefName=Java
 organizeImportsPrefName=Organize Imports

--- a/org.eclipse.jdt.ui/plugin.xml
+++ b/org.eclipse.jdt.ui/plugin.xml
@@ -1318,6 +1318,15 @@
             %coloredLabels.writeaccess_highlight.description
          </description>
       </colorDefinition>
+      <colorDefinition
+            label="%packageExplorerHighlightColor.label"
+            categoryId="org.eclipse.jdt.ui.presentation"
+            value="COLOR_LIST_FOREGROUND"
+            id="org.eclipse.jdt.ui.packageExplorerHighlightColor">
+         <description>
+            %packageExplorerHighlightColor.description
+         </description>
+      </colorDefinition>
    </extension>
 
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/IJavaThemeConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/IJavaThemeConstants.java
@@ -142,4 +142,9 @@ public interface IJavaThemeConstants {
 	 */
 	String PROPERTIES_FILE_COLORING_COMMENT= ID_PREFIX + PreferenceConstants.PROPERTIES_FILE_COLORING_COMMENT;
 
+	/**
+	 * Theme constant for the color used to highlight resources in the Package Explorer.
+	 */
+	String PACKAGE_EXPLORER_HIGHLIGHT_COLOR= ID_PREFIX + PreferenceConstants.PACKAGE_EXPLORER_HIGHLIGHT_COLOR;
+
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerActionGroup.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerActionGroup.java
@@ -18,8 +18,11 @@ package org.eclipse.jdt.internal.ui.packageview;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyEvent;
 
+import org.eclipse.core.runtime.IPath;
+
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 
 import org.eclipse.jface.action.GroupMarker;
@@ -111,6 +114,9 @@ class PackageExplorerActionGroup extends CompositeActionGroup {
 
 	private ToggleLinkingAction fToggleLinkingAction;
 
+	private HighlightAction fHighlightAction;
+	private RemoveHighlightAction fRemoveHighlightAction;
+
 	private RefactorActionGroup fRefactorActionGroup;
 	private NavigateActionGroup fNavigateActionGroup;
 	private ViewActionGroup fViewActionGroup;
@@ -174,6 +180,9 @@ class PackageExplorerActionGroup extends CompositeActionGroup {
 
 		fGotoRequiredProjectAction= new GotoRequiredProjectAction(fPart);
 		fSelectAllAction= new SelectAllAction(fPart.getTreeViewer());
+
+		fHighlightAction= new HighlightAction(part.getLabelProvider());
+		fRemoveHighlightAction= new RemoveHighlightAction(part.getLabelProvider());
 	}
 
 	@Override
@@ -278,6 +287,13 @@ class PackageExplorerActionGroup extends CompositeActionGroup {
 		addOpenNewWindowAction(menu, element);
 
 		super.fillContextMenu(menu);
+
+		fHighlightAction.selectionChanged(selection);
+		fRemoveHighlightAction.selectionChanged(selection);
+		if (fHighlightAction.isEnabled())
+			menu.appendToGroup(IContextMenuConstants.GROUP_SHOW, fHighlightAction);
+		if (fRemoveHighlightAction.isEnabled())
+			menu.appendToGroup(IContextMenuConstants.GROUP_SHOW, fRemoveHighlightAction);
 	}
 
 	 private void addGotoMenu(IMenuManager menu, Object element, int size) {
@@ -445,5 +461,86 @@ class PackageExplorerActionGroup extends CompositeActionGroup {
 
 	public FrameList getFrameList() {
 		return fFrameList;
+	}
+
+	private static IPath resolveResourcePath(Object element) {
+		if (element instanceof IResource)
+			return ((IResource) element).getFullPath();
+		if (element instanceof IJavaElement) {
+			IResource r= ((IJavaElement) element).getResource();
+			if (r != null)
+				return r.getFullPath();
+		}
+		return null;
+	}
+
+	private static class HighlightAction extends org.eclipse.jface.action.Action {
+		private final PackageExplorerLabelProvider fLabelProvider;
+		private IPath fPath;
+
+		HighlightAction(PackageExplorerLabelProvider labelProvider) {
+			super(PackagesMessages.HighlightAction_label);
+			setToolTipText(PackagesMessages.HighlightAction_tooltip);
+			fLabelProvider= labelProvider;
+			setEnabled(false);
+		}
+
+		void selectionChanged(IStructuredSelection selection) {
+			fPath= null;
+			setEnabled(false);
+			if (selection.size() != 1)
+				return;
+			Object element= selection.getFirstElement();
+			if (!PackageExplorerLabelProvider.isOpenableFile(element))
+				return;
+			IPath path= resolveResourcePath(element);
+			if (path != null && !fLabelProvider.isHighlighted(path)) {
+				fPath= path;
+				setEnabled(true);
+			}
+		}
+
+		@Override
+		public void run() {
+			if (fPath != null) {
+				fLabelProvider.toggleHighlight(fPath);
+				fLabelProvider.notifyChanged();
+			}
+		}
+	}
+
+	private static class RemoveHighlightAction extends org.eclipse.jface.action.Action {
+		private final PackageExplorerLabelProvider fLabelProvider;
+		private IPath fPath;
+
+		RemoveHighlightAction(PackageExplorerLabelProvider labelProvider) {
+			super(PackagesMessages.RemoveHighlightAction_label);
+			setToolTipText(PackagesMessages.RemoveHighlightAction_tooltip);
+			fLabelProvider= labelProvider;
+			setEnabled(false);
+		}
+
+		void selectionChanged(IStructuredSelection selection) {
+			fPath= null;
+			setEnabled(false);
+			if (selection.size() != 1)
+				return;
+			Object element= selection.getFirstElement();
+			if (!PackageExplorerLabelProvider.isOpenableFile(element))
+				return;
+			IPath path= resolveResourcePath(element);
+			if (path != null && fLabelProvider.isHighlighted(path)) {
+				fPath= path;
+				setEnabled(true);
+			}
+		}
+
+		@Override
+		public void run() {
+			if (fPath != null) {
+				fLabelProvider.toggleHighlight(fPath);
+				fLabelProvider.notifyChanged();
+			}
+		}
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerLabelProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerLabelProvider.java
@@ -14,24 +14,35 @@
 package org.eclipse.jdt.internal.ui.packageview;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.TextStyle;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.IPath;
 
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IResource;
 
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.viewers.LabelProviderChangedEvent;
 import org.eclipse.jface.viewers.StyledString;
 
 import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.PlatformUI;
 
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IPackageFragment;
 
 import org.eclipse.jdt.ui.JavaElementLabels;
 
+import org.eclipse.jdt.internal.ui.IJavaThemeConstants;
 import org.eclipse.jdt.internal.ui.viewsupport.AppearanceAwareLabelProvider;
 import org.eclipse.jdt.internal.ui.viewsupport.JavaElementImageProvider;
 
@@ -51,6 +62,23 @@ public class PackageExplorerLabelProvider extends AppearanceAwareLabelProvider {
 	private boolean fIsFlatLayout;
 	private PackageExplorerProblemsDecorator fProblemDecorator;
 
+	private final Set<String> fHighlightedPaths = new HashSet<>();
+
+	private static final StyledString.Styler HIGHLIGHT_STYLER = new StyledString.Styler() {
+		@Override
+		public void applyStyles(TextStyle textStyle) {
+			textStyle.font = JFaceResources.getFontRegistry().getBold(JFaceResources.DEFAULT_FONT);
+			textStyle.foreground = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme()
+					.getColorRegistry().get(IJavaThemeConstants.PACKAGE_EXPLORER_HIGHLIGHT_COLOR);
+		}
+	};
+
+	private final IPropertyChangeListener fColorChangeListener = event -> {
+		if (IJavaThemeConstants.PACKAGE_EXPLORER_HIGHLIGHT_COLOR.equals(event.getProperty())) {
+			notifyChanged();
+		}
+	};
+
 	public PackageExplorerLabelProvider(PackageExplorerContentProvider cp) {
 		super(DEFAULT_TEXTFLAGS | JavaElementLabels.P_COMPRESSED | JavaElementLabels.ALL_CATEGORY2, DEFAULT_IMAGEFLAGS | JavaElementImageProvider.SMALL_ICONS);
 
@@ -59,15 +87,24 @@ public class PackageExplorerLabelProvider extends AppearanceAwareLabelProvider {
 		Assert.isNotNull(cp);
 		fContentProvider= cp;
 		fWorkingSetImages= null;
+		PlatformUI.getWorkbench().getThemeManager().getCurrentTheme()
+				.getColorRegistry().addListener(fColorChangeListener);
 	}
 
 	@Override
 	public StyledString getStyledText(Object element) {
 		String text= getSpecificText(element);
+		StyledString result;
 		if (text != null) {
-			return new StyledString(decorateText(text, element));
+			result= new StyledString(decorateText(text, element));
+		} else {
+			result= super.getStyledText(element);
 		}
-		return super.getStyledText(element);
+		IPath path = getResourcePath(element);
+		if (isHighlighted(path) && isOpenableFile(element)) {
+			result.setStyle(0, result.length(), HIGHLIGHT_STYLER);
+		}
+		return result;
 	}
 
 	private String getSpecificText(Object element) {
@@ -139,6 +176,44 @@ public class PackageExplorerLabelProvider extends AppearanceAwareLabelProvider {
 		return super.getImage(element);
 	}
 
+	void toggleHighlight(IPath path) {
+		if (path == null)
+			return;
+		String key = path.toString();
+		if (!fHighlightedPaths.remove(key))
+			fHighlightedPaths.add(key);
+	}
+
+	boolean isHighlighted(IPath path) {
+		return path != null && fHighlightedPaths.contains(path.toString());
+	}
+
+	void notifyChanged() {
+		fireLabelProviderChanged(new LabelProviderChangedEvent(this, null));
+	}
+
+	static boolean isOpenableFile(Object element) {
+		if (element instanceof IFile)
+			return true;
+		if (element instanceof IJavaElement) {
+			IResource resource = ((IJavaElement) element).getResource();
+			return resource instanceof IFile;
+		}
+		return false;
+	}
+
+	private IPath getResourcePath(Object element) {
+		if (element instanceof IResource) {
+			return ((IResource) element).getFullPath();
+		}
+		if (element instanceof IJavaElement) {
+			IResource resource = ((IJavaElement) element).getResource();
+			if (resource != null)
+				return resource.getFullPath();
+		}
+		return null;
+	}
+
 	public void setIsFlatLayout(boolean state) {
 		fIsFlatLayout= state;
 		fProblemDecorator.setIsFlatLayout(state);
@@ -146,6 +221,8 @@ public class PackageExplorerLabelProvider extends AppearanceAwareLabelProvider {
 
 	@Override
 	public void dispose() {
+		PlatformUI.getWorkbench().getThemeManager().getCurrentTheme()
+				.getColorRegistry().removeListener(fColorChangeListener);
 		if (fWorkingSetImages != null) {
 			for (Image image : fWorkingSetImages.values()) {
 				image.dispose();

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackageExplorerPart.java
@@ -449,7 +449,7 @@ public class PackageExplorerPart extends ViewPart
 		}
 	}
 
-	 @Override
+	@Override
 	public void dispose() {
 		XMLMemento memento= XMLMemento.createWriteRoot("packageExplorer"); //$NON-NLS-1$
 		saveState(memento);
@@ -602,7 +602,6 @@ public class PackageExplorerPart extends ViewPart
 		fLabelProvider.setIsFlatLayout(fIsCurrentLayoutFlat);
 		fDecoratingLabelProvider= new DecoratingJavaLabelProvider(fLabelProvider, false, fIsCurrentLayoutFlat);
 		fViewer.setLabelProvider(fDecoratingLabelProvider);
-		// problem decoration provided by PackageLabelProvider
 	}
 
 	public void setShowLibrariesNode(boolean enabled) {
@@ -634,6 +633,10 @@ public class PackageExplorerPart extends ViewPart
 			fViewer.refresh();
 			fViewer.getControl().setRedraw(true);
 		}
+	}
+
+	PackageExplorerLabelProvider getLabelProvider() {
+		return fLabelProvider;
 	}
 
 	/**

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackagesMessages.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackagesMessages.java
@@ -66,6 +66,10 @@ public final class PackagesMessages extends NLS {
 	public static String ClassPathContainer_unknown_label;
 	public static String PackageExplorerPart_workspace;
 	public static String PackageExplorerPart_workingSetModel;
+	public static String HighlightAction_label;
+	public static String HighlightAction_tooltip;
+	public static String RemoveHighlightAction_label;
+	public static String RemoveHighlightAction_tooltip;
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, PackagesMessages.class);

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackagesMessages.properties
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/packageview/PackagesMessages.properties
@@ -67,3 +67,8 @@ LayoutActionGroup_hierarchicalLayoutAction_label= &Hierarchical
 ClassPathContainer_unbound_label={0} (unbound)
 ClassPathContainer_unknown_label={0} (unknown)
 LibraryContainer_name=Referenced Libraries
+
+HighlightAction_label=Highlight Resource
+HighlightAction_tooltip=Highlight this resource in the Package Explorer
+RemoveHighlightAction_label=Remove Highlight
+RemoveHighlightAction_tooltip=Remove the highlight from this resource

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/PreferenceConstants.java
@@ -4056,6 +4056,16 @@ public class PreferenceConstants {
 	public static final String EDITOR_JAVA_CODEMINING_FILTER_IMPLIED_PARAMETER_NAMES = "java.codemining.filter.implied.parameterNames"; //$NON-NLS-1$
 
 	/**
+	 * A named preference that holds the color used to highlight resources
+	 * in the Package Explorer.
+	 * <p>
+	 * Value is of type <code>String</code>.When this preference has a non-default value, the specified foreground color is applied in addition to the bold styling.
+	 * </p>
+	 * @since 3.39
+	 */
+	public static final String PACKAGE_EXPLORER_HIGHLIGHT_COLOR= "packageExplorerHighlightColor"; //$NON-NLS-1$
+
+	/**
 	 * A named preference that stores the maximum number of chain completions
 	 * to be proposed at one time.
 	 * <p>


### PR DESCRIPTION
This PR adds a new highlight feature to the Eclipse Package Explorer. It allows users to mark individual files with bold text with COLOR_LIST_FOREGROUND and an optional foreground colour, making important files easier to identify quickly.

In large Eclipse workspaces with many projects and files, it can be difficult to find the files you need. For example:

- Files with similar names — for eg, files such as IBreakpointListener.java, IBreakpointManager.java, IBreakpointManagerListener.java, and IBreakpointsListener.java can look very similar and be difficult to distinguish. Highlighting makes the file you need stand out.
- Files currently being worked on — Highlighting helps users keep track of files that are important for the current task.
- Important configuration files — Build scripts, deployment files, properties files, and other important configuration files can be highlighted so they are easier to notice.



To remove the highlight, right-click the highlighted resource and select `Remove Highlight`. The highlight is then removed. The highlight color can optionally be customized through the Colors and Fonts preference page. 



## What it does

To highlight a resource:

- Right-click a file in the Package Explorer.
- Select `Highlight Resource` from the context menu.
- The resource is displayed using bold text and the default foreground colour COLOR_LIST_FOREGROUND.




https://github.com/user-attachments/assets/11da691e-b9f5-41db-ad84-9cf6f2adb130






## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
