### PR TITLE
Wait for LastSaveReferenceProvider job before making test changes in SaveParticipantTest

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/SaveParticipantTest.java
@@ -35,6 +35,7 @@ import org.eclipse.jface.internal.text.reconciler.ReconcilerJobFamilies;
 
 import org.eclipse.jface.text.CopyOnWriteTextStore;
 
+import org.eclipse.ui.internal.editors.quickdiff.LastSaveReferenceProvider;
 import org.eclipse.ui.internal.texteditor.quickdiff.DocumentLineDiffer;
 
 import org.eclipse.jdt.core.IClasspathEntry;
@@ -108,6 +109,7 @@ public class SaveParticipantTest extends CleanUpTestCase {
 		JavaEditor editor= (JavaEditor) EditorUtility.openInEditor(cu);
 		Job.getJobManager().join(ReconcilerJobFamilies.FAMILY_RECONCILER, null);
 		Job.getJobManager().join(DocumentLineDiffer.QUICKDIFF_INITIALIZE_FAMILY, null);
+		Job.getJobManager().join(LastSaveReferenceProvider.JOB_FAMILY, null);
 		TestUtils.cancelDecorationJob();
 
 		cu.getBuffer().setContents(newContent);


### PR DESCRIPTION
Tracings during `SaveParticipantTest` indicate that `LastSaveReferenceProvider` jobs can change text buffer contents in parallel to the test case. So we wait on these jobs, to avoid jobs setting unexpected contents in the text buffer.

See: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1445

