### PR TITLE
Fix Javadoc hover when there are @index tags before html text

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
@@ -989,7 +989,7 @@ public class CoreJavadocAccessImpl implements IJavadocAccess {
 		} else
 		if (isSnippet)
 			fBuf.append("</code></pre>"); //$NON-NLS-1$
-		if (isLiteral || isCode)
+		if (isLiteral || isCode || isIndex)
 			fLiteralContent--;
 
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/JavadocHoverTests.java
@@ -699,5 +699,37 @@ public class JavadocHoverTests extends CoreTests {
 		}
 	}
 
+	@Test
+	public void testIndexInDescription() throws Exception {
+		String source=
+				"""
+				package p;
+				public class Javadoc {
+					/**
+					 * This is {@index foo}
+					 * <p>It is a simple function</p>
+					 */
+					String foo(){ return "abc";}
+				}
+			""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Javadoc.java", source, null);
+		assertNotNull("Javadoc.java", cu);
+
+		IType type= cu.getType("Javadoc");
+		// check javadoc on each member:
+		for (IJavaElement member : type.getChildren()) {
+			IJavaElement[] elements= { member };
+			ISourceRange range= ((ISourceReference) member).getNameRange();
+			JavadocBrowserInformationControlInput hoverInfo= JavadocHover.getHoverInfo(elements, cu, new Region(range.getOffset(), range.getLength()), null);
+			String actualHtmlContent= hoverInfo.getHtml();
+
+			int snippetStartIndex = actualHtmlContent.indexOf("This");
+			assertNotEquals(-1, snippetStartIndex);
+		    String expectedContent = "This is  foo\n <p>It is a simple function</p>";
+		    String actualSnippetContent = actualHtmlContent.substring(snippetStartIndex, snippetStartIndex + expectedContent.length());
+		    assertEquals(expectedContent, actualSnippetContent);
+		}
+	}
+
 }
 


### PR DESCRIPTION
- modify CoreJavadocAccessImpl.handleInlineTagElement() to reset fLiteralContent at end when we have an index tag
- add new test to JavadocHoverTests
- fixes #3078

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
