### PR TITLE
Add @EnumSource exclude/reinclude actions to JUnit view

### DIFF
--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.17.600.qualifier
+Bundle-Version: 3.17.700.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
@@ -24,7 +24,10 @@ import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.TextEdit;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IField;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -50,8 +53,6 @@ import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 
 import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
-
-import org.eclipse.jdt.junit.model.ITestElement;
 
 import org.eclipse.jdt.internal.junit.model.TestCaseElement;
 import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
@@ -86,6 +87,12 @@ public final class EnumSourceValidator {
 
 	private static final Pattern INVOCATION_INDEX_PATTERN=
 			Pattern.compile("\\[test-template-invocation:#(\\d+)\\]"); //$NON-NLS-1$
+
+	private enum ArgumentsSourceStatus {
+		FOUND,
+		NOT_FOUND,
+		UNKNOWN
+	}
 
 	static final class ExclusionTarget {
 		private final IMethod fMethod;
@@ -498,35 +505,58 @@ public final class EnumSourceValidator {
 				argumentSourceCount++;
 			} else if (ENUM_SOURCES_ANNOTATION.equals(qualifiedName)) {
 				argumentSourceCount += 2;
-			} else if (hasArgumentsSourceMetaAnnotation(annotationType, new HashSet<>(), 0)) {
-				argumentSourceCount++;
+			} else {
+				ArgumentsSourceStatus status=
+						hasArgumentsSourceMetaAnnotation(annotationType, new HashSet<>());
+				if (status == ArgumentsSourceStatus.UNKNOWN) {
+					return null;
+				}
+				if (status == ArgumentsSourceStatus.FOUND) {
+					argumentSourceCount++;
+				}
 			}
 		}
 
 		return hasDirectParameterizedTest && argumentSourceCount == 1 ? enumSource : null;
 	}
 
-	private static boolean hasArgumentsSourceMetaAnnotation(ITypeBinding annotationType,
-			Set<String> visited, int depth) {
-		if (annotationType == null || depth > 4) {
-			return false;
+	private static ArgumentsSourceStatus hasArgumentsSourceMetaAnnotation(ITypeBinding annotationType,
+			Set<String> visited) {
+		if (annotationType == null) {
+			return ArgumentsSourceStatus.UNKNOWN;
 		}
 
 		String qualifiedName= annotationType.getQualifiedName();
 		if (ARGUMENTS_SOURCE_ANNOTATION.equals(qualifiedName)
 				|| ARGUMENTS_SOURCES_ANNOTATION.equals(qualifiedName)) {
-			return true;
-		}
-		if (!visited.add(qualifiedName)) {
-			return false;
+			return ArgumentsSourceStatus.FOUND;
 		}
 
+		String key= annotationType.getKey();
+		String visitedKey= key == null || key.isEmpty() ? qualifiedName : key;
+		if (visitedKey == null || visitedKey.isEmpty()) {
+			return ArgumentsSourceStatus.UNKNOWN;
+		}
+		if (!visited.add(visitedKey)) {
+			return ArgumentsSourceStatus.NOT_FOUND;
+		}
+
+		boolean unknown= false;
 		for (IAnnotationBinding metaAnnotation : annotationType.getAnnotations()) {
-			if (hasArgumentsSourceMetaAnnotation(metaAnnotation.getAnnotationType(), visited, depth + 1)) {
-				return true;
+			if (metaAnnotation == null) {
+				unknown= true;
+				continue;
+			}
+			ArgumentsSourceStatus status=
+					hasArgumentsSourceMetaAnnotation(metaAnnotation.getAnnotationType(), visited);
+			if (status == ArgumentsSourceStatus.FOUND) {
+				return status;
+			}
+			if (status == ArgumentsSourceStatus.UNKNOWN) {
+				unknown= true;
 			}
 		}
-		return false;
+		return unknown ? ArgumentsSourceStatus.UNKNOWN : ArgumentsSourceStatus.NOT_FOUND;
 	}
 
 	private static ITypeBinding getEnumType(IAnnotationBinding enumSourceBinding,
@@ -545,14 +575,24 @@ public final class EnumSourceValidator {
 		return parameterTypes[0].getTypeDeclaration();
 	}
 
-	private static List<String> getEnumConstants(ITypeBinding enumType) {
+	private static List<String> getEnumConstants(ITypeBinding enumType) throws JavaModelException {
 		List<String> result= new ArrayList<>();
 		if (enumType == null || !enumType.isEnum()) {
 			return result;
 		}
-		for (IVariableBinding field : enumType.getDeclaredFields()) {
+
+		IJavaElement javaElement= enumType.getJavaElement();
+		if (!(javaElement instanceof IType)) {
+			return result;
+		}
+		IType javaType= (IType) javaElement;
+		if (!javaType.isEnum()) {
+			return result;
+		}
+
+		for (IField field : javaType.getFields()) {
 			if (field.isEnumConstant()) {
-				result.add(field.getName());
+				result.add(field.getElementName());
 			}
 		}
 		return result;
@@ -622,28 +662,20 @@ public final class EnumSourceValidator {
 
 	private static int getInvocationIndex(TestCaseElement testCaseElement, int valueCount) {
 		String uniqueId= testCaseElement.getUniqueId();
-		if (uniqueId != null) {
-			Matcher matcher= INVOCATION_INDEX_PATTERN.matcher(uniqueId);
-			int oneBasedIndex= -1;
+		if (uniqueId == null) {
+			return -1;
+		}
+
+		Matcher matcher= INVOCATION_INDEX_PATTERN.matcher(uniqueId);
+		int oneBasedIndex= -1;
+		try {
 			while (matcher.find()) {
 				oneBasedIndex= Integer.parseInt(matcher.group(1));
 			}
-			if (oneBasedIndex >= 1 && oneBasedIndex <= valueCount) {
-				return oneBasedIndex - 1;
-			}
-		}
-
-		TestSuiteElement parent= testCaseElement.getParent();
-		ITestElement[] children= parent.getChildren();
-		if (children.length != valueCount) {
+		} catch (NumberFormatException e) {
 			return -1;
 		}
-		for (int i= 0; i < children.length; i++) {
-			if (children[i] == testCaseElement) {
-				return i;
-			}
-		}
-		return -1;
+		return oneBasedIndex >= 1 && oneBasedIndex <= valueCount ? oneBasedIndex - 1 : -1;
 	}
 
 	private static MemberValuePair findMemberValuePair(NormalAnnotation annotation, String name) {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
@@ -285,12 +285,12 @@ public final class EnumSourceValidator {
 			}
 		} else {
 			NormalAnnotation replacement= ast.newNormalAnnotation();
-			replacement.setTypeName(ASTNode.copySubtree(ast, parsed.fAnnotation.getTypeName()));
+			replacement.setTypeName((Name) ASTNode.copySubtree(ast, parsed.fAnnotation.getTypeName()));
 
 			if (parsed.fAnnotation instanceof SingleMemberAnnotation) {
 				MemberValuePair valuePair= ast.newMemberValuePair();
 				valuePair.setName(ast.newSimpleName(MEMBER_VALUE));
-				valuePair.setValue(ASTNode.copySubtree(ast,
+				valuePair.setValue((Expression) ASTNode.copySubtree(ast,
 						((SingleMemberAnnotation) parsed.fAnnotation).getValue()));
 				replacement.values().add(valuePair);
 			}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
@@ -279,18 +279,18 @@ public final class EnumSourceValidator {
 				namesRewrite.insertLast(newStringLiteral(ast, enumConstantName), null);
 			} else {
 				ArrayInitializer names= ast.newArrayInitializer();
-				names.expressions().add((Expression) ASTNode.copySubtree(ast, namesPair.getValue()));
+				names.expressions().add(ASTNode.copySubtree(ast, namesPair.getValue()));
 				names.expressions().add(newStringLiteral(ast, enumConstantName));
 				rewrite.replace(namesPair.getValue(), names, null);
 			}
 		} else {
 			NormalAnnotation replacement= ast.newNormalAnnotation();
-			replacement.setTypeName((Name) ASTNode.copySubtree(ast, parsed.fAnnotation.getTypeName()));
+			replacement.setTypeName(ASTNode.copySubtree(ast, parsed.fAnnotation.getTypeName()));
 
 			if (parsed.fAnnotation instanceof SingleMemberAnnotation) {
 				MemberValuePair valuePair= ast.newMemberValuePair();
 				valuePair.setName(ast.newSimpleName(MEMBER_VALUE));
-				valuePair.setValue((Expression) ASTNode.copySubtree(ast,
+				valuePair.setValue(ASTNode.copySubtree(ast,
 						((SingleMemberAnnotation) parsed.fAnnotation).getValue()));
 				replacement.values().add(valuePair);
 			}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/EnumSourceValidator.java
@@ -1,0 +1,708 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer using github copilot - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.junit.ui;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.text.edits.MultiTextEdit;
+import org.eclipse.text.edits.TextEdit;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.Annotation;
+import org.eclipse.jdt.core.dom.ArrayInitializer;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
+
+import org.eclipse.jdt.internal.corext.refactoring.structure.ImportRemover;
+
+import org.eclipse.jdt.junit.model.ITestElement;
+
+import org.eclipse.jdt.internal.junit.model.TestCaseElement;
+import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
+
+import org.eclipse.jdt.ui.CodeStyleConfiguration;
+
+/**
+ * Validates and modifies a single direct {@code @EnumSource} on a parameterized test.
+ *
+ * <p>The exclusion action is deliberately conservative. It is available only when the
+ * selected invocation can be mapped unambiguously to one enum constant and when changing
+ * the annotation preserves its existing semantics. Methods with multiple argument sources,
+ * repeatable {@code @EnumSource} annotations, or non-EXCLUDE name filters are rejected.
+ *
+ * @since 3.17
+ */
+public final class EnumSourceValidator {
+
+	private static final String JUNIT5_PARAMETERIZED_TEST= "org.junit.jupiter.params.ParameterizedTest"; //$NON-NLS-1$
+	private static final String ENUM_SOURCE_ANNOTATION= "org.junit.jupiter.params.provider.EnumSource"; //$NON-NLS-1$
+	private static final String ENUM_SOURCES_ANNOTATION= "org.junit.jupiter.params.provider.EnumSources"; //$NON-NLS-1$
+	private static final String ARGUMENTS_SOURCE_ANNOTATION= "org.junit.jupiter.params.provider.ArgumentsSource"; //$NON-NLS-1$
+	private static final String ARGUMENTS_SOURCES_ANNOTATION= "org.junit.jupiter.params.provider.ArgumentsSources"; //$NON-NLS-1$
+
+	private static final String MODE_INCLUDE= "INCLUDE"; //$NON-NLS-1$
+	private static final String MODE_EXCLUDE= "EXCLUDE"; //$NON-NLS-1$
+	private static final String MEMBER_VALUE= "value"; //$NON-NLS-1$
+	private static final String MEMBER_MODE= "mode"; //$NON-NLS-1$
+	private static final String MEMBER_NAMES= "names"; //$NON-NLS-1$
+	private static final String MEMBER_FROM= "from"; //$NON-NLS-1$
+	private static final String MEMBER_TO= "to"; //$NON-NLS-1$
+
+	private static final Pattern INVOCATION_INDEX_PATTERN=
+			Pattern.compile("\\[test-template-invocation:#(\\d+)\\]"); //$NON-NLS-1$
+
+	static final class ExclusionTarget {
+		private final IMethod fMethod;
+		private final String fEnumConstantName;
+		private final int fRemainingValues;
+
+		ExclusionTarget(IMethod method, String enumConstantName, int remainingValues) {
+			fMethod= method;
+			fEnumConstantName= enumConstantName;
+			fRemainingValues= remainingValues;
+		}
+
+		IMethod getMethod() {
+			return fMethod;
+		}
+
+		String getEnumConstantName() {
+			return fEnumConstantName;
+		}
+
+		int getRemainingValues() {
+			return fRemainingValues;
+		}
+	}
+
+	private static final class ParsedEnumSource {
+		private final ICompilationUnit fCompilationUnit;
+		private final CompilationUnit fAstRoot;
+		private final Annotation fAnnotation;
+		private final String fMode;
+		private final List<String> fNames;
+		private final List<String> fEffectiveValues;
+		private final boolean fSupportsExclusion;
+
+		ParsedEnumSource(ICompilationUnit compilationUnit, CompilationUnit astRoot, Annotation annotation,
+				String mode, List<String> names, List<String> effectiveValues, boolean supportsExclusion) {
+			fCompilationUnit= compilationUnit;
+			fAstRoot= astRoot;
+			fAnnotation= annotation;
+			fMode= mode;
+			fNames= names;
+			fEffectiveValues= effectiveValues;
+			fSupportsExclusion= supportsExclusion;
+		}
+	}
+
+	static ExclusionTarget findExclusionTarget(TestCaseElement testCaseElement) {
+		if (testCaseElement == null) {
+			return null;
+		}
+
+		TestSuiteElement parent= testCaseElement.getParent();
+		if (parent == null) {
+			return null;
+		}
+
+		IMethod method= TestMethodFinder.findMethodForParameterizedTest(parent);
+		if (method == null) {
+			return null;
+		}
+
+		try {
+			ParsedEnumSource parsed= parse(method);
+			if (parsed == null || !parsed.fSupportsExclusion) {
+				return null;
+			}
+
+			int invocationIndex= getInvocationIndex(testCaseElement, parsed.fEffectiveValues.size());
+			if (invocationIndex < 0) {
+				return null;
+			}
+
+			String enumConstantName= parsed.fEffectiveValues.get(invocationIndex);
+			return new ExclusionTarget(method, enumConstantName, parsed.fEffectiveValues.size() - 1);
+		} catch (JavaModelException e) {
+			JUnitPlugin.log(e);
+			return null;
+		}
+	}
+
+	/**
+	 * Returns the enum constant for a one-based JUnit invocation index.
+	 *
+	 * @param method the parameterized test method
+	 * @param invocationIndex one-based invocation index
+	 * @return the enum constant name, or <code>null</code> if the source is unsupported
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static String getEnumConstantForInvocation(IMethod method, int invocationIndex) throws JavaModelException {
+		ParsedEnumSource parsed= parse(method);
+		if (parsed == null || !parsed.fSupportsExclusion
+				|| invocationIndex < 1 || invocationIndex > parsed.fEffectiveValues.size()) {
+			return null;
+		}
+		return parsed.fEffectiveValues.get(invocationIndex - 1);
+	}
+
+	/**
+	 * Returns whether the given enum constant can safely be excluded.
+	 *
+	 * @param method the parameterized test method
+	 * @param enumConstantName the enum constant name
+	 * @return <code>true</code> if the transformation is supported
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static boolean canExcludeEnumValue(IMethod method, String enumConstantName) throws JavaModelException {
+		ParsedEnumSource parsed= parse(method);
+		return parsed != null && parsed.fSupportsExclusion
+				&& parsed.fEffectiveValues.contains(enumConstantName)
+				&& !parsed.fNames.contains(enumConstantName);
+	}
+
+	/**
+	 * Returns whether the method has one supported {@code @EnumSource} in EXCLUDE mode.
+	 *
+	 * @param method the method to inspect
+	 * @return <code>true</code> if EXCLUDE mode is active
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static boolean isExcludeMode(IMethod method) throws JavaModelException {
+		ParsedEnumSource parsed= parse(method);
+		return parsed != null && parsed.fSupportsExclusion && MODE_EXCLUDE.equals(parsed.fMode);
+	}
+
+	/**
+	 * Returns excluded enum constant names for one supported direct {@code @EnumSource}.
+	 *
+	 * @param method the method to inspect
+	 * @return excluded names, never <code>null</code>
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static List<String> getExcludedNames(IMethod method) throws JavaModelException {
+		ParsedEnumSource parsed= parse(method);
+		if (parsed == null || !parsed.fSupportsExclusion || !MODE_EXCLUDE.equals(parsed.fMode)) {
+			return new ArrayList<>();
+		}
+		return new ArrayList<>(parsed.fNames);
+	}
+
+	/**
+	 * Adds an enum constant to the EXCLUDE filter while preserving all unrelated annotation
+	 * members such as {@code from} and {@code to}.
+	 *
+	 * @param method the parameterized test method
+	 * @param enumConstantName the enum constant to exclude
+	 * @return <code>true</code> if the source was changed
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static boolean excludeEnumValue(IMethod method, String enumConstantName) throws JavaModelException {
+		ParsedEnumSource parsed= parse(method);
+		if (parsed == null || !parsed.fSupportsExclusion
+				|| !parsed.fEffectiveValues.contains(enumConstantName)
+				|| parsed.fNames.contains(enumConstantName)) {
+			return false;
+		}
+
+		AST ast= parsed.fAstRoot.getAST();
+		ASTRewrite rewrite= ASTRewrite.create(ast);
+		ImportRewrite importRewrite= CodeStyleConfiguration.createImportRewrite(parsed.fAstRoot, true);
+		List<ASTNode> removedNodes= new ArrayList<>();
+
+		if (parsed.fAnnotation instanceof NormalAnnotation) {
+			NormalAnnotation annotation= (NormalAnnotation) parsed.fAnnotation;
+			ListRewrite valuesRewrite= rewrite.getListRewrite(annotation, NormalAnnotation.VALUES_PROPERTY);
+
+			MemberValuePair modePair= findMemberValuePair(annotation, MEMBER_MODE);
+			if (!MODE_EXCLUDE.equals(parsed.fMode)) {
+				Expression excludeMode= createExcludeModeExpression(ast, importRewrite);
+				if (modePair == null) {
+					modePair= ast.newMemberValuePair();
+					modePair.setName(ast.newSimpleName(MEMBER_MODE));
+					modePair.setValue(excludeMode);
+					valuesRewrite.insertLast(modePair, null);
+				} else {
+					removedNodes.add(modePair.getValue());
+					rewrite.replace(modePair.getValue(), excludeMode, null);
+				}
+			}
+
+			MemberValuePair namesPair= findMemberValuePair(annotation, MEMBER_NAMES);
+			if (namesPair == null) {
+				namesPair= ast.newMemberValuePair();
+				namesPair.setName(ast.newSimpleName(MEMBER_NAMES));
+				ArrayInitializer names= ast.newArrayInitializer();
+				names.expressions().add(newStringLiteral(ast, enumConstantName));
+				namesPair.setValue(names);
+				valuesRewrite.insertLast(namesPair, null);
+			} else if (namesPair.getValue() instanceof ArrayInitializer) {
+				ArrayInitializer names= (ArrayInitializer) namesPair.getValue();
+				ListRewrite namesRewrite= rewrite.getListRewrite(names, ArrayInitializer.EXPRESSIONS_PROPERTY);
+				namesRewrite.insertLast(newStringLiteral(ast, enumConstantName), null);
+			} else {
+				ArrayInitializer names= ast.newArrayInitializer();
+				names.expressions().add((Expression) ASTNode.copySubtree(ast, namesPair.getValue()));
+				names.expressions().add(newStringLiteral(ast, enumConstantName));
+				rewrite.replace(namesPair.getValue(), names, null);
+			}
+		} else {
+			NormalAnnotation replacement= ast.newNormalAnnotation();
+			replacement.setTypeName((Name) ASTNode.copySubtree(ast, parsed.fAnnotation.getTypeName()));
+
+			if (parsed.fAnnotation instanceof SingleMemberAnnotation) {
+				MemberValuePair valuePair= ast.newMemberValuePair();
+				valuePair.setName(ast.newSimpleName(MEMBER_VALUE));
+				valuePair.setValue((Expression) ASTNode.copySubtree(ast,
+						((SingleMemberAnnotation) parsed.fAnnotation).getValue()));
+				replacement.values().add(valuePair);
+			}
+
+			MemberValuePair modePair= ast.newMemberValuePair();
+			modePair.setName(ast.newSimpleName(MEMBER_MODE));
+			modePair.setValue(createExcludeModeExpression(ast, importRewrite));
+			replacement.values().add(modePair);
+
+			MemberValuePair namesPair= ast.newMemberValuePair();
+			namesPair.setName(ast.newSimpleName(MEMBER_NAMES));
+			ArrayInitializer names= ast.newArrayInitializer();
+			names.expressions().add(newStringLiteral(ast, enumConstantName));
+			namesPair.setValue(names);
+			replacement.values().add(namesPair);
+
+			rewrite.replace(parsed.fAnnotation, replacement, null);
+		}
+
+		return applyChanges(parsed, rewrite, importRewrite, removedNodes);
+	}
+
+	/**
+	 * Removes one enum constant from the EXCLUDE filter.
+	 *
+	 * @param method the parameterized test method
+	 * @param enumConstantName the enum constant to re-include
+	 * @return <code>true</code> if the source was changed
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static boolean removeValueFromExclusion(IMethod method, String enumConstantName) throws JavaModelException {
+		ParsedEnumSource parsed= parse(method);
+		if (parsed == null || !parsed.fSupportsExclusion || !MODE_EXCLUDE.equals(parsed.fMode)
+				|| !parsed.fNames.contains(enumConstantName)) {
+			return false;
+		}
+		if (parsed.fNames.size() == 1) {
+			return removeExcludeMode(method);
+		}
+		if (!(parsed.fAnnotation instanceof NormalAnnotation)) {
+			return false;
+		}
+
+		NormalAnnotation annotation= (NormalAnnotation) parsed.fAnnotation;
+		MemberValuePair namesPair= findMemberValuePair(annotation, MEMBER_NAMES);
+		if (namesPair == null) {
+			return false;
+		}
+
+		ASTRewrite rewrite= ASTRewrite.create(parsed.fAstRoot.getAST());
+		ASTNode removedNode= null;
+		if (namesPair.getValue() instanceof ArrayInitializer) {
+			ArrayInitializer names= (ArrayInitializer) namesPair.getValue();
+			for (Object value : names.expressions()) {
+				Expression expression= (Expression) value;
+				if (enumConstantName.equals(expression.resolveConstantExpressionValue())) {
+					rewrite.getListRewrite(names, ArrayInitializer.EXPRESSIONS_PROPERTY).remove(expression, null);
+					removedNode= expression;
+					break;
+				}
+			}
+		} else if (enumConstantName.equals(namesPair.getValue().resolveConstantExpressionValue())) {
+			removedNode= namesPair;
+			rewrite.getListRewrite(annotation, NormalAnnotation.VALUES_PROPERTY).remove(namesPair, null);
+		}
+
+		if (removedNode == null) {
+			return false;
+		}
+		List<ASTNode> removedNodes= new ArrayList<>();
+		removedNodes.add(removedNode);
+		return applyChanges(parsed, rewrite,
+				CodeStyleConfiguration.createImportRewrite(parsed.fAstRoot, true), removedNodes);
+	}
+
+	/**
+	 * Removes {@code mode} and {@code names}, preserving every other annotation member.
+	 *
+	 * @param method the parameterized test method
+	 * @return <code>true</code> if the source was changed
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static boolean removeExcludeMode(IMethod method) throws JavaModelException {
+		ParsedEnumSource parsed= parse(method);
+		if (parsed == null || !parsed.fSupportsExclusion || !MODE_EXCLUDE.equals(parsed.fMode)
+				|| !(parsed.fAnnotation instanceof NormalAnnotation)) {
+			return false;
+		}
+
+		NormalAnnotation annotation= (NormalAnnotation) parsed.fAnnotation;
+		ASTRewrite rewrite= ASTRewrite.create(parsed.fAstRoot.getAST());
+		ListRewrite valuesRewrite= rewrite.getListRewrite(annotation, NormalAnnotation.VALUES_PROPERTY);
+
+		List<ASTNode> removedNodes= new ArrayList<>();
+		MemberValuePair modePair= findMemberValuePair(annotation, MEMBER_MODE);
+		if (modePair != null) {
+			valuesRewrite.remove(modePair, null);
+			removedNodes.add(modePair);
+		}
+		MemberValuePair namesPair= findMemberValuePair(annotation, MEMBER_NAMES);
+		if (namesPair != null) {
+			valuesRewrite.remove(namesPair, null);
+			removedNodes.add(namesPair);
+		}
+		if (removedNodes.isEmpty()) {
+			return false;
+		}
+
+		return applyChanges(parsed, rewrite,
+				CodeStyleConfiguration.createImportRewrite(parsed.fAstRoot, true), removedNodes);
+	}
+
+	private static ParsedEnumSource parse(IMethod method) throws JavaModelException {
+		ICompilationUnit compilationUnit= method.getCompilationUnit();
+		if (compilationUnit == null) {
+			return null;
+		}
+
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(compilationUnit);
+		parser.setResolveBindings(true);
+		parser.setBindingsRecovery(true);
+		CompilationUnit astRoot= (CompilationUnit) parser.createAST(null);
+
+		MethodDeclaration methodDeclaration= findMethodDeclaration(astRoot, method);
+		if (methodDeclaration == null) {
+			return null;
+		}
+
+		Annotation enumSource= findSingleDirectEnumSource(methodDeclaration);
+		if (enumSource == null) {
+			return null;
+		}
+
+		IAnnotationBinding enumSourceBinding= enumSource.resolveAnnotationBinding();
+		IMethodBinding methodBinding= methodDeclaration.resolveBinding();
+		if (enumSourceBinding == null || methodBinding == null) {
+			return null;
+		}
+
+		String mode= getMode(enumSourceBinding);
+		List<String> names= getNames(enumSourceBinding);
+		if (mode == null || names == null) {
+			return null;
+		}
+
+		boolean supportsExclusion= MODE_EXCLUDE.equals(mode)
+				|| MODE_INCLUDE.equals(mode) && names.isEmpty();
+
+		ITypeBinding enumType= getEnumType(enumSourceBinding, methodBinding);
+		List<String> enumConstants= getEnumConstants(enumType);
+		if (enumConstants.isEmpty()) {
+			return null;
+		}
+
+		String from= getStringMember(enumSourceBinding, MEMBER_FROM);
+		String to= getStringMember(enumSourceBinding, MEMBER_TO);
+		List<String> effectiveValues= computeEffectiveValues(enumConstants, from, to, mode, names);
+		if (effectiveValues == null) {
+			supportsExclusion= false;
+			effectiveValues= new ArrayList<>();
+		}
+
+		return new ParsedEnumSource(compilationUnit, astRoot, enumSource, mode, names,
+				effectiveValues, supportsExclusion);
+	}
+
+	private static MethodDeclaration findMethodDeclaration(CompilationUnit astRoot, IMethod method) {
+		MethodDeclaration[] result= new MethodDeclaration[1];
+		astRoot.accept(new ASTVisitor() {
+			@Override
+			public boolean visit(MethodDeclaration node) {
+				IMethodBinding binding= node.resolveBinding();
+				if (binding != null && method.equals(binding.getJavaElement())) {
+					result[0]= node;
+				}
+				return false;
+			}
+		});
+		return result[0];
+	}
+
+	private static Annotation findSingleDirectEnumSource(MethodDeclaration methodDeclaration) {
+		boolean hasDirectParameterizedTest= false;
+		Annotation enumSource= null;
+		int argumentSourceCount= 0;
+
+		for (Object modifier : methodDeclaration.modifiers()) {
+			if (!(modifier instanceof Annotation)) {
+				continue;
+			}
+			Annotation annotation= (Annotation) modifier;
+			IAnnotationBinding binding= annotation.resolveAnnotationBinding();
+			if (binding == null || binding.getAnnotationType() == null) {
+				return null;
+			}
+
+			ITypeBinding annotationType= binding.getAnnotationType();
+			String qualifiedName= annotationType.getQualifiedName();
+			if (JUNIT5_PARAMETERIZED_TEST.equals(qualifiedName)) {
+				hasDirectParameterizedTest= true;
+			}
+			if (ENUM_SOURCE_ANNOTATION.equals(qualifiedName)) {
+				enumSource= annotation;
+				argumentSourceCount++;
+			} else if (ENUM_SOURCES_ANNOTATION.equals(qualifiedName)) {
+				argumentSourceCount += 2;
+			} else if (hasArgumentsSourceMetaAnnotation(annotationType, new HashSet<>(), 0)) {
+				argumentSourceCount++;
+			}
+		}
+
+		return hasDirectParameterizedTest && argumentSourceCount == 1 ? enumSource : null;
+	}
+
+	private static boolean hasArgumentsSourceMetaAnnotation(ITypeBinding annotationType,
+			Set<String> visited, int depth) {
+		if (annotationType == null || depth > 4) {
+			return false;
+		}
+
+		String qualifiedName= annotationType.getQualifiedName();
+		if (ARGUMENTS_SOURCE_ANNOTATION.equals(qualifiedName)
+				|| ARGUMENTS_SOURCES_ANNOTATION.equals(qualifiedName)) {
+			return true;
+		}
+		if (!visited.add(qualifiedName)) {
+			return false;
+		}
+
+		for (IAnnotationBinding metaAnnotation : annotationType.getAnnotations()) {
+			if (hasArgumentsSourceMetaAnnotation(metaAnnotation.getAnnotationType(), visited, depth + 1)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static ITypeBinding getEnumType(IAnnotationBinding enumSourceBinding,
+			IMethodBinding methodBinding) {
+		for (IMemberValuePairBinding pair : enumSourceBinding.getDeclaredMemberValuePairs()) {
+			if (MEMBER_VALUE.equals(pair.getName()) && pair.getValue() instanceof ITypeBinding) {
+				ITypeBinding type= (ITypeBinding) pair.getValue();
+				return type.isEnum() ? type.getTypeDeclaration() : null;
+			}
+		}
+
+		ITypeBinding[] parameterTypes= methodBinding.getParameterTypes();
+		if (parameterTypes.length == 0 || !parameterTypes[0].isEnum()) {
+			return null;
+		}
+		return parameterTypes[0].getTypeDeclaration();
+	}
+
+	private static List<String> getEnumConstants(ITypeBinding enumType) {
+		List<String> result= new ArrayList<>();
+		if (enumType == null || !enumType.isEnum()) {
+			return result;
+		}
+		for (IVariableBinding field : enumType.getDeclaredFields()) {
+			if (field.isEnumConstant()) {
+				result.add(field.getName());
+			}
+		}
+		return result;
+	}
+
+	private static String getMode(IAnnotationBinding binding) {
+		for (IMemberValuePairBinding pair : binding.getDeclaredMemberValuePairs()) {
+			if (MEMBER_MODE.equals(pair.getName())) {
+				return pair.getValue() instanceof IVariableBinding
+						? ((IVariableBinding) pair.getValue()).getName()
+						: null;
+			}
+		}
+		return MODE_INCLUDE;
+	}
+
+	private static List<String> getNames(IAnnotationBinding binding) {
+		for (IMemberValuePairBinding pair : binding.getDeclaredMemberValuePairs()) {
+			if (!MEMBER_NAMES.equals(pair.getName())) {
+				continue;
+			}
+			List<String> result= new ArrayList<>();
+			Object value= pair.getValue();
+			if (value instanceof Object[]) {
+				for (Object item : (Object[]) value) {
+					if (!(item instanceof String)) {
+						return null;
+					}
+					result.add((String) item);
+				}
+				return result;
+			}
+			if (value instanceof String) {
+				result.add((String) value);
+				return result;
+			}
+			return null;
+		}
+		return new ArrayList<>();
+	}
+
+	private static String getStringMember(IAnnotationBinding binding, String memberName) {
+		for (IMemberValuePairBinding pair : binding.getDeclaredMemberValuePairs()) {
+			if (memberName.equals(pair.getName())) {
+				return pair.getValue() instanceof String ? (String) pair.getValue() : null;
+			}
+		}
+		return null;
+	}
+
+	private static List<String> computeEffectiveValues(List<String> enumConstants, String from,
+			String to, String mode, List<String> names) {
+		int first= from == null || from.isEmpty() ? 0 : enumConstants.indexOf(from);
+		int last= to == null || to.isEmpty() ? enumConstants.size() - 1 : enumConstants.indexOf(to);
+		if (first < 0 || last < first) {
+			return null;
+		}
+
+		List<String> result= new ArrayList<>(enumConstants.subList(first, last + 1));
+		if (MODE_EXCLUDE.equals(mode)) {
+			result.removeIf(names::contains);
+		} else if (!MODE_INCLUDE.equals(mode) || !names.isEmpty()) {
+			return null;
+		}
+		return result;
+	}
+
+	private static int getInvocationIndex(TestCaseElement testCaseElement, int valueCount) {
+		String uniqueId= testCaseElement.getUniqueId();
+		if (uniqueId != null) {
+			Matcher matcher= INVOCATION_INDEX_PATTERN.matcher(uniqueId);
+			int oneBasedIndex= -1;
+			while (matcher.find()) {
+				oneBasedIndex= Integer.parseInt(matcher.group(1));
+			}
+			if (oneBasedIndex >= 1 && oneBasedIndex <= valueCount) {
+				return oneBasedIndex - 1;
+			}
+		}
+
+		TestSuiteElement parent= testCaseElement.getParent();
+		ITestElement[] children= parent.getChildren();
+		if (children.length != valueCount) {
+			return -1;
+		}
+		for (int i= 0; i < children.length; i++) {
+			if (children[i] == testCaseElement) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	private static MemberValuePair findMemberValuePair(NormalAnnotation annotation, String name) {
+		for (Object value : annotation.values()) {
+			MemberValuePair pair= (MemberValuePair) value;
+			if (name.equals(pair.getName().getIdentifier())) {
+				return pair;
+			}
+		}
+		return null;
+	}
+
+	private static Expression createExcludeModeExpression(AST ast, ImportRewrite importRewrite) {
+		String enumSourceType= importRewrite.addImport(ENUM_SOURCE_ANNOTATION);
+		Name modeType= ast.newQualifiedName(ast.newName(enumSourceType), ast.newSimpleName("Mode")); //$NON-NLS-1$
+		return ast.newQualifiedName(modeType, ast.newSimpleName(MODE_EXCLUDE));
+	}
+
+	private static StringLiteral newStringLiteral(AST ast, String value) {
+		StringLiteral literal= ast.newStringLiteral();
+		literal.setLiteralValue(value);
+		return literal;
+	}
+
+	private static boolean applyChanges(ParsedEnumSource parsed, ASTRewrite rewrite,
+			ImportRewrite importRewrite, List<ASTNode> removedNodes) {
+		try {
+			if (!removedNodes.isEmpty()) {
+				ImportRemover importRemover=
+						new ImportRemover(parsed.fCompilationUnit.getJavaProject(), parsed.fAstRoot);
+				for (ASTNode removedNode : removedNodes) {
+					importRemover.registerRemovedNode(removedNode);
+				}
+				importRemover.applyRemoves(importRewrite);
+			}
+
+			MultiTextEdit combinedEdit= new MultiTextEdit();
+			TextEdit importEdit= importRewrite.rewriteImports(null);
+			if (importEdit.hasChildren() || importEdit.getLength() != 0) {
+				combinedEdit.addChild(importEdit);
+			}
+			TextEdit rewriteEdit= rewrite.rewriteAST();
+			if (rewriteEdit.hasChildren() || rewriteEdit.getLength() != 0) {
+				combinedEdit.addChild(rewriteEdit);
+			}
+			if (!combinedEdit.hasChildren()) {
+				return false;
+			}
+
+			parsed.fCompilationUnit.applyTextEdit(combinedEdit, null);
+			parsed.fCompilationUnit.save(null, true);
+			return true;
+		} catch (Exception e) {
+			JUnitPlugin.log(e);
+			return false;
+		}
+	}
+
+	private EnumSourceValidator() {
+		// Utility class - no instances
+	}
+}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ExcludeParameterValueAction.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ExcludeParameterValueAction.java
@@ -32,7 +32,7 @@ import org.eclipse.jdt.internal.junit.ui.EnumSourceValidator.ExclusionTarget;
  */
 public final class ExcludeParameterValueAction extends Action {
 
-	private ExclusionTarget fTarget;
+	private TestCaseElement fTestCaseElement;
 
 	public ExcludeParameterValueAction() {
 		super(JUnitMessages.ExcludeParameterValueAction_label);
@@ -44,37 +44,51 @@ public final class ExcludeParameterValueAction extends Action {
 	 * @param testCaseElement the selected test invocation
 	 */
 	public void update(TestCaseElement testCaseElement) {
-		fTarget= EnumSourceValidator.findExclusionTarget(testCaseElement);
-		setEnabled(fTarget != null);
+		fTestCaseElement= testCaseElement;
+		setEnabled(EnumSourceValidator.findExclusionTarget(testCaseElement) != null);
 	}
 
 	@Override
 	public void run() {
-		if (fTarget == null) {
+		ExclusionTarget target= EnumSourceValidator.findExclusionTarget(fTestCaseElement);
+		if (target == null) {
+			setEnabled(false);
 			return;
 		}
 
-		int remaining= fTarget.getRemainingValues();
+		int remaining= target.getRemainingValues();
 		if (remaining <= 1) {
 			String message= remaining == 0
 					? Messages.format(JUnitMessages.ExcludeParameterValueAction_warning_noValues,
-							fTarget.getEnumConstantName())
+							target.getEnumConstantName())
 					: Messages.format(JUnitMessages.ExcludeParameterValueAction_warning_oneValue,
-							fTarget.getEnumConstantName());
+							target.getEnumConstantName());
 			if (!MessageDialog.openQuestion(null, JUnitMessages.ExcludeParameterValueAction_label, message)) {
 				return;
 			}
 		}
 
+		ExclusionTarget currentTarget= EnumSourceValidator.findExclusionTarget(fTestCaseElement);
+		if (!isSameTarget(target, currentTarget)) {
+			return;
+		}
+
 		try {
 			if (EnumSourceValidator.excludeEnumValue(
-					fTarget.getMethod(), fTarget.getEnumConstantName())) {
-				JavaUI.openInEditor(fTarget.getMethod());
+					currentTarget.getMethod(), currentTarget.getEnumConstantName())) {
+				JavaUI.openInEditor(currentTarget.getMethod());
 			}
 		} catch (JavaModelException e) {
 			JUnitPlugin.log(e);
 		} catch (Exception e) {
 			JUnitPlugin.log(e);
 		}
+	}
+
+	private static boolean isSameTarget(ExclusionTarget first, ExclusionTarget second) {
+		return second != null
+				&& first.getMethod().equals(second.getMethod())
+				&& first.getEnumConstantName().equals(second.getEnumConstantName())
+				&& first.getRemainingValues() == second.getRemainingValues();
 	}
 }

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ExcludeParameterValueAction.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ExcludeParameterValueAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Carsten Hammer and others.
+ * Copyright (c) 2025, 2026 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -56,6 +56,7 @@ public final class ExcludeParameterValueAction extends Action {
 			return;
 		}
 
+		ExclusionTarget currentTarget= target;
 		int remaining= target.getRemainingValues();
 		if (remaining <= 1) {
 			String message= remaining == 0
@@ -63,14 +64,15 @@ public final class ExcludeParameterValueAction extends Action {
 							target.getEnumConstantName())
 					: Messages.format(JUnitMessages.ExcludeParameterValueAction_warning_oneValue,
 							target.getEnumConstantName());
-			if (!MessageDialog.openQuestion(null, JUnitMessages.ExcludeParameterValueAction_label, message)) {
+			if (!MessageDialog.openQuestion(JUnitPlugin.getActiveWorkbenchShell(),
+					JUnitMessages.ExcludeParameterValueAction_label, message)) {
 				return;
 			}
-		}
 
-		ExclusionTarget currentTarget= EnumSourceValidator.findExclusionTarget(fTestCaseElement);
-		if (!isSameTarget(target, currentTarget)) {
-			return;
+			currentTarget= EnumSourceValidator.findExclusionTarget(fTestCaseElement);
+			if (!isSameTarget(target, currentTarget)) {
+				return;
+			}
 		}
 
 		try {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ExcludeParameterValueAction.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ExcludeParameterValueAction.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer using github copilot - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.junit.ui;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.dialogs.MessageDialog;
+
+import org.eclipse.jdt.core.JavaModelException;
+
+import org.eclipse.jdt.ui.JavaUI;
+
+import org.eclipse.jdt.internal.junit.Messages;
+import org.eclipse.jdt.internal.junit.model.TestCaseElement;
+import org.eclipse.jdt.internal.junit.ui.EnumSourceValidator.ExclusionTarget;
+
+/**
+ * Context-menu action that adds the selected enum constant to the
+ * {@code @EnumSource} EXCLUDE filter.
+ *
+ * @since 3.17
+ */
+public final class ExcludeParameterValueAction extends Action {
+
+	private ExclusionTarget fTarget;
+
+	public ExcludeParameterValueAction() {
+		super(JUnitMessages.ExcludeParameterValueAction_label);
+	}
+
+	/**
+	 * Updates this action for the selected test invocation.
+	 *
+	 * @param testCaseElement the selected test invocation
+	 */
+	public void update(TestCaseElement testCaseElement) {
+		fTarget= EnumSourceValidator.findExclusionTarget(testCaseElement);
+		setEnabled(fTarget != null);
+	}
+
+	@Override
+	public void run() {
+		if (fTarget == null) {
+			return;
+		}
+
+		int remaining= fTarget.getRemainingValues();
+		if (remaining <= 1) {
+			String message= remaining == 0
+					? Messages.format(JUnitMessages.ExcludeParameterValueAction_warning_noValues,
+							fTarget.getEnumConstantName())
+					: Messages.format(JUnitMessages.ExcludeParameterValueAction_warning_oneValue,
+							fTarget.getEnumConstantName());
+			if (!MessageDialog.openQuestion(null, JUnitMessages.ExcludeParameterValueAction_label, message)) {
+				return;
+			}
+		}
+
+		try {
+			if (EnumSourceValidator.excludeEnumValue(
+					fTarget.getMethod(), fTarget.getEnumConstantName())) {
+				JavaUI.openInEditor(fTarget.getMethod());
+			}
+		} catch (JavaModelException e) {
+			JUnitPlugin.log(e);
+		} catch (Exception e) {
+			JUnitPlugin.log(e);
+		}
+	}
+}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.java
@@ -54,6 +54,12 @@ public final class JUnitMessages extends NLS {
 	public static String EnableStackFilterAction_action_tooltip;
 	public static String DisableTestAction_label;
 	public static String DisableTestAction_enable_label;
+	public static String ExcludeParameterValueAction_label;
+	public static String ExcludeParameterValueAction_warning_noValues;
+	public static String ExcludeParameterValueAction_warning_oneValue;
+	public static String ReincludeAllEnumValuesAction_label;
+	public static String ReincludeEnumValueAction_label;
+	public static String TestViewer_reinclude_submenu_label;
 	public static String ExpandAllAction_text;
 	public static String ExpandAllAction_tooltip;
 	public static String CollapseAllAction_text;

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/JUnitMessages.properties
@@ -37,6 +37,12 @@ EnableStackFilterAction_action_description=Filter the stack trace
 EnableStackFilterAction_action_tooltip=Filter Stack Trace
 DisableTestAction_label=Disable This Test
 DisableTestAction_enable_label=Enable This Test
+ExcludeParameterValueAction_label=Exclude Enum Value from @EnumSource
+ExcludeParameterValueAction_warning_noValues=Excluding ''{0}'' would leave no values. Proceed anyway?
+ExcludeParameterValueAction_warning_oneValue=Excluding ''{0}'' would leave only one value. Proceed anyway?
+ReincludeAllEnumValuesAction_label=Re-include All Enum Values
+ReincludeEnumValueAction_label=Re-include ''{0}''
+TestViewer_reinclude_submenu_label=Re-include Excluded Enum Values
 
 ScrollLockAction_action_label=Scroll Lock
 ScrollLockAction_action_tooltip=Scroll Lock

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ReincludeAllEnumValuesAction.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ReincludeAllEnumValuesAction.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer using github copilot - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.junit.ui;
+
+import org.eclipse.jface.action.Action;
+
+import org.eclipse.jdt.core.IMethod;
+
+import org.eclipse.jdt.ui.JavaUI;
+
+/**
+ * Re-includes all enum constants by removing the {@code mode} and {@code names}
+ * members from {@code @EnumSource}.
+ *
+ * @since 3.17
+ */
+public final class ReincludeAllEnumValuesAction extends Action {
+
+	private final IMethod fMethod;
+
+	public ReincludeAllEnumValuesAction(IMethod method) {
+		super(JUnitMessages.ReincludeAllEnumValuesAction_label);
+		fMethod= method;
+		setEnabled(method != null);
+	}
+
+	@Override
+	public void run() {
+		if (fMethod == null) {
+			return;
+		}
+		try {
+			if (EnumSourceValidator.removeExcludeMode(fMethod)) {
+				JavaUI.openInEditor(fMethod);
+			}
+		} catch (Exception e) {
+			JUnitPlugin.log(e);
+		}
+	}
+}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ReincludeEnumValueAction.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ReincludeEnumValueAction.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer using github copilot - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.junit.ui;
+
+import org.eclipse.jface.action.Action;
+
+import org.eclipse.jdt.core.IMethod;
+
+import org.eclipse.jdt.ui.JavaUI;
+
+import org.eclipse.jdt.internal.junit.Messages;
+
+/**
+ * Re-includes one enum constant by removing it from the {@code @EnumSource}
+ * EXCLUDE filter.
+ *
+ * @since 3.17
+ */
+public final class ReincludeEnumValueAction extends Action {
+
+	private final IMethod fMethod;
+	private final String fEnumConstantName;
+
+	public ReincludeEnumValueAction(IMethod method, String enumConstantName) {
+		super(Messages.format(JUnitMessages.ReincludeEnumValueAction_label, enumConstantName));
+		fMethod= method;
+		fEnumConstantName= enumConstantName;
+	}
+
+	@Override
+	public void run() {
+		try {
+			if (EnumSourceValidator.removeValueFromExclusion(fMethod, fEnumConstantName)) {
+				JavaUI.openInEditor(fMethod);
+			}
+		} catch (Exception e) {
+			JUnitPlugin.log(e);
+		}
+	}
+}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
@@ -132,10 +132,73 @@ public final class TestMethodFinder {
 			return null;
 		}
 		String result= parameterType.trim();
+		if (result.isEmpty()) {
+			return null;
+		}
+		if (result.startsWith("[")) { //$NON-NLS-1$
+			return normalizeArrayDescriptor(result);
+		}
 		if (result.endsWith("...")) { //$NON-NLS-1$
 			result= result.substring(0, result.length() - 3) + "[]"; //$NON-NLS-1$
 		}
 		return result;
+	}
+
+	private static String normalizeArrayDescriptor(String descriptor) {
+		int dimensions= 0;
+		while (dimensions < descriptor.length() && descriptor.charAt(dimensions) == '[') {
+			dimensions++;
+		}
+		if (dimensions == 0 || dimensions >= descriptor.length()) {
+			return null;
+		}
+
+		String componentType;
+		char kind= descriptor.charAt(dimensions);
+		switch (kind) {
+			case 'B':
+				componentType= "byte"; //$NON-NLS-1$
+				break;
+			case 'C':
+				componentType= "char"; //$NON-NLS-1$
+				break;
+			case 'D':
+				componentType= "double"; //$NON-NLS-1$
+				break;
+			case 'F':
+				componentType= "float"; //$NON-NLS-1$
+				break;
+			case 'I':
+				componentType= "int"; //$NON-NLS-1$
+				break;
+			case 'J':
+				componentType= "long"; //$NON-NLS-1$
+				break;
+			case 'S':
+				componentType= "short"; //$NON-NLS-1$
+				break;
+			case 'Z':
+				componentType= "boolean"; //$NON-NLS-1$
+				break;
+			case 'L':
+				if (!descriptor.endsWith(";") || dimensions + 2 > descriptor.length()) { //$NON-NLS-1$
+					return null;
+				}
+				componentType= descriptor.substring(dimensions + 1, descriptor.length() - 1)
+						.replace('/', '.');
+				break;
+			default:
+				return null;
+		}
+		if (kind != 'L' && dimensions + 1 != descriptor.length()) {
+			return null;
+		}
+
+		StringBuilder result= new StringBuilder(componentType);
+		for (int i= 0; i < dimensions; i++) {
+			result.append("[]"); //$NON-NLS-1$
+		}
+		return result.toString();
 	}
 
 	private TestMethodFinder() {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
@@ -114,17 +114,39 @@ public final class TestMethodFinder {
 			}
 
 			String erasedType= Signature.getTypeErasure(parameterTypes[i]);
-			String binaryType= JavaModelUtil.getResolvedTypeName(erasedType, declaringType, '$');
+			String binaryType= resolveTypeName(erasedType, declaringType, '$');
 			if (expectedType.equals(binaryType)) {
 				continue;
 			}
 
-			String sourceType= JavaModelUtil.getResolvedTypeName(erasedType, declaringType, '.');
+			String sourceType= resolveTypeName(erasedType, declaringType, '.');
 			if (!expectedType.equals(sourceType)) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	private static String resolveTypeName(String typeSignature, IType declaringType,
+			char enclosingTypeSeparator) throws JavaModelException {
+		int dimensions= Signature.getArrayCount(typeSignature);
+		String elementTypeSignature= Signature.getElementType(typeSignature);
+		String resolvedTypeName;
+		if (Signature.getTypeSignatureKind(elementTypeSignature) == Signature.BASE_TYPE_SIGNATURE) {
+			resolvedTypeName= Signature.toString(elementTypeSignature);
+		} else {
+			resolvedTypeName= JavaModelUtil.getResolvedTypeName(elementTypeSignature, declaringType,
+					enclosingTypeSeparator);
+		}
+		if (resolvedTypeName == null) {
+			return null;
+		}
+
+		StringBuilder result= new StringBuilder(resolvedTypeName);
+		for (int i= 0; i < dimensions; i++) {
+			result.append("[]"); //$NON-NLS-1$
+		}
+		return result.toString();
 	}
 
 	private static String normalizeParameterType(String parameterType) {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
@@ -85,26 +85,55 @@ public final class TestMethodFinder {
 	 */
 	public static IMethod findMethod(IType type, String methodName, String[] parameterTypes)
 			throws JavaModelException {
-		if (parameterTypes != null) {
-			String[] signatures= new String[parameterTypes.length];
-			for (int i= 0; i < parameterTypes.length; i++) {
-				String parameterType= parameterTypes[i];
-				if (parameterType.endsWith("...")) { //$NON-NLS-1$
-					parameterType= parameterType.substring(0, parameterType.length() - 3) + "[]"; //$NON-NLS-1$
-				}
-				signatures[i]= Signature.createTypeSignature(parameterType, true);
-			}
-			return JavaModelUtil.findMethod(methodName, signatures, false, type);
-		}
-
 		IMethod result= null;
 		for (IMethod method : type.getMethods()) {
-			if (methodName.equals(method.getElementName())) {
-				if (result != null) {
-					return null;
-				}
-				result= method;
+			if (!methodName.equals(method.getElementName())
+					|| parameterTypes != null && !hasParameterTypes(method, parameterTypes)) {
+				continue;
 			}
+			if (result != null) {
+				return null;
+			}
+			result= method;
+		}
+		return result;
+	}
+
+	private static boolean hasParameterTypes(IMethod method, String[] expectedParameterTypes)
+			throws JavaModelException {
+		String[] parameterTypes= method.getParameterTypes();
+		if (parameterTypes.length != expectedParameterTypes.length) {
+			return false;
+		}
+
+		IType declaringType= method.getDeclaringType();
+		for (int i= 0; i < parameterTypes.length; i++) {
+			String expectedType= normalizeParameterType(expectedParameterTypes[i]);
+			if (expectedType == null) {
+				return false;
+			}
+
+			String erasedType= Signature.getTypeErasure(parameterTypes[i]);
+			String binaryType= JavaModelUtil.getResolvedTypeName(erasedType, declaringType, '$');
+			if (expectedType.equals(binaryType)) {
+				continue;
+			}
+
+			String sourceType= JavaModelUtil.getResolvedTypeName(erasedType, declaringType, '.');
+			if (!expectedType.equals(sourceType)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static String normalizeParameterType(String parameterType) {
+		if (parameterType == null) {
+			return null;
+		}
+		String result= parameterType.trim();
+		if (result.endsWith("...")) { //$NON-NLS-1$
+			result= result.substring(0, result.length() - 3) + "[]"; //$NON-NLS-1$
 		}
 		return result;
 	}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
@@ -17,36 +17,42 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+
+import org.eclipse.jdt.internal.corext.util.JavaModelUtil;
 
 import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
 
 /**
- * Utility class for finding IMethod from TestSuiteElement.
- * 
+ * Resolves the Java method represented by a parameterized-test suite node.
+ *
  * @since 3.15
  */
-public class TestMethodFinder {
+public final class TestMethodFinder {
 
 	private static final char PARAM_START= '(';
 
 	/**
-	 * Find the IMethod for a TestSuiteElement representing a parameterized test.
-	 * Extracts method name from test name pattern "methodName(ParameterType)" and
-	 * looks up the method in the test class.
-	 * 
+	 * Finds the method represented by a parameterized-test suite.
+	 *
+	 * <p>When JUnit supplied parameter types, they are used to resolve overloads.
+	 * Without parameter metadata, a method is returned only if its name is unique.
+	 *
 	 * @param testSuiteElement the test suite element
-	 * @return the IMethod, or null if not found
+	 * @return the method, or <code>null</code> if it cannot be resolved unambiguously
 	 */
 	public static IMethod findMethodForParameterizedTest(TestSuiteElement testSuiteElement) {
+		if (testSuiteElement == null) {
+			return null;
+		}
+
 		String testName= testSuiteElement.getTestName();
 		int index= testName.indexOf(PARAM_START);
 		if (index < 0) {
-			return null; // Not a parameterized test method signature
+			return null;
 		}
 
-		String methodName= testName.substring(0, index);
 		String className= testSuiteElement.getSuiteTypeName();
-
 		if (className == null || className.isEmpty()) {
 			return null;
 		}
@@ -61,19 +67,46 @@ public class TestMethodFinder {
 			if (type == null) {
 				return null;
 			}
-
-			// Find the method - for parameterized tests, method name is without parameters
-			IMethod[] methods= type.getMethods();
-			for (IMethod method : methods) {
-				if (method.getElementName().equals(methodName)) {
-					return method;
-				}
-			}
-		} catch (JavaModelException e) {
+			return findMethod(type, testName.substring(0, index), testSuiteElement.getParameterTypes());
+		} catch (JavaModelException | IllegalArgumentException e) {
 			JUnitPlugin.log(e);
+			return null;
+		}
+	}
+
+	/**
+	 * Resolves a method by name and optional fully qualified parameter type names.
+	 *
+	 * @param type the declaring type
+	 * @param methodName the method name
+	 * @param parameterTypes parameter type names supplied by JUnit, or <code>null</code>
+	 * @return the method, or <code>null</code> if resolution is ambiguous
+	 * @throws JavaModelException if the Java model cannot be read
+	 */
+	public static IMethod findMethod(IType type, String methodName, String[] parameterTypes)
+			throws JavaModelException {
+		if (parameterTypes != null) {
+			String[] signatures= new String[parameterTypes.length];
+			for (int i= 0; i < parameterTypes.length; i++) {
+				String parameterType= parameterTypes[i];
+				if (parameterType.endsWith("...")) { //$NON-NLS-1$
+					parameterType= parameterType.substring(0, parameterType.length() - 3) + "[]"; //$NON-NLS-1$
+				}
+				signatures[i]= Signature.createTypeSignature(parameterType, true);
+			}
+			return JavaModelUtil.findMethod(methodName, signatures, false, type);
 		}
 
-		return null;
+		IMethod result= null;
+		for (IMethod method : type.getMethods()) {
+			if (methodName.equals(method.getElementName())) {
+				if (result != null) {
+					return null;
+				}
+				result= method;
+			}
+		}
+		return result;
 	}
 
 	private TestMethodFinder() {

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestMethodFinder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 Carsten Hammer and others.
+ * Copyright (c) 2025, 2026 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -181,7 +181,7 @@ public final class TestMethodFinder {
 				componentType= "boolean"; //$NON-NLS-1$
 				break;
 			case 'L':
-				if (!descriptor.endsWith(";") || dimensions + 2 > descriptor.length()) { //$NON-NLS-1$
+				if (!descriptor.endsWith(";") || dimensions + 2 >= descriptor.length()) { //$NON-NLS-1$
 					return null;
 				}
 				componentType= descriptor.substring(dimensions + 1, descriptor.length() - 1)

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestViewer.java
@@ -69,7 +69,9 @@ import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchManager;
 
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.jdt.internal.junit.launcher.ITestFinder;
 import org.eclipse.jdt.internal.junit.model.TestCaseElement;
@@ -200,6 +202,7 @@ public class TestViewer {
 	private final IgnoredOnlyFilter fIgnoredOnlyFilter= new IgnoredOnlyFilter();
 
 	private final DisableTestAction fDisableTestAction;
+	private final ExcludeParameterValueAction fExcludeParameterValueAction;
 
 	private final TestRunnerViewPart fTestRunnerPart;
 	private final Clipboard fClipboard;
@@ -233,6 +236,7 @@ public class TestViewer {
 		fClipboard= clipboard;
 
 		fDisableTestAction= new DisableTestAction();
+		fExcludeParameterValueAction= new ExcludeParameterValueAction();
 
 		fLayoutMode= TestRunnerViewPart.LAYOUT_HIERARCHICAL;
 
@@ -302,6 +306,10 @@ public class TestViewer {
 					manager.add(new Separator());
 					manager.add(fDisableTestAction);
 				}
+
+				// Add re-include submenu for @EnumSource tests with exclusions
+				addReincludeExcludedValuesSubmenu(manager, testSuiteElement);
+
 			} else {
 				TestCaseElement testCaseElement= (TestCaseElement) testElement;
 				manager.add(getOpenTestAction(testCaseElement));
@@ -314,6 +322,16 @@ public class TestViewer {
 					manager.add(new Separator());
 					manager.add(fDisableTestAction);
 				}
+
+				// For @EnumSource parameterized test invocations, offer to exclude the value
+				fExcludeParameterValueAction.update(testCaseElement);
+				if (fExcludeParameterValueAction.isEnabled()) {
+					manager.add(new Separator());
+					manager.add(fExcludeParameterValueAction);
+				}
+
+				// Re-inclusion must also be reachable in flat layout, where suite nodes are absent.
+				addReincludeExcludedValuesSubmenu(manager, testCaseElement.getParent());
 			}
 			if (fLayoutMode == TestRunnerViewPart.LAYOUT_HIERARCHICAL) {
 				manager.add(new Separator());
@@ -329,6 +347,41 @@ public class TestViewer {
 		}
 		manager.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS));
 		manager.add(new Separator(IWorkbenchActionConstants.MB_ADDITIONS + "-end")); //$NON-NLS-1$
+	}
+
+	/**
+	 * Adds a "Re-include Excluded Enum Values" submenu to the context menu for
+	 * {@code @EnumSource} parameterized tests that currently have exclusions.
+	 *
+	 * @param manager the context menu manager
+	 * @param testSuiteElement the selected test suite element
+	 */
+	private void addReincludeExcludedValuesSubmenu(IMenuManager manager, TestSuiteElement testSuiteElement) {
+		try {
+			IMethod method= TestMethodFinder.findMethodForParameterizedTest(testSuiteElement);
+			if (method == null) {
+				return;
+			}
+
+			List<String> excludedNames= EnumSourceValidator.getExcludedNames(method);
+			if (excludedNames.isEmpty()) {
+				return;
+			}
+
+			manager.add(new Separator());
+			MenuManager submenu= new MenuManager(JUnitMessages.TestViewer_reinclude_submenu_label);
+
+			// "Re-include All" action
+			submenu.add(new ReincludeAllEnumValuesAction(method));
+			submenu.add(new Separator());
+			for (String name : excludedNames) {
+				submenu.add(new ReincludeEnumValueAction(method, name));
+			}
+
+			manager.add(submenu);
+		} catch (JavaModelException e) {
+			JUnitPlugin.log(e);
+		}
 	}
 
 	private void addRerunActions(IMenuManager manager, TestCaseElement testCaseElement) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceFilterTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceFilterTest.java
@@ -13,20 +13,20 @@
  *******************************************************************************/
 package org.eclipse.jdt.junit.tests;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.eclipse.jdt.junit.JUnitCore;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
@@ -55,13 +55,13 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
  */
 public class EnumSourceFilterTest {
 
-	@RegisterExtension
+	@Rule
 	public ProjectTestSetup projectSetup= new Java1d8ProjectTestSetup();
 
 	private IJavaProject fJProject;
 	private IPackageFragmentRoot fSourceFolder;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		fJProject= projectSetup.getProject();
 		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject, "src"); //$NON-NLS-1$
@@ -72,7 +72,7 @@ public class EnumSourceFilterTest {
 		JavaProjectHelper.set18CompilerOptions(fJProject);
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		JavaProjectHelper.clear(fJProject, projectSetup.getDefaultClasspath());
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceFilterTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceFilterTest.java
@@ -1,0 +1,442 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer using github copilot - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import org.eclipse.jdt.internal.junit.ui.EnumSourceValidator;
+import org.eclipse.jdt.internal.junit.ui.TestMethodFinder;
+
+import org.eclipse.jdt.ui.tests.core.rules.Java1d8ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+/**
+ * Tests for safe {@code @EnumSource} exclusion and re-inclusion.
+ */
+public class EnumSourceFilterTest {
+
+	@RegisterExtension
+	public ProjectTestSetup projectSetup= new Java1d8ProjectTestSetup();
+
+	private IJavaProject fJProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		fJProject= projectSetup.getProject();
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject, "src"); //$NON-NLS-1$
+
+		JavaProjectHelper.addRTJar(fJProject);
+		IClasspathEntry cpe= JavaCore.newContainerEntry(JUnitCore.JUNIT5_CONTAINER_PATH);
+		JavaProjectHelper.addToClasspath(fJProject, cpe);
+		JavaProjectHelper.set18CompilerOptions(fJProject);
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		JavaProjectHelper.clear(fJProject, projectSetup.getDefaultClasspath());
+	}
+
+	@Test
+	public void testExcludePreservesRangeAndCompiles() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN, BLUE }
+
+				    @ParameterizedTest
+				    @EnumSource(value = Color.class, from = "GREEN", to = "BLUE")
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertEquals("GREEN", EnumSourceValidator.getEnumConstantForInvocation(method, 1)); //$NON-NLS-1$
+		assertEquals("BLUE", EnumSourceValidator.getEnumConstantForInvocation(method, 2)); //$NON-NLS-1$
+		assertNull(EnumSourceValidator.getEnumConstantForInvocation(method, 3));
+
+		assertTrue(EnumSourceValidator.excludeEnumValue(method, "GREEN")); //$NON-NLS-1$
+
+		String source= cu.getSource();
+		assertTrue(source.contains("from = \"GREEN\"")); //$NON-NLS-1$
+		assertTrue(source.contains("to = \"BLUE\"")); //$NON-NLS-1$
+		assertTrue(source.contains("\"GREEN\"")); //$NON-NLS-1$
+		assertEquals(List.of("GREEN"), EnumSourceValidator.getExcludedNames(method)); //$NON-NLS-1$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testAppendExclusionWithoutDuplicates() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN, BLUE }
+
+				    @ParameterizedTest
+				    @EnumSource(value = Color.class, mode = EnumSource.Mode.EXCLUDE, names = {"RED"})
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertTrue(EnumSourceValidator.excludeEnumValue(method, "GREEN")); //$NON-NLS-1$
+		assertFalse(EnumSourceValidator.excludeEnumValue(method, "GREEN")); //$NON-NLS-1$
+		assertEquals(List.of("RED", "GREEN"), EnumSourceValidator.getExcludedNames(method)); //$NON-NLS-1$ //$NON-NLS-2$
+		assertEquals(1, countOccurrences(cu.getSource(), "\"GREEN\"")); //$NON-NLS-1$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testIncludeAndRegexFiltersAreRejectedWithoutChanges() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN, BLUE }
+
+				    @ParameterizedTest
+				    @EnumSource(names = {"RED", "GREEN"})
+				    public void included(Color color) {
+				    }
+
+				    @ParameterizedTest
+				    @EnumSource(mode = EnumSource.Mode.MATCH_ANY, names = "R.*")
+				    public void matched(Color color) {
+				    }
+				}
+				""");
+		IMethod included= getMethod(cu, "included", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod matched= getMethod(cu, "matched", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+		String original= cu.getSource();
+
+		assertFalse(EnumSourceValidator.canExcludeEnumValue(included, "RED")); //$NON-NLS-1$
+		assertFalse(EnumSourceValidator.canExcludeEnumValue(matched, "RED")); //$NON-NLS-1$
+		assertFalse(EnumSourceValidator.excludeEnumValue(included, "RED")); //$NON-NLS-1$
+		assertFalse(EnumSourceValidator.excludeEnumValue(matched, "RED")); //$NON-NLS-1$
+		assertEquals(original, cu.getSource());
+	}
+
+	@Test
+	public void testFullyQualifiedAnnotationRemainsCompilable() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+
+				public class MyTest {
+				    enum Color { RED, GREEN }
+
+				    @ParameterizedTest
+				    @org.junit.jupiter.params.provider.EnumSource(Color.class)
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertTrue(EnumSourceValidator.excludeEnumValue(method, "RED")); //$NON-NLS-1$
+
+		assertTrue(cu.getSource().contains(
+				"@org.junit.jupiter.params.provider.EnumSource(")); //$NON-NLS-1$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testReincludeAllPreservesRangeAndSharedModeImport() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+				import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+				public class MyTest {
+				    enum Color { RED, GREEN, BLUE }
+
+				    @ParameterizedTest
+				    @EnumSource(value = Color.class, from = "RED", to = "BLUE",
+				            mode = Mode.EXCLUDE, names = {"RED"})
+				    public void first(Color color) {
+				    }
+
+				    @ParameterizedTest
+				    @EnumSource(value = Color.class, mode = Mode.EXCLUDE, names = {"BLUE"})
+				    public void second(Color color) {
+				    }
+				}
+				""");
+		IMethod first= getMethod(cu, "first", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod second= getMethod(cu, "second", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertTrue(EnumSourceValidator.removeExcludeMode(first));
+
+		String source= cu.getSource();
+		assertTrue(source.contains("from = \"RED\"")); //$NON-NLS-1$
+		assertTrue(source.contains("to = \"BLUE\"")); //$NON-NLS-1$
+		assertTrue(source.contains("import org.junit.jupiter.params.provider.EnumSource.Mode;")); //$NON-NLS-1$
+		assertFalse(EnumSourceValidator.isExcludeMode(first));
+		assertTrue(EnumSourceValidator.isExcludeMode(second));
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testReincludeLastValueRemovesUnusedModeImport() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+				import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+				public class MyTest {
+				    enum Color { RED, GREEN, BLUE }
+
+				    @ParameterizedTest
+				    @EnumSource(value = Color.class, from = "GREEN", to = "BLUE",
+				            mode = Mode.EXCLUDE, names = {"GREEN"})
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertTrue(EnumSourceValidator.removeValueFromExclusion(method, "GREEN")); //$NON-NLS-1$
+
+		String source= cu.getSource();
+		assertFalse(source.contains("import org.junit.jupiter.params.provider.EnumSource.Mode;")); //$NON-NLS-1$
+		assertTrue(source.contains("from = \"GREEN\"")); //$NON-NLS-1$
+		assertTrue(source.contains("to = \"BLUE\"")); //$NON-NLS-1$
+		assertFalse(EnumSourceValidator.isExcludeMode(method));
+		assertCompiles(cu);
+	}
+
+
+	@Test
+	public void testReincludeSingleValuePreservesOtherExclusions() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN, BLUE }
+
+				    @ParameterizedTest
+				    @EnumSource(value = Color.class, mode = EnumSource.Mode.EXCLUDE,
+				            names = {"RED", "GREEN"})
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertTrue(EnumSourceValidator.removeValueFromExclusion(method, "RED")); //$NON-NLS-1$
+
+		assertEquals(List.of("GREEN"), EnumSourceValidator.getExcludedNames(method)); //$NON-NLS-1$
+		assertTrue(EnumSourceValidator.isExcludeMode(method));
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testOverloadedMethodChangesOnlyExactBinding() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN }
+				    enum Shape { CIRCLE, SQUARE }
+
+				    @ParameterizedTest
+				    @EnumSource(Color.class)
+				    public void testValue(Color color) {
+				    }
+
+				    @ParameterizedTest
+				    @EnumSource(Shape.class)
+				    public void testValue(Shape shape) {
+				    }
+				}
+				""");
+		IMethod colorMethod= getMethod(cu, "testValue", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod shapeMethod= getMethod(cu, "testValue", "QShape;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertTrue(EnumSourceValidator.excludeEnumValue(shapeMethod, "CIRCLE")); //$NON-NLS-1$
+
+		assertTrue(EnumSourceValidator.getExcludedNames(colorMethod).isEmpty());
+		assertEquals(List.of("CIRCLE"), EnumSourceValidator.getExcludedNames(shapeMethod)); //$NON-NLS-1$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testMultipleAndRepeatedArgumentSourcesAreRejected() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+				import org.junit.jupiter.params.provider.ValueSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN }
+
+				    @ParameterizedTest
+				    @EnumSource(Color.class)
+				    @ValueSource(strings = "other")
+				    public void mixed(Object value) {
+				    }
+
+				    @ParameterizedTest
+				    @EnumSource(names = "RED")
+				    @EnumSource(names = "GREEN")
+				    public void repeated(Color color) {
+				    }
+				}
+				""");
+		IMethod mixed= getMethod(cu, "mixed", "QObject;"); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod repeated= getMethod(cu, "repeated", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertFalse(EnumSourceValidator.canExcludeEnumValue(mixed, "RED")); //$NON-NLS-1$
+		assertFalse(EnumSourceValidator.canExcludeEnumValue(repeated, "RED")); //$NON-NLS-1$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testInvocationOrderHonorsRangeAndExclusions() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN, BLUE, YELLOW }
+
+				    @ParameterizedTest
+				    @EnumSource(value = Color.class, from = "GREEN", to = "YELLOW",
+				            mode = EnumSource.Mode.EXCLUDE, names = {"BLUE"})
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertEquals("GREEN", EnumSourceValidator.getEnumConstantForInvocation(method, 1)); //$NON-NLS-1$
+		assertEquals("YELLOW", EnumSourceValidator.getEnumConstantForInvocation(method, 2)); //$NON-NLS-1$
+		assertNull(EnumSourceValidator.getEnumConstantForInvocation(method, 3));
+	}
+
+	@Test
+	public void testMethodFinderUsesParameterTypesAndRejectsAmbiguity() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("""
+				package test1;
+
+				public class MyTest {
+				    public void overloaded(String value) {
+				    }
+
+				    public void overloaded(int value) {
+				    }
+
+				    public void unique(long value) {
+				    }
+				}
+				""");
+		IType type= cu.getType("MyTest"); //$NON-NLS-1$
+
+		IMethod stringMethod= TestMethodFinder.findMethod(
+				type, "overloaded", new String[] { "java.lang.String" }); //$NON-NLS-1$ //$NON-NLS-2$
+		assertNotNull(stringMethod);
+		assertEquals("QString;", stringMethod.getParameterTypes()[0]); //$NON-NLS-1$
+		assertNull(TestMethodFinder.findMethod(type, "overloaded", null)); //$NON-NLS-1$
+		assertEquals("unique", TestMethodFinder.findMethod(type, "unique", null).getElementName()); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private ICompilationUnit createCompilationUnit(String source) throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null); //$NON-NLS-1$
+		return pack.createCompilationUnit("MyTest.java", source, false, null); //$NON-NLS-1$
+	}
+
+	private static IMethod getMethod(ICompilationUnit cu, String name, String parameterSignature) {
+		return cu.getType("MyTest").getMethod(name, new String[] { parameterSignature }); //$NON-NLS-1$
+	}
+
+	private static void assertCompiles(ICompilationUnit cu) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(cu);
+		parser.setResolveBindings(true);
+		CompilationUnit astRoot= (CompilationUnit) parser.createAST(null);
+
+		String errors= Arrays.stream(astRoot.getProblems())
+				.filter(IProblem::isError)
+				.map(IProblem::toString)
+				.collect(Collectors.joining(System.lineSeparator()));
+		assertEquals("", errors); //$NON-NLS-1$
+	}
+
+	private static int countOccurrences(String text, String pattern) {
+		int count= 0;
+		int index= 0;
+		while ((index= text.indexOf(pattern, index)) >= 0) {
+			count++;
+			index += pattern.length();
+		}
+		return count;
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceSafetyTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceSafetyTest.java
@@ -13,20 +13,20 @@
  *******************************************************************************/
 package org.eclipse.jdt.junit.tests;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.eclipse.jdt.junit.JUnitCore;
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
@@ -60,13 +60,13 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
  */
 public class EnumSourceSafetyTest {
 
-	@RegisterExtension
+	@Rule
 	public ProjectTestSetup projectSetup= new Java1d8ProjectTestSetup();
 
 	private IJavaProject fJProject;
 	private IPackageFragmentRoot fSourceFolder;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		fJProject= projectSetup.getProject();
 		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject, "src"); //$NON-NLS-1$
@@ -77,7 +77,7 @@ public class EnumSourceSafetyTest {
 		JavaProjectHelper.set18CompilerOptions(fJProject);
 	}
 
-	@AfterEach
+	@After
 	public void tearDown() throws Exception {
 		JavaProjectHelper.clear(fJProject, projectSetup.getDefaultClasspath());
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceSafetyTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceSafetyTest.java
@@ -1,0 +1,357 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial tests
+ *******************************************************************************/
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import org.eclipse.jdt.internal.junit.model.TestCaseElement;
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+import org.eclipse.jdt.internal.junit.model.TestSuiteElement;
+import org.eclipse.jdt.internal.junit.ui.EnumSourceValidator;
+import org.eclipse.jdt.internal.junit.ui.ExcludeParameterValueAction;
+import org.eclipse.jdt.internal.junit.ui.TestMethodFinder;
+
+import org.eclipse.jdt.ui.tests.core.rules.Java1d8ProjectTestSetup;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+/**
+ * Regression tests for conservative {@code @EnumSource} invocation mapping.
+ */
+public class EnumSourceSafetyTest {
+
+	@RegisterExtension
+	public ProjectTestSetup projectSetup= new Java1d8ProjectTestSetup();
+
+	private IJavaProject fJProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		fJProject= projectSetup.getProject();
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fJProject, "src"); //$NON-NLS-1$
+
+		JavaProjectHelper.addRTJar(fJProject);
+		IClasspathEntry cpe= JavaCore.newContainerEntry(JUnitCore.JUNIT5_CONTAINER_PATH);
+		JavaProjectHelper.addToClasspath(fJProject, cpe);
+		JavaProjectHelper.set18CompilerOptions(fJProject);
+	}
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		JavaProjectHelper.clear(fJProject, projectSetup.getDefaultClasspath());
+	}
+
+	@Test
+	public void testEnumDeclarationOrderFromSeparateSourceFile() throws Exception {
+		createCompilationUnit("test1.enums", "Color.java", """
+				package test1.enums;
+
+				public enum Color {
+				    ZETA, ALPHA, MIDDLE
+				}
+				""");
+		ICompilationUnit cu= createCompilationUnit("test1", "MyTest.java", """
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				import test1.enums.Color;
+
+				public class MyTest {
+				    @ParameterizedTest
+				    @EnumSource(Color.class)
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QColor;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertEquals("ZETA", EnumSourceValidator.getEnumConstantForInvocation(method, 1)); //$NON-NLS-1$
+		assertEquals("ALPHA", EnumSourceValidator.getEnumConstantForInvocation(method, 2)); //$NON-NLS-1$
+		assertEquals("MIDDLE", EnumSourceValidator.getEnumConstantForInvocation(method, 3)); //$NON-NLS-1$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testEnumDeclarationOrderFromBinaryType() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("test1", "MyTest.java", """
+				package test1;
+
+				import java.time.DayOfWeek;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    @ParameterizedTest
+				    @EnumSource(DayOfWeek.class)
+				    public void testWithEnum(DayOfWeek day) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "testWithEnum", "QDayOfWeek;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertEquals("MONDAY", EnumSourceValidator.getEnumConstantForInvocation(method, 1)); //$NON-NLS-1$
+		assertEquals("SUNDAY", EnumSourceValidator.getEnumConstantForInvocation(method, 7)); //$NON-NLS-1$
+		assertNull(EnumSourceValidator.getEnumConstantForInvocation(method, 8));
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testMethodFinderDistinguishesEqualSimpleTypeNames() throws Exception {
+		createCompilationUnit("first", "Color.java", """
+				package first;
+				public enum Color { RED }
+				""");
+		createCompilationUnit("second", "Color.java", """
+				package second;
+				public enum Color { BLUE }
+				""");
+		ICompilationUnit cu= createCompilationUnit("test1", "MyTest.java", """
+				package test1;
+
+				public class MyTest {
+				    public void overloaded(first.Color value) {
+				    }
+
+				    public void overloaded(second.Color value) {
+				    }
+				}
+				""");
+		IType type= cu.getType("MyTest"); //$NON-NLS-1$
+
+		IMethod first= TestMethodFinder.findMethod(
+				type, "overloaded", new String[] { "first.Color" }); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod second= TestMethodFinder.findMethod(
+				type, "overloaded", new String[] { "second.Color" }); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertNotNull(first);
+		assertNotNull(second);
+		assertNotEquals(first, second);
+		assertEquals("first.Color", Signature.toString(first.getParameterTypes()[0])); //$NON-NLS-1$
+		assertEquals("second.Color", Signature.toString(second.getParameterTypes()[0])); //$NON-NLS-1$
+		assertNull(TestMethodFinder.findMethod(type, "overloaded", new String[] { "Color" })); //$NON-NLS-1$ //$NON-NLS-2$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testMethodFinderAcceptsReflectionArrayTypeNames() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("test1", "MyTest.java", """
+				package test1;
+
+				public class MyTest {
+				    static class Value {
+				    }
+
+				    public void values(String[] value) {
+				    }
+
+				    public void values(int[][] value) {
+				    }
+
+				    public void values(Value[] value) {
+				    }
+				}
+				""");
+		IType type= cu.getType("MyTest"); //$NON-NLS-1$
+
+		IMethod strings= TestMethodFinder.findMethod(
+				type, "values", new String[] { "[Ljava.lang.String;" }); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod primitives= TestMethodFinder.findMethod(
+				type, "values", new String[] { "[[I" }); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod nested= TestMethodFinder.findMethod(
+				type, "values", new String[] { "[Ltest1.MyTest$Value;" }); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertNotNull(strings);
+		assertNotNull(primitives);
+		assertNotNull(nested);
+		assertEquals("String[]", Signature.toString(strings.getParameterTypes()[0])); //$NON-NLS-1$
+		assertEquals("int[][]", Signature.toString(primitives.getParameterTypes()[0])); //$NON-NLS-1$
+		assertEquals("Value[]", Signature.toString(nested.getParameterTypes()[0])); //$NON-NLS-1$
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testDeepComposedArgumentSourceIsRejected() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("test1", "MyTest.java", """
+				package test1;
+
+				import java.lang.annotation.ElementType;
+				import java.lang.annotation.Retention;
+				import java.lang.annotation.RetentionPolicy;
+				import java.lang.annotation.Target;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+				import org.junit.jupiter.params.provider.ValueSource;
+
+				public class MyTest {
+				    enum Color { RED, GREEN }
+
+				    @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+				    @Retention(RetentionPolicy.RUNTIME)
+				    @Level2
+				    @interface Level1 {
+				    }
+
+				    @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+				    @Retention(RetentionPolicy.RUNTIME)
+				    @Level3
+				    @interface Level2 {
+				    }
+
+				    @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+				    @Retention(RetentionPolicy.RUNTIME)
+				    @Level4
+				    @interface Level3 {
+				    }
+
+				    @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+				    @Retention(RetentionPolicy.RUNTIME)
+				    @Level5
+				    @interface Level4 {
+				    }
+
+				    @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+				    @Retention(RetentionPolicy.RUNTIME)
+				    @ValueSource(strings = "other")
+				    @interface Level5 {
+				    }
+
+				    @ParameterizedTest
+				    @EnumSource(Color.class)
+				    @Level1
+				    public void mixed(Object value) {
+				    }
+				}
+				""");
+		IMethod method= getMethod(cu, "mixed", "QObject;"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		assertFalse(EnumSourceValidator.canExcludeEnumValue(method, "RED")); //$NON-NLS-1$
+		assertNull(EnumSourceValidator.getEnumConstantForInvocation(method, 1));
+		assertCompiles(cu);
+	}
+
+	@Test
+	public void testInvocationMappingRequiresUniqueId() throws Exception {
+		ICompilationUnit cu= createCompilationUnit("test1", "MyTest.java", """
+				package test1;
+
+				import org.junit.jupiter.params.ParameterizedTest;
+				import org.junit.jupiter.params.provider.EnumSource;
+
+				public class MyTest {
+				    enum Color { ZETA, ALPHA, MIDDLE }
+
+				    @ParameterizedTest(name = "custom {index}: {0}")
+				    @EnumSource(Color.class)
+				    public void testWithEnum(Color color) {
+				    }
+				}
+				""");
+
+		TestRunSession session= new TestRunSession("EnumSource run", fJProject); //$NON-NLS-1$
+		TestSuiteElement validSuite= createParameterizedSuite(session, "valid-suite", 1); //$NON-NLS-1$
+		TestCaseElement validCase= new TestCaseElement(validSuite, "valid-case", //$NON-NLS-1$
+				"arbitrary display(test1.MyTest)", "not an enum value", false, null, //$NON-NLS-1$ //$NON-NLS-2$
+				"[engine:junit-jupiter]/[class:test1.MyTest]/" //$NON-NLS-1$
+						+ "[test-template:testWithEnum(test1.MyTest$Color)]/" //$NON-NLS-1$
+						+ "[test-template-invocation:#2]"); //$NON-NLS-1$
+
+		ExcludeParameterValueAction action= new ExcludeParameterValueAction();
+		action.update(validCase);
+		assertTrue(action.isEnabled());
+
+		TestSuiteElement fallbackSuite= createParameterizedSuite(session, "fallback-suite", 3); //$NON-NLS-1$
+		TestCaseElement withoutUniqueId= new TestCaseElement(fallbackSuite, "fallback-case-1", //$NON-NLS-1$
+				"first(test1.MyTest)", "first", false, null, null); //$NON-NLS-1$ //$NON-NLS-2$
+		new TestCaseElement(fallbackSuite, "fallback-case-2", //$NON-NLS-1$
+				"second(test1.MyTest)", "second", false, null, null); //$NON-NLS-1$ //$NON-NLS-2$
+		new TestCaseElement(fallbackSuite, "fallback-case-3", //$NON-NLS-1$
+				"third(test1.MyTest)", "third", false, null, null); //$NON-NLS-1$ //$NON-NLS-2$
+
+		action.update(withoutUniqueId);
+		assertFalse(action.isEnabled());
+
+		TestSuiteElement invalidSuite= createParameterizedSuite(session, "invalid-suite", 1); //$NON-NLS-1$
+		TestCaseElement invalidCase= new TestCaseElement(invalidSuite, "invalid-case", //$NON-NLS-1$
+				"invalid(test1.MyTest)", "invalid", false, null, //$NON-NLS-1$ //$NON-NLS-2$
+				"[test-template-invocation:#99]"); //$NON-NLS-1$
+		action.update(invalidCase);
+		assertFalse(action.isEnabled());
+		assertCompiles(cu);
+	}
+
+	private TestSuiteElement createParameterizedSuite(TestRunSession session, String id, int childCount) {
+		return new TestSuiteElement(session.getTestRoot(), id,
+				"testWithEnum(test1.MyTest$Color)(test1.MyTest)", childCount, //$NON-NLS-1$
+				"custom parameterized test", new String[] { "test1.MyTest$Color" }, //$NON-NLS-1$ //$NON-NLS-2$
+				"[engine:junit-jupiter]/[class:test1.MyTest]/" //$NON-NLS-1$
+						+ "[test-template:testWithEnum(test1.MyTest$Color)]"); //$NON-NLS-1$
+	}
+
+	private ICompilationUnit createCompilationUnit(String packageName, String unitName, String source)
+			throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment(packageName, false, null);
+		return pack.createCompilationUnit(unitName, source, false, null);
+	}
+
+	private static IMethod getMethod(ICompilationUnit cu, String name, String parameterSignature) {
+		return cu.getType("MyTest").getMethod(name, new String[] { parameterSignature }); //$NON-NLS-1$
+	}
+
+	private static void assertCompiles(ICompilationUnit cu) {
+		ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+		parser.setSource(cu);
+		parser.setResolveBindings(true);
+		CompilationUnit astRoot= (CompilationUnit) parser.createAST(null);
+
+		String errors= Arrays.stream(astRoot.getProblems())
+				.filter(IProblem::isError)
+				.map(IProblem::toString)
+				.collect(Collectors.joining(System.lineSeparator()));
+		assertEquals("", errors); //$NON-NLS-1$
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceSafetyTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/EnumSourceSafetyTest.java
@@ -119,23 +119,22 @@ public class EnumSourceSafetyTest {
 		ICompilationUnit cu= createCompilationUnit("test1", "MyTest.java", """
 				package test1;
 
-				import java.time.DayOfWeek;
-
 				import org.junit.jupiter.params.ParameterizedTest;
 				import org.junit.jupiter.params.provider.EnumSource;
+				import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 				public class MyTest {
 				    @ParameterizedTest
-				    @EnumSource(DayOfWeek.class)
-				    public void testWithEnum(DayOfWeek day) {
+				    @EnumSource(Mode.class)
+				    public void testWithEnum(Mode mode) {
 				    }
 				}
 				""");
-		IMethod method= getMethod(cu, "testWithEnum", "QDayOfWeek;"); //$NON-NLS-1$ //$NON-NLS-2$
+		IMethod method= getMethod(cu, "testWithEnum", "QMode;"); //$NON-NLS-1$ //$NON-NLS-2$
 
-		assertEquals("MONDAY", EnumSourceValidator.getEnumConstantForInvocation(method, 1)); //$NON-NLS-1$
-		assertEquals("SUNDAY", EnumSourceValidator.getEnumConstantForInvocation(method, 7)); //$NON-NLS-1$
-		assertNull(EnumSourceValidator.getEnumConstantForInvocation(method, 8));
+		assertEquals("INCLUDE", EnumSourceValidator.getEnumConstantForInvocation(method, 1)); //$NON-NLS-1$
+		assertEquals("MATCH_NONE", EnumSourceValidator.getEnumConstantForInvocation(method, 5)); //$NON-NLS-1$
+		assertNull(EnumSourceValidator.getEnumConstantForInvocation(method, 6));
 		assertCompiles(cu);
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -47,6 +47,7 @@ JUnit6TestFinderJupiterTest.class,
 JUnitStandaloneDetectionTest.class,
 
 JUnitQuickAssistTest.class,
+EnumSourceFilterTest.class,
 
 TestSorting.class
 //LegacyTestRunListenerTest.class

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -48,6 +48,7 @@ JUnitStandaloneDetectionTest.class,
 
 JUnitQuickAssistTest.class,
 EnumSourceFilterTest.class,
+EnumSourceSafetyTest.class,
 
 TestSorting.class
 //LegacyTestRunListenerTest.class


### PR DESCRIPTION
This PR extracts the remaining `@EnumSource` context-menu work from #2744 after the test enable/disable part was merged via #2907.

The implementation is based on the cleaned feature portion of #2940 and deliberately excludes all fork-specific workflow files.

## What it does

- Adds **Exclude Enum Value from `@EnumSource`** to the JUnit view context menu for an individual parameterized-test invocation.
- Maps the selected JUnit invocation conservatively and unambiguously to its enum constant, then updates the test source to use `EnumSource.Mode.EXCLUDE` and adds the constant to `names`.
- Adds a **Re-include Excluded Enum Values** submenu that can restore one excluded value or all excluded values. It is available from both hierarchical and flat JUnit layouts.
- Preserves unrelated annotation members such as `value`, `from`, and `to`, and updates imports when `EnumSource.Mode` is introduced or becomes unused.
- Resolves overloaded methods using their parameter types and supports primitive arrays, reference arrays, nested types, source enums, and binary enum types.
- Warns before an exclusion would leave only one value or no values.
- Keeps the action disabled when the transformation cannot be proven safe, including ambiguous invocation mappings, multiple or repeated argument sources, composed argument sources, INCLUDE filters, and regex-based enum filters.

## How to test

1. Create and run a JUnit 5 parameterized test such as:

   ```java
   import static org.junit.jupiter.api.Assertions.assertNotEquals;

   import org.junit.jupiter.params.ParameterizedTest;
   import org.junit.jupiter.params.provider.EnumSource;

   class MyTest {
       enum Color { RED, GREEN, BLUE }

       @ParameterizedTest
       @EnumSource(Color.class)
       void testColor(Color color) {
           assertNotEquals(Color.GREEN, color);
       }
   }
   ```

2. In the JUnit view, right-click the failing `GREEN` invocation and select **Exclude Enum Value from `@EnumSource`**.
3. Verify that the source is rewritten to EXCLUDE mode with `GREEN` in `names`, then rerun the test.
4. Open **Re-include Excluded Enum Values** from the parameterized-test suite or invocation and verify both the single-value and **Re-include All Enum Values** actions.
5. Verify that existing `from`/`to` ranges are preserved and that unsupported or ambiguous argument-source combinations do not offer the exclusion action.

Automated coverage is provided by `EnumSourceFilterTest` and `EnumSourceSafetyTest`, including source rewriting, re-inclusion, ranges, overloads, arrays, nested and binary enums, unique-ID invocation mapping, and conservative rejection cases.

The current PR head passes the complete Eclipse Jenkins build and test suite.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
