### PR TITLE
Persist JUnit history across restart

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.15.0.qualifier
+Bundle-Version: 3.15.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnitLaunchConfigurationConstants.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/launcher/JUnitLaunchConfigurationConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.resources.ResourcesPlugin;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -70,6 +71,8 @@ public class JUnitLaunchConfigurationConstants {
 
 	public static final String ATTR_FAILURES_NAMES= JUnitCorePlugin.PLUGIN_ID+".FAILURENAMES"; //$NON-NLS-1$
 
+	public static final String ATTR_RERUN_LAUNCH_CONFIG_MEMENTO= JUnitCorePlugin.PLUGIN_ID + ".RERUN_LAUNCH_CONFIG_MEMENTO"; //$NON-NLS-1$
+
 	public static final String ATTR_TEST_RUNNER_KIND= JUnitCorePlugin.PLUGIN_ID+".TEST_KIND"; //$NON-NLS-1$
 
 	public static final String ATTR_TEST_HAS_INCLUDE_TAGS= JUnitCorePlugin.PLUGIN_ID + ".HAS_INCLUDE_TAGS"; //$NON-NLS-1$
@@ -84,6 +87,44 @@ public class JUnitLaunchConfigurationConstants {
 	 * The unique ID of test to run or "" if not available (applicable to JUnit 5 and above).
 	 */
 	public static final String ATTR_TEST_UNIQUE_ID= JUnitCorePlugin.PLUGIN_ID + ".TEST_UNIQUE_ID"; //$NON-NLS-1$
+
+	/**
+	 * Creates a detached working copy for a rerun and remembers the persistent
+	 * launch configuration from which it was derived.
+	 *
+	 * @param launchConfiguration the configuration to copy
+	 * @param name the name of the temporary configuration
+	 * @return the temporary rerun configuration
+	 * @throws CoreException if the configuration cannot be copied or inspected
+	 */
+	public static ILaunchConfigurationWorkingCopy createRerunLaunchConfiguration(
+			ILaunchConfiguration launchConfiguration, String name) throws CoreException {
+		ILaunchConfigurationWorkingCopy rerunConfiguration= launchConfiguration.copy(name);
+		String memento= getRerunLaunchConfigurationMemento(launchConfiguration);
+		if (memento != null)
+			rerunConfiguration.setAttribute(ATTR_RERUN_LAUNCH_CONFIG_MEMENTO, memento);
+		return rerunConfiguration;
+	}
+
+	/**
+	 * Returns the memento of the persistent configuration from which the given
+	 * configuration ultimately originated.
+	 *
+	 * @param launchConfiguration a saved configuration or temporary working copy
+	 * @return the persistent configuration memento, or <code>null</code>
+	 * @throws CoreException if the configuration cannot be inspected
+	 */
+	public static String getRerunLaunchConfigurationMemento(ILaunchConfiguration launchConfiguration) throws CoreException {
+		String memento= launchConfiguration.getAttribute(ATTR_RERUN_LAUNCH_CONFIG_MEMENTO, (String) null);
+		if (memento != null && !memento.isEmpty())
+			return memento;
+		if (launchConfiguration instanceof ILaunchConfigurationWorkingCopy workingCopy) {
+			ILaunchConfiguration original= workingCopy.getOriginal();
+			if (original != null && original.exists())
+				return original.getMemento();
+		}
+		return launchConfiguration.exists() ? launchConfiguration.getMemento() : null;
+	}
 
 	public static ITestKind getTestRunnerKind(ILaunchConfiguration launchConfiguration) {
 		try {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -261,33 +261,10 @@ public final class JUnitModel {
 		ILaunchManager launchManager= DebugPlugin.getDefault().getLaunchManager();
 		launchManager.addLaunchListener(fLaunchListener);
 
-/*
- * TODO: restore on restart:
- * - only import headers!
- * - only import last n sessions; remove all other files in historyDirectory
- */
-//		File historyDirectory= JUnitPlugin.getHistoryDirectory();
-//		File[] swapFiles= historyDirectory.listFiles();
-//		if (swapFiles != null) {
-//			Arrays.sort(swapFiles, new Comparator() {
-//				public int compare(Object o1, Object o2) {
-//					String name1= ((File) o1).getName();
-//					String name2= ((File) o2).getName();
-//					return name1.compareTo(name2);
-//				}
-//			});
-//			for (int i= 0; i < swapFiles.length; i++) {
-//				final File file= swapFiles[i];
-//				SafeRunner.run(new ISafeRunnable() {
-//					public void run() throws Exception {
-//						importTestRunSession(file );
-//					}
-//					public void handleException(Throwable exception) {
-//						JUnitPlugin.log(exception);
-//					}
-//				});
-//			}
-//		}
+		List<TestRunSession> restoredSessions= TestRunSessionHistory.load(JUnitCorePlugin.getHistoryDirectory(), getMaxTestRunCount());
+		for (int i= restoredSessions.size() - 1; i >= 0; i--) {
+			addTestRunSession(restoredSessions.get(i));
+		}
 
 		addTestRunSessionListener(new LegacyTestRunSessionListener());
 	}
@@ -299,25 +276,7 @@ public final class JUnitModel {
 		ILaunchManager launchManager= DebugPlugin.getDefault().getLaunchManager();
 		launchManager.removeLaunchListener(fLaunchListener);
 
-		File historyDirectory= JUnitCorePlugin.getHistoryDirectory();
-		File[] swapFiles= historyDirectory.listFiles();
-		if (swapFiles != null) {
-			for (File swapFile : swapFiles) {
-				swapFile.delete();
-			}
-		}
-
-//		for (Iterator iter= fTestRunSessions.iterator(); iter.hasNext();) {
-//			final TestRunSession session= (TestRunSession) iter.next();
-//			SafeRunner.run(new ISafeRunnable() {
-//				public void run() throws Exception {
-//					session.swapOut();
-//				}
-//				public void handleException(Throwable exception) {
-//					JUnitPlugin.log(exception);
-//				}
-//			});
-//		}
+		TestRunSessionHistory.store(getTestRunSessions(), JUnitCorePlugin.getHistoryDirectory(), getMaxTestRunCount());
 	}
 
 
@@ -339,6 +298,10 @@ public final class JUnitModel {
 		return new ArrayList<>(fTestRunSessions);
 	}
 
+	private static int getMaxTestRunCount() {
+		return Math.max(0, Platform.getPreferencesService().getInt(JUnitCorePlugin.CORE_PLUGIN_ID, JUnitPreferencesConstants.MAX_TEST_RUNS, 10, null));
+	}
+
 	/**
 	 * Adds the given {@link TestRunSession} and notifies all registered
 	 * {@link ITestRunSessionListener}s.
@@ -353,7 +316,7 @@ public final class JUnitModel {
 			Assert.isLegal(! fTestRunSessions.contains(testRunSession));
 			fTestRunSessions.addFirst(testRunSession);
 
-			int maxCount = Platform.getPreferencesService().getInt(JUnitCorePlugin.CORE_PLUGIN_ID, JUnitPreferencesConstants.MAX_TEST_RUNS, 10, null);
+			int maxCount= getMaxTestRunCount();
 			int size= fTestRunSessions.size();
 			if (size > maxCount) {
 				List<TestRunSession> excess= fTestRunSessions.subList(maxCount, size);
@@ -369,6 +332,7 @@ public final class JUnitModel {
 
 		for (TestRunSession oldSession : toRemove) {
 			notifyTestRunSessionRemoved(oldSession);
+			oldSession.removeSwapFile();
 		}
 		notifyTestRunSessionAdded(testRunSession);
 	}

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
@@ -367,29 +367,37 @@ public class TestRunSession implements ITestRunSession {
 	}
 
 	public synchronized void swapOut() {
-		if (fTestRoot == null)
+		if (!canSwapOut())
 			return;
-		if (isRunning() || isStarting() || isKeptAlive())
-			return;
-
-		for (ITestSessionListener registered : fSessionListeners) {
-			if (! registered.acceptsSwapToDisk())
-				return;
-		}
 
 		try {
 			TestRunSessionHistory.exportAtomically(this, getSwapFile());
-			fTestResult= fTestRoot.getTestResult(true);
-			fTestRoot= null;
-			fTestRunnerClient= null;
-			fIdToTest= new HashMap<>();
-			fIncompleteTestSuites= null;
-			fFactoryTestSuites= null;
-			fUnrootedSuite= null;
-
+			discardTestTree();
 		} catch (IllegalStateException | CoreException | IOException e) {
 			LOG.error(e.getMessage(), e);
 		}
+	}
+
+	synchronized boolean canSwapOut() {
+		if (fTestRoot == null || isRunning() || isStarting() || isKeptAlive())
+			return false;
+		for (ITestSessionListener registered : fSessionListeners) {
+			if (!registered.acceptsSwapToDisk())
+				return false;
+		}
+		return true;
+	}
+
+	synchronized void discardTestTree() {
+		if (fTestRoot == null)
+			return;
+		fTestResult= fTestRoot.getTestResult(true);
+		fTestRoot= null;
+		fTestRunnerClient= null;
+		fIdToTest= new HashMap<>();
+		fIncompleteTestSuites= null;
+		fFactoryTestSuites= null;
+		fUnrootedSuite= null;
 	}
 
 	public boolean isStarting() {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,13 +16,14 @@
 package org.eclipse.jdt.internal.junit.model;
 
 import java.io.File;
+import java.io.IOException;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 import org.eclipse.jdt.junit.model.ITestElement;
 import org.eclipse.jdt.junit.model.ITestElementContainer;
@@ -104,6 +105,10 @@ public class TestRunSession implements ITestRunSession {
 	private static final ILog LOG = ILog.of(TestRunSession.class);
 
 	private static final String EMPTY_STRING= ""; //$NON-NLS-1$
+	private static final String SWAP_FILE_PREFIX= "swap-"; //$NON-NLS-1$
+	private static final String XML_SUFFIX= ".xml"; //$NON-NLS-1$
+
+	private final String fSwapFileName= SWAP_FILE_PREFIX + UUID.randomUUID() + XML_SUFFIX;
 
 	/**
 	 * Tags included in this test run.
@@ -150,6 +155,7 @@ public class TestRunSession implements ITestRunSession {
 	volatile boolean fIsRunning;
 
 	volatile boolean fIsStopped;
+	volatile boolean fSwapInFailed;
 
 
 	/**
@@ -238,6 +244,7 @@ public class TestRunSession implements ITestRunSession {
 		fErrorCount= 0;
 		fIgnoredCount= 0;
 		fTotalCount= 0;
+		fSwapInFailed= false;
 
 		fTestRoot= new TestRoot(this);
 		fTestResult= null;
@@ -371,9 +378,7 @@ public class TestRunSession implements ITestRunSession {
 		}
 
 		try {
-			File swapFile= getSwapFile();
-
-			JUnitModel.exportTestRunSession(this, swapFile);
+			TestRunSessionHistory.exportAtomically(this, getSwapFile());
 			fTestResult= fTestRoot.getTestResult(true);
 			fTestRoot= null;
 			fTestRunnerClient= null;
@@ -382,7 +387,7 @@ public class TestRunSession implements ITestRunSession {
 			fFactoryTestSuites= null;
 			fUnrootedSuite= null;
 
-		} catch (IllegalStateException | CoreException e) {
+		} catch (IllegalStateException | CoreException | IOException e) {
 			LOG.error(e.getMessage(), e);
 		}
 	}
@@ -399,10 +404,7 @@ public class TestRunSession implements ITestRunSession {
 	}
 
 	private File getSwapFile() throws IllegalStateException {
-		File historyDir= JUnitCorePlugin.getHistoryDirectory();
-		String isoTime= new SimpleDateFormat("yyyyMMdd-HHmmss.SSS").format(new Date(getStartTime())); //$NON-NLS-1$
-		String swapFileName= isoTime + ".xml"; //$NON-NLS-1$
-		return new File(historyDir, swapFileName);
+		return new File(JUnitCorePlugin.getHistoryDirectory(), fSwapFileName);
 	}
 
 
@@ -412,11 +414,17 @@ public class TestRunSession implements ITestRunSession {
 
 		try {
 			JUnitModel.importIntoTestRunSession(getSwapFile(), this);
+			fSwapInFailed= false;
 		} catch (IllegalStateException | CoreException e) {
+			fSwapInFailed= true;
 			LOG.error(e.getMessage(), e);
 			fTestRoot= new TestRoot(this);
 			fTestResult= null;
 		}
+	}
+
+	boolean hasSwapInFailed() {
+		return fSwapInFailed;
 	}
 
 	public void stopTestRun() {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
@@ -317,6 +317,30 @@ public class TestRunSession implements ITestRunSession {
 		return fLaunch;
 	}
 
+	/**
+	 * @return the launch configuration that can be used to rerun this session,
+	 *         or <code>null</code> if no configuration is available
+	 */
+	public ILaunchConfiguration getRerunLaunchConfiguration() {
+		return fLaunch == null ? null : fLaunch.getLaunchConfiguration();
+	}
+
+	/**
+	 * @return the original launch mode, or <code>null</code> if it is not available
+	 */
+	public String getRerunLaunchMode() {
+		return fLaunch == null ? null : fLaunch.getLaunchMode();
+	}
+
+	/**
+	 * @return <code>true</code> if this session has an existing launch
+	 *         configuration and a launch mode for rerunning it
+	 */
+	public boolean canRerun() {
+		ILaunchConfiguration configuration= getRerunLaunchConfiguration();
+		return configuration != null && configuration.exists() && getRerunLaunchMode() != null;
+	}
+
 	@Override
 	public String getTestRunName() {
 		return fTestRunName;

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSession.java
@@ -333,12 +333,12 @@ public class TestRunSession implements ITestRunSession {
 	}
 
 	/**
-	 * @return <code>true</code> if this session has an existing launch
-	 *         configuration and a launch mode for rerunning it
+	 * @return <code>true</code> if this session has a usable launch configuration
+	 *         and a launch mode for rerunning it
 	 */
 	public boolean canRerun() {
 		ILaunchConfiguration configuration= getRerunLaunchConfiguration();
-		return configuration != null && configuration.exists() && getRerunLaunchMode() != null;
+		return configuration != null && (configuration.exists() || configuration.isWorkingCopy()) && getRerunLaunchMode() != null;
 	}
 
 	@Override

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -37,9 +37,15 @@ import org.eclipse.core.runtime.ILog;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+
 import org.eclipse.jdt.core.IJavaModel;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.internal.junit.launcher.ITestKind;
+import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
 
 
 /**
@@ -62,6 +68,8 @@ public final class TestRunSessionHistory {
 	private static final String KEY_ID= "id"; //$NON-NLS-1$
 	private static final String KEY_NAME= "name"; //$NON-NLS-1$
 	private static final String KEY_PROJECT= "project"; //$NON-NLS-1$
+	private static final String KEY_LAUNCH_CONFIGURATION_MEMENTO= "launchConfigurationMemento"; //$NON-NLS-1$
+	private static final String KEY_LAUNCH_MODE= "launchMode"; //$NON-NLS-1$
 	private static final String KEY_START_TIME= "startTime"; //$NON-NLS-1$
 	private static final String KEY_HISTORY_TIMESTAMP= "historyTimestamp"; //$NON-NLS-1$
 	private static final String KEY_PROGRESS= "progress"; //$NON-NLS-1$
@@ -307,6 +315,8 @@ public final class TestRunSessionHistory {
 		properties.setProperty(entryKey(index, KEY_ID), session.fId);
 		properties.setProperty(entryKey(index, KEY_NAME), session.fTestRunName);
 		setOptional(properties, entryKey(index, KEY_PROJECT), session.fProjectName);
+		setOptional(properties, entryKey(index, KEY_LAUNCH_CONFIGURATION_MEMENTO), session.fLaunchConfigurationMemento);
+		setOptional(properties, entryKey(index, KEY_LAUNCH_MODE), session.fLaunchMode);
 		properties.setProperty(entryKey(index, KEY_START_TIME), Long.toString(session.fStartTime));
 		properties.setProperty(entryKey(index, KEY_HISTORY_TIMESTAMP), Long.toString(session.fHistoryTimestamp));
 		properties.setProperty(entryKey(index, KEY_PROGRESS), session.fStopped ? PROGRESS_STOPPED : PROGRESS_COMPLETED);
@@ -326,6 +336,13 @@ public final class TestRunSessionHistory {
 		String id= UUID.fromString(required(properties, entryKey(index, KEY_ID))).toString();
 		String testRunName= required(properties, entryKey(index, KEY_NAME));
 		String projectName= properties.getProperty(entryKey(index, KEY_PROJECT));
+		String launchConfigurationMemento= properties.getProperty(entryKey(index, KEY_LAUNCH_CONFIGURATION_MEMENTO));
+		String launchMode= properties.getProperty(entryKey(index, KEY_LAUNCH_MODE));
+		if (launchConfigurationMemento == null || launchConfigurationMemento.isEmpty()
+				|| launchMode == null || launchMode.isEmpty()) {
+			launchConfigurationMemento= null;
+			launchMode= null;
+		}
 		long startTime= readLong(properties, entryKey(index, KEY_START_TIME));
 		long historyTimestamp= readLong(properties, entryKey(index, KEY_HISTORY_TIMESTAMP), 0, Long.MAX_VALUE);
 		String progress= required(properties, entryKey(index, KEY_PROGRESS));
@@ -351,9 +368,10 @@ public final class TestRunSessionHistory {
 		String excludeTags= properties.getProperty(entryKey(index, KEY_EXCLUDE_TAGS));
 		long fileLength= readLong(properties, entryKey(index, KEY_FILE_LENGTH), 1, Long.MAX_VALUE);
 		File historyFile= new File(historyDirectory, historyFileName(id));
-		return new StoredSession(id, historyFile, fileLength, testRunName, projectName, startTime,
-				historyTimestamp, stopped, result, totalCount, startedCount, failureCount, errorCount,
-				ignoredCount, assumptionFailureCount, includeTags, excludeTags);
+		return new StoredSession(id, historyFile, fileLength, testRunName, projectName,
+				launchConfigurationMemento, launchMode, startTime, historyTimestamp, stopped, result,
+				totalCount, startedCount, failureCount, errorCount, ignoredCount, assumptionFailureCount,
+				includeTags, excludeTags);
 	}
 
 	private static String resultName(Result result) {
@@ -430,6 +448,17 @@ public final class TestRunSessionHistory {
 		return historyDirectory.toPath().toAbsolutePath().normalize();
 	}
 
+	private static ILaunchConfiguration resolveLaunchConfiguration(String memento) {
+		if (memento == null)
+			return null;
+		try {
+			return DebugPlugin.getDefault().getLaunchManager().getLaunchConfiguration(memento);
+		} catch (CoreException e) {
+			LOG.log(e.getStatus());
+			return null;
+		}
+	}
+
 	private static IJavaProject resolveProject(String projectName) {
 		if (projectName == null)
 			return null;
@@ -490,6 +519,8 @@ public final class TestRunSessionHistory {
 		final long fFileLength;
 		final String fTestRunName;
 		final String fProjectName;
+		final String fLaunchConfigurationMemento;
+		final String fLaunchMode;
 		final long fStartTime;
 		final long fHistoryTimestamp;
 		final boolean fStopped;
@@ -504,14 +535,16 @@ public final class TestRunSessionHistory {
 		final String fExcludeTags;
 
 		StoredSession(String id, File historyFile, long fileLength, String testRunName, String projectName,
-				long startTime, long historyTimestamp, boolean stopped, Result result, int totalCount, int startedCount,
-				int failureCount, int errorCount, int ignoredCount, int assumptionFailureCount,
-				String includeTags, String excludeTags) {
+				String launchConfigurationMemento, String launchMode, long startTime, long historyTimestamp,
+				boolean stopped, Result result, int totalCount, int startedCount, int failureCount, int errorCount,
+				int ignoredCount, int assumptionFailureCount, String includeTags, String excludeTags) {
 			fId= id;
 			fHistoryFile= historyFile;
 			fFileLength= fileLength;
 			fTestRunName= testRunName;
 			fProjectName= projectName;
+			fLaunchConfigurationMemento= launchConfigurationMemento;
+			fLaunchMode= launchMode;
 			fStartTime= startTime;
 			fHistoryTimestamp= historyTimestamp;
 			fStopped= stopped;
@@ -528,16 +561,34 @@ public final class TestRunSessionHistory {
 
 		static StoredSession from(TestRunSession session, String id, File historyFile, long historyTimestamp) {
 			IJavaProject project= session.getLaunchedProject();
+			String launchConfigurationMemento= null;
+			String launchMode= null;
+			ILaunchConfiguration launchConfiguration= session.getRerunLaunchConfiguration();
+			if (launchConfiguration != null && launchConfiguration.exists()) {
+				try {
+					launchConfigurationMemento= launchConfiguration.getMemento();
+					launchMode= session.getRerunLaunchMode();
+				} catch (CoreException e) {
+					LOG.log(e.getStatus());
+				}
+				if (launchConfigurationMemento == null || launchConfigurationMemento.isEmpty()
+						|| launchMode == null || launchMode.isEmpty()) {
+					launchConfigurationMemento= null;
+					launchMode= null;
+				}
+			}
 			return new StoredSession(id, historyFile, historyFile.length(), session.getTestRunName(),
-					project == null ? null : project.getElementName(), session.getStartTime(), historyTimestamp,
-					session.isStopped(), session.getTestResult(true), session.getTotalCount(), session.getStartedCount(),
-					session.getFailureCount(), session.getErrorCount(), session.getIgnoredCount(),
-					session.getAssumptionFailureCount(), session.getIncludeTags(), session.getExcludeTags());
+					project == null ? null : project.getElementName(), launchConfigurationMemento, launchMode,
+					session.getStartTime(), historyTimestamp, session.isStopped(), session.getTestResult(true),
+					session.getTotalCount(), session.getStartedCount(), session.getFailureCount(), session.getErrorCount(),
+					session.getIgnoredCount(), session.getAssumptionFailureCount(), session.getIncludeTags(),
+					session.getExcludeTags());
 		}
 	}
 
 	private static final class RestoredTestRunSession extends TestRunSession {
 		private final StoredSession fStoredSession;
+		private final ILaunchConfiguration fRerunLaunchConfiguration;
 		private final Result fHeaderResult;
 		private boolean fLoadingContents;
 		private boolean fContentsLoaded;
@@ -546,6 +597,7 @@ public final class TestRunSessionHistory {
 		RestoredTestRunSession(StoredSession storedSession) {
 			super(storedSession.fTestRunName, resolveProject(storedSession.fProjectName));
 			fStoredSession= storedSession;
+			fRerunLaunchConfiguration= resolveLaunchConfiguration(storedSession.fLaunchConfigurationMemento);
 			fHeaderResult= storedSession.fResult;
 			fStartTime= storedSession.fStartTime;
 			fTotalCount= storedSession.fTotalCount;
@@ -557,6 +609,24 @@ public final class TestRunSessionHistory {
 			fIsStopped= storedSession.fStopped;
 			setIncludeTags(storedSession.fIncludeTags);
 			setExcludeTags(storedSession.fExcludeTags);
+		}
+
+		@Override
+		public ILaunchConfiguration getRerunLaunchConfiguration() {
+			return fRerunLaunchConfiguration != null && fRerunLaunchConfiguration.exists()
+					? fRerunLaunchConfiguration : null;
+		}
+
+		@Override
+		public String getRerunLaunchMode() {
+			return getRerunLaunchConfiguration() == null ? null : fStoredSession.fLaunchMode;
+		}
+
+		@Override
+		public ITestKind getTestRunnerKind() {
+			ILaunchConfiguration configuration= getRerunLaunchConfiguration();
+			return configuration == null ? super.getTestRunnerKind()
+					: JUnitLaunchConfigurationConstants.getTestRunnerKind(configuration);
 		}
 
 		@Override

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -240,6 +240,8 @@ public final class TestRunSessionHistory {
 	}
 
 	private static boolean isPersistable(TestRunSession session) {
+		if (session instanceof RestoredTestRunSession restoredSession && !restoredSession.fValid)
+			return false;
 		return session.getStartTime() != 0
 				&& !session.isRunning()
 				&& !session.isStarting()

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -19,6 +19,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jdt.junit.model.ITestElement.Result;
 
@@ -78,6 +80,7 @@ public final class TestRunSessionHistory {
 	private static final String PROGRESS_STOPPED= "stopped"; //$NON-NLS-1$
 
 	private static final ILog LOG= ILog.of(TestRunSessionHistory.class);
+	private static final Set<Path> BLOCKED_HISTORY_DIRECTORIES= ConcurrentHashMap.newKeySet();
 
 	private TestRunSessionHistory() {
 	}
@@ -91,12 +94,19 @@ public final class TestRunSessionHistory {
 	 * @return the restored sessions, youngest first
 	 */
 	public static List<TestRunSession> load(File historyDirectory, int maxCount) {
+		Path historyPath= historyDirectoryPath(historyDirectory);
 		deleteTemporaryFiles(historyDirectory);
 		deleteTransientSwapFiles(historyDirectory);
 
 		File indexFile= new File(historyDirectory, INDEX_FILE_NAME);
-		if (!indexFile.isFile()) {
+		if (!indexFile.exists()) {
+			BLOCKED_HISTORY_DIRECTORIES.remove(historyPath);
 			deleteOrphanedXmlFiles(historyDirectory, Set.of(), true);
+			return List.of();
+		}
+		if (!indexFile.isFile()) {
+			BLOCKED_HISTORY_DIRECTORIES.add(historyPath);
+			LOG.error("Could not read the JUnit history index: " + indexFile); //$NON-NLS-1$
 			return List.of();
 		}
 
@@ -104,6 +114,7 @@ public final class TestRunSessionHistory {
 		try (BufferedInputStream input= new BufferedInputStream(new FileInputStream(indexFile))) {
 			properties.load(input);
 		} catch (IOException | IllegalArgumentException e) {
+			BLOCKED_HISTORY_DIRECTORIES.add(historyPath);
 			LOG.error("Could not read the JUnit history index", e); //$NON-NLS-1$
 			return List.of();
 		}
@@ -114,13 +125,16 @@ public final class TestRunSessionHistory {
 			formatVersion= readInt(properties, KEY_FORMAT_VERSION, 0, Integer.MAX_VALUE);
 			entryCount= readInt(properties, KEY_ENTRY_COUNT, 0, MAX_INDEX_ENTRIES);
 		} catch (IllegalArgumentException e) {
+			BLOCKED_HISTORY_DIRECTORIES.add(historyPath);
 			LOG.error("Invalid JUnit history index", e); //$NON-NLS-1$
 			return List.of();
 		}
 		if (formatVersion != FORMAT_VERSION) {
+			BLOCKED_HISTORY_DIRECTORIES.add(historyPath);
 			LOG.error("Unsupported JUnit history index version: " + formatVersion); //$NON-NLS-1$
 			return List.of();
 		}
+		BLOCKED_HISTORY_DIRECTORIES.remove(historyPath);
 
 		int limit= Math.max(0, maxCount);
 		List<StoredSession> validEntries= new ArrayList<>(entryCount);
@@ -169,6 +183,11 @@ public final class TestRunSessionHistory {
 	 * @param maxCount the maximum number of entries to retain
 	 */
 	public static void store(List<TestRunSession> sessions, File historyDirectory, int maxCount) {
+		if (BLOCKED_HISTORY_DIRECTORIES.contains(historyDirectoryPath(historyDirectory))) {
+			LOG.error("Keeping the existing JUnit history because its index could not be read"); //$NON-NLS-1$
+			return;
+		}
+
 		try {
 			Files.createDirectories(historyDirectory.toPath());
 		} catch (IOException e) {
@@ -382,6 +401,10 @@ public final class TestRunSessionHistory {
 
 	private static long historyTimestamp(long startTime) {
 		return startTime == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(startTime);
+	}
+
+	private static Path historyDirectoryPath(File historyDirectory) {
+		return historyDirectory.toPath().toAbsolutePath().normalize();
 	}
 
 	private static IJavaProject resolveProject(String projectName) {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -564,9 +564,10 @@ public final class TestRunSessionHistory {
 			String launchConfigurationMemento= null;
 			String launchMode= null;
 			ILaunchConfiguration launchConfiguration= session.getRerunLaunchConfiguration();
-			if (launchConfiguration != null && launchConfiguration.exists()) {
+			if (launchConfiguration != null) {
 				try {
-					launchConfigurationMemento= launchConfiguration.getMemento();
+					launchConfigurationMemento=
+							JUnitLaunchConfigurationConstants.getRerunLaunchConfigurationMemento(launchConfiguration);
 					launchMode= session.getRerunLaunchMode();
 				} catch (CoreException e) {
 					LOG.log(e.getStatus());

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -11,35 +11,27 @@
 
 package org.eclipse.jdt.internal.junit.model;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.text.ParsePosition;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
+import java.util.UUID;
 
 import org.eclipse.jdt.junit.model.ITestElement.Result;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 
@@ -47,47 +39,130 @@ import org.eclipse.jdt.core.IJavaModel;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 
-import org.eclipse.jdt.internal.junit.BasicElementLabels;
-import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
-import org.eclipse.jdt.internal.junit.Messages;
-import org.eclipse.jdt.internal.junit.util.XmlProcessorFactoryJdtJunit;
 
+/**
+ * Persists the bounded JUnit test-run history independently of the transient
+ * swap files used by {@link TestRunSession} while Eclipse is running.
+ */
 public final class TestRunSessionHistory {
 
+	private static final int FORMAT_VERSION= 1;
+	private static final int MAX_INDEX_ENTRIES= 10_000;
+
+	private static final String INDEX_FILE_NAME= "history.properties"; //$NON-NLS-1$
+	private static final String HISTORY_FILE_PREFIX= "history-"; //$NON-NLS-1$
 	private static final String XML_SUFFIX= ".xml"; //$NON-NLS-1$
 	private static final String TEMP_SUFFIX= ".tmp"; //$NON-NLS-1$
-	private static final String HISTORY_FILE_DATE_PATTERN= "yyyyMMdd-HHmmss.SSS"; //$NON-NLS-1$
+
+	private static final String KEY_FORMAT_VERSION= "formatVersion"; //$NON-NLS-1$
+	private static final String KEY_ENTRY_COUNT= "entryCount"; //$NON-NLS-1$
+	private static final String KEY_ID= "id"; //$NON-NLS-1$
+	private static final String KEY_NAME= "name"; //$NON-NLS-1$
+	private static final String KEY_PROJECT= "project"; //$NON-NLS-1$
+	private static final String KEY_START_TIME= "startTime"; //$NON-NLS-1$
+	private static final String KEY_HISTORY_TIMESTAMP= "historyTimestamp"; //$NON-NLS-1$
+	private static final String KEY_PROGRESS= "progress"; //$NON-NLS-1$
+	private static final String KEY_TOTAL_COUNT= "totalCount"; //$NON-NLS-1$
+	private static final String KEY_STARTED_COUNT= "startedCount"; //$NON-NLS-1$
+	private static final String KEY_FAILURE_COUNT= "failureCount"; //$NON-NLS-1$
+	private static final String KEY_ERROR_COUNT= "errorCount"; //$NON-NLS-1$
+	private static final String KEY_IGNORED_COUNT= "ignoredCount"; //$NON-NLS-1$
+	private static final String KEY_ASSUMPTION_FAILURE_COUNT= "assumptionFailureCount"; //$NON-NLS-1$
+	private static final String KEY_INCLUDE_TAGS= "includeTags"; //$NON-NLS-1$
+	private static final String KEY_EXCLUDE_TAGS= "excludeTags"; //$NON-NLS-1$
+	private static final String KEY_FILE_LENGTH= "fileLength"; //$NON-NLS-1$
+
+	private static final String PROGRESS_COMPLETED= "completed"; //$NON-NLS-1$
+	private static final String PROGRESS_STOPPED= "stopped"; //$NON-NLS-1$
 
 	private static final ILog LOG= ILog.of(TestRunSessionHistory.class);
 
 	private TestRunSessionHistory() {
 	}
 
+	/**
+	 * Restores at most {@code maxCount} history entries. Only the small index is
+	 * read here; the test trees remain in their XML files until selected.
+	 *
+	 * @param historyDirectory the JUnit history directory
+	 * @param maxCount the maximum number of entries to restore
+	 * @return the restored sessions, youngest first
+	 */
 	public static List<TestRunSession> load(File historyDirectory, int maxCount) {
 		deleteTemporaryFiles(historyDirectory);
 
-		File[] historyFiles= historyDirectory.listFiles(file -> file.isFile() && file.getName().endsWith(XML_SUFFIX));
-		if (historyFiles == null || historyFiles.length == 0)
+		File indexFile= new File(historyDirectory, INDEX_FILE_NAME);
+		if (!indexFile.isFile())
 			return List.of();
 
-		Arrays.sort(historyFiles, Comparator.comparing(File::getName).reversed());
+		Properties properties= new Properties();
+		try (BufferedInputStream input= new BufferedInputStream(new FileInputStream(indexFile))) {
+			properties.load(input);
+		} catch (IOException | IllegalArgumentException e) {
+			LOG.error("Could not read the JUnit history index", e); //$NON-NLS-1$
+			return List.of();
+		}
+
+		int formatVersion;
+		int entryCount;
+		try {
+			formatVersion= readInt(properties, KEY_FORMAT_VERSION, 0, Integer.MAX_VALUE);
+			entryCount= readInt(properties, KEY_ENTRY_COUNT, 0, MAX_INDEX_ENTRIES);
+		} catch (IllegalArgumentException e) {
+			LOG.error("Invalid JUnit history index", e); //$NON-NLS-1$
+			return List.of();
+		}
+		if (formatVersion != FORMAT_VERSION) {
+			LOG.error("Unsupported JUnit history index version: " + formatVersion); //$NON-NLS-1$
+			return List.of();
+		}
+
 		int limit= Math.max(0, maxCount);
-		List<TestRunSession> sessions= new ArrayList<>(Math.min(limit, historyFiles.length));
-		for (File historyFile : historyFiles) {
-			if (sessions.size() >= limit) {
-				delete(historyFile);
-				continue;
-			}
+		List<StoredSession> validEntries= new ArrayList<>(entryCount);
+		Set<String> referencedFiles= new HashSet<>();
+		Set<String> seenIds= new HashSet<>();
+		boolean indexFullyUnderstood= true;
+		for (int i= 0; i < entryCount; i++) {
 			try {
-				sessions.add(read(historyFile));
-			} catch (CoreException e) {
-				LOG.log(e.getStatus());
-				delete(historyFile);
+				StoredSession storedSession= readEntry(properties, i, historyDirectory);
+				if (!seenIds.add(storedSession.fId))
+					throw new IllegalArgumentException("Duplicate JUnit history identifier: " + storedSession.fId); //$NON-NLS-1$
+				File historyFile= storedSession.fHistoryFile;
+				if (!historyFile.isFile() || historyFile.length() != storedSession.fFileLength) {
+					LOG.error("Ignoring incomplete JUnit history file: " + historyFile); //$NON-NLS-1$
+					delete(historyFile);
+					continue;
+				}
+				referencedFiles.add(historyFile.getName());
+				validEntries.add(storedSession);
+			} catch (IllegalArgumentException e) {
+				indexFullyUnderstood= false;
+				LOG.error("Invalid JUnit history entry " + i, e); //$NON-NLS-1$
 			}
+		}
+
+		if (indexFullyUnderstood)
+			deleteOrphanedXmlFiles(historyDirectory, referencedFiles, false);
+
+		validEntries.sort(Comparator.comparingLong((StoredSession entry) -> entry.fHistoryTimestamp).reversed());
+		List<TestRunSession> sessions= new ArrayList<>(Math.min(limit, validEntries.size()));
+		for (StoredSession storedSession : validEntries) {
+			if (sessions.size() >= limit)
+				break;
+			sessions.add(new RestoredTestRunSession(storedSession));
 		}
 		return sessions;
 	}
 
+	/**
+	 * Atomically persists at most {@code maxCount} completed sessions and then
+	 * atomically publishes the new history index. Files not referenced by the
+	 * new index are removed only after the index has been committed.
+	 *
+	 * @param sessions sessions ordered youngest first
+	 * @param historyDirectory the JUnit history directory
+	 * @param maxCount the maximum number of entries to retain
+	 */
 	public static void store(List<TestRunSession> sessions, File historyDirectory, int maxCount) {
 		try {
 			Files.createDirectories(historyDirectory.toPath());
@@ -97,78 +172,208 @@ public final class TestRunSessionHistory {
 		}
 
 		deleteTemporaryFiles(historyDirectory);
-		Set<String> retainedFileNames= new HashSet<>();
 		int limit= Math.max(0, maxCount);
+		List<StoredSession> storedSessions= new ArrayList<>(Math.min(limit, sessions.size()));
+		boolean persistenceFailure= false;
 		for (TestRunSession session : sessions) {
-			if (retainedFileNames.size() >= limit)
+			if (storedSessions.size() >= limit)
 				break;
-			if (session.getStartTime() == 0 || session.isRunning() || session.isStarting() || session.isKeptAlive())
+			if (!isPersistable(session))
 				continue;
 
-			File historyFile= historyFile(historyDirectory, session.getStartTime());
-			String fileName= historyFile.getName();
-			retainedFileNames.add(fileName);
-
-			// Inactive sessions may already have been swapped to this file. Keeping an
-			// existing file avoids loading a potentially large test tree during shutdown.
-			if (historyFile.isFile())
-				continue;
-
-			File temporaryFile= new File(historyDirectory, fileName + TEMP_SUFFIX);
-			try {
-				Files.deleteIfExists(temporaryFile.toPath());
-				JUnitModel.exportTestRunSession(session, temporaryFile);
-				moveReplacing(temporaryFile, historyFile);
-			} catch (CoreException | IOException e) {
-				LOG.error("Could not persist JUnit test run history", e); //$NON-NLS-1$
-				delete(temporaryFile);
-				if (!historyFile.isFile())
-					retainedFileNames.remove(fileName);
+			StoredSession storedSession= null;
+			if (session instanceof RestoredTestRunSession restoredSession) {
+				storedSession= restoredSession.reusableStoredSession();
+				if (storedSession == null && !restoredSession.canWriteFromMemory()) {
+					persistenceFailure= true;
+					continue;
+				}
 			}
+			if (storedSession == null) {
+				try {
+					storedSession= writeSessionAtomically(session, historyDirectory);
+				} catch (CoreException | IOException e) {
+					persistenceFailure= true;
+					LOG.error("Could not persist JUnit test run history", e); //$NON-NLS-1$
+				}
+			}
+			if (storedSession != null)
+				storedSessions.add(storedSession);
 		}
 
-		File[] historyFiles= historyDirectory.listFiles(file -> file.isFile() && file.getName().endsWith(XML_SUFFIX));
-		if (historyFiles != null) {
-			for (File historyFile : historyFiles) {
-				if (!retainedFileNames.contains(historyFile.getName()))
-					delete(historyFile);
-			}
-		}
+		if (!writeIndexAtomically(storedSessions, historyDirectory))
+			return;
+
+		Set<String> retainedFiles= new HashSet<>();
+		for (StoredSession storedSession : storedSessions)
+			retainedFiles.add(storedSession.fHistoryFile.getName());
+		deleteOrphanedXmlFiles(historyDirectory, retainedFiles, !persistenceFailure);
 	}
 
-	static TestRunSession read(File historyFile) throws CoreException {
-		long startTime= readStartTime(historyFile);
-		HeaderHandler handler= new HeaderHandler(historyFile, startTime);
+	private static boolean isPersistable(TestRunSession session) {
+		return session.getStartTime() != 0
+				&& !session.isRunning()
+				&& !session.isStarting()
+				&& !session.isKeptAlive();
+	}
+
+	private static StoredSession writeSessionAtomically(TestRunSession session, File historyDirectory) throws CoreException, IOException {
+		String id;
+		File historyFile;
+		do {
+			id= UUID.randomUUID().toString();
+			historyFile= new File(historyDirectory, historyFileName(id));
+		} while (historyFile.exists());
+		File temporaryFile= Files.createTempFile(historyDirectory.toPath(), HISTORY_FILE_PREFIX + id + '-', TEMP_SUFFIX).toFile();
 		try {
-			SAXParserFactory parserFactory= XmlProcessorFactoryJdtJunit.createSAXFactoryWithErrorOnDOCTYPE();
-			SAXParser parser= parserFactory.newSAXParser();
-			parser.parse(historyFile, handler);
-		} catch (StopParsingException e) {
-			return handler.getSession();
-		} catch (ParserConfigurationException | SAXException | IOException | IllegalArgumentException e) {
-			throw readError(historyFile, e);
+			JUnitModel.exportTestRunSession(session, temporaryFile);
+			moveReplacing(temporaryFile, historyFile);
+			return StoredSession.from(session, id, historyFile, historyTimestamp(session.getStartTime()));
+		} finally {
+			delete(temporaryFile);
 		}
-		throw readError(historyFile, new SAXException("JUnit history file has no test-run root element")); //$NON-NLS-1$
 	}
 
-	static File historyFile(File historyDirectory, long startTime) {
-		String timestamp= new SimpleDateFormat(HISTORY_FILE_DATE_PATTERN).format(new Date(startTime));
-		return new File(historyDirectory, timestamp + XML_SUFFIX);
+	private static boolean writeIndexAtomically(List<StoredSession> storedSessions, File historyDirectory) {
+		Properties properties= new Properties();
+		properties.setProperty(KEY_FORMAT_VERSION, Integer.toString(FORMAT_VERSION));
+		properties.setProperty(KEY_ENTRY_COUNT, Integer.toString(storedSessions.size()));
+		for (int i= 0; i < storedSessions.size(); i++)
+			writeEntry(properties, i, storedSessions.get(i));
+
+		File indexFile= new File(historyDirectory, INDEX_FILE_NAME);
+		File temporaryFile;
+		try {
+			temporaryFile= Files.createTempFile(historyDirectory.toPath(), INDEX_FILE_NAME + '.', TEMP_SUFFIX).toFile();
+		} catch (IOException e) {
+			LOG.error("Could not create a temporary JUnit history index", e); //$NON-NLS-1$
+			return false;
+		}
+
+		try {
+			try (BufferedOutputStream output= new BufferedOutputStream(new FileOutputStream(temporaryFile))) {
+				properties.store(output, null);
+			}
+			moveReplacing(temporaryFile, indexFile);
+			return true;
+		} catch (IOException e) {
+			LOG.error("Could not write the JUnit history index", e); //$NON-NLS-1$
+			return false;
+		} finally {
+			delete(temporaryFile);
+		}
 	}
 
-	private static long readStartTime(File historyFile) throws CoreException {
-		String fileName= historyFile.getName();
-		if (!fileName.endsWith(XML_SUFFIX))
-			throw readError(historyFile, new IllegalArgumentException("Not a JUnit history XML file")); //$NON-NLS-1$
+	private static void writeEntry(Properties properties, int index, StoredSession session) {
+		properties.setProperty(entryKey(index, KEY_ID), session.fId);
+		properties.setProperty(entryKey(index, KEY_NAME), session.fTestRunName);
+		setOptional(properties, entryKey(index, KEY_PROJECT), session.fProjectName);
+		properties.setProperty(entryKey(index, KEY_START_TIME), Long.toString(session.fStartTime));
+		properties.setProperty(entryKey(index, KEY_HISTORY_TIMESTAMP), Long.toString(session.fHistoryTimestamp));
+		properties.setProperty(entryKey(index, KEY_PROGRESS), session.fStopped ? PROGRESS_STOPPED : PROGRESS_COMPLETED);
+		properties.setProperty(entryKey(index, KEY_TOTAL_COUNT), Integer.toString(session.fTotalCount));
+		properties.setProperty(entryKey(index, KEY_STARTED_COUNT), Integer.toString(session.fStartedCount));
+		properties.setProperty(entryKey(index, KEY_FAILURE_COUNT), Integer.toString(session.fFailureCount));
+		properties.setProperty(entryKey(index, KEY_ERROR_COUNT), Integer.toString(session.fErrorCount));
+		properties.setProperty(entryKey(index, KEY_IGNORED_COUNT), Integer.toString(session.fIgnoredCount));
+		properties.setProperty(entryKey(index, KEY_ASSUMPTION_FAILURE_COUNT), Integer.toString(session.fAssumptionFailureCount));
+		setOptional(properties, entryKey(index, KEY_INCLUDE_TAGS), session.fIncludeTags);
+		setOptional(properties, entryKey(index, KEY_EXCLUDE_TAGS), session.fExcludeTags);
+		properties.setProperty(entryKey(index, KEY_FILE_LENGTH), Long.toString(session.fFileLength));
+	}
 
-		String timestamp= fileName.substring(0, fileName.length() - XML_SUFFIX.length());
-		SimpleDateFormat format= new SimpleDateFormat(HISTORY_FILE_DATE_PATTERN);
-		format.setLenient(false);
-		ParsePosition position= new ParsePosition(0);
-		Date parsed= format.parse(timestamp, position);
-		if (parsed == null || position.getIndex() != timestamp.length())
-			throw readError(historyFile, new IllegalArgumentException("Invalid JUnit history file name")); //$NON-NLS-1$
-		return parsed.getTime();
+	private static StoredSession readEntry(Properties properties, int index, File historyDirectory) {
+		String id= UUID.fromString(required(properties, entryKey(index, KEY_ID))).toString();
+		String testRunName= required(properties, entryKey(index, KEY_NAME));
+		String projectName= properties.getProperty(entryKey(index, KEY_PROJECT));
+		long startTime= readLong(properties, entryKey(index, KEY_START_TIME));
+		long historyTimestamp= readLong(properties, entryKey(index, KEY_HISTORY_TIMESTAMP), 0, Long.MAX_VALUE);
+		String progress= required(properties, entryKey(index, KEY_PROGRESS));
+		boolean stopped;
+		if (PROGRESS_STOPPED.equals(progress)) {
+			stopped= true;
+		} else if (PROGRESS_COMPLETED.equals(progress)) {
+			stopped= false;
+		} else {
+			throw new IllegalArgumentException("Unsupported JUnit history progress state: " + progress); //$NON-NLS-1$
+		}
+
+		int totalCount= readInt(properties, entryKey(index, KEY_TOTAL_COUNT), 0, Integer.MAX_VALUE);
+		int startedCount= readInt(properties, entryKey(index, KEY_STARTED_COUNT), 0, Integer.MAX_VALUE);
+		int failureCount= readInt(properties, entryKey(index, KEY_FAILURE_COUNT), 0, Integer.MAX_VALUE);
+		int errorCount= readInt(properties, entryKey(index, KEY_ERROR_COUNT), 0, Integer.MAX_VALUE);
+		int ignoredCount= readInt(properties, entryKey(index, KEY_IGNORED_COUNT), 0, Integer.MAX_VALUE);
+		int assumptionFailureCount= readInt(properties, entryKey(index, KEY_ASSUMPTION_FAILURE_COUNT), 0, Integer.MAX_VALUE);
+		String includeTags= properties.getProperty(entryKey(index, KEY_INCLUDE_TAGS));
+		String excludeTags= properties.getProperty(entryKey(index, KEY_EXCLUDE_TAGS));
+		long fileLength= readLong(properties, entryKey(index, KEY_FILE_LENGTH), 1, Long.MAX_VALUE);
+		File historyFile= new File(historyDirectory, historyFileName(id));
+		return new StoredSession(id, historyFile, fileLength, testRunName, projectName, startTime,
+				historyTimestamp, stopped, totalCount, startedCount, failureCount, errorCount,
+				ignoredCount, assumptionFailureCount, includeTags, excludeTags);
+	}
+
+	private static String historyFileName(String id) {
+		return HISTORY_FILE_PREFIX + id + XML_SUFFIX;
+	}
+
+	private static String entryKey(int index, String name) {
+		return "entry." + index + '.' + name; //$NON-NLS-1$
+	}
+
+	private static String required(Properties properties, String key) {
+		String value= properties.getProperty(key);
+		if (value == null)
+			throw new IllegalArgumentException("Missing JUnit history property: " + key); //$NON-NLS-1$
+		return value;
+	}
+
+	private static int readInt(Properties properties, String key, int minimum, int maximum) {
+		long value= readLong(properties, key, minimum, maximum);
+		return (int) value;
+	}
+
+	private static long readLong(Properties properties, String key) {
+		String value= required(properties, key);
+		try {
+			return Long.parseLong(value);
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Invalid JUnit history number: " + key, e); //$NON-NLS-1$
+		}
+	}
+
+	private static long readLong(Properties properties, String key, long minimum, long maximum) {
+		long value= readLong(properties, key);
+		if (value < minimum || value > maximum)
+			throw new IllegalArgumentException("JUnit history number out of range: " + key); //$NON-NLS-1$
+		return value;
+	}
+
+	private static void setOptional(Properties properties, String key, String value) {
+		if (value != null)
+			properties.setProperty(key, value);
+	}
+
+	private static long historyTimestamp(long startTime) {
+		return startTime == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(startTime);
+	}
+
+	private static IJavaProject resolveProject(String projectName) {
+		if (projectName == null)
+			return null;
+		IJavaModel javaModel= JavaCore.create(ResourcesPlugin.getWorkspace().getRoot());
+		IJavaProject project= javaModel.getJavaProject(projectName);
+		return project.exists() ? project : null;
+	}
+
+	private static Result result(StoredSession session) {
+		if (session.fErrorCount > 0)
+			return Result.ERROR;
+		if (session.fFailureCount > 0)
+			return Result.FAILURE;
+		if (session.fStopped)
+			return Result.UNDEFINED;
+		return Result.OK;
 	}
 
 	private static void deleteTemporaryFiles(File historyDirectory) {
@@ -176,6 +381,18 @@ public final class TestRunSessionHistory {
 		if (temporaryFiles != null) {
 			for (File temporaryFile : temporaryFiles)
 				delete(temporaryFile);
+		}
+	}
+
+	private static void deleteOrphanedXmlFiles(File historyDirectory, Set<String> retainedFileNames, boolean deleteLegacyFiles) {
+		File[] historyFiles= historyDirectory.listFiles(file -> file.isFile() && file.getName().endsWith(XML_SUFFIX));
+		if (historyFiles != null) {
+			for (File historyFile : historyFiles) {
+				String fileName= historyFile.getName();
+				if (!retainedFileNames.contains(fileName)
+						&& (deleteLegacyFiles || fileName.startsWith(HISTORY_FILE_PREFIX)))
+					delete(historyFile);
+			}
 		}
 	}
 
@@ -195,116 +412,77 @@ public final class TestRunSessionHistory {
 		}
 	}
 
-	private static CoreException readError(File file, Exception e) {
-		return new CoreException(new Status(IStatus.ERROR,
-				JUnitCorePlugin.getPluginId(),
-				Messages.format(ModelMessages.JUnitModel_could_not_read, BasicElementLabels.getPathLabel(file)),
-				e));
-	}
+	private static final class StoredSession {
+		final String fId;
+		final File fHistoryFile;
+		final long fFileLength;
+		final String fTestRunName;
+		final String fProjectName;
+		final long fStartTime;
+		final long fHistoryTimestamp;
+		final boolean fStopped;
+		final int fTotalCount;
+		final int fStartedCount;
+		final int fFailureCount;
+		final int fErrorCount;
+		final int fIgnoredCount;
+		final int fAssumptionFailureCount;
+		final String fIncludeTags;
+		final String fExcludeTags;
 
-	private static IJavaProject resolveProject(String projectName) {
-		if (projectName == null)
-			return null;
-		IJavaModel javaModel= JavaCore.create(ResourcesPlugin.getWorkspace().getRoot());
-		IJavaProject project= javaModel.getJavaProject(projectName);
-		return project.exists() ? project : null;
-	}
-
-	private static int readCount(Attributes attributes, String name) throws SAXException {
-		String value= attributes.getValue(name);
-		if (value == null)
-			return 0;
-		try {
-			return Math.max(0, Integer.parseInt(value));
-		} catch (NumberFormatException e) {
-			throw new SAXException("Invalid JUnit history count: " + name, e); //$NON-NLS-1$
-		}
-	}
-
-	private static final class HeaderHandler extends DefaultHandler {
-		private final File fHistoryFile;
-		private final long fStartTime;
-		private TestRunSession fSession;
-
-		HeaderHandler(File historyFile, long startTime) {
+		StoredSession(String id, File historyFile, long fileLength, String testRunName, String projectName,
+				long startTime, long historyTimestamp, boolean stopped, int totalCount, int startedCount,
+				int failureCount, int errorCount, int ignoredCount, int assumptionFailureCount,
+				String includeTags, String excludeTags) {
+			fId= id;
 			fHistoryFile= historyFile;
+			fFileLength= fileLength;
+			fTestRunName= testRunName;
+			fProjectName= projectName;
 			fStartTime= startTime;
-		}
-
-		@Override
-		public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-			if (!IXMLTags.NODE_TESTRUN.equals(qName))
-				throw new SAXException("JUnit history file has an unexpected root element: " + qName); //$NON-NLS-1$
-
-			String name= attributes.getValue(IXMLTags.ATTR_NAME);
-			if (name == null)
-				throw new SAXException("JUnit history file has no test-run name"); //$NON-NLS-1$
-
-			int totalCount= readCount(attributes, IXMLTags.ATTR_TESTS);
-			int startedCount= readCount(attributes, IXMLTags.ATTR_STARTED);
-			int failureCount= readCount(attributes, IXMLTags.ATTR_FAILURES);
-			int errorCount= readCount(attributes, IXMLTags.ATTR_ERRORS);
-			int ignoredCount= readCount(attributes, IXMLTags.ATTR_IGNORED);
-			boolean stopped= startedCount < totalCount && failureCount == 0 && errorCount == 0;
-			Result result= result(errorCount, failureCount, stopped);
-
-			fSession= new RestoredTestRunSession(
-					fHistoryFile,
-					name,
-					resolveProject(attributes.getValue(IXMLTags.ATTR_PROJECT)),
-					fStartTime,
-					totalCount,
-					startedCount,
-					failureCount,
-					errorCount,
-					ignoredCount,
-					stopped,
-					result,
-					attributes.getValue(IXMLTags.ATTR_INCLUDE_TAGS),
-					attributes.getValue(IXMLTags.ATTR_EXCLUDE_TAGS));
-			throw new StopParsingException();
-		}
-
-		TestRunSession getSession() {
-			return fSession;
-		}
-
-		private static Result result(int errorCount, int failureCount, boolean stopped) {
-			if (errorCount > 0)
-				return Result.ERROR;
-			if (failureCount > 0)
-				return Result.FAILURE;
-			if (stopped)
-				return Result.UNDEFINED;
-			return Result.OK;
-		}
-	}
-
-	private static final class StopParsingException extends SAXException {
-		private static final long serialVersionUID= 1L;
-	}
-
-	private static final class RestoredTestRunSession extends TestRunSession {
-		private final File fHistoryFile;
-		private final Result fHeaderResult;
-		private boolean fLoadingContents;
-		private boolean fContentsLoaded;
-
-		RestoredTestRunSession(File historyFile, String testRunName, IJavaProject project, long startTime,
-				int totalCount, int startedCount, int failureCount, int errorCount, int ignoredCount,
-				boolean stopped, Result result, String includeTags, String excludeTags) {
-			super(testRunName, project);
-			fHistoryFile= historyFile;
-			fHeaderResult= result;
-			fStartTime= startTime;
+			fHistoryTimestamp= historyTimestamp;
+			fStopped= stopped;
 			fTotalCount= totalCount;
 			fStartedCount= startedCount;
 			fFailureCount= failureCount;
 			fErrorCount= errorCount;
 			fIgnoredCount= ignoredCount;
-			fIsStopped= stopped;
-			setIncludeTags(includeTags);
-			setExcludeTags(excludeTags);
+			fAssumptionFailureCount= assumptionFailureCount;
+			fIncludeTags= includeTags;
+			fExcludeTags= excludeTags;
+		}
+
+		static StoredSession from(TestRunSession session, String id, File historyFile, long historyTimestamp) {
+			IJavaProject project= session.getLaunchedProject();
+			return new StoredSession(id, historyFile, historyFile.length(), session.getTestRunName(),
+					project == null ? null : project.getElementName(), session.getStartTime(), historyTimestamp,
+					session.isStopped(), session.getTotalCount(), session.getStartedCount(),
+					session.getFailureCount(), session.getErrorCount(), session.getIgnoredCount(),
+					session.getAssumptionFailureCount(), session.getIncludeTags(), session.getExcludeTags());
+		}
+	}
+
+	private static final class RestoredTestRunSession extends TestRunSession {
+		private final StoredSession fStoredSession;
+		private final Result fHeaderResult;
+		private boolean fLoadingContents;
+		private boolean fContentsLoaded;
+		private boolean fValid= true;
+
+		RestoredTestRunSession(StoredSession storedSession) {
+			super(storedSession.fTestRunName, resolveProject(storedSession.fProjectName));
+			fStoredSession= storedSession;
+			fHeaderResult= result(storedSession);
+			fStartTime= storedSession.fStartTime;
+			fTotalCount= storedSession.fTotalCount;
+			fStartedCount= storedSession.fStartedCount;
+			fFailureCount= storedSession.fFailureCount;
+			fErrorCount= storedSession.fErrorCount;
+			fIgnoredCount= storedSession.fIgnoredCount;
+			fAssumptionFailureCount= storedSession.fAssumptionFailureCount;
+			fIsStopped= storedSession.fStopped;
+			setIncludeTags(storedSession.fIncludeTags);
+			setExcludeTags(storedSession.fExcludeTags);
 		}
 
 		@Override
@@ -319,22 +497,19 @@ public final class TestRunSessionHistory {
 
 		@Override
 		public synchronized void swapIn() {
-			if (fContentsLoaded) {
-				super.swapIn();
-				return;
-			}
-			if (fLoadingContents)
+			if (fContentsLoaded || fLoadingContents || !fValid)
 				return;
 
 			fLoadingContents= true;
 			try {
-				JUnitModel.importIntoTestRunSession(fHistoryFile, this);
+				JUnitModel.importIntoTestRunSession(fStoredSession.fHistoryFile, this);
 				fContentsLoaded= true;
 			} catch (CoreException e) {
 				LOG.log(e.getStatus());
 				reset();
 				fContentsLoaded= true;
-				delete(fHistoryFile);
+				fValid= false;
+				delete(fStoredSession.fHistoryFile);
 			} finally {
 				fLoadingContents= false;
 			}
@@ -342,14 +517,25 @@ public final class TestRunSessionHistory {
 
 		@Override
 		public synchronized void swapOut() {
-			if (fContentsLoaded)
-				super.swapOut();
+			// The persistent XML file already owns the test tree. Keeping a selected
+			// restored session in memory avoids creating a second, legacy swap file.
 		}
 
 		@Override
 		public void removeSwapFile() {
-			delete(fHistoryFile);
+			fValid= false;
+			delete(fStoredSession.fHistoryFile);
 		}
 
+		StoredSession reusableStoredSession() {
+			if (fValid && fStoredSession.fHistoryFile.isFile()
+					&& fStoredSession.fHistoryFile.length() == fStoredSession.fFileLength)
+				return fStoredSession;
+			return null;
+		}
+
+		boolean canWriteFromMemory() {
+			return fValid && fContentsLoaded;
+		}
 	}
 }

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -46,11 +46,12 @@ import org.eclipse.jdt.core.JavaCore;
  */
 public final class TestRunSessionHistory {
 
-	private static final int FORMAT_VERSION= 1;
+	private static final int FORMAT_VERSION= 2;
 	private static final int MAX_INDEX_ENTRIES= 10_000;
 
 	private static final String INDEX_FILE_NAME= "history.properties"; //$NON-NLS-1$
 	private static final String HISTORY_FILE_PREFIX= "history-"; //$NON-NLS-1$
+	private static final String SWAP_FILE_PREFIX= "swap-"; //$NON-NLS-1$
 	private static final String XML_SUFFIX= ".xml"; //$NON-NLS-1$
 	private static final String TEMP_SUFFIX= ".tmp"; //$NON-NLS-1$
 
@@ -62,6 +63,7 @@ public final class TestRunSessionHistory {
 	private static final String KEY_START_TIME= "startTime"; //$NON-NLS-1$
 	private static final String KEY_HISTORY_TIMESTAMP= "historyTimestamp"; //$NON-NLS-1$
 	private static final String KEY_PROGRESS= "progress"; //$NON-NLS-1$
+	private static final String KEY_RESULT= "result"; //$NON-NLS-1$
 	private static final String KEY_TOTAL_COUNT= "totalCount"; //$NON-NLS-1$
 	private static final String KEY_STARTED_COUNT= "startedCount"; //$NON-NLS-1$
 	private static final String KEY_FAILURE_COUNT= "failureCount"; //$NON-NLS-1$
@@ -90,10 +92,13 @@ public final class TestRunSessionHistory {
 	 */
 	public static List<TestRunSession> load(File historyDirectory, int maxCount) {
 		deleteTemporaryFiles(historyDirectory);
+		deleteTransientSwapFiles(historyDirectory);
 
 		File indexFile= new File(historyDirectory, INDEX_FILE_NAME);
-		if (!indexFile.isFile())
+		if (!indexFile.isFile()) {
+			deleteOrphanedXmlFiles(historyDirectory, Set.of(), true);
 			return List.of();
+		}
 
 		Properties properties= new Properties();
 		try (BufferedInputStream input= new BufferedInputStream(new FileInputStream(indexFile))) {
@@ -171,7 +176,6 @@ public final class TestRunSessionHistory {
 			return;
 		}
 
-		deleteTemporaryFiles(historyDirectory);
 		int limit= Math.max(0, maxCount);
 		List<StoredSession> storedSessions= new ArrayList<>(Math.min(limit, sessions.size()));
 		boolean persistenceFailure= false;
@@ -284,6 +288,7 @@ public final class TestRunSessionHistory {
 		properties.setProperty(entryKey(index, KEY_START_TIME), Long.toString(session.fStartTime));
 		properties.setProperty(entryKey(index, KEY_HISTORY_TIMESTAMP), Long.toString(session.fHistoryTimestamp));
 		properties.setProperty(entryKey(index, KEY_PROGRESS), session.fStopped ? PROGRESS_STOPPED : PROGRESS_COMPLETED);
+		properties.setProperty(entryKey(index, KEY_RESULT), session.fResult.name());
 		properties.setProperty(entryKey(index, KEY_TOTAL_COUNT), Integer.toString(session.fTotalCount));
 		properties.setProperty(entryKey(index, KEY_STARTED_COUNT), Integer.toString(session.fStartedCount));
 		properties.setProperty(entryKey(index, KEY_FAILURE_COUNT), Integer.toString(session.fFailureCount));
@@ -311,6 +316,14 @@ public final class TestRunSessionHistory {
 			throw new IllegalArgumentException("Unsupported JUnit history progress state: " + progress); //$NON-NLS-1$
 		}
 
+		Result result;
+		String resultName= required(properties, entryKey(index, KEY_RESULT));
+		try {
+			result= Result.valueOf(resultName);
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException("Unsupported JUnit history result: " + resultName, e); //$NON-NLS-1$
+		}
+
 		int totalCount= readInt(properties, entryKey(index, KEY_TOTAL_COUNT), 0, Integer.MAX_VALUE);
 		int startedCount= readInt(properties, entryKey(index, KEY_STARTED_COUNT), 0, Integer.MAX_VALUE);
 		int failureCount= readInt(properties, entryKey(index, KEY_FAILURE_COUNT), 0, Integer.MAX_VALUE);
@@ -322,7 +335,7 @@ public final class TestRunSessionHistory {
 		long fileLength= readLong(properties, entryKey(index, KEY_FILE_LENGTH), 1, Long.MAX_VALUE);
 		File historyFile= new File(historyDirectory, historyFileName(id));
 		return new StoredSession(id, historyFile, fileLength, testRunName, projectName, startTime,
-				historyTimestamp, stopped, totalCount, startedCount, failureCount, errorCount,
+				historyTimestamp, stopped, result, totalCount, startedCount, failureCount, errorCount,
 				ignoredCount, assumptionFailureCount, includeTags, excludeTags);
 	}
 
@@ -379,14 +392,14 @@ public final class TestRunSessionHistory {
 		return project.exists() ? project : null;
 	}
 
-	private static Result result(StoredSession session) {
-		if (session.fErrorCount > 0)
-			return Result.ERROR;
-		if (session.fFailureCount > 0)
-			return Result.FAILURE;
-		if (session.fStopped)
-			return Result.UNDEFINED;
-		return Result.OK;
+	private static void deleteTransientSwapFiles(File historyDirectory) {
+		File[] swapFiles= historyDirectory.listFiles(file -> file.isFile()
+				&& file.getName().startsWith(SWAP_FILE_PREFIX)
+				&& file.getName().endsWith(XML_SUFFIX));
+		if (swapFiles != null) {
+			for (File swapFile : swapFiles)
+				delete(swapFile);
+		}
 	}
 
 	private static void deleteTemporaryFiles(File historyDirectory) {
@@ -434,6 +447,7 @@ public final class TestRunSessionHistory {
 		final long fStartTime;
 		final long fHistoryTimestamp;
 		final boolean fStopped;
+		final Result fResult;
 		final int fTotalCount;
 		final int fStartedCount;
 		final int fFailureCount;
@@ -444,7 +458,7 @@ public final class TestRunSessionHistory {
 		final String fExcludeTags;
 
 		StoredSession(String id, File historyFile, long fileLength, String testRunName, String projectName,
-				long startTime, long historyTimestamp, boolean stopped, int totalCount, int startedCount,
+				long startTime, long historyTimestamp, boolean stopped, Result result, int totalCount, int startedCount,
 				int failureCount, int errorCount, int ignoredCount, int assumptionFailureCount,
 				String includeTags, String excludeTags) {
 			fId= id;
@@ -455,6 +469,7 @@ public final class TestRunSessionHistory {
 			fStartTime= startTime;
 			fHistoryTimestamp= historyTimestamp;
 			fStopped= stopped;
+			fResult= result;
 			fTotalCount= totalCount;
 			fStartedCount= startedCount;
 			fFailureCount= failureCount;
@@ -469,7 +484,7 @@ public final class TestRunSessionHistory {
 			IJavaProject project= session.getLaunchedProject();
 			return new StoredSession(id, historyFile, historyFile.length(), session.getTestRunName(),
 					project == null ? null : project.getElementName(), session.getStartTime(), historyTimestamp,
-					session.isStopped(), session.getTotalCount(), session.getStartedCount(),
+					session.isStopped(), session.getTestResult(true), session.getTotalCount(), session.getStartedCount(),
 					session.getFailureCount(), session.getErrorCount(), session.getIgnoredCount(),
 					session.getAssumptionFailureCount(), session.getIncludeTags(), session.getExcludeTags());
 		}
@@ -485,7 +500,7 @@ public final class TestRunSessionHistory {
 		RestoredTestRunSession(StoredSession storedSession) {
 			super(storedSession.fTestRunName, resolveProject(storedSession.fProjectName));
 			fStoredSession= storedSession;
-			fHeaderResult= result(storedSession);
+			fHeaderResult= storedSession.fResult;
 			fStartTime= storedSession.fStartTime;
 			fTotalCount= storedSession.fTotalCount;
 			fStartedCount= storedSession.fStartedCount;

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -598,7 +598,8 @@ public final class TestRunSessionHistory {
 		@Override
 		public void removeSwapFile() {
 			fValid= false;
-			delete(fStoredSession.fHistoryFile);
+			// Keep the last published history generation intact. store() removes
+			// unreferenced files after publishing the replacement index.
 		}
 
 		StoredSession reusableStoredSession() {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -156,6 +156,7 @@ public final class TestRunSessionHistory {
 				validEntries.add(storedSession);
 			} catch (IllegalArgumentException e) {
 				indexFullyUnderstood= false;
+				BLOCKED_HISTORY_DIRECTORIES.add(historyPath);
 				LOG.error("Invalid JUnit history entry " + i, e); //$NON-NLS-1$
 			}
 		}
@@ -307,7 +308,7 @@ public final class TestRunSessionHistory {
 		properties.setProperty(entryKey(index, KEY_START_TIME), Long.toString(session.fStartTime));
 		properties.setProperty(entryKey(index, KEY_HISTORY_TIMESTAMP), Long.toString(session.fHistoryTimestamp));
 		properties.setProperty(entryKey(index, KEY_PROGRESS), session.fStopped ? PROGRESS_STOPPED : PROGRESS_COMPLETED);
-		properties.setProperty(entryKey(index, KEY_RESULT), session.fResult.name());
+		properties.setProperty(entryKey(index, KEY_RESULT), resultName(session.fResult));
 		properties.setProperty(entryKey(index, KEY_TOTAL_COUNT), Integer.toString(session.fTotalCount));
 		properties.setProperty(entryKey(index, KEY_STARTED_COUNT), Integer.toString(session.fStartedCount));
 		properties.setProperty(entryKey(index, KEY_FAILURE_COUNT), Integer.toString(session.fFailureCount));
@@ -335,13 +336,8 @@ public final class TestRunSessionHistory {
 			throw new IllegalArgumentException("Unsupported JUnit history progress state: " + progress); //$NON-NLS-1$
 		}
 
-		Result result;
 		String resultName= required(properties, entryKey(index, KEY_RESULT));
-		try {
-			result= Result.valueOf(resultName);
-		} catch (IllegalArgumentException e) {
-			throw new IllegalArgumentException("Unsupported JUnit history result: " + resultName, e); //$NON-NLS-1$
-		}
+		Result result= parseResult(resultName);
 
 		int totalCount= readInt(properties, entryKey(index, KEY_TOTAL_COUNT), 0, Integer.MAX_VALUE);
 		int startedCount= readInt(properties, entryKey(index, KEY_STARTED_COUNT), 0, Integer.MAX_VALUE);
@@ -356,6 +352,31 @@ public final class TestRunSessionHistory {
 		return new StoredSession(id, historyFile, fileLength, testRunName, projectName, startTime,
 				historyTimestamp, stopped, result, totalCount, startedCount, failureCount, errorCount,
 				ignoredCount, assumptionFailureCount, includeTags, excludeTags);
+	}
+
+	private static String resultName(Result result) {
+		if (result == Result.UNDEFINED)
+			return "UNDEFINED"; //$NON-NLS-1$
+		if (result == Result.OK)
+			return "OK"; //$NON-NLS-1$
+		if (result == Result.ERROR)
+			return "ERROR"; //$NON-NLS-1$
+		if (result == Result.FAILURE)
+			return "FAILURE"; //$NON-NLS-1$
+		if (result == Result.IGNORED)
+			return "IGNORED"; //$NON-NLS-1$
+		throw new IllegalArgumentException("Unsupported JUnit history result: " + result); //$NON-NLS-1$
+	}
+
+	private static Result parseResult(String resultName) {
+		return switch (resultName) {
+			case "UNDEFINED" -> Result.UNDEFINED; //$NON-NLS-1$
+			case "OK" -> Result.OK; //$NON-NLS-1$
+			case "ERROR" -> Result.ERROR; //$NON-NLS-1$
+			case "FAILURE" -> Result.FAILURE; //$NON-NLS-1$
+			case "IGNORED" -> Result.IGNORED; //$NON-NLS-1$
+			default -> throw new IllegalArgumentException("Unsupported JUnit history result: " + resultName); //$NON-NLS-1$
+		};
 	}
 
 	private static String historyFileName(String id) {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 Eclipse Foundation and others.
+ * Copyright (c) 2026 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -130,7 +130,7 @@ public final class TestRunSessionHistory {
 				File historyFile= storedSession.fHistoryFile;
 				if (!historyFile.isFile() || historyFile.length() != storedSession.fFileLength) {
 					LOG.error("Ignoring incomplete JUnit history file: " + historyFile); //$NON-NLS-1$
-					delete(historyFile);
+					indexFullyUnderstood= false;
 					continue;
 				}
 				referencedFiles.add(historyFile.getName());
@@ -192,7 +192,7 @@ public final class TestRunSessionHistory {
 			if (storedSession == null) {
 				try {
 					storedSession= writeSessionAtomically(session, historyDirectory);
-				} catch (CoreException | IOException e) {
+				} catch (CoreException | IOException | RuntimeException e) {
 					persistenceFailure= true;
 					LOG.error("Could not persist JUnit test run history", e); //$NON-NLS-1$
 				}
@@ -201,13 +201,18 @@ public final class TestRunSessionHistory {
 				storedSessions.add(storedSession);
 		}
 
+		if (persistenceFailure) {
+			LOG.error("Keeping the previous JUnit history because not all sessions could be persisted"); //$NON-NLS-1$
+			return;
+		}
+
 		if (!writeIndexAtomically(storedSessions, historyDirectory))
 			return;
 
 		Set<String> retainedFiles= new HashSet<>();
 		for (StoredSession storedSession : storedSessions)
 			retainedFiles.add(storedSession.fHistoryFile.getName());
-		deleteOrphanedXmlFiles(historyDirectory, retainedFiles, !persistenceFailure);
+		deleteOrphanedXmlFiles(historyDirectory, retainedFiles, true);
 	}
 
 	private static boolean isPersistable(TestRunSession session) {
@@ -217,6 +222,20 @@ public final class TestRunSessionHistory {
 				&& !session.isKeptAlive();
 	}
 
+	static void exportAtomically(TestRunSession session, File targetFile) throws CoreException, IOException {
+		File directory= targetFile.getParentFile();
+		Files.createDirectories(directory.toPath());
+		File temporaryFile= Files.createTempFile(directory.toPath(), targetFile.getName() + '.', TEMP_SUFFIX).toFile();
+		try {
+			JUnitModel.exportTestRunSession(session, temporaryFile);
+			if (session.hasSwapInFailed())
+				throw new IOException("Could not load the complete JUnit test tree"); //$NON-NLS-1$
+			moveReplacing(temporaryFile, targetFile);
+		} finally {
+			delete(temporaryFile);
+		}
+	}
+
 	private static StoredSession writeSessionAtomically(TestRunSession session, File historyDirectory) throws CoreException, IOException {
 		String id;
 		File historyFile;
@@ -224,14 +243,8 @@ public final class TestRunSessionHistory {
 			id= UUID.randomUUID().toString();
 			historyFile= new File(historyDirectory, historyFileName(id));
 		} while (historyFile.exists());
-		File temporaryFile= Files.createTempFile(historyDirectory.toPath(), HISTORY_FILE_PREFIX + id + '-', TEMP_SUFFIX).toFile();
-		try {
-			JUnitModel.exportTestRunSession(session, temporaryFile);
-			moveReplacing(temporaryFile, historyFile);
-			return StoredSession.from(session, id, historyFile, historyTimestamp(session.getStartTime()));
-		} finally {
-			delete(temporaryFile);
-		}
+		exportAtomically(session, historyFile);
+		return StoredSession.from(session, id, historyFile, historyTimestamp(session.getStartTime()));
 	}
 
 	private static boolean writeIndexAtomically(List<StoredSession> storedSessions, File historyDirectory) {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -1,0 +1,355 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse Foundation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.jdt.internal.junit.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import org.eclipse.jdt.junit.model.ITestElement.Result;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import org.eclipse.jdt.core.IJavaModel;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.internal.junit.BasicElementLabels;
+import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.Messages;
+import org.eclipse.jdt.internal.junit.util.XmlProcessorFactoryJdtJunit;
+
+public final class TestRunSessionHistory {
+
+	private static final String XML_SUFFIX= ".xml"; //$NON-NLS-1$
+	private static final String TEMP_SUFFIX= ".tmp"; //$NON-NLS-1$
+	private static final String HISTORY_FILE_DATE_PATTERN= "yyyyMMdd-HHmmss.SSS"; //$NON-NLS-1$
+
+	private static final ILog LOG= ILog.of(TestRunSessionHistory.class);
+
+	private TestRunSessionHistory() {
+	}
+
+	public static List<TestRunSession> load(File historyDirectory, int maxCount) {
+		deleteTemporaryFiles(historyDirectory);
+
+		File[] historyFiles= historyDirectory.listFiles(file -> file.isFile() && file.getName().endsWith(XML_SUFFIX));
+		if (historyFiles == null || historyFiles.length == 0)
+			return List.of();
+
+		Arrays.sort(historyFiles, Comparator.comparing(File::getName).reversed());
+		int limit= Math.max(0, maxCount);
+		List<TestRunSession> sessions= new ArrayList<>(Math.min(limit, historyFiles.length));
+		for (File historyFile : historyFiles) {
+			if (sessions.size() >= limit) {
+				delete(historyFile);
+				continue;
+			}
+			try {
+				sessions.add(read(historyFile));
+			} catch (CoreException e) {
+				LOG.log(e.getStatus());
+				delete(historyFile);
+			}
+		}
+		return sessions;
+	}
+
+	public static void store(List<TestRunSession> sessions, File historyDirectory, int maxCount) {
+		try {
+			Files.createDirectories(historyDirectory.toPath());
+		} catch (IOException e) {
+			LOG.error("Could not create the JUnit history directory", e); //$NON-NLS-1$
+			return;
+		}
+
+		deleteTemporaryFiles(historyDirectory);
+		Set<String> retainedFileNames= new HashSet<>();
+		int limit= Math.max(0, maxCount);
+		for (TestRunSession session : sessions) {
+			if (retainedFileNames.size() >= limit)
+				break;
+			if (session.getStartTime() == 0 || session.isRunning() || session.isStarting() || session.isKeptAlive())
+				continue;
+
+			File historyFile= historyFile(historyDirectory, session.getStartTime());
+			String fileName= historyFile.getName();
+			retainedFileNames.add(fileName);
+
+			// Inactive sessions may already have been swapped to this file. Keeping an
+			// existing file avoids loading a potentially large test tree during shutdown.
+			if (historyFile.isFile())
+				continue;
+
+			File temporaryFile= new File(historyDirectory, fileName + TEMP_SUFFIX);
+			try {
+				Files.deleteIfExists(temporaryFile.toPath());
+				JUnitModel.exportTestRunSession(session, temporaryFile);
+				moveReplacing(temporaryFile, historyFile);
+			} catch (CoreException | IOException e) {
+				LOG.error("Could not persist JUnit test run history", e); //$NON-NLS-1$
+				delete(temporaryFile);
+				if (!historyFile.isFile())
+					retainedFileNames.remove(fileName);
+			}
+		}
+
+		File[] historyFiles= historyDirectory.listFiles(file -> file.isFile() && file.getName().endsWith(XML_SUFFIX));
+		if (historyFiles != null) {
+			for (File historyFile : historyFiles) {
+				if (!retainedFileNames.contains(historyFile.getName()))
+					delete(historyFile);
+			}
+		}
+	}
+
+	static TestRunSession read(File historyFile) throws CoreException {
+		long startTime= readStartTime(historyFile);
+		HeaderHandler handler= new HeaderHandler(historyFile, startTime);
+		try {
+			SAXParserFactory parserFactory= XmlProcessorFactoryJdtJunit.createSAXFactoryWithErrorOnDOCTYPE();
+			SAXParser parser= parserFactory.newSAXParser();
+			parser.parse(historyFile, handler);
+		} catch (StopParsingException e) {
+			return handler.getSession();
+		} catch (ParserConfigurationException | SAXException | IOException | IllegalArgumentException e) {
+			throw readError(historyFile, e);
+		}
+		throw readError(historyFile, new SAXException("JUnit history file has no test-run root element")); //$NON-NLS-1$
+	}
+
+	static File historyFile(File historyDirectory, long startTime) {
+		String timestamp= new SimpleDateFormat(HISTORY_FILE_DATE_PATTERN).format(new Date(startTime));
+		return new File(historyDirectory, timestamp + XML_SUFFIX);
+	}
+
+	private static long readStartTime(File historyFile) throws CoreException {
+		String fileName= historyFile.getName();
+		if (!fileName.endsWith(XML_SUFFIX))
+			throw readError(historyFile, new IllegalArgumentException("Not a JUnit history XML file")); //$NON-NLS-1$
+
+		String timestamp= fileName.substring(0, fileName.length() - XML_SUFFIX.length());
+		SimpleDateFormat format= new SimpleDateFormat(HISTORY_FILE_DATE_PATTERN);
+		format.setLenient(false);
+		ParsePosition position= new ParsePosition(0);
+		Date parsed= format.parse(timestamp, position);
+		if (parsed == null || position.getIndex() != timestamp.length())
+			throw readError(historyFile, new IllegalArgumentException("Invalid JUnit history file name")); //$NON-NLS-1$
+		return parsed.getTime();
+	}
+
+	private static void deleteTemporaryFiles(File historyDirectory) {
+		File[] temporaryFiles= historyDirectory.listFiles(file -> file.isFile() && file.getName().endsWith(TEMP_SUFFIX));
+		if (temporaryFiles != null) {
+			for (File temporaryFile : temporaryFiles)
+				delete(temporaryFile);
+		}
+	}
+
+	private static void moveReplacing(File source, File target) throws IOException {
+		try {
+			Files.move(source.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		} catch (AtomicMoveNotSupportedException e) {
+			Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	private static void delete(File file) {
+		try {
+			Files.deleteIfExists(file.toPath());
+		} catch (IOException e) {
+			LOG.error("Could not delete obsolete JUnit history file", e); //$NON-NLS-1$
+		}
+	}
+
+	private static CoreException readError(File file, Exception e) {
+		return new CoreException(new Status(IStatus.ERROR,
+				JUnitCorePlugin.getPluginId(),
+				Messages.format(ModelMessages.JUnitModel_could_not_read, BasicElementLabels.getPathLabel(file)),
+				e));
+	}
+
+	private static IJavaProject resolveProject(String projectName) {
+		if (projectName == null)
+			return null;
+		IJavaModel javaModel= JavaCore.create(ResourcesPlugin.getWorkspace().getRoot());
+		IJavaProject project= javaModel.getJavaProject(projectName);
+		return project.exists() ? project : null;
+	}
+
+	private static int readCount(Attributes attributes, String name) throws SAXException {
+		String value= attributes.getValue(name);
+		if (value == null)
+			return 0;
+		try {
+			return Math.max(0, Integer.parseInt(value));
+		} catch (NumberFormatException e) {
+			throw new SAXException("Invalid JUnit history count: " + name, e); //$NON-NLS-1$
+		}
+	}
+
+	private static final class HeaderHandler extends DefaultHandler {
+		private final File fHistoryFile;
+		private final long fStartTime;
+		private TestRunSession fSession;
+
+		HeaderHandler(File historyFile, long startTime) {
+			fHistoryFile= historyFile;
+			fStartTime= startTime;
+		}
+
+		@Override
+		public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+			if (!IXMLTags.NODE_TESTRUN.equals(qName))
+				throw new SAXException("JUnit history file has an unexpected root element: " + qName); //$NON-NLS-1$
+
+			String name= attributes.getValue(IXMLTags.ATTR_NAME);
+			if (name == null)
+				throw new SAXException("JUnit history file has no test-run name"); //$NON-NLS-1$
+
+			int totalCount= readCount(attributes, IXMLTags.ATTR_TESTS);
+			int startedCount= readCount(attributes, IXMLTags.ATTR_STARTED);
+			int failureCount= readCount(attributes, IXMLTags.ATTR_FAILURES);
+			int errorCount= readCount(attributes, IXMLTags.ATTR_ERRORS);
+			int ignoredCount= readCount(attributes, IXMLTags.ATTR_IGNORED);
+			boolean stopped= startedCount < totalCount && failureCount == 0 && errorCount == 0;
+			Result result= result(errorCount, failureCount, stopped);
+
+			fSession= new RestoredTestRunSession(
+					fHistoryFile,
+					name,
+					resolveProject(attributes.getValue(IXMLTags.ATTR_PROJECT)),
+					fStartTime,
+					totalCount,
+					startedCount,
+					failureCount,
+					errorCount,
+					ignoredCount,
+					stopped,
+					result,
+					attributes.getValue(IXMLTags.ATTR_INCLUDE_TAGS),
+					attributes.getValue(IXMLTags.ATTR_EXCLUDE_TAGS));
+			throw new StopParsingException();
+		}
+
+		TestRunSession getSession() {
+			return fSession;
+		}
+
+		private static Result result(int errorCount, int failureCount, boolean stopped) {
+			if (errorCount > 0)
+				return Result.ERROR;
+			if (failureCount > 0)
+				return Result.FAILURE;
+			if (stopped)
+				return Result.UNDEFINED;
+			return Result.OK;
+		}
+	}
+
+	private static final class StopParsingException extends SAXException {
+		private static final long serialVersionUID= 1L;
+	}
+
+	private static final class RestoredTestRunSession extends TestRunSession {
+		private final File fHistoryFile;
+		private final Result fHeaderResult;
+		private boolean fLoadingContents;
+		private boolean fContentsLoaded;
+
+		RestoredTestRunSession(File historyFile, String testRunName, IJavaProject project, long startTime,
+				int totalCount, int startedCount, int failureCount, int errorCount, int ignoredCount,
+				boolean stopped, Result result, String includeTags, String excludeTags) {
+			super(testRunName, project);
+			fHistoryFile= historyFile;
+			fHeaderResult= result;
+			fStartTime= startTime;
+			fTotalCount= totalCount;
+			fStartedCount= startedCount;
+			fFailureCount= failureCount;
+			fErrorCount= errorCount;
+			fIgnoredCount= ignoredCount;
+			fIsStopped= stopped;
+			setIncludeTags(includeTags);
+			setExcludeTags(excludeTags);
+		}
+
+		@Override
+		public Result getTestResult(boolean includeChildren) {
+			return fContentsLoaded ? super.getTestResult(includeChildren) : fHeaderResult;
+		}
+
+		@Override
+		public double getElapsedTimeInSeconds() {
+			return fContentsLoaded ? super.getElapsedTimeInSeconds() : Double.NaN;
+		}
+
+		@Override
+		public synchronized void swapIn() {
+			if (fContentsLoaded) {
+				super.swapIn();
+				return;
+			}
+			if (fLoadingContents)
+				return;
+
+			fLoadingContents= true;
+			try {
+				JUnitModel.importIntoTestRunSession(fHistoryFile, this);
+				fContentsLoaded= true;
+			} catch (CoreException e) {
+				LOG.log(e.getStatus());
+				reset();
+				fContentsLoaded= true;
+				delete(fHistoryFile);
+			} finally {
+				fLoadingContents= false;
+			}
+		}
+
+		@Override
+		public synchronized void swapOut() {
+			if (fContentsLoaded)
+				super.swapOut();
+		}
+
+		@Override
+		public void removeSwapFile() {
+			delete(fHistoryFile);
+		}
+
+	}
+}

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -545,8 +545,10 @@ public final class TestRunSessionHistory {
 
 		@Override
 		public synchronized void swapOut() {
-			// The persistent XML file already owns the test tree. Keeping a selected
-			// restored session in memory avoids creating a second, legacy swap file.
+			if (!fValid || !fContentsLoaded || !canSwapOut())
+				return;
+			discardTestTree();
+			fContentsLoaded= false;
 		}
 
 		@Override

--- a/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit;singleton:=true
-Bundle-Version: 3.17.600.qualifier
+Bundle-Version: 3.17.700.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.ui.JUnitPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
@@ -738,7 +738,7 @@ public class TestRunnerViewPart extends ViewPart {
 			startUpdateJobs();
 
 			fStopAction.setEnabled(true);
-			fRerunLastTestAction.setEnabled(true);
+			fRerunLastTestAction.setEnabled(fTestRunSession.canRerun());
 
 			// While tests are running, always use the execution order
 			getDisplay().asyncExec(new Runnable() {
@@ -764,6 +764,7 @@ public class TestRunnerViewPart extends ViewPart {
 					return;
 				fStopAction.setEnabled(lastLaunchIsKeptAlive());
 				updateRerunFailedFirstAction();
+				fRerunLastTestAction.setEnabled(fTestRunSession.canRerun());
 				processChangesInUI();
 				if (hasErrorsOrFailures()) {
 					selectFirstFailure();
@@ -1411,7 +1412,8 @@ public class TestRunnerViewPart extends ViewPart {
 			return;
 		ILaunchConfiguration launchConfiguration= fTestRunSession.getRerunLaunchConfiguration();
 		String launchMode= fTestRunSession.getRerunLaunchMode();
-		if (launchConfiguration == null || !launchConfiguration.exists() || launchMode == null)
+		if (launchConfiguration == null || (!launchConfiguration.exists() && !launchConfiguration.isWorkingCopy())
+				|| launchMode == null)
 			return;
 
 		ILaunchConfiguration configuration= prepareLaunchConfigForRelaunch(launchConfiguration);
@@ -1426,7 +1428,8 @@ public class TestRunnerViewPart extends ViewPart {
 				if (configName.endsWith(JUnitMessages.TestRunnerViewPart_failures_first_suffix)) {
 					configName= configName.substring(0, configName.length() - JUnitMessages.TestRunnerViewPart_failures_first_suffix.length());
 				}
-				ILaunchConfigurationWorkingCopy tmp= configuration.copy(configName);
+				ILaunchConfigurationWorkingCopy tmp=
+						JUnitLaunchConfigurationConstants.createRerunLaunchConfiguration(configuration, configName);
 				tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, (String)null);
 				return tmp;
 			}
@@ -1447,7 +1450,8 @@ public class TestRunnerViewPart extends ViewPart {
 			return;
 		ILaunchConfiguration launchConfiguration= fTestRunSession.getRerunLaunchConfiguration();
 		String launchMode= fTestRunSession.getRerunLaunchMode();
-		if (launchConfiguration == null || !launchConfiguration.exists() || launchMode == null)
+		if (launchConfiguration == null || (!launchConfiguration.exists() && !launchConfiguration.isWorkingCopy())
+				|| launchMode == null)
 			return;
 		try {
 			String oldName= launchConfiguration.getName();
@@ -1458,7 +1462,8 @@ public class TestRunnerViewPart extends ViewPart {
 			} else {
 				configName= Messages.format(JUnitMessages.TestRunnerViewPart_rerunFailedFirstLaunchConfigName, oldName);
 			}
-			ILaunchConfigurationWorkingCopy tmp= launchConfiguration.copy(configName);
+			ILaunchConfigurationWorkingCopy tmp=
+					JUnitLaunchConfigurationConstants.createRerunLaunchConfiguration(launchConfiguration, configName);
 			tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, createFailureNamesFile());
 			relaunch(tmp, launchMode);
 			return;
@@ -1536,6 +1541,7 @@ public class TestRunnerViewPart extends ViewPart {
 			resetViewIcon();
 			fStopAction.setEnabled(false);
 			updateRerunFailedFirstAction();
+			fRerunLastTestAction.setEnabled(fTestRunSession.canRerun());
 		});
 		stopUpdateJobs();
 		logMessageIfNoTests();
@@ -2241,7 +2247,7 @@ action enablement
 
 		if (fTestRunSession != null) {
 			ILaunchConfiguration launchConfiguration= fTestRunSession.getRerunLaunchConfiguration();
-			if (launchConfiguration != null && launchConfiguration.exists()) {
+			if (launchConfiguration != null && (launchConfiguration.exists() || launchConfiguration.isWorkingCopy())) {
 				try {
 					String name;
 					if (testDisplayName != null) {
@@ -2252,7 +2258,8 @@ action enablement
 							name+= "."+testName; //$NON-NLS-1$
 					}
 					String configName= Messages.format(JUnitMessages.TestRunnerViewPart_configName, name);
-					ILaunchConfigurationWorkingCopy tmp = launchConfiguration.copy(configName);
+					ILaunchConfigurationWorkingCopy tmp=
+							JUnitLaunchConfigurationConstants.createRerunLaunchConfiguration(launchConfiguration, configName);
 					tmp.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, className);
 					tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, ""); //$NON-NLS-1$
 					tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, testName);

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
@@ -126,7 +126,6 @@ import org.eclipse.ui.progress.IWorkbenchSiteProgressService;
 import org.eclipse.ui.progress.UIJob;
 import org.eclipse.ui.statushandlers.StatusManager;
 
-import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 
@@ -1403,7 +1402,6 @@ public class TestRunnerViewPart extends ViewPart {
 	 */
 	public void rerunTestRun() {
 		if (lastLaunchIsKeptAlive()) {
-			// prompt for terminating the existing run
 			if (MessageDialog.openQuestion(getSite().getShell(), JUnitMessages.TestRunnerViewPart_terminate_title, JUnitMessages.TestRunnerViewPart_terminate_message)) {
 				stopTest(); // TODO: wait for termination
 			}
@@ -1411,15 +1409,13 @@ public class TestRunnerViewPart extends ViewPart {
 
 		if (fTestRunSession == null)
 			return;
-		ILaunch launch= fTestRunSession.getLaunch();
-		if (launch == null)
-			return;
-		ILaunchConfiguration launchConfiguration= launch.getLaunchConfiguration();
-		if (launchConfiguration == null)
+		ILaunchConfiguration launchConfiguration= fTestRunSession.getRerunLaunchConfiguration();
+		String launchMode= fTestRunSession.getRerunLaunchMode();
+		if (launchConfiguration == null || !launchConfiguration.exists() || launchMode == null)
 			return;
 
 		ILaunchConfiguration configuration= prepareLaunchConfigForRelaunch(launchConfiguration);
-		relaunch(configuration, launch.getLaunchMode());
+		relaunch(configuration, launchMode);
 	}
 
 	private ILaunchConfiguration prepareLaunchConfigForRelaunch(ILaunchConfiguration configuration) {
@@ -1442,40 +1438,39 @@ public class TestRunnerViewPart extends ViewPart {
 
 	public void rerunTestFailedFirst() {
 		if (lastLaunchIsKeptAlive()) {
-			// prompt for terminating the existing run
 			if (MessageDialog.openQuestion(getSite().getShell(), JUnitMessages.TestRunnerViewPart_terminate_title, JUnitMessages.TestRunnerViewPart_terminate_message)) {
 				if (fTestRunSession != null)
 					fTestRunSession.stopTestRun();
 			}
 		}
-		ILaunch launch= fTestRunSession.getLaunch();
-		if (launch != null && launch.getLaunchConfiguration() != null) {
-				ILaunchConfiguration launchConfiguration= launch.getLaunchConfiguration();
-				if (launchConfiguration != null) {
-					try {
-						String oldName= launchConfiguration.getName();
-						String oldFailuresFilename= launchConfiguration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, (String) null);
-						String configName;
-						if (oldFailuresFilename != null) {
-							configName= oldName;
-						} else {
-							configName= Messages.format(JUnitMessages.TestRunnerViewPart_rerunFailedFirstLaunchConfigName, oldName);
-						}
-						ILaunchConfigurationWorkingCopy tmp= launchConfiguration.copy(configName);
-						tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, createFailureNamesFile());
-						relaunch(tmp, launch.getLaunchMode());
-						return;
-					} catch (CoreException e) {
-						ErrorDialog.openError(getSite().getShell(),
-							JUnitMessages.TestRunnerViewPart_error_cannotrerun, e.getMessage(), e.getStatus()
-						);
-					}
-				}
-				MessageDialog.openInformation(getSite().getShell(),
-					JUnitMessages.TestRunnerViewPart_cannotrerun_title,
-					JUnitMessages.TestRunnerViewPart_cannotrerurn_message
-				);
+		if (fTestRunSession == null)
+			return;
+		ILaunchConfiguration launchConfiguration= fTestRunSession.getRerunLaunchConfiguration();
+		String launchMode= fTestRunSession.getRerunLaunchMode();
+		if (launchConfiguration == null || !launchConfiguration.exists() || launchMode == null)
+			return;
+		try {
+			String oldName= launchConfiguration.getName();
+			String oldFailuresFilename= launchConfiguration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, (String) null);
+			String configName;
+			if (oldFailuresFilename != null) {
+				configName= oldName;
+			} else {
+				configName= Messages.format(JUnitMessages.TestRunnerViewPart_rerunFailedFirstLaunchConfigName, oldName);
+			}
+			ILaunchConfigurationWorkingCopy tmp= launchConfiguration.copy(configName);
+			tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES, createFailureNamesFile());
+			relaunch(tmp, launchMode);
+			return;
+		} catch (CoreException e) {
+			ErrorDialog.openError(getSite().getShell(),
+					JUnitMessages.TestRunnerViewPart_error_cannotrerun, e.getMessage(), e.getStatus()
+			);
 		}
+		MessageDialog.openInformation(getSite().getShell(),
+				JUnitMessages.TestRunnerViewPart_cannotrerun_title,
+				JUnitMessages.TestRunnerViewPart_cannotrerurn_message
+		);
 	}
 
 	private void relaunch(ILaunchConfiguration configuration, String launchMode) {
@@ -1657,7 +1652,7 @@ action enablement
 			registerInfoMessage(BasicElementLabels.getJavaElementName(fTestRunSession.getTestRunName()));
 
 			updateRerunFailedFirstAction();
-			fRerunLastTestAction.setEnabled(fTestRunSession.getLaunch() != null);
+			fRerunLastTestAction.setEnabled(fTestRunSession.canRerun());
 
 			if (fTestRunSession.isRunning()) {
 				startUpdateJobs();
@@ -1684,7 +1679,7 @@ action enablement
 	}
 
 	private void updateRerunFailedFirstAction() {
-		boolean state= hasErrorsOrFailures() && fTestRunSession.getLaunch() != null;
+		boolean state= hasErrorsOrFailures() && fTestRunSession.canRerun();
 		fRerunFailedFirstAction.setEnabled(state);
 	}
 
@@ -2245,36 +2240,30 @@ action enablement
 		}
 
 		if (fTestRunSession != null) {
-			ILaunch launch= fTestRunSession.getLaunch();
-			if (launch != null) {
-				// run the selected test using the previous launch configuration
-				ILaunchConfiguration launchConfiguration= launch.getLaunchConfiguration();
-				if (launchConfiguration != null) {
-					try {
-						String name;
-						if (testDisplayName != null) {
-							name= testDisplayName;
-						} else {
-							name= className;
-							if (testName != null)
-								name+= "."+testName; //$NON-NLS-1$
-						}
-						String configName= Messages.format(JUnitMessages.TestRunnerViewPart_configName, name);
-						ILaunchConfigurationWorkingCopy tmp = launchConfiguration.copy(configName);
-						// fix for bug: 64838  junit view run single test does not use correct class [JUnit]
-						tmp.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, className);
-						// reset the container
-						tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, ""); //$NON-NLS-1$
-						tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, testName);
-						tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_UNIQUE_ID, uniqueId);
-						relaunch(tmp, launchMode);
-						return;
-						} catch (CoreException e) {
-							ErrorDialog.openError(getSite().getShell(),
-									JUnitMessages.TestRunnerViewPart_error_cannotrerun, e.getMessage(), e.getStatus()
-								);
-							return;
-						}
+			ILaunchConfiguration launchConfiguration= fTestRunSession.getRerunLaunchConfiguration();
+			if (launchConfiguration != null && launchConfiguration.exists()) {
+				try {
+					String name;
+					if (testDisplayName != null) {
+						name= testDisplayName;
+					} else {
+						name= className;
+						if (testName != null)
+							name+= "."+testName; //$NON-NLS-1$
+					}
+					String configName= Messages.format(JUnitMessages.TestRunnerViewPart_configName, name);
+					ILaunchConfigurationWorkingCopy tmp = launchConfiguration.copy(configName);
+					tmp.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, className);
+					tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, ""); //$NON-NLS-1$
+					tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, testName);
+					tmp.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_UNIQUE_ID, uniqueId);
+					relaunch(tmp, launchMode);
+					return;
+				} catch (CoreException e) {
+					ErrorDialog.openError(getSite().getShell(),
+							JUnitMessages.TestRunnerViewPart_error_cannotrerun, e.getMessage(), e.getStatus()
+					);
+					return;
 				}
 			}
 		}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -38,6 +38,7 @@ TestRunFilteredParameterizedRunnerTest4.class,
 
 TestRunSessionSerializationTests3.class,
 TestRunSessionSerializationTests4.class,
+TestRunSessionHistoryTests.class,
 
 JUnit3TestFinderTest.class,
 JUnitTestFinderTest.class,

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -367,6 +367,8 @@ public class TestRunSessionHistoryTests {
 
 		assertEquals(1, sessions.size());
 		assertEquals("valid", sessions.get(0).getTestRunName()); //$NON-NLS-1$
+		sessions.get(0).removeSwapFile();
+		assertTrue(validEntry.file(historyDirectory).isFile());
 		TestRunSessionHistory.store(sessions, historyDirectory, 10);
 
 		assertArrayEquals(indexBefore, Files.readAllBytes(indexFile.toPath()));

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -313,6 +313,25 @@ public class TestRunSessionHistoryTests {
 	}
 
 	@Test
+	public void invalidRestoredSessionDoesNotBlockPersistingOtherRuns() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry invalidEntry= emptyEntry("invalid", 1_788_336_010_500L); //$NON-NLS-1$
+		writeHistory(historyDirectory, invalidEntry);
+		TestRunSession invalidSession= TestRunSessionHistory.load(historyDirectory, 10).get(0);
+		Files.writeString(invalidEntry.file(historyDirectory).toPath(), "broken"); //$NON-NLS-1$
+
+		assertEquals(0, invalidSession.getChildren().length);
+		assertFalse(invalidEntry.file(historyDirectory).isFile());
+
+		TestRunSession currentSession= new TestRunSession("current", null); //$NON-NLS-1$
+		TestRunSessionHistory.store(List.of(currentSession, invalidSession), historyDirectory, 10);
+		List<TestRunSession> restored= TestRunSessionHistory.load(historyDirectory, 10);
+
+		assertEquals(1, restored.size());
+		assertEquals("current", restored.get(0).getTestRunName()); //$NON-NLS-1$
+	}
+
+	@Test
 	public void removesUnpublishedXmlFilesWhenNoIndexExists() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
 		File historyFile= new File(historyDirectory, HISTORY_FILE_PREFIX + UUID.randomUUID() + XML_SUFFIX);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.jdt.junit.tests;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -326,6 +327,41 @@ public class TestRunSessionHistoryTests {
 		assertFalse(historyFile.exists());
 		assertFalse(swapFile.exists());
 		assertFalse(legacyFile.exists());
+	}
+
+	@Test
+	public void keepsAnUnsupportedHistoryGenerationUntouched() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= emptyEntry("future", 1_788_336_011_000L); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+		File indexFile= new File(historyDirectory, INDEX_FILE_NAME);
+		String index= Files.readString(indexFile.toPath());
+		Files.writeString(indexFile.toPath(), index.replace("formatVersion=2", "formatVersion=999")); //$NON-NLS-1$ //$NON-NLS-2$
+		byte[] indexBefore= Files.readAllBytes(indexFile.toPath());
+		byte[] xmlBefore= Files.readAllBytes(entry.file(historyDirectory).toPath());
+
+		assertTrue(TestRunSessionHistory.load(historyDirectory, 10).isEmpty());
+		TestRunSessionHistory.store(List.of(), historyDirectory, 10);
+
+		assertArrayEquals(indexBefore, Files.readAllBytes(indexFile.toPath()));
+		assertArrayEquals(xmlBefore, Files.readAllBytes(entry.file(historyDirectory).toPath()));
+	}
+
+	@Test
+	public void keepsANonRegularHistoryIndexUntouched() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= emptyEntry("unreadable-index", 1_788_336_012_000L); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+		File indexFile= new File(historyDirectory, INDEX_FILE_NAME);
+		byte[] xmlBefore= Files.readAllBytes(entry.file(historyDirectory).toPath());
+		Files.delete(indexFile.toPath());
+		assertTrue(indexFile.mkdir());
+
+		assertTrue(TestRunSessionHistory.load(historyDirectory, 10).isEmpty());
+		TestRunSessionHistory.store(List.of(), historyDirectory, 10);
+
+		assertTrue(indexFile.isDirectory());
+		assertArrayEquals(xmlBefore, Files.readAllBytes(entry.file(historyDirectory).toPath()));
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -169,6 +169,37 @@ public class TestRunSessionHistoryTests {
 	}
 
 	@Test
+	public void persistsOriginalConfigurationForTemporaryRelaunch() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		ILaunchManager launchManager= DebugPlugin.getDefault().getLaunchManager();
+		ILaunchConfiguration configuration= createLaunchConfiguration();
+		try {
+			ILaunchConfigurationWorkingCopy temporaryConfiguration=
+					JUnitLaunchConfigurationConstants.createRerunLaunchConfiguration(configuration,
+							launchManager.generateLaunchConfigurationName("JUnit failures first")); //$NON-NLS-1$
+			temporaryConfiguration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_FAILURES_NAMES,
+					"failures.txt"); //$NON-NLS-1$
+			TestRunSession session= relaunchableSession("temporary relaunch", temporaryConfiguration, //$NON-NLS-1$
+					ILaunchManager.DEBUG_MODE);
+
+			assertTrue(temporaryConfiguration.isWorkingCopy());
+			assertTrue(session.canRerun());
+			assertEquals(configuration.getMemento(),
+					JUnitLaunchConfigurationConstants.getRerunLaunchConfigurationMemento(temporaryConfiguration));
+
+			TestRunSessionHistory.store(List.of(session), historyDirectory, 10);
+			TestRunSession restored= TestRunSessionHistory.load(historyDirectory, 10).get(0);
+
+			assertTrue(restored.canRerun());
+			assertEquals(configuration.getMemento(), restored.getRerunLaunchConfiguration().getMemento());
+			assertEquals(ILaunchManager.DEBUG_MODE, restored.getRerunLaunchMode());
+		} finally {
+			if (configuration.exists())
+				configuration.delete();
+		}
+	}
+
+	@Test
 	public void missingLaunchConfigurationDisablesRelaunchWithoutLosingHistory() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
 		ILaunchConfiguration configuration= createLaunchConfiguration();

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Eclipse Foundation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.eclipse.jdt.junit.model.ITestElement.Result;
+
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+import org.eclipse.jdt.internal.junit.model.TestRunSessionHistory;
+
+public class TestRunSessionHistoryTests {
+
+	@Rule
+	public TemporaryFolder fTemporaryFolder= new TemporaryFolder();
+
+	@Test
+	public void readsOnlyTheTestRunHeader() throws Exception {
+		File historyFile= fTemporaryFolder.newFile("20260901-120000.000.xml"); //$NON-NLS-1$
+		Files.writeString(historyFile.toPath(), """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<testrun name="header" tests="3" started="3" failures="1" errors="0" ignored="0">
+				  <malformed
+				"""); //$NON-NLS-1$
+
+		TestRunSession session= TestRunSessionHistory.load(historyFile.getParentFile(), 1).get(0);
+
+		assertEquals("header", session.getTestRunName()); //$NON-NLS-1$
+		assertEquals(3, session.getTotalCount());
+		assertEquals(3, session.getStartedCount());
+		assertEquals(1, session.getFailureCount());
+		assertEquals(Result.FAILURE, session.getTestResult(true));
+	}
+
+	@Test
+	public void loadsTheTestTreeOnDemand() throws Exception {
+		File historyFile= fTemporaryFolder.newFile("20260901-120001.000.xml"); //$NON-NLS-1$
+		Files.writeString(historyFile.toPath(), """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<testrun name="lazy" tests="1" started="1" failures="0" errors="0" ignored="0">
+				  <testcase name="testOne" classname="example.ExampleTest" time="0.1"/>
+				</testrun>
+				"""); //$NON-NLS-1$
+
+		TestRunSession session= TestRunSessionHistory.load(historyFile.getParentFile(), 1).get(0);
+
+		assertEquals(1, session.getChildren().length);
+		assertEquals(Result.OK, session.getTestResult(true));
+	}
+
+	@Test
+	public void restoresNewestEntriesAndRemovesOlderOnes() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		File oldest= writeTestRun(historyDirectory, "20260901-120000.000.xml", "oldest"); //$NON-NLS-1$ //$NON-NLS-2$
+		File middle= writeTestRun(historyDirectory, "20260901-120001.000.xml", "middle"); //$NON-NLS-1$ //$NON-NLS-2$
+		File newest= writeTestRun(historyDirectory, "20260901-120002.000.xml", "newest"); //$NON-NLS-1$ //$NON-NLS-2$
+		List<TestRunSession> sessions= TestRunSessionHistory.load(historyDirectory, 2);
+
+		assertEquals(2, sessions.size());
+		assertEquals("newest", sessions.get(0).getTestRunName()); //$NON-NLS-1$
+		assertEquals("middle", sessions.get(1).getTestRunName()); //$NON-NLS-1$
+		assertFalse(oldest.exists());
+		assertTrue(middle.exists());
+		assertTrue(newest.exists());
+	}
+
+	@Test
+	public void persistsCompletedSessions() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		File historyFile= writeTestRun(historyDirectory, "20260901-120004.000.xml", "persisted"); //$NON-NLS-1$ //$NON-NLS-2$
+		TestRunSession session= TestRunSessionHistory.load(historyFile.getParentFile(), 1).get(0);
+		session.getChildren();
+		Files.delete(historyFile.toPath());
+
+		TestRunSessionHistory.store(List.of(session), historyDirectory, 10);
+
+		assertTrue(historyFile.isFile());
+		TestRunSession restored= TestRunSessionHistory.load(historyDirectory, 1).get(0);
+		assertEquals("persisted", restored.getTestRunName()); //$NON-NLS-1$
+		assertEquals(0, restored.getTotalCount());
+		assertEquals(Result.OK, restored.getTestResult(true));
+	}
+
+	private static File writeTestRun(File directory, String fileName, String testRunName) throws Exception {
+		File file= new File(directory, fileName);
+		Files.writeString(file.toPath(), "<testrun name=\"" + testRunName //$NON-NLS-1$
+				+ "\" tests=\"0\" started=\"0\" failures=\"0\" errors=\"0\" ignored=\"0\"/>"); //$NON-NLS-1$
+		return file;
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -31,8 +31,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+
 import org.eclipse.jdt.junit.model.ITestElement.Result;
 
+import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 import org.eclipse.jdt.internal.junit.model.TestRunSession;
 import org.eclipse.jdt.internal.junit.model.TestRunSessionHistory;
 
@@ -62,6 +70,7 @@ public class TestRunSessionHistoryTests {
 		assertEquals(3, session.getStartedCount());
 		assertEquals(1, session.getFailureCount());
 		assertEquals(Result.FAILURE, session.getTestResult(true));
+		assertFalse(session.canRerun());
 	}
 
 	@Test
@@ -136,6 +145,46 @@ public class TestRunSessionHistoryTests {
 		} finally {
 			Locale.setDefault(originalLocale);
 			TimeZone.setDefault(originalTimeZone);
+		}
+	}
+
+	@Test
+	public void restoresRelaunchConfigurationAndMode() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		ILaunchConfiguration configuration= createLaunchConfiguration();
+		try {
+			TestRunSession session= relaunchableSession("relaunchable", configuration, ILaunchManager.DEBUG_MODE); //$NON-NLS-1$
+
+			TestRunSessionHistory.store(List.of(session), historyDirectory, 10);
+			TestRunSession restored= TestRunSessionHistory.load(historyDirectory, 10).get(0);
+
+			assertTrue(restored.canRerun());
+			assertEquals(configuration.getMemento(), restored.getRerunLaunchConfiguration().getMemento());
+			assertEquals(ILaunchManager.DEBUG_MODE, restored.getRerunLaunchMode());
+			assertEquals(TestKindRegistry.JUNIT5_TEST_KIND_ID, restored.getTestRunnerKind().getId());
+		} finally {
+			if (configuration.exists())
+				configuration.delete();
+		}
+	}
+
+	@Test
+	public void missingLaunchConfigurationDisablesRelaunchWithoutLosingHistory() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		ILaunchConfiguration configuration= createLaunchConfiguration();
+		try {
+			TestRunSession session= relaunchableSession("deleted configuration", configuration, ILaunchManager.RUN_MODE); //$NON-NLS-1$
+			TestRunSessionHistory.store(List.of(session), historyDirectory, 10);
+			configuration.delete();
+
+			TestRunSession restored= TestRunSessionHistory.load(historyDirectory, 10).get(0);
+
+			assertFalse(restored.canRerun());
+			assertEquals("deleted configuration", restored.getTestRunName()); //$NON-NLS-1$
+			assertEquals(Result.UNDEFINED, restored.getTestResult(true));
+		} finally {
+			if (configuration.exists())
+				configuration.delete();
 		}
 	}
 
@@ -421,6 +470,32 @@ public class TestRunSessionHistoryTests {
 		TestRunSessionHistory.load(historyDirectory, 10);
 
 		assertFalse(temporaryFile.exists());
+	}
+
+	private static ILaunchConfiguration createLaunchConfiguration() throws Exception {
+		ILaunchManager launchManager= DebugPlugin.getDefault().getLaunchManager();
+		ILaunchConfigurationType type= launchManager.getLaunchConfigurationType(
+				JUnitLaunchConfigurationConstants.ID_JUNIT_APPLICATION);
+		ILaunchConfigurationWorkingCopy workingCopy= type.newInstance(null,
+				launchManager.generateLaunchConfigurationName("JUnit history relaunch")); //$NON-NLS-1$
+		workingCopy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND,
+				TestKindRegistry.JUNIT5_TEST_KIND_ID);
+		return workingCopy.doSave();
+	}
+
+	private static TestRunSession relaunchableSession(String name, ILaunchConfiguration configuration,
+			String launchMode) {
+		return new TestRunSession(name, null) {
+			@Override
+			public ILaunchConfiguration getRerunLaunchConfiguration() {
+				return configuration;
+			}
+
+			@Override
+			public String getRerunLaunchMode() {
+				return launchMode;
+			}
+		};
 	}
 
 	private static HistoryEntry emptyEntry(String name, long timestamp) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -39,6 +39,7 @@ public class TestRunSessionHistoryTests {
 
 	private static final String INDEX_FILE_NAME= "history.properties"; //$NON-NLS-1$
 	private static final String HISTORY_FILE_PREFIX= "history-"; //$NON-NLS-1$
+	private static final String SWAP_FILE_PREFIX= "swap-"; //$NON-NLS-1$
 	private static final String XML_SUFFIX= ".xml"; //$NON-NLS-1$
 
 	@Rule
@@ -78,6 +79,19 @@ public class TestRunSessionHistoryTests {
 
 		assertEquals(1, session.getChildren().length);
 		assertEquals(Result.OK, session.getTestResult(true));
+	}
+
+	@Test
+	public void preservesUndefinedResultForAnEmptyCompletedRun() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= emptyEntry("empty", 1_788_336_001_500L); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
+
+		assertEquals(Result.UNDEFINED, session.getTestResult(true));
+		assertEquals(0, session.getChildren().length);
+		assertEquals(Result.UNDEFINED, session.getTestResult(true));
 	}
 
 	@Test
@@ -273,6 +287,23 @@ public class TestRunSessionHistoryTests {
 	}
 
 	@Test
+	public void removesUnpublishedXmlFilesWhenNoIndexExists() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		File historyFile= new File(historyDirectory, HISTORY_FILE_PREFIX + UUID.randomUUID() + XML_SUFFIX);
+		File swapFile= new File(historyDirectory, SWAP_FILE_PREFIX + UUID.randomUUID() + XML_SUFFIX);
+		File legacyFile= new File(historyDirectory, "20260901-120000.000.xml"); //$NON-NLS-1$
+		Files.writeString(historyFile.toPath(), "unpublished"); //$NON-NLS-1$
+		Files.writeString(swapFile.toPath(), "transient"); //$NON-NLS-1$
+		Files.writeString(legacyFile.toPath(), "legacy"); //$NON-NLS-1$
+
+		assertTrue(TestRunSessionHistory.load(historyDirectory, 10).isEmpty());
+
+		assertFalse(historyFile.exists());
+		assertFalse(swapFile.exists());
+		assertFalse(legacyFile.exists());
+	}
+
+	@Test
 	public void removesAbandonedTemporaryFiles() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
 		File temporaryFile= new File(historyDirectory, "abandoned.tmp"); //$NON-NLS-1$
@@ -290,13 +321,22 @@ public class TestRunSessionHistoryTests {
 
 	private static HistoryEntry entry(String name, long startTime, long historyTimestamp, String progress,
 			int totalCount, int startedCount, int failureCount, int errorCount, int ignoredCount, String xml) {
-		return new HistoryEntry(UUID.randomUUID().toString(), name, startTime, historyTimestamp, progress,
+		Result result;
+		if (errorCount > 0)
+			result= Result.ERROR;
+		else if (failureCount > 0)
+			result= Result.FAILURE;
+		else if ("stopped".equals(progress) || totalCount == 0) //$NON-NLS-1$
+			result= Result.UNDEFINED;
+		else
+			result= Result.OK;
+		return new HistoryEntry(UUID.randomUUID().toString(), name, startTime, historyTimestamp, progress, result,
 				totalCount, startedCount, failureCount, errorCount, ignoredCount, 0, xml);
 	}
 
 	private static void writeHistory(File directory, HistoryEntry... entries) throws Exception {
 		Properties properties= new Properties();
-		properties.setProperty("formatVersion", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("formatVersion", "2"); //$NON-NLS-1$ //$NON-NLS-2$
 		properties.setProperty("entryCount", Integer.toString(entries.length)); //$NON-NLS-1$
 		for (int i= 0; i < entries.length; i++) {
 			HistoryEntry entry= entries[i];
@@ -308,6 +348,7 @@ public class TestRunSessionHistoryTests {
 			properties.setProperty(prefix + "startTime", Long.toString(entry.fStartTime)); //$NON-NLS-1$
 			properties.setProperty(prefix + "historyTimestamp", Long.toString(entry.fHistoryTimestamp)); //$NON-NLS-1$
 			properties.setProperty(prefix + "progress", entry.fProgress); //$NON-NLS-1$
+			properties.setProperty(prefix + "result", entry.fResult.name()); //$NON-NLS-1$
 			properties.setProperty(prefix + "totalCount", Integer.toString(entry.fTotalCount)); //$NON-NLS-1$
 			properties.setProperty(prefix + "startedCount", Integer.toString(entry.fStartedCount)); //$NON-NLS-1$
 			properties.setProperty(prefix + "failureCount", Integer.toString(entry.fFailureCount)); //$NON-NLS-1$
@@ -336,6 +377,7 @@ public class TestRunSessionHistoryTests {
 		final long fStartTime;
 		final long fHistoryTimestamp;
 		final String fProgress;
+		final Result fResult;
 		final int fTotalCount;
 		final int fStartedCount;
 		final int fFailureCount;
@@ -344,7 +386,7 @@ public class TestRunSessionHistoryTests {
 		final int fAssumptionFailureCount;
 		final String fXml;
 
-		HistoryEntry(String id, String name, long startTime, long historyTimestamp, String progress,
+		HistoryEntry(String id, String name, long startTime, long historyTimestamp, String progress, Result result,
 				int totalCount, int startedCount, int failureCount, int errorCount, int ignoredCount,
 				int assumptionFailureCount, String xml) {
 			fId= id;
@@ -352,6 +394,7 @@ public class TestRunSessionHistoryTests {
 			fStartTime= startTime;
 			fHistoryTimestamp= historyTimestamp;
 			fProgress= progress;
+			fResult= result;
 			fTotalCount= totalCount;
 			fStartedCount= startedCount;
 			fFailureCount= failureCount;

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -348,6 +348,33 @@ public class TestRunSessionHistoryTests {
 	}
 
 	@Test
+	public void keepsHistoryWithAnInvalidEntryUntouched() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry validEntry= emptyEntry("valid", 1_788_336_012_000L); //$NON-NLS-1$
+		HistoryEntry invalidEntry= emptyEntry("invalid", 1_788_336_011_000L); //$NON-NLS-1$
+		writeHistory(historyDirectory, validEntry, invalidEntry);
+		File indexFile= new File(historyDirectory, INDEX_FILE_NAME);
+		String index= Files.readString(indexFile.toPath());
+		String invalidIdProperty= "entry.1.id=" + invalidEntry.fId; //$NON-NLS-1$
+		assertTrue(index.contains(invalidIdProperty));
+		Files.writeString(indexFile.toPath(),
+				index.replace(invalidIdProperty, "entry.1.id=invalid")); //$NON-NLS-1$
+		byte[] indexBefore= Files.readAllBytes(indexFile.toPath());
+		byte[] validXmlBefore= Files.readAllBytes(validEntry.file(historyDirectory).toPath());
+		byte[] invalidXmlBefore= Files.readAllBytes(invalidEntry.file(historyDirectory).toPath());
+
+		List<TestRunSession> sessions= TestRunSessionHistory.load(historyDirectory, 10);
+
+		assertEquals(1, sessions.size());
+		assertEquals("valid", sessions.get(0).getTestRunName()); //$NON-NLS-1$
+		TestRunSessionHistory.store(sessions, historyDirectory, 10);
+
+		assertArrayEquals(indexBefore, Files.readAllBytes(indexFile.toPath()));
+		assertArrayEquals(validXmlBefore, Files.readAllBytes(validEntry.file(historyDirectory).toPath()));
+		assertArrayEquals(invalidXmlBefore, Files.readAllBytes(invalidEntry.file(historyDirectory).toPath()));
+	}
+
+	@Test
 	public void keepsANonRegularHistoryIndexUntouched() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
 		HistoryEntry entry= emptyEntry("unreadable-index", 1_788_336_012_000L); //$NON-NLS-1$
@@ -409,7 +436,7 @@ public class TestRunSessionHistoryTests {
 			properties.setProperty(prefix + "startTime", Long.toString(entry.fStartTime)); //$NON-NLS-1$
 			properties.setProperty(prefix + "historyTimestamp", Long.toString(entry.fHistoryTimestamp)); //$NON-NLS-1$
 			properties.setProperty(prefix + "progress", entry.fProgress); //$NON-NLS-1$
-			properties.setProperty(prefix + "result", entry.fResult.name()); //$NON-NLS-1$
+			properties.setProperty(prefix + "result", resultName(entry.fResult)); //$NON-NLS-1$
 			properties.setProperty(prefix + "totalCount", Integer.toString(entry.fTotalCount)); //$NON-NLS-1$
 			properties.setProperty(prefix + "startedCount", Integer.toString(entry.fStartedCount)); //$NON-NLS-1$
 			properties.setProperty(prefix + "failureCount", Integer.toString(entry.fFailureCount)); //$NON-NLS-1$
@@ -422,6 +449,20 @@ public class TestRunSessionHistoryTests {
 				new FileOutputStream(new File(directory, INDEX_FILE_NAME)))) {
 			properties.store(output, null);
 		}
+	}
+
+	private static String resultName(Result result) {
+		if (result == Result.UNDEFINED)
+			return "UNDEFINED"; //$NON-NLS-1$
+		if (result == Result.OK)
+			return "OK"; //$NON-NLS-1$
+		if (result == Result.ERROR)
+			return "ERROR"; //$NON-NLS-1$
+		if (result == Result.FAILURE)
+			return "FAILURE"; //$NON-NLS-1$
+		if (result == Result.IGNORED)
+			return "IGNORED"; //$NON-NLS-1$
+		throw new AssertionError("Unsupported result: " + result); //$NON-NLS-1$
 	}
 
 	private static List<File> xmlFiles(File directory) throws Exception {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2026 Eclipse Foundation and others.
+ * Copyright (c) 2026 Carsten Hammer and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -125,6 +125,20 @@ public class TestRunSessionHistoryTests {
 	}
 
 	@Test
+	public void storesExplicitStoppedState() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		TestRunSession stopped= new TestRunSession("stopped", null); //$NON-NLS-1$
+		long startTime= stopped.getStartTime();
+		stopped.stopTestRun();
+
+		TestRunSessionHistory.store(List.of(stopped), historyDirectory, 10);
+		TestRunSession restored= TestRunSessionHistory.load(historyDirectory, 10).get(0);
+
+		assertTrue(restored.isStopped());
+		assertEquals(startTime, restored.getStartTime());
+	}
+
+	@Test
 	public void preservesStoppedStateWhenTheRunContainsAFailure() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
 		HistoryEntry entry= entry("stoppedWithFailure", 1_788_336_004_000L, 1_788_336_004_000L, //$NON-NLS-1$
@@ -213,8 +227,12 @@ public class TestRunSessionHistoryTests {
 
 		assertEquals(1, sessions.size());
 		assertEquals("older", sessions.get(0).getTestRunName()); //$NON-NLS-1$
-		assertFalse(newer.file(historyDirectory).exists());
+		assertTrue(newer.file(historyDirectory).isFile());
 		assertTrue(older.file(historyDirectory).isFile());
+
+		TestRunSessionHistory.store(sessions, historyDirectory, 1);
+
+		assertFalse(newer.file(historyDirectory).exists());
 	}
 
 	@Test
@@ -251,6 +269,7 @@ public class TestRunSessionHistoryTests {
 		TestRunSessionHistory.store(List.of(session), historyDirectory, 10);
 
 		assertTrue(TestRunSessionHistory.load(historyDirectory, 10).isEmpty());
+		assertTrue(entry.file(historyDirectory).isFile());
 	}
 
 	@Test

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -15,9 +15,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.TimeZone;
+import java.util.UUID;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,21 +37,25 @@ import org.eclipse.jdt.internal.junit.model.TestRunSessionHistory;
 
 public class TestRunSessionHistoryTests {
 
+	private static final String INDEX_FILE_NAME= "history.properties"; //$NON-NLS-1$
+	private static final String HISTORY_FILE_PREFIX= "history-"; //$NON-NLS-1$
+	private static final String XML_SUFFIX= ".xml"; //$NON-NLS-1$
+
 	@Rule
 	public TemporaryFolder fTemporaryFolder= new TemporaryFolder();
 
 	@Test
-	public void readsOnlyTheTestRunHeader() throws Exception {
-		File historyFile= fTemporaryFolder.newFile("20260901-120000.000.xml"); //$NON-NLS-1$
-		Files.writeString(historyFile.toPath(), """
-				<?xml version="1.0" encoding="UTF-8"?>
-				<testrun name="header" tests="3" started="3" failures="1" errors="0" ignored="0">
-				  <malformed
-				"""); //$NON-NLS-1$
+	public void readsMetadataWithoutParsingTheTestTree() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= entry("header", -1_788_336_000_000L, 1_788_336_000_000L, //$NON-NLS-1$
+				"completed", 3, 3, 1, 0, 0, //$NON-NLS-1$
+				"<testrun name=\"header\"><malformed"); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
 
-		TestRunSession session= TestRunSessionHistory.load(historyFile.getParentFile(), 1).get(0);
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
 
 		assertEquals("header", session.getTestRunName()); //$NON-NLS-1$
+		assertEquals(-1_788_336_000_000L, session.getStartTime());
 		assertEquals(3, session.getTotalCount());
 		assertEquals(3, session.getStartedCount());
 		assertEquals(1, session.getFailureCount());
@@ -53,57 +64,286 @@ public class TestRunSessionHistoryTests {
 
 	@Test
 	public void loadsTheTestTreeOnDemand() throws Exception {
-		File historyFile= fTemporaryFolder.newFile("20260901-120001.000.xml"); //$NON-NLS-1$
-		Files.writeString(historyFile.toPath(), """
-				<?xml version="1.0" encoding="UTF-8"?>
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= entry("lazy", 1_788_336_001_000L, 1_788_336_001_000L, //$NON-NLS-1$
+				"completed", 1, 1, 0, 0, 0, //$NON-NLS-1$
+				"""
 				<testrun name="lazy" tests="1" started="1" failures="0" errors="0" ignored="0">
 				  <testcase name="testOne" classname="example.ExampleTest" time="0.1"/>
 				</testrun>
 				"""); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
 
-		TestRunSession session= TestRunSessionHistory.load(historyFile.getParentFile(), 1).get(0);
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
 
 		assertEquals(1, session.getChildren().length);
 		assertEquals(Result.OK, session.getTestResult(true));
 	}
 
 	@Test
-	public void restoresNewestEntriesAndRemovesOlderOnes() throws Exception {
+	public void restoresConfiguredNumberWithoutDeletingValidExcessEntries() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
-		File oldest= writeTestRun(historyDirectory, "20260901-120000.000.xml", "oldest"); //$NON-NLS-1$ //$NON-NLS-2$
-		File middle= writeTestRun(historyDirectory, "20260901-120001.000.xml", "middle"); //$NON-NLS-1$ //$NON-NLS-2$
-		File newest= writeTestRun(historyDirectory, "20260901-120002.000.xml", "newest"); //$NON-NLS-1$ //$NON-NLS-2$
+		HistoryEntry newest= emptyEntry("newest", 1_788_336_003_000L); //$NON-NLS-1$
+		HistoryEntry middle= emptyEntry("middle", 1_788_336_002_000L); //$NON-NLS-1$
+		HistoryEntry oldest= emptyEntry("oldest", 1_788_336_001_000L); //$NON-NLS-1$
+		writeHistory(historyDirectory, newest, middle, oldest);
+
 		List<TestRunSession> sessions= TestRunSessionHistory.load(historyDirectory, 2);
 
 		assertEquals(2, sessions.size());
 		assertEquals("newest", sessions.get(0).getTestRunName()); //$NON-NLS-1$
 		assertEquals("middle", sessions.get(1).getTestRunName()); //$NON-NLS-1$
-		assertFalse(oldest.exists());
-		assertTrue(middle.exists());
-		assertTrue(newest.exists());
+		assertTrue(oldest.file(historyDirectory).isFile());
 	}
 
 	@Test
-	public void persistsCompletedSessions() throws Exception {
+	public void preservesImportedStartTimeAcrossLocaleAndTimeZoneChanges() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
-		File historyFile= writeTestRun(historyDirectory, "20260901-120004.000.xml", "persisted"); //$NON-NLS-1$ //$NON-NLS-2$
-		TestRunSession session= TestRunSessionHistory.load(historyFile.getParentFile(), 1).get(0);
+		Locale originalLocale= Locale.getDefault();
+		TimeZone originalTimeZone= TimeZone.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("th-TH")); //$NON-NLS-1$
+			TimeZone.setDefault(TimeZone.getTimeZone("Asia/Bangkok")); //$NON-NLS-1$
+			TestRunSession imported= new TestRunSession("imported", null); //$NON-NLS-1$
+			long originalStartTime= imported.getStartTime();
+
+			TestRunSessionHistory.store(List.of(imported), historyDirectory, 10);
+			assertEquals(1, xmlFiles(historyDirectory).size());
+			assertTrue(xmlFiles(historyDirectory).get(0).getName().matches(
+					"history-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\.xml")); //$NON-NLS-1$
+
+			Locale.setDefault(Locale.GERMANY);
+			TimeZone.setDefault(TimeZone.getTimeZone("UTC")); //$NON-NLS-1$
+			TestRunSession restored= TestRunSessionHistory.load(historyDirectory, 10).get(0);
+
+			assertTrue(originalStartTime < 0);
+			assertEquals(originalStartTime, restored.getStartTime());
+		} finally {
+			Locale.setDefault(originalLocale);
+			TimeZone.setDefault(originalTimeZone);
+		}
+	}
+
+	@Test
+	public void preservesStoppedStateWhenTheRunContainsAFailure() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= entry("stoppedWithFailure", 1_788_336_004_000L, 1_788_336_004_000L, //$NON-NLS-1$
+				"stopped", 10, 3, 1, 0, 0, //$NON-NLS-1$
+				"""
+				<testrun name="stoppedWithFailure" tests="10" started="3" failures="1" errors="0" ignored="0">
+				  <testcase name="testOne" classname="example.ExampleTest" time="0.1">
+				    <failure>failed</failure>
+				  </testcase>
+				</testrun>
+				"""); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
+
+		assertTrue(session.isStopped());
+		assertEquals(Result.FAILURE, session.getTestResult(true));
+		assertEquals(1, session.getChildren().length);
+		assertTrue(session.isStopped());
+		assertEquals(Result.FAILURE, session.getTestResult(true));
+	}
+
+	@Test
+	public void preservesStoppedStateWhenAllTestsWereStarted() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= entry("stoppedAfterStart", 1_788_336_005_000L, 1_788_336_005_000L, //$NON-NLS-1$
+				"stopped", 1, 1, 0, 0, 0, //$NON-NLS-1$
+				"""
+				<testrun name="stoppedAfterStart" tests="1" started="1" failures="0" errors="0" ignored="0">
+				  <testcase name="testOne" classname="example.ExampleTest" incomplete="true"/>
+				</testrun>
+				"""); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
+
+		assertTrue(session.isStopped());
+		assertEquals(Result.UNDEFINED, session.getTestResult(true));
+		assertEquals(1, session.getChildren().length);
+		assertTrue(session.isStopped());
+	}
+
+	@Test
+	public void keepsEqualHistoryTimestampsDistinct() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		long timestamp= 1_788_336_006_000L;
+		HistoryEntry first= emptyEntry("first", timestamp); //$NON-NLS-1$
+		HistoryEntry second= emptyEntry("second", timestamp); //$NON-NLS-1$
+		writeHistory(historyDirectory, first, second);
+
+		List<TestRunSession> sessions= TestRunSessionHistory.load(historyDirectory, 10);
+		TestRunSessionHistory.store(sessions, historyDirectory, 10);
+		List<TestRunSession> restored= TestRunSessionHistory.load(historyDirectory, 10);
+
+		assertEquals(2, xmlFiles(historyDirectory).size());
+		assertEquals(2, restored.size());
+		assertEquals("first", restored.get(0).getTestRunName()); //$NON-NLS-1$
+		assertEquals("second", restored.get(1).getTestRunName()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void doesNotReuseAnUnownedStaleFile() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		File staleFile= new File(historyDirectory, HISTORY_FILE_PREFIX + UUID.randomUUID() + XML_SUFFIX);
+		Files.writeString(staleFile.toPath(), "<testrun name=\"stale\"/>"); //$NON-NLS-1$
+		TestRunSession current= new TestRunSession("current", null); //$NON-NLS-1$
+
+		TestRunSessionHistory.store(List.of(current), historyDirectory, 10);
+		List<TestRunSession> restored= TestRunSessionHistory.load(historyDirectory, 10);
+
+		assertFalse(staleFile.exists());
+		assertEquals(1, xmlFiles(historyDirectory).size());
+		assertEquals(1, restored.size());
+		assertEquals("current", restored.get(0).getTestRunName()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void ignoresATruncatedNewerFileWithoutPruningAnOlderValidEntry() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry newer= emptyEntry("newer", 1_788_336_008_000L); //$NON-NLS-1$
+		HistoryEntry older= emptyEntry("older", 1_788_336_007_000L); //$NON-NLS-1$
+		writeHistory(historyDirectory, newer, older);
+		Files.writeString(newer.file(historyDirectory).toPath(), "<testrun"); //$NON-NLS-1$
+
+		List<TestRunSession> sessions= TestRunSessionHistory.load(historyDirectory, 1);
+
+		assertEquals(1, sessions.size());
+		assertEquals("older", sessions.get(0).getTestRunName()); //$NON-NLS-1$
+		assertFalse(newer.file(historyDirectory).exists());
+		assertTrue(older.file(historyDirectory).isFile());
+	}
+
+	@Test
+	public void rewritesALoadedSessionWhenItsPersistentFileDisappears() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= entry("loaded", 1_788_336_009_000L, 1_788_336_009_000L, //$NON-NLS-1$
+				"completed", 1, 1, 0, 0, 0, //$NON-NLS-1$
+				"""
+				<testrun name="loaded" tests="1" started="1" failures="0" errors="0" ignored="0">
+				  <testcase name="testOne" classname="example.ExampleTest"/>
+				</testrun>
+				"""); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
 		session.getChildren();
-		Files.delete(historyFile.toPath());
+		Files.delete(entry.file(historyDirectory).toPath());
+
+		TestRunSessionHistory.store(List.of(session), historyDirectory, 10);
+		List<TestRunSession> restored= TestRunSessionHistory.load(historyDirectory, 10);
+
+		assertEquals(1, restored.size());
+		assertEquals("loaded", restored.get(0).getTestRunName()); //$NON-NLS-1$
+		assertEquals(1, restored.get(0).getChildren().length);
+	}
+
+	@Test
+	public void doesNotRewriteAnUnreadableSessionAsAnEmptyRun() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= emptyEntry("unreadable", 1_788_336_010_000L); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
+		Files.writeString(entry.file(historyDirectory).toPath(), "broken"); //$NON-NLS-1$
 
 		TestRunSessionHistory.store(List.of(session), historyDirectory, 10);
 
-		assertTrue(historyFile.isFile());
-		TestRunSession restored= TestRunSessionHistory.load(historyDirectory, 1).get(0);
-		assertEquals("persisted", restored.getTestRunName()); //$NON-NLS-1$
-		assertEquals(0, restored.getTotalCount());
-		assertEquals(Result.OK, restored.getTestResult(true));
+		assertTrue(TestRunSessionHistory.load(historyDirectory, 10).isEmpty());
 	}
 
-	private static File writeTestRun(File directory, String fileName, String testRunName) throws Exception {
-		File file= new File(directory, fileName);
-		Files.writeString(file.toPath(), "<testrun name=\"" + testRunName //$NON-NLS-1$
-				+ "\" tests=\"0\" started=\"0\" failures=\"0\" errors=\"0\" ignored=\"0\"/>"); //$NON-NLS-1$
-		return file;
+	@Test
+	public void removesAbandonedTemporaryFiles() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		File temporaryFile= new File(historyDirectory, "abandoned.tmp"); //$NON-NLS-1$
+		Files.writeString(temporaryFile.toPath(), "temporary"); //$NON-NLS-1$
+
+		TestRunSessionHistory.load(historyDirectory, 10);
+
+		assertFalse(temporaryFile.exists());
+	}
+
+	private static HistoryEntry emptyEntry(String name, long timestamp) {
+		return entry(name, timestamp, timestamp, "completed", 0, 0, 0, 0, 0, //$NON-NLS-1$
+				"<testrun name=\"" + name + "\" tests=\"0\" started=\"0\" failures=\"0\" errors=\"0\" ignored=\"0\"/>"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	private static HistoryEntry entry(String name, long startTime, long historyTimestamp, String progress,
+			int totalCount, int startedCount, int failureCount, int errorCount, int ignoredCount, String xml) {
+		return new HistoryEntry(UUID.randomUUID().toString(), name, startTime, historyTimestamp, progress,
+				totalCount, startedCount, failureCount, errorCount, ignoredCount, 0, xml);
+	}
+
+	private static void writeHistory(File directory, HistoryEntry... entries) throws Exception {
+		Properties properties= new Properties();
+		properties.setProperty("formatVersion", "1"); //$NON-NLS-1$ //$NON-NLS-2$
+		properties.setProperty("entryCount", Integer.toString(entries.length)); //$NON-NLS-1$
+		for (int i= 0; i < entries.length; i++) {
+			HistoryEntry entry= entries[i];
+			File file= entry.file(directory);
+			Files.writeString(file.toPath(), entry.fXml);
+			String prefix= "entry." + i + '.'; //$NON-NLS-1$
+			properties.setProperty(prefix + "id", entry.fId); //$NON-NLS-1$
+			properties.setProperty(prefix + "name", entry.fName); //$NON-NLS-1$
+			properties.setProperty(prefix + "startTime", Long.toString(entry.fStartTime)); //$NON-NLS-1$
+			properties.setProperty(prefix + "historyTimestamp", Long.toString(entry.fHistoryTimestamp)); //$NON-NLS-1$
+			properties.setProperty(prefix + "progress", entry.fProgress); //$NON-NLS-1$
+			properties.setProperty(prefix + "totalCount", Integer.toString(entry.fTotalCount)); //$NON-NLS-1$
+			properties.setProperty(prefix + "startedCount", Integer.toString(entry.fStartedCount)); //$NON-NLS-1$
+			properties.setProperty(prefix + "failureCount", Integer.toString(entry.fFailureCount)); //$NON-NLS-1$
+			properties.setProperty(prefix + "errorCount", Integer.toString(entry.fErrorCount)); //$NON-NLS-1$
+			properties.setProperty(prefix + "ignoredCount", Integer.toString(entry.fIgnoredCount)); //$NON-NLS-1$
+			properties.setProperty(prefix + "assumptionFailureCount", Integer.toString(entry.fAssumptionFailureCount)); //$NON-NLS-1$
+			properties.setProperty(prefix + "fileLength", Long.toString(file.length())); //$NON-NLS-1$
+		}
+		try (BufferedOutputStream output= new BufferedOutputStream(
+				new FileOutputStream(new File(directory, INDEX_FILE_NAME)))) {
+			properties.store(output, null);
+		}
+	}
+
+	private static List<File> xmlFiles(File directory) throws Exception {
+		File[] files= directory.listFiles(file -> file.isFile() && file.getName().endsWith(XML_SUFFIX));
+		List<File> result= new ArrayList<>();
+		if (files != null)
+			result.addAll(List.of(files));
+		return result;
+	}
+
+	private static final class HistoryEntry {
+		final String fId;
+		final String fName;
+		final long fStartTime;
+		final long fHistoryTimestamp;
+		final String fProgress;
+		final int fTotalCount;
+		final int fStartedCount;
+		final int fFailureCount;
+		final int fErrorCount;
+		final int fIgnoredCount;
+		final int fAssumptionFailureCount;
+		final String fXml;
+
+		HistoryEntry(String id, String name, long startTime, long historyTimestamp, String progress,
+				int totalCount, int startedCount, int failureCount, int errorCount, int ignoredCount,
+				int assumptionFailureCount, String xml) {
+			fId= id;
+			fName= name;
+			fStartTime= startTime;
+			fHistoryTimestamp= historyTimestamp;
+			fProgress= progress;
+			fTotalCount= totalCount;
+			fStartedCount= startedCount;
+			fFailureCount= failureCount;
+			fErrorCount= errorCount;
+			fIgnoredCount= ignoredCount;
+			fAssumptionFailureCount= assumptionFailureCount;
+			fXml= xml;
+		}
+
+		File file(File directory) {
+			return new File(directory, HISTORY_FILE_PREFIX + fId + XML_SUFFIX);
+		}
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunSessionHistoryTests.java
@@ -196,6 +196,31 @@ public class TestRunSessionHistoryTests {
 	}
 
 	@Test
+	public void releasesAndReloadsTheSelectedTestTree() throws Exception {
+		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
+		HistoryEntry entry= entry("reload", 1_788_336_005_500L, 1_788_336_005_500L, //$NON-NLS-1$
+				"completed", 1, 1, 0, 0, 0, //$NON-NLS-1$
+				"""
+				<testrun name="reload" tests="1" started="1" failures="0" errors="0" ignored="0">
+				  <testcase name="testOne" classname="example.ExampleTest"/>
+				</testrun>
+				"""); //$NON-NLS-1$
+		writeHistory(historyDirectory, entry);
+		TestRunSession session= TestRunSessionHistory.load(historyDirectory, 1).get(0);
+		assertEquals(1, session.getChildren().length);
+
+		session.swapOut();
+		Files.writeString(entry.file(historyDirectory).toPath(), """
+				<testrun name="reload" tests="2" started="2" failures="0" errors="0" ignored="0">
+				  <testcase name="testOne" classname="example.ExampleTest"/>
+				  <testcase name="testTwo" classname="example.ExampleTest"/>
+				</testrun>
+				"""); //$NON-NLS-1$
+
+		assertEquals(2, session.getChildren().length);
+	}
+
+	@Test
 	public void keepsEqualHistoryTimestampsDistinct() throws Exception {
 		File historyDirectory= fTemporaryFolder.newFolder("history"); //$NON-NLS-1$
 		long timestamp= 1_788_336_006_000L;


### PR DESCRIPTION
Persist and restore the bounded JUnit test-run history for a workspace across
clean Eclipse restarts.

Fixes #2394  
Related to #2040

## Problem

The JUnit Results view already keeps multiple test-run sessions during an
Eclipse session. However, this history is discarded when Eclipse shuts down.

This can be inconvenient when Eclipse must be restarted while a developer still
needs to inspect a failure trace, compare recent runs, or rerun tests using the
same launch configuration.

## User-visible behavior

This change persists the existing bounded JUnit test-run history in the
workspace state area and restores it when the same workspace is opened again.

After a restart:

- the retained test runs are available through the existing JUnit history
  dropdown and page switcher;
- the most recent retained run is displayed initially;
- users can switch between all restored runs up to the configured history
  limit;
- run name, project, original start time, stopped/completed state, aggregate
  result, counters, and include/exclude tags are preserved;
- the complete test tree and failure details are loaded only when a restored run
  is accessed;
- “Rerun Tests” and “Run Errors First” can use the original saved launch
  configuration when it is still available.

The original launch process is not reconstructed. For rerunning, the persisted
history stores only:

- the memento of the persistent source launch configuration; and
- the original launch mode.

Temporary launch configurations created by JUnit rerun actions, including
“Run Errors First”, retain a reference to their persistent source
configuration. This allows subsequent reruns to work during the current Eclipse
session and after a restart.

If the original saved launch configuration has been deleted, the historical
test result remains available, but actions requiring that configuration are
disabled.

## Configuration

The existing “Maximum count of remembered test runs” setting continues to
define the maximum number of sessions kept by the JUnit history. The same limit
is applied to the persisted history.

No additional preference is introduced by this change.

## Implementation

The persisted history consists of:

1. a small, versioned metadata index used during Eclipse startup; and
2. one XML file per retained test run, using the existing JUnit test-run
   serialization format.

Only the metadata index is read during startup. Complete test trees, stack
traces, and failure details remain on disk until the corresponding history entry
is accessed.

The implementation:

- stores history only in the JUnit core state area of the workspace and does not
  modify project files;
- uses UUID-based file identities that do not depend on locale, time zone, or
  timestamp uniqueness;
- writes test-run files and the history index through temporary files and
  atomically replaces their published versions where supported;
- keeps the previously published history generation intact until a replacement
  index has been written successfully;
- does not overwrite an unsupported, unreadable, or only partially understood
  history generation;
- excludes restored sessions that became invalid after a failed lazy load,
  without preventing other valid sessions from being persisted;
- removes obsolete, unpublished, and abandoned temporary files only when it is
  safe to do so;
- preserves files referenced by the currently published index until a
  replacement index has been published.

## Scope and limitations

The feature applies to clean Eclipse shutdowns and restarts.

It does not attempt to recover a test run that existed only in memory when the
Eclipse process crashed or was terminated forcibly.

The history is local to the workspace. It is not synchronized between
workspaces or machines.

Rerunning a restored session requires that its persistent source launch
configuration can still be resolved. Imported test reports or restored entries
without a resolvable launch configuration remain available for inspection but
cannot be rerun.

## Automated tests

Automated coverage is provided by `TestRunSessionHistoryTests`.

The tests cover:

- metadata-only restoration and lazy test-tree loading;
- releasing and repeatedly loading restored test trees;
- preservation of imported start times across locale and time-zone changes;
- stopped runs, including runs containing failures and runs where all tests had
  already started;
- completed empty runs and their undefined result;
- equal timestamps without file collisions;
- configured history limits;
- restoration of the launch configuration and launch mode required for reruns;
- preservation of the persistent source configuration for temporary rerun
  working copies created by “Run Errors First”;
- disabling rerun without losing the historical result when the original saved
  launch configuration no longer exists;
- invalid restored sessions without blocking persistence of other runs;
- stale, missing, truncated, and unpublished test-run files;
- unsupported, non-regular, and partially invalid history indexes;
- preservation of the last published history generation when a replacement
  cannot safely be written;
- cleanup of abandoned temporary files.

Validation results:

- `TestRunSessionHistoryTests`: 23 tests, 0 failures, 0 errors, 0 skipped;
- complete Maven/Tycho reactor validation: successful;
- pull-request checks: successful;
- CodeQL: successful;
- service-version, merge-commit, freeze-period, and Eclipse ECA checks:
  successful.

## Suggested manual verification

1. Run several saved JUnit launch configurations, including successful and
   failing tests.
2. Optionally stop one test run before it completes.
3. Switch between the runs using the JUnit history dropdown.
4. Close Eclipse cleanly and reopen the same workspace.
5. Verify that the retained runs reappear with the expected names, ordering,
   result icons, counters, and stopped state.
6. Select restored runs and verify that their complete test trees and failure
   traces are loaded.
7. Switch away from a restored run and select it again.
8. Run a configuration containing failures and select “Run Errors First”.
9. Verify that “Rerun Tests” works for the resulting run.
10. Restart Eclipse and verify that “Rerun Tests” resolves and launches the
    original saved configuration.
11. Delete the original saved launch configuration and verify that the
    historical result remains available while rerun actions are disabled.
12. Remove individual history entries and clear the history.
13. Change the maximum number of remembered test runs and verify that the
    current and restored history remain bounded.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change follows the coding conventions
- [x] I have signed the Eclipse Contributor Agreement (ECA)