### PR TITLE
Skip top level types in collapse all editor actions

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTest.java
@@ -31,7 +31,6 @@ import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -824,7 +823,26 @@ public class FoldingTest {
 		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 10, 20); // class A2
 		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 12, 17); // Runnable
 		JavaPlugin.getDefault().getPreferenceStore().setToDefault(PreferenceConstants.EDITOR_FOLDING_INNERTYPES);
+	}
 
+	/**
+	 * "Collapse All" should not collapse top-level types, so that classes are not left completely
+	 * empty. See <a href="https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3126">GitHub Issue
+	 * #3126</a>
+	 */
+	@Test
+	public void testCollapseAllSkipsTopLevelType() throws Exception {
+		String str= """
+				class MyClass {
+					void someMethod() {
+						// does some work
+					}
+				}
+				""";
+		FoldingTestUtils.collapseAll(packageFragment, str);
+		List<FoldingTestUtils.ProjectionRegion> regions= FoldingTestUtils.getProjectionRangesOfPackage(packageFragment, str);
+		FoldingTestUtils.assertContainsExpandedRegionUsingStartAndEndLine(regions, str, 0, 4); // class MyClass
+		FoldingTestUtils.assertContainsCollapsedRegionUsingStartAndEndLine(regions, str, 1, 3); // someMethod
 	}
 }
 

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/folding/FoldingTestUtils.java
@@ -29,12 +29,14 @@ import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
 
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
 
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
 import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
+import org.eclipse.jdt.internal.ui.javaeditor.JavaSourceViewer;
 
 public final class FoldingTestUtils {
 	private record StartEnd(int start, int end) {
@@ -53,6 +55,17 @@ public final class FoldingTestUtils {
 			ProjectionAnnotationModel model= editor.getAdapter(ProjectionAnnotationModel.class);
 
 			return extractRegions(model);
+		} finally {
+			editor.close(false);
+		}
+	}
+
+	public static void collapseAll(IPackageFragment packageFragment, String code) throws Exception {
+		ICompilationUnit cu= packageFragment.createCompilationUnit("A.java", code, true, null);
+		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
+		try {
+			JavaSourceViewer viewer= (JavaSourceViewer) editor.getViewer();
+			viewer.doOperation(ProjectionViewer.COLLAPSE_ALL);
 		} finally {
 			editor.close(false);
 		}

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaSourceViewer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaSourceViewer.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.ui.javaeditor;
 import java.text.Bidi;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.swt.SWT;
@@ -45,9 +46,12 @@ import org.eclipse.jface.text.formatter.FormattingContextProperties;
 import org.eclipse.jface.text.formatter.IFormattingContext;
 import org.eclipse.jface.text.information.IInformationPresenter;
 import org.eclipse.jface.text.reconciler.IReconciler;
+import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IOverviewRuler;
 import org.eclipse.jface.text.source.IVerticalRuler;
 import org.eclipse.jface.text.source.SourceViewerConfiguration;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 
 import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
@@ -60,6 +64,7 @@ import org.eclipse.jdt.ui.PreferenceConstants;
 import org.eclipse.jdt.ui.text.IJavaColorConstants;
 import org.eclipse.jdt.ui.text.IJavaPartitions;
 import org.eclipse.jdt.ui.text.JavaSourceViewerConfiguration;
+import org.eclipse.jdt.ui.text.folding.DefaultJavaFoldingStructureProvider.JavaProjectionAnnotation;
 
 import org.eclipse.jdt.internal.ui.text.SmartBackspaceManager;
 import org.eclipse.jdt.internal.ui.text.java.CompletionProposalComputerRegistry;
@@ -178,8 +183,37 @@ public class JavaSourceViewer extends ProjectionViewer implements IPropertyChang
 				if (fHierarchyPresenter != null)
 					fHierarchyPresenter.showInformation();
 				return true;
+			case COLLAPSE_ALL:
+				if (!canDoOperation(operation))
+					return false;
+				collapseAllExceptTopLevelTypes();
+				return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Collapses all foldable regions except for top-level types, so that classes are not left
+	 * completely empty after a "Collapse All" operation.
+	 *
+	 * @see ProjectionViewer#COLLAPSE_ALL
+	 */
+	private void collapseAllExceptTopLevelTypes() {
+		ProjectionAnnotationModel model= getProjectionAnnotationModel();
+		if (model == null) {
+			return;
+		}
+
+		for (Iterator<Annotation> it= model.getAnnotationIterator(); it.hasNext();) {
+			Annotation annotation= it.next();
+			if (!(annotation instanceof ProjectionAnnotation projectionAnnotation) || projectionAnnotation.isCollapsed())
+				continue;
+
+			if (annotation instanceof JavaProjectionAnnotation javaAnnotation && javaAnnotation.isTopLevelType())
+				continue;
+
+			model.collapse(projectionAnnotation);
+		}
 	}
 
 	/*

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/ui/text/folding/DefaultJavaFoldingStructureProvider.java
@@ -326,8 +326,10 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 	/**
 	 * A {@link ProjectionAnnotation} for java code.
+	 *
+	 * @noextend This class is not intended to be subclassed by clients.
 	 */
-	protected static final class JavaProjectionAnnotation extends ProjectionAnnotation {
+	public static final class JavaProjectionAnnotation extends ProjectionAnnotation {
 
 		private IJavaElement fJavaElement;
 		private boolean fIsComment;
@@ -361,6 +363,18 @@ public class DefaultJavaFoldingStructureProvider implements IJavaFoldingStructur
 
 		void setIsComment(boolean isComment) {
 			fIsComment= isComment;
+		}
+
+		/**
+		 * Returns whether this annotation's java element is a top-level type, i.e. a type that
+		 * has no declaring type.
+		 *
+		 * @return <code>true</code> if this annotation refers to a top-level type,
+		 *         <code>false</code> otherwise
+		 * @since 3.39
+		 */
+		public boolean isTopLevelType() {
+			return fJavaElement instanceof IType type && type.getDeclaringType() == null;
 		}
 
 		/*


### PR DESCRIPTION
## What it does
This is a JDT-only alternative to eclipse-jdt/eclipse.jdt.ui#3126 (which requires a new API in platform).

## How to test
Same as with #3126 , use this class and `Ctrl + 3 > Collapse All`

```java
class MyClass {
    void someMethod() {
        // does some work
    }
}
// notice the extra line here. This is necessary, otherwise MyClass will never have a region in the first place. See https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/3117
```

`someMethod()` should be folded but `MyClass` shouldn't

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
