### PR TITLE
Move SortMembersOperation to core.manipulation

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/SortMembersOperation.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/codemanipulation/SortMembersOperation.java
@@ -13,10 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.codemanipulation;
 
+import java.text.Collator;
 import java.util.Comparator;
 import java.util.List;
-
-import java.text.Collator;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -39,13 +38,11 @@ import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.util.CompilationUnitSorter;
 
+import org.eclipse.jdt.internal.core.manipulation.JavaManipulationPlugin;
 import org.eclipse.jdt.internal.core.manipulation.MembersOrderPreferenceCacheCommon;
 import org.eclipse.jdt.internal.corext.dom.ASTNodes;
-import org.eclipse.jdt.internal.corext.util.JdtFlags;
-
-import org.eclipse.jdt.internal.ui.JavaPlugin;
 import org.eclipse.jdt.internal.corext.dom.IASTSharedValues;
-import org.eclipse.jdt.internal.ui.preferences.MembersOrderPreferenceCache;
+import org.eclipse.jdt.internal.corext.util.JdtFlags;
 
 /**
  * Orders members in a compilation unit. A working copy must be passed.
@@ -59,13 +56,13 @@ public class SortMembersOperation implements IWorkspaceRunnable {
 	public static class DefaultJavaElementComparator implements Comparator<BodyDeclaration> {
 
 		private final Collator fCollator;
-		private final MembersOrderPreferenceCache fMemberOrderCache;
+		private final MembersOrderPreferenceCacheCommon fMemberOrderCache;
 		private final boolean fDoNotSortFields;
 
 		public DefaultJavaElementComparator(boolean doNotSortFields) {
 			fDoNotSortFields= doNotSortFields;
 			fCollator= Collator.getInstance();
-			fMemberOrderCache= JavaPlugin.getDefault().getMemberOrderPreferenceCache();
+			fMemberOrderCache= JavaManipulationPlugin.getDefault().getMembersOrderPreferenceCacheCommon();
 		}
 
 		private int category(BodyDeclaration bodyDeclaration) {


### PR DESCRIPTION
This moves SortMembersOperation from org.eclipse.jdt.ui into org.eclipse.jdt.core.manipulation, so headless clients like the Eclipse JDT Language Server can actually use it. Right now it's stuck in the UI plug-in, so anything that isn't a full Eclipse IDE can't reach it.

The only thing blocking the move was one line depending on a UI-only class (JavaPlugin.getDefault().getMemberOrderPreferenceCache()). I swapped it for the equivalent that already exists in core.manipulation (JavaManipulationPlugin.getDefault().getMembersOrderPreferenceCacheCommon()), so the file no longer needs anything from org.eclipse.jdt.ui.

Related to redhat-developer/vscode-java#3990, which asks for alphabetical member sorting in jdtls,  jdtls will pick this up in a follow-up change.

Manually tested in a runtime Eclipse instance: created a class with out-of-order fields and methods, ran Source > Sort Members with "Sort all members" selected, and confirmed everything sorted alphabetically as expected.