### PR TITLE
Issue 3128 reload imported test results

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Achim Demelt <a.demelt@exxcellent.de> - [junit] Separate UI from non-UI code - https://bugs.eclipse.org/bugs/show_bug.cgi?id=278844
+ *     Carsten Hammer - reload imported test runs
  *******************************************************************************/
 
 package org.eclipse.jdt.internal.junit.model;
@@ -22,9 +23,11 @@ import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -252,6 +255,7 @@ public final class JUnitModel {
 	 * Active test run sessions, youngest first.
 	 */
 	private final LinkedList<TestRunSession> fTestRunSessions= new LinkedList<>();
+	private final Map<TestRunSession, File> fImportedTestRunSources= new IdentityHashMap<>();
 	private final ILaunchListener fLaunchListener= new JUnitLaunchListener();
 
 	/**
@@ -298,6 +302,16 @@ public final class JUnitModel {
 		return new ArrayList<>(fTestRunSessions);
 	}
 
+	/**
+	 * Returns the file from which the given session was imported.
+	 *
+	 * @param testRunSession the session
+	 * @return the normalized absolute source file, or <code>null</code>
+	 */
+	public synchronized File getImportedTestRunSource(TestRunSession testRunSession) {
+		return fImportedTestRunSources.get(testRunSession);
+	}
+
 	private static int getMaxTestRunCount() {
 		return Math.max(0, Platform.getPreferencesService().getInt(JUnitCorePlugin.CORE_PLUGIN_ID, JUnitPreferencesConstants.MAX_TEST_RUNS, 10, null));
 	}
@@ -309,12 +323,19 @@ public final class JUnitModel {
 	 * @param testRunSession the session to add
 	 */
 	public void addTestRunSession(TestRunSession testRunSession) {
+		addTestRunSession(testRunSession, null);
+	}
+
+	private void addTestRunSession(TestRunSession testRunSession, File importedTestRunSource) {
 		Assert.isNotNull(testRunSession);
 		ArrayList<TestRunSession> toRemove= new ArrayList<>();
 
 		synchronized (this) {
 			Assert.isLegal(! fTestRunSessions.contains(testRunSession));
 			fTestRunSessions.addFirst(testRunSession);
+			if (importedTestRunSource != null) {
+				fImportedTestRunSources.put(testRunSession, importedTestRunSource);
+			}
 
 			int maxCount= getMaxTestRunCount();
 			int size= fTestRunSessions.size();
@@ -325,6 +346,7 @@ public final class JUnitModel {
 					if (!oldSession.isStarting() && !oldSession.isRunning() && !oldSession.isKeptAlive()) {
 						toRemove.add(oldSession);
 						iter.remove();
+						fImportedTestRunSources.remove(oldSession);
 					}
 				}
 			}
@@ -345,15 +367,44 @@ public final class JUnitModel {
 	 * @throws CoreException if the import failed
 	 */
 	public static TestRunSession importTestRunSession(File file) throws CoreException {
+		File sourceFile= file.toPath().toAbsolutePath().normalize().toFile();
+		TestRunSession session= readTestRunSession(sourceFile);
+		JUnitCorePlugin.getModel().addTestRunSession(session, sourceFile);
+		return session;
+	}
+
+	/**
+	 * Reloads a file-imported test run. The existing session is replaced only after
+	 * the source file has been parsed successfully.
+	 *
+	 * @param testRunSession the imported session to replace
+	 * @return the replacement session, or <code>null</code> if the original session is no longer
+	 *         registered or was not imported from a file
+	 * @throws CoreException if the source file cannot be read or parsed
+	 */
+	public static TestRunSession reloadTestRunSession(TestRunSession testRunSession) throws CoreException {
+		Assert.isNotNull(testRunSession);
+		JUnitModel model= JUnitCorePlugin.getModel();
+		File sourceFile= model.getImportedTestRunSource(testRunSession);
+		if (sourceFile == null) {
+			return null;
+		}
+
+		TestRunSession replacementSession= readTestRunSession(sourceFile);
+		if (!model.replaceTestRunSession(testRunSession, replacementSession, sourceFile)) {
+			return null;
+		}
+		return replacementSession;
+	}
+
+	private static TestRunSession readTestRunSession(File file) throws CoreException {
 		try {
 			SAXParserFactory parserFactory= XmlProcessorFactoryJdtJunit.createSAXFactoryWithErrorOnDOCTYPE();
 //			parserFactory.setValidating(true); // TODO: add DTD and debug flag
 			SAXParser parser= parserFactory.newSAXParser();
 			TestRunHandler handler= new TestRunHandler();
 			parser.parse(file, handler);
-			TestRunSession session= handler.getTestRunSession();
-			JUnitCorePlugin.getModel().addTestRunSession(session);
-			return session;
+			return handler.getTestRunSession();
 		} catch (ParserConfigurationException | SAXException e) {
 			throwImportError(file, e);
 		} catch (IOException e) {
@@ -503,6 +554,27 @@ public final class JUnitModel {
 				e));
 	}
 
+	private boolean replaceTestRunSession(TestRunSession oldSession, TestRunSession newSession, File sourceFile) {
+		Assert.isNotNull(oldSession);
+		Assert.isNotNull(newSession);
+		boolean replaced;
+		synchronized (this) {
+			int index= fTestRunSessions.indexOf(oldSession);
+			replaced= index >= 0;
+			if (replaced) {
+				fTestRunSessions.set(index, newSession);
+				fImportedTestRunSources.remove(oldSession);
+				fImportedTestRunSources.put(newSession, sourceFile);
+			}
+		}
+		if (replaced) {
+			notifyTestRunSessionRemoved(oldSession);
+			oldSession.removeSwapFile();
+			notifyTestRunSessionAdded(newSession);
+		}
+		return replaced;
+	}
+
 	/**
 	 * Removes the given {@link TestRunSession} and notifies all registered
 	 * {@link ITestRunSessionListener}s.
@@ -513,6 +585,7 @@ public final class JUnitModel {
 		boolean existed;
 		synchronized (this) {
 			existed= fTestRunSessions.remove(testRunSession);
+			fImportedTestRunSources.remove(testRunSession);
 		}
 		if (existed) {
 			notifyTestRunSessionRemoved(testRunSession);

--- a/org.eclipse.jdt.junit/icons/full/elcl16/refresh.svg
+++ b/org.eclipse.jdt.junit/icons/full/elcl16/refresh.svg
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="16"
+   height="16"
+   id="svg2"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4">
+    <linearGradient
+       xlink:href="#linearGradient7584-5-1"
+       id="linearGradient7608-3-3"
+       gradientUnits="userSpaceOnUse"
+       x1="22.519354"
+       y1="1042.0283"
+       x2="22.519354"
+       y2="1040.7345" />
+    <linearGradient
+       id="linearGradient7584-5-1">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-4-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-5-8" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient7592-1-2"
+       id="linearGradient7610-5-8"
+       gradientUnits="userSpaceOnUse"
+       x1="23.551146"
+       y1="1037.3622"
+       x2="23.551146"
+       y2="1045.3622" />
+    <linearGradient
+       id="linearGradient7592-1-2">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7594-6-7" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7596-9-7" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient7584-9-3-2"
+       id="linearGradient7608-9-7-1"
+       gradientUnits="userSpaceOnUse"
+       x1="22.930616"
+       y1="1039.6982"
+       x2="22.930616"
+       y2="1041.7356" />
+    <linearGradient
+       id="linearGradient7584-9-3-2">
+      <stop
+         style="stop-color:#f9cd5f;stop-opacity:1;"
+         offset="0"
+         id="stop7586-6-3-6" />
+      <stop
+         style="stop-color:#ffebb7;stop-opacity:1;"
+         offset="1"
+         id="stop7588-9-9-0" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient7134"
+       id="linearGradient7140"
+       x1="25.363291"
+       y1="1044.7311"
+       x2="25.363291"
+       y2="1037.7311"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7134">
+      <stop
+         style="stop-color:#bd8416;stop-opacity:1"
+         offset="0"
+         id="stop7136" />
+      <stop
+         style="stop-color:#a66b10;stop-opacity:1"
+         offset="1"
+         id="stop7138" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1036.3622)">
+    <g
+       style="display:inline"
+       id="g7604"
+       transform="translate(-13.086169,0.51822429)">
+      <path
+         id="path7582"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 1.546796,1.4584 1.546796,0.088 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.694788,0.3552 2.039845,0.6884 0.345482,0.3336 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.174793,-1.2439 -0.71875,-1.9687 -0.293544,-0.3911 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-3-3);fill-opacity:1;stroke:url(#linearGradient7610-5-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         transform="translate(0,1036.3622)"
+         id="path7602"
+         d="m 23.069359,2.3660973 0,-0.5966213 c 0,0 0.110485,-0.3756505 -0.220971,-0.243068 -0.331456,0.1325826 -0.972272,0.6629126 -1.038563,0.773398 -0.06629,0.1104855 -0.751301,0.5966214 -0.596622,0.8175923 0.15468,0.2209709 1.458408,0.066291 1.458408,0.066291 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       style="display:inline"
+       id="g7604-6"
+       transform="matrix(-1,0,0,-1,29.049623,2089.2948)">
+      <path
+         id="path7582-7"
+         d="m 23.585155,1039.3249 0,-1.591 c 0,0 -0.353553,-0.8397 -1.370019,-0.044 -1.016466,0.7955 -2.209709,2.0772 -2.386486,2.4307 -0.176776,0.3536 -0.928077,0.9723 0.08839,1.9446 1.016466,0.9722 2.121321,1.9887 2.121321,1.9887 0,0 0.404271,0.3812 0.799458,0.5707 0.37782,0.1811 0.747338,0.1871 0.747338,-0.4827 0,-1.37 0,-1.812 0,-1.812 1.366404,-0.063 1.727345,0.3446 2.039845,0.6884 0.3125,0.3437 0.8125,1.9687 1.21875,2.0937 0.40625,0.125 0.625,-2.1875 0.625,-2.625 0,-0.4375 -0.09375,-1.3125 -0.71875,-1.9687 -0.625,-0.6563 -1.006571,-0.9555 -1.53125,-1.0998 -0.524679,-0.1444 -1.633595,-0.094 -1.633595,-0.094 z"
+         style="fill:url(#linearGradient7608-9-7-1);fill-opacity:1;stroke:url(#linearGradient7140);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+      <path
+         id="path7602-2"
+         d="m 23.069359,1042.9731 0,0.5966 c 0,0 0.110485,0.3757 -0.220971,0.2431 -0.331456,-0.1326 -0.972272,-0.6629 -1.038563,-0.7734 -0.06629,-0.1105 -0.751301,-0.5966 -0.596622,-0.8176 0.15468,-0.221 1.458408,-0.066 1.458408,-0.066 z"
+         style="opacity:0.85714285;fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <image
+       y="1052.3622"
+       x="0"
+       id="image3013"
+       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAXZJREFU OI2lUj1Iw1AQ/l5wKF1MKTaDiy7F3bEu6iS0Dh0EaREnQVoc1EVEkNDgYpbSqdBBhbpVLYhDbRYR 3Cw42UkcSgzWgqKm9uccNCHBpBX94IN3j7vvvnfvGBHhP+B+k6RIAimS4Nipr4AiCTS5cfs3B+di wCzudAglUaCSaHfC3GZwtjVE08ltcJ4R2/2bdo3LgzRmRI31dNBqE/BaA5qajd7BYYTmFnCRHSUA GHATmN15ZIU1P4VjEXC+IIoZGQAQjkXg9QWhVZ/7zyAq19nxXhHdRhXtNiEq19mREbe6X0lEBCJC ORUg69ka5xM85RO8LTbOZkG30zCLyqkA6bpqE3Gj+YSPVhOhZBbWhRmPp+G2QAYYEUGRBArFVwF+ 7EeCrlZwo+QwsXzPnAQ4AJjafGBKbhdQrwBdtdEDHS+1994ODBTW/QQCCEB4aQXQ73C6f4Ko/OTY 3fYLVuYTPOmVRdvk3ei4yodJHwHAfKbh3vkbn+0qFz9A+1qMAAAAAElFTkSuQmCC "
+       height="16"
+       width="16" />
+  </g>
+</svg>

--- a/org.eclipse.jdt.junit/plugin.properties
+++ b/org.eclipse.jdt.junit/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2019 IBM Corporation and others.
+# Copyright (c) 2000, 2026 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
 # Contributors:
 #     IBM Corporation - initial API and implementation
 #	  Andrew Eisenberg <andrew@eisenberg.as> - [JUnit] Add a monospace font option for the junit results view - https://bugs.eclipse.org/bugs/show_bug.cgi?id=411794
+#     Carsten Hammer - reload imported test runs
 ###############################################################################
 pluginName=Java Development Tools JUnit support
 providerName=Eclipse.org
@@ -52,6 +53,8 @@ JUnitShortcut.description.run= Run JUnit Test
 JUnitShortcut.description.debug= Debug JUnit Test
 JUnitShortcut.description.rerunLast= Rerun JUnit Test
 JUnitShortcut.description.rerunFailedFirst= Rerun JUnit Test - Failures First
+ReloadTestRunAction.label= Reload Test Run
+ReloadTestRunAction.tooltip= Reload the imported test results from their source file
 
 
 searchMenu.label= Se&arch

--- a/org.eclipse.jdt.junit/plugin.xml
+++ b/org.eclipse.jdt.junit/plugin.xml
@@ -413,7 +413,7 @@
             locationURI="toolbar:org.eclipse.jdt.junit.ResultView">
          <command
                commandId="org.eclipse.jdt.junit.reloadImportedTestRun"
-               icon="$nl$/icons/full/elcl16/relaunch.svg"
+               icon="$nl$/icons/full/elcl16/refresh.svg"
                id="org.eclipse.jdt.junit.reloadImportedTestRun.toolbar"
                label="%ReloadTestRunAction.label"
                style="push"

--- a/org.eclipse.jdt.junit/plugin.xml
+++ b/org.eclipse.jdt.junit/plugin.xml
@@ -383,6 +383,43 @@
             categoryId="org.eclipse.debug.ui.category.run"
             id="org.eclipse.jdt.junit.junitShortcut.rerunFailedFirst">
       </command>
+      <command
+            name="%ReloadTestRunAction.label"
+            description="%ReloadTestRunAction.tooltip"
+            categoryId="org.eclipse.debug.ui.category.run"
+            id="org.eclipse.jdt.junit.reloadImportedTestRun">
+      </command>
+   </extension>
+
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="org.eclipse.jdt.internal.junit.ui.ReloadTestRunHandler"
+            commandId="org.eclipse.jdt.junit.reloadImportedTestRun">
+         <activeWhen>
+            <with
+                  variable="activePartId">
+               <equals
+                     value="org.eclipse.jdt.junit.ResultView">
+               </equals>
+            </with>
+         </activeWhen>
+      </handler>
+   </extension>
+
+   <extension
+         point="org.eclipse.ui.menus">
+      <menuContribution
+            locationURI="toolbar:org.eclipse.jdt.junit.ResultView">
+         <command
+               commandId="org.eclipse.jdt.junit.reloadImportedTestRun"
+               icon="$nl$/icons/full/elcl16/relaunch.svg"
+               id="org.eclipse.jdt.junit.reloadImportedTestRun.toolbar"
+               label="%ReloadTestRunAction.label"
+               style="push"
+               tooltip="%ReloadTestRunAction.tooltip">
+         </command>
+      </menuContribution>
    </extension>
 
    <extension

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ReloadTestRunHandler.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/ReloadTestRunHandler.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.junit.ui;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.common.NotDefinedException;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jface.dialogs.ErrorDialog;
+
+import org.eclipse.ui.ISources;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.model.JUnitModel;
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+
+/**
+ * Reloads the active file-imported JUnit test run from its original source.
+ */
+public final class ReloadTestRunHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		IWorkbenchPart activePart= HandlerUtil.getActivePart(event);
+		if (!(activePart instanceof TestRunnerViewPart testRunnerView)) {
+			return null;
+		}
+
+		TestRunSession testRunSession= testRunnerView.getTestRunSession();
+		JUnitModel model= JUnitCorePlugin.getModel();
+		if (testRunSession == null || model.getImportedTestRunSource(testRunSession) == null) {
+			return null;
+		}
+
+		try {
+			JUnitModel.reloadTestRunSession(testRunSession);
+		} catch (CoreException e) {
+			JUnitPlugin.log(e);
+			String title;
+			try {
+				title= event.getCommand().getName();
+			} catch (NotDefinedException exception) {
+				title= JUnitMessages.TestRunnerViewPart_ImportTestRunSessionAction_error_title;
+			}
+			ErrorDialog.openError(testRunnerView.getSite().getShell(), title, e.getStatus().getMessage(), e.getStatus());
+		}
+		return null;
+	}
+
+	@Override
+	public void setEnabled(Object evaluationContext) {
+		Object activePart= HandlerUtil.getVariable(evaluationContext, ISources.ACTIVE_PART_NAME);
+		boolean enabled= false;
+		if (activePart instanceof TestRunnerViewPart testRunnerView) {
+			TestRunSession testRunSession= testRunnerView.getTestRunSession();
+			enabled= testRunSession != null
+					&& JUnitCorePlugin.getModel().getImportedTestRunSource(testRunSession) != null;
+		}
+		setBaseEnabled(enabled);
+	}
+}

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -107,6 +107,7 @@ import org.eclipse.ui.IEditorActionBarContributor;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.ISources;
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.IWorkbenchActionConstants;
@@ -124,6 +125,7 @@ import org.eclipse.ui.part.PageSwitcher;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.progress.IWorkbenchSiteProgressService;
 import org.eclipse.ui.progress.UIJob;
+import org.eclipse.ui.services.IEvaluationService;
 import org.eclipse.ui.statushandlers.StatusManager;
 
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -1674,6 +1676,8 @@ action enablement
 				setSortingCriterion(fSortingCriterion);
 			}
 		}
+		// A history switch changes the view input without changing the active part.
+		getSite().getService(IEvaluationService.class).requestEvaluation(ISources.ACTIVE_PART_NAME);
 		return deactivatedSession;
 	}
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/ImportedTestRunReloadTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/ImportedTestRunReloadTest.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial tests
+ *******************************************************************************/
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.model.JUnitModel;
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+
+public class ImportedTestRunReloadTest {
+
+	private Path fTemporaryDirectory;
+	private final List<TestRunSession> fSessionsToRemove= new ArrayList<>();
+
+	@Before
+	public void setUp() throws Exception {
+		fTemporaryDirectory= Files.createTempDirectory("junit-reload-test"); //$NON-NLS-1$
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		JUnitModel model= JUnitCorePlugin.getModel();
+		for (TestRunSession session : fSessionsToRemove) {
+			if (session != null && model.getTestRunSessions().contains(session)) {
+				model.removeTestRunSession(session);
+			}
+		}
+		if (fTemporaryDirectory != null) {
+			try (Stream<Path> paths= Files.walk(fTemporaryDirectory)) {
+				paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+					try {
+						Files.deleteIfExists(path);
+					} catch (Exception e) {
+						// Best-effort cleanup.
+					}
+				});
+			}
+		}
+	}
+
+	@Test
+	public void testReloadReplacesSessionAtSameHistoryPosition() throws Exception {
+		Path firstFile= fTemporaryDirectory.resolve("first.xml"); //$NON-NLS-1$
+		Path secondFile= fTemporaryDirectory.resolve("second.xml"); //$NON-NLS-1$
+		writeTestRun(firstFile, "first run", "firstTest"); //$NON-NLS-1$ //$NON-NLS-2$
+		writeTestRun(secondFile, "second run", "secondTest"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		JUnitModel model= JUnitCorePlugin.getModel();
+		TestRunSession first= JUnitModel.importTestRunSession(firstFile.toFile());
+		TestRunSession second= JUnitModel.importTestRunSession(secondFile.toFile());
+		fSessionsToRemove.add(first);
+		fSessionsToRemove.add(second);
+
+		List<TestRunSession> beforeReload= model.getTestRunSessions();
+		int firstIndex= beforeReload.indexOf(first);
+		int secondIndex= beforeReload.indexOf(second);
+		assertTrue(firstIndex >= 0);
+		assertTrue(secondIndex >= 0);
+		assertEquals(firstFile.toAbsolutePath().normalize().toFile(), model.getImportedTestRunSource(first));
+
+		writeTestRun(firstFile, "reloaded run", "reloadedTest"); //$NON-NLS-1$ //$NON-NLS-2$
+		TestRunSession reloaded= JUnitModel.reloadTestRunSession(first);
+		fSessionsToRemove.add(reloaded);
+
+		List<TestRunSession> afterReload= model.getTestRunSessions();
+		assertEquals(beforeReload.size(), afterReload.size());
+		assertSame(second, afterReload.get(secondIndex));
+		assertSame(reloaded, afterReload.get(firstIndex));
+		assertFalse(afterReload.contains(first));
+		assertEquals(firstFile.toAbsolutePath().normalize().toFile(), model.getImportedTestRunSource(reloaded));
+		assertEquals("reloaded run", reloaded.getTestRunName()); //$NON-NLS-1$
+	}
+
+	@Test
+	public void testReloadRemovedSessionReturnsNull() throws Exception {
+		Path resultFile= fTemporaryDirectory.resolve("removed.xml"); //$NON-NLS-1$
+		writeTestRun(resultFile, "removed run", "test"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		JUnitModel model= JUnitCorePlugin.getModel();
+		TestRunSession imported= JUnitModel.importTestRunSession(resultFile.toFile());
+		fSessionsToRemove.add(imported);
+		model.removeTestRunSession(imported);
+
+		assertNull(JUnitModel.reloadTestRunSession(imported));
+		assertFalse(model.getTestRunSessions().contains(imported));
+	}
+
+	@Test
+	public void testFailedReloadKeepsPreviousSession() throws Exception {
+		Path resultFile= fTemporaryDirectory.resolve("results.xml"); //$NON-NLS-1$
+		writeTestRun(resultFile, "valid run", "test"); //$NON-NLS-1$ //$NON-NLS-2$
+
+		JUnitModel model= JUnitCorePlugin.getModel();
+		TestRunSession imported= JUnitModel.importTestRunSession(resultFile.toFile());
+		fSessionsToRemove.add(imported);
+		List<TestRunSession> beforeReload= model.getTestRunSessions();
+		int importedIndex= beforeReload.indexOf(imported);
+
+		Files.writeString(resultFile, "<testrun", StandardCharsets.UTF_8); //$NON-NLS-1$
+		try {
+			JUnitModel.reloadTestRunSession(imported);
+			fail("Expected invalid XML to fail"); //$NON-NLS-1$
+		} catch (CoreException expected) {
+			// Expected.
+		}
+
+		List<TestRunSession> afterReload= model.getTestRunSessions();
+		assertEquals(beforeReload.size(), afterReload.size());
+		assertSame(imported, afterReload.get(importedIndex));
+		assertEquals(resultFile.toAbsolutePath().normalize().toFile(), model.getImportedTestRunSource(imported));
+		assertEquals("valid run", imported.getTestRunName()); //$NON-NLS-1$
+	}
+
+	private static void writeTestRun(Path file, String runName, String testName) throws Exception {
+		String xml= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" //$NON-NLS-1$
+				+ "<testrun name=\"" + runName //$NON-NLS-1$
+				+ "\" tests=\"1\" started=\"1\" failures=\"0\" errors=\"0\" ignored=\"0\">\n" //$NON-NLS-1$
+				+ "  <testsuite name=\"example.Tests\" time=\"0.0\">\n" //$NON-NLS-1$
+				+ "    <testcase name=\"" + testName //$NON-NLS-1$
+				+ "\" classname=\"example.Tests\" time=\"0.0\"/>\n" //$NON-NLS-1$
+				+ "  </testsuite>\n" //$NON-NLS-1$
+				+ "</testrun>\n"; //$NON-NLS-1$
+		Files.writeString(file, xml, StandardCharsets.UTF_8);
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/ImportedTestRunReloadUITest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/ImportedTestRunReloadUITest.java
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial tests
+ *******************************************************************************/
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.eclipse.jdt.testplugin.util.DisplayHelper;
+
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.ToolBar;
+import org.eclipse.swt.widgets.ToolItem;
+
+import org.eclipse.core.commands.Command;
+
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.commands.ICommandService;
+import org.eclipse.ui.handlers.IHandlerService;
+
+import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.model.JUnitModel;
+import org.eclipse.jdt.internal.junit.model.TestRunSession;
+import org.eclipse.jdt.internal.junit.ui.JUnitPlugin;
+import org.eclipse.jdt.internal.junit.ui.TestRunnerViewPart;
+
+import org.eclipse.jdt.internal.ui.viewsupport.ViewHistory;
+
+public class ImportedTestRunReloadUITest {
+
+	private static final String RELOAD_COMMAND= "org.eclipse.jdt.junit.reloadImportedTestRun"; //$NON-NLS-1$
+
+	@Rule
+	public TemporaryFolder fTemporaryFolder= new TemporaryFolder();
+
+	private final List<TestRunSession> fSessionsToRemove= new ArrayList<>();
+	private IWorkbenchPage fPage;
+	private IWorkbenchPart fPreviousPart;
+	private TestRunnerViewPart fView;
+	private ViewHistory<TestRunSession> fHistory;
+	private TestRunSession fPreviousSession;
+	private boolean fViewWasOpen;
+	private Command fReloadCommand;
+
+	@Before
+	public void setUp() throws Exception {
+		fPage= JUnitPlugin.getActivePage();
+		assertNotNull(fPage);
+		fPreviousPart= fPage.getActivePart();
+		fViewWasOpen= fPage.findView(TestRunnerViewPart.NAME) != null;
+		fView= (TestRunnerViewPart) fPage.showView(TestRunnerViewPart.NAME);
+		fPreviousSession= fView.getTestRunSession();
+		Field historyField= TestRunnerViewPart.class.getDeclaredField("fViewHistory"); //$NON-NLS-1$
+		historyField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		ViewHistory<TestRunSession> history= (ViewHistory<TestRunSession>) historyField.get(fView);
+		fHistory= history;
+		fPage.activate(fView);
+		DisplayHelper.driveEventQueue(Display.getCurrent());
+		ICommandService commandService= fView.getSite().getService(ICommandService.class);
+		fReloadCommand= commandService.getCommand(RELOAD_COMMAND);
+		assertTrue(fReloadCommand.isDefined());
+		assertTrue(fReloadCommand.isHandled());
+	}
+
+	@After
+	public void tearDown() {
+		JUnitModel model= JUnitCorePlugin.getModel();
+		try {
+			if (fHistory != null) {
+				fHistory.setActiveEntry(model.getTestRunSessions().contains(fPreviousSession) ? fPreviousSession : null);
+			}
+		} finally {
+			for (TestRunSession session : fSessionsToRemove) {
+				if (session != null && model.getTestRunSessions().contains(session)) {
+					model.removeTestRunSession(session);
+				}
+			}
+			if (fView != null && !fViewWasOpen) {
+				fPage.hideView(fView);
+			}
+			if (fPreviousPart != null) {
+				fPage.activate(fPreviousPart);
+			}
+			DisplayHelper.driveEventQueue(Display.getCurrent());
+		}
+	}
+
+	@Test
+	public void testReloadEnablementFollowsHistorySelection() throws Exception {
+		JUnitModel model= JUnitCorePlugin.getModel();
+		Path resultFile= fTemporaryFolder.newFile("results.xml").toPath(); //$NON-NLS-1$
+		writeTestRun(resultFile, "original run"); //$NON-NLS-1$
+		TestRunSession imported= JUnitModel.importTestRunSession(resultFile.toFile());
+		fSessionsToRemove.add(imported);
+		DisplayHelper.driveEventQueue(Display.getCurrent());
+
+		TestRunSession other= new TestRunSession("non-file session", null); //$NON-NLS-1$
+		fSessionsToRemove.add(other);
+		model.addTestRunSession(other);
+		DisplayHelper.driveEventQueue(Display.getCurrent());
+
+		// Use the same history entry point as the drop-down without refreshing the handler in the test.
+		fHistory.setActiveEntry(imported);
+		assertReloadState(imported, true);
+		fHistory.setActiveEntry(other);
+		assertReloadState(other, false);
+		fHistory.setActiveEntry(imported);
+		assertReloadState(imported, true);
+
+		int historySize= model.getTestRunSessions().size();
+		writeTestRun(resultFile, "reloaded run"); //$NON-NLS-1$
+		IHandlerService handlerService= fView.getSite().getService(IHandlerService.class);
+		handlerService.executeCommand(RELOAD_COMMAND, null);
+		DisplayHelper.driveEventQueue(Display.getCurrent());
+		TestRunSession reloaded= fView.getTestRunSession();
+		fSessionsToRemove.add(reloaded);
+		assertNotNull(reloaded);
+		assertNotSame(imported, reloaded);
+		assertEquals("reloaded run", reloaded.getTestRunName()); //$NON-NLS-1$
+		assertEquals(historySize, model.getTestRunSessions().size());
+		assertReloadState(reloaded, true);
+
+		fHistory.setActiveEntry(null);
+		assertReloadState(null, false);
+		fHistory.setActiveEntry(reloaded);
+		assertReloadState(reloaded, true);
+		model.removeTestRunSession(reloaded);
+		DisplayHelper.driveEventQueue(Display.getCurrent());
+		assertFalse(model.getTestRunSessions().contains(reloaded));
+		assertReloadState(other, false);
+	}
+
+	private void assertReloadState(TestRunSession session, boolean enabled) throws Exception {
+		DisplayHelper.driveEventQueue(Display.getCurrent());
+		assertSame(session, fView.getTestRunSession());
+		assertSame(fView, fPage.getActivePart());
+		ToolItem item= findToolItem(fView.getSite().getShell(), fReloadCommand.getDescription());
+		assertNotNull("Reload toolbar item must be present", item); //$NON-NLS-1$
+		// Toolbar enablement is updated asynchronously. Observe the widget before
+		// querying the command, since isEnabled() can itself re-evaluate the handler.
+		assertTrue("Reload toolbar must follow the selected history entry (enabled=" + enabled + ")", new DisplayHelper() { //$NON-NLS-1$ //$NON-NLS-2$
+			@Override
+			protected boolean condition() {
+				return !item.isDisposed() && item.getEnabled() == enabled;
+			}
+		}.waitForCondition(Display.getCurrent(), 5000));
+		assertEquals("Reload command must follow the selected history entry", enabled, fReloadCommand.isEnabled()); //$NON-NLS-1$
+		assertNotNull("Reload toolbar item must have an image", item.getImage()); //$NON-NLS-1$
+	}
+
+	private static ToolItem findToolItem(Composite parent, String tooltip) {
+		for (Control child : parent.getChildren()) {
+			if (child instanceof ToolBar toolbar) {
+				for (ToolItem item : toolbar.getItems()) {
+					if (tooltip.equals(item.getToolTipText())) {
+						return item;
+					}
+				}
+			}
+			if (child instanceof Composite composite) {
+				ToolItem item= findToolItem(composite, tooltip);
+				if (item != null) {
+					return item;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static void writeTestRun(Path file, String name) throws Exception {
+		String xml= """
+				<?xml version="1.0" encoding="UTF-8"?>
+				<testrun name="%s" tests="1" started="1" failures="0" errors="0" ignored="0">
+				  <testsuite name="example.Tests" time="0.0">
+				    <testcase name="test" classname="example.Tests" time="0.0"/>
+				  </testsuite>
+				</testrun>
+				""".formatted(name); //$NON-NLS-1$
+		Files.writeString(file, xml, StandardCharsets.UTF_8);
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/ImportedTestRunReloadUITest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/ImportedTestRunReloadUITest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -26,6 +27,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.After;
 import org.junit.Before;
@@ -33,6 +37,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.junit.TestRunListener;
+import org.eclipse.jdt.junit.model.ITestCaseElement;
+import org.eclipse.jdt.junit.model.ITestElement.ProgressState;
+import org.eclipse.jdt.junit.model.ITestElement.Result;
+import org.eclipse.jdt.junit.model.ITestRunSession;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
 import org.eclipse.jdt.testplugin.util.DisplayHelper;
 
 import org.eclipse.swt.widgets.Composite;
@@ -48,7 +59,13 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.handlers.IHandlerService;
 
+import org.eclipse.debug.core.ILaunch;
+
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+
 import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 import org.eclipse.jdt.internal.junit.model.JUnitModel;
 import org.eclipse.jdt.internal.junit.model.TestRunSession;
 import org.eclipse.jdt.internal.junit.ui.JUnitPlugin;
@@ -56,7 +73,7 @@ import org.eclipse.jdt.internal.junit.ui.TestRunnerViewPart;
 
 import org.eclipse.jdt.internal.ui.viewsupport.ViewHistory;
 
-public class ImportedTestRunReloadUITest {
+public class ImportedTestRunReloadUITest extends AbstractTestRunListenerTest {
 
 	private static final String RELOAD_COMMAND= "org.eclipse.jdt.junit.reloadImportedTestRun"; //$NON-NLS-1$
 
@@ -72,8 +89,12 @@ public class ImportedTestRunReloadUITest {
 	private boolean fViewWasOpen;
 	private Command fReloadCommand;
 
+	@Override
 	@Before
 	public void setUp() throws Exception {
+		fProject= JavaProjectHelper.createJavaProject("ImportedTestRunReloadUITest", "bin"); //$NON-NLS-1$ //$NON-NLS-2$
+		JavaProjectHelper.addToClasspath(fProject, JavaCore.newContainerEntry(JUnitCore.JUNIT4_CONTAINER_PATH));
+		JavaProjectHelper.addRTJar15(fProject);
 		fPage= JUnitPlugin.getActivePage();
 		assertNotNull(fPage);
 		fPreviousPart= fPage.getActivePart();
@@ -94,7 +115,7 @@ public class ImportedTestRunReloadUITest {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDownView() {
 		JUnitModel model= JUnitCorePlugin.getModel();
 		try {
 			if (fHistory != null) {
@@ -159,6 +180,118 @@ public class ImportedTestRunReloadUITest {
 		DisplayHelper.driveEventQueue(Display.getCurrent());
 		assertFalse(model.getTestRunSessions().contains(reloaded));
 		assertReloadState(other, false);
+	}
+
+	@Test
+	public void testReloadEnablementAfterJUnitLaunch() throws Exception {
+		JUnitModel model= JUnitCorePlugin.getModel();
+		Path resultFile= fTemporaryFolder.newFile("launched-results.xml").toPath(); //$NON-NLS-1$
+		writeTestRun(resultFile, "imported before launch"); //$NON-NLS-1$
+		TestRunSession imported= JUnitModel.importTestRunSession(resultFile.toFile());
+		fSessionsToRemove.add(imported);
+		String source= """
+				package reload;
+				import org.junit.Test;
+				public class LaunchedTest {
+				    @Test public void testPass() { }
+				}
+				"""; //$NON-NLS-1$
+		IType testType= createType(source, "reload", "LaunchedTest.java"); //$NON-NLS-1$ //$NON-NLS-2$
+		AtomicReference<ILaunch> launched= new AtomicReference<>();
+		AtomicBoolean finished= new AtomicBoolean();
+		AtomicInteger finishedTests= new AtomicInteger();
+		AtomicReference<String> finishedTest= new AtomicReference<>();
+		AtomicReference<Result> testResult= new AtomicReference<>();
+		AtomicReference<Result> sessionResult= new AtomicReference<>();
+		TestRunListener listener= new TestRunListener() {
+			@Override
+			public void sessionLaunched(ITestRunSession session) {
+				if (fProject.equals(session.getLaunchedProject())) {
+					launched.compareAndSet(null, ((TestRunSession) session).getLaunch());
+				}
+			}
+
+			private boolean isLaunchedSession(ITestRunSession session) {
+				return launched.get() != null && ((TestRunSession) session).getLaunch() == launched.get();
+			}
+
+			@Override
+			public void testCaseFinished(ITestCaseElement testCase) {
+				if (isLaunchedSession(testCase.getTestRunSession())) {
+					finishedTest.set(testCase.getTestClassName() + "#" + testCase.getTestMethodName()); //$NON-NLS-1$
+					testResult.set(testCase.getTestResult(false));
+					finishedTests.incrementAndGet();
+				}
+			}
+
+			@Override
+			public void sessionFinished(ITestRunSession session) {
+				if (isLaunchedSession(session)) {
+					sessionResult.set(session.getTestResult(true));
+					finished.set(true);
+				}
+			}
+		};
+		JUnitCore.addTestRunListener(listener);
+		try {
+			launchJUnit(testType, TestKindRegistry.JUNIT4_TEST_KIND_ID);
+			assertTrue("The launched JUnit session must finish", waitForCondition(finished::get, 15000, 100)); //$NON-NLS-1$
+			assertEquals(1, finishedTests.get());
+			assertEquals("reload.LaunchedTest#testPass", finishedTest.get()); //$NON-NLS-1$
+			assertEquals(Result.OK, testResult.get());
+			assertEquals(Result.OK, sessionResult.get());
+
+			// Identify the session by the actual launch, not by its position in history.
+			List<TestRunSession> sessions= model.getTestRunSessions().stream()
+					.filter(session -> session.getLaunch() == launched.get()).toList();
+			assertEquals(1, sessions.size());
+			TestRunSession executed= sessions.get(0);
+			assertEquals(ProgressState.COMPLETED, executed.getProgressState());
+			assertNull(model.getImportedTestRunSource(executed));
+			// A launch may activate a different part. Set focus once, not between history selections.
+			fPage.activate(fView);
+			for (int i= 0; i < 2; i++) {
+				fHistory.setActiveEntry(imported);
+				assertReloadState(imported, true);
+				fHistory.setActiveEntry(executed);
+				assertReloadState(executed, false);
+			}
+			fHistory.setActiveEntry(imported);
+			assertReloadState(imported, true);
+
+			int historySize= model.getTestRunSessions().size();
+			writeTestRun(resultFile, "reloaded after launch"); //$NON-NLS-1$
+			fView.getSite().getService(IHandlerService.class).executeCommand(RELOAD_COMMAND, null);
+			DisplayHelper.driveEventQueue(Display.getCurrent());
+			TestRunSession reloaded= fView.getTestRunSession();
+			fSessionsToRemove.add(reloaded);
+			assertNotNull(reloaded);
+			assertNotSame(imported, reloaded);
+			assertNotSame(executed, reloaded);
+			assertEquals("reloaded after launch", reloaded.getTestRunName()); //$NON-NLS-1$
+			assertEquals(historySize, model.getTestRunSessions().size());
+			assertTrue(model.getTestRunSessions().contains(executed));
+			assertEquals(Result.OK, executed.getTestResult(true));
+			assertNull(model.getImportedTestRunSource(executed));
+			assertReloadState(reloaded, true);
+			fHistory.setActiveEntry(executed);
+			assertReloadState(executed, false);
+			fHistory.setActiveEntry(reloaded);
+			assertReloadState(reloaded, true);
+		} finally {
+			JUnitCore.removeTestRunListener(listener);
+			ILaunch launch= launched.get();
+			if (launch != null) {
+				try {
+					if (!launch.isTerminated()) {
+						launch.terminate();
+					}
+				} finally {
+					model.getTestRunSessions().stream().filter(session -> session.getLaunch() == launch)
+							.forEach(fSessionsToRemove::add);
+				}
+			}
+		}
 	}
 
 	private void assertReloadState(TestRunSession session, boolean enabled) throws Exception {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -40,6 +40,7 @@ TestRunSessionSerializationTests3.class,
 TestRunSessionSerializationTests4.class,
 TestRunSessionHistoryTests.class,
 ImportedTestRunReloadTest.class,
+ImportedTestRunReloadUITest.class,
 
 JUnit3TestFinderTest.class,
 JUnitTestFinderTest.class,

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -39,6 +39,7 @@ TestRunFilteredParameterizedRunnerTest4.class,
 TestRunSessionSerializationTests3.class,
 TestRunSessionSerializationTests4.class,
 TestRunSessionHistoryTests.class,
+ImportedTestRunReloadTest.class,
 
 JUnit3TestFinderTest.class,
 JUnitTestFinderTest.class,


### PR DESCRIPTION
Fixes #3128.

## What it does

Imported JUnit XML results are currently loaded as one-time snapshots. When the
underlying file is updated by a Maven or Gradle run, reopening it creates another
test-run history entry instead of refreshing the existing one.

This change adds a **Reload Test Run** command to the JUnit view for sessions
imported from a local XML file.

- Retains the normalized source file of an imported test-run session.
- Re-reads and parses the source XML when the reload command is invoked.
- Parses into a new session first and replaces the existing session only after
  the import completed successfully.
- Keeps the replacement at the same position in the test-run history instead of
  adding a duplicate entry.
- Preserves the previously displayed session when the source file cannot be
  read or contains incomplete or invalid XML.
- Enables the reload command only when the active session was imported from a
  local file.
- Adds regression tests for successful replacement and failed reloads.

### Scope

This PR implements the manual reload requested by #3128.

An optional `WatchService`-based automatic reload was also discussed in the
issue. It is intentionally left for a separate follow-up so that this change
remains focused and independently reviewable. Manual reload would remain
necessary as a fallback even with automatic file watching.

## How to test

1. Run tests from Maven or Gradle and import the generated JUnit XML file into
   the JUnit view.
2. Regenerate or modify the XML file without reopening it in Eclipse.
3. Select the imported test-run session.
4. Invoke **Reload Test Run** from the JUnit view toolbar.
5. Verify that the displayed results are updated and that no additional history
   entry is created.
6. Replace the XML contents with incomplete or invalid XML and invoke reload
   again.
7. Verify that an error is reported and that the previously displayed valid
   session remains unchanged.

Automated coverage is provided by `ImportedTestRunReloadTest`, including:

- replacement at the same test-run history position;
- retention of the original source file for the replacement session;
- preservation of the previous session after a failed XML parse.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)