### PR TITLE
Fix JUnit view after external process termination

### DIFF
--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/RemoteTestRunnerClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.ISafeRunnable;
@@ -264,6 +265,7 @@ public class RemoteTestRunnerClient {
 
 	private volatile boolean stopped;
 	private volatile boolean ended;
+	private final AtomicBoolean terminationNotified= new AtomicBoolean();
 	private final ITestKind testRunnerKind;
 
 	public RemoteTestRunnerClient(ITestKind testRunnerKind) {
@@ -294,7 +296,7 @@ public class RemoteTestRunnerClient {
 				while(fPushbackReader != null && (message= readMessage(fPushbackReader)) != null)
 					receiveMessage(message);
 			} catch (SocketException e) {
-				notifyTestRunTerminated();
+				// fall through
 			} catch (IOException e) {
 				LOG.error(e.getMessage(), e);
 				// fall through
@@ -363,13 +365,17 @@ public class RemoteTestRunnerClient {
 			}
 		} catch(IOException e) {
 		}
-		if (stopped || !ended) {
-			// JUnit 3 and 4 RemoteTestRunnerClient properly handle notifying stopped/terminated
-			String testKind= testRunnerKind.getId();
-			if (TestKindRegistry.JUNIT3_TEST_KIND_ID.equals(testKind)
-					|| TestKindRegistry.JUNIT4_TEST_KIND_ID.equals(testKind)) {
-				return;
-			}
+		if (terminationNotified.get() || ended) {
+			return;
+		}
+
+		String testKind= testRunnerKind.getId();
+		boolean isJUnit3Or4= TestKindRegistry.JUNIT3_TEST_KIND_ID.equals(testKind)
+				|| TestKindRegistry.JUNIT4_TEST_KIND_ID.equals(testKind);
+		if (isJUnit3Or4 && !stopped) {
+			// An externally terminated VM can close the socket without sending a final protocol message.
+			notifyTestRunTerminated();
+		} else {
 			notifyTestRunStopped(0);
 		}
 	}
@@ -519,7 +525,7 @@ public class RemoteTestRunnerClient {
 	}
 
 	private void notifyTestRunStopped(final long elapsedTime) {
-		if (JUnitCorePlugin.isStopped())
+		if (JUnitCorePlugin.isStopped() || !terminationNotified.compareAndSet(false, true))
 			return;
 		for (ITestRunListener2 listener : fListeners) {
 			SafeRunner.run(new ListenerSafeRunnable() {
@@ -534,7 +540,7 @@ public class RemoteTestRunnerClient {
 
 	private void testRunEnded(final long elapsedTime) {
 		ended = true;
-		if (JUnitCorePlugin.isStopped())
+		if (JUnitCorePlugin.isStopped() || !terminationNotified.compareAndSet(false, true))
 			return;
 		for (ITestRunListener2 listener : fListeners) {
 			SafeRunner.run(new ListenerSafeRunnable() {
@@ -575,6 +581,9 @@ public class RemoteTestRunnerClient {
 	}
 
 	private void notifyTestRunStarted(final int count) {
+		stopped= false;
+		ended= false;
+		terminationNotified.set(false);
 		if (JUnitCorePlugin.isStopped())
 			return;
 		for (ITestRunListener2 listener : fListeners) {
@@ -628,7 +637,7 @@ public class RemoteTestRunnerClient {
 
 	private void notifyTestRunTerminated() {
 		// fix for 77771 RemoteTestRunnerClient doing work after junit shutdown [JUnit]
-		if (JUnitCorePlugin.isStopped())
+		if (JUnitCorePlugin.isStopped() || !terminationNotified.compareAndSet(false, true))
 			return;
 		for (ITestRunListener2 listener : fListeners) {
 			SafeRunner.run(new ListenerSafeRunnable() {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -28,6 +28,7 @@ TestEnableAssertions.class,
 TestPriorization.class,
 TestTestSearchEngine.class,
 
+RemoteTestRunnerClientTest.class,
 TestRunListenerTest3.class,
 TestRunListenerTest4.class,
 TestRunListenerTest5.class,

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/RemoteTestRunnerClientTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/RemoteTestRunnerClientTest.java
@@ -1,0 +1,236 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.eclipse.jdt.internal.junit.launcher.ITestKind;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+import org.eclipse.jdt.internal.junit.model.ITestRunListener2;
+import org.eclipse.jdt.internal.junit.model.RemoteTestRunnerClient;
+import org.eclipse.jdt.internal.junit.runner.MessageIds;
+
+public class RemoteTestRunnerClientTest {
+
+	private static final int TIMEOUT_MILLIS= 10_000;
+
+	@Test
+	public void testUnexpectedEofNotifiesTerminationForJUnit3() throws Exception {
+		assertUnexpectedEofNotifiesTermination(TestKindRegistry.JUNIT3_TEST_KIND_ID);
+	}
+
+	@Test
+	public void testUnexpectedEofNotifiesTerminationForJUnit4() throws Exception {
+		assertUnexpectedEofNotifiesTermination(TestKindRegistry.JUNIT4_TEST_KIND_ID);
+	}
+
+	private static void assertUnexpectedEofNotifiesTermination(String testKindId) throws Exception {
+		RecordingListener listener= new RecordingListener();
+		int port= findFreePort();
+		RemoteTestRunnerClient client= startClient(listener, port, testKindId);
+		try (Socket socket= connect(port);
+				InputStream input= socket.getInputStream();
+				OutputStream output= socket.getOutputStream()) {
+			socket.setSoTimeout(TIMEOUT_MILLIS);
+			sendRunStarted(output, listener);
+			closeOutputAndWaitForShutdown(socket, input, client);
+		} finally {
+			client.stopWaiting();
+		}
+
+		assertEquals(0, listener.endedCount.get());
+		assertEquals(0, listener.stoppedCount.get());
+		assertEquals(1, listener.terminatedCount.get());
+	}
+
+	@Test
+	public void testRunEndIsNotReportedAsTermination() throws Exception {
+		RecordingListener listener= new RecordingListener();
+		int port= findFreePort();
+		RemoteTestRunnerClient client= startClient(listener, port, TestKindRegistry.JUNIT4_TEST_KIND_ID);
+		try (Socket socket= connect(port);
+				InputStream input= socket.getInputStream();
+				OutputStream output= socket.getOutputStream()) {
+			socket.setSoTimeout(TIMEOUT_MILLIS);
+			sendRunStarted(output, listener);
+			sendMessage(output, MessageIds.TEST_RUN_END + "0"); //$NON-NLS-1$
+			closeOutputAndWaitForShutdown(socket, input, client);
+		} finally {
+			client.stopWaiting();
+		}
+
+		assertEquals(1, listener.endedCount.get());
+		assertEquals(0, listener.stoppedCount.get());
+		assertEquals(0, listener.terminatedCount.get());
+	}
+
+	@Test
+	public void testRunEndAfterStopRequestIsNotReportedAsStopped() throws Exception {
+		RecordingListener listener= new RecordingListener();
+		int port= findFreePort();
+		RemoteTestRunnerClient client= startClient(listener, port, TestKindRegistry.JUNIT4_TEST_KIND_ID);
+		try (Socket socket= connect(port);
+				InputStream input= socket.getInputStream();
+				OutputStream output= socket.getOutputStream()) {
+			socket.setSoTimeout(TIMEOUT_MILLIS);
+			sendRunStarted(output, listener);
+			client.stopTest();
+			sendMessage(output, MessageIds.TEST_RUN_END + "0"); //$NON-NLS-1$
+			closeOutputAndWaitForShutdown(socket, input, client);
+		} finally {
+			client.stopWaiting();
+		}
+
+		assertEquals(1, listener.endedCount.get());
+		assertEquals(0, listener.stoppedCount.get());
+		assertEquals(0, listener.terminatedCount.get());
+	}
+
+	@Test
+	public void testStoppedRunIsNotReportedTwiceOnEof() throws Exception {
+		RecordingListener listener= new RecordingListener();
+		int port= findFreePort();
+		RemoteTestRunnerClient client= startClient(listener, port, TestKindRegistry.JUNIT4_TEST_KIND_ID);
+		try (Socket socket= connect(port);
+				InputStream input= socket.getInputStream();
+				OutputStream output= socket.getOutputStream()) {
+			socket.setSoTimeout(TIMEOUT_MILLIS);
+			sendRunStarted(output, listener);
+			sendMessage(output, MessageIds.TEST_STOPPED + "0"); //$NON-NLS-1$
+			waitForShutdown(input, client);
+		} finally {
+			client.stopWaiting();
+		}
+
+		assertEquals(0, listener.endedCount.get());
+		assertEquals(1, listener.stoppedCount.get());
+		assertEquals(0, listener.terminatedCount.get());
+	}
+
+	private static RemoteTestRunnerClient startClient(RecordingListener listener, int port, String testKindId) {
+		ITestKind testKind= TestKindRegistry.getDefault().getKind(testKindId);
+		assertFalse("JUnit test kind is unavailable: " + testKindId, testKind.isNull());
+		RemoteTestRunnerClient client= new RemoteTestRunnerClient(testKind);
+		client.startListening(new ITestRunListener2[] { listener }, port);
+		return client;
+	}
+
+	private static Socket connect(int port) throws Exception {
+		IOException lastException= null;
+		long deadline= System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(TIMEOUT_MILLIS);
+		do {
+			try {
+				return new Socket(InetAddress.getLoopbackAddress(), port);
+			} catch (IOException e) {
+				lastException= e;
+				Thread.sleep(10);
+			}
+		} while (System.nanoTime() < deadline);
+		throw new IOException("Could not connect to the JUnit client", lastException); //$NON-NLS-1$
+	}
+
+	private static int findFreePort() throws IOException {
+		try (ServerSocket serverSocket= new ServerSocket(0)) {
+			return serverSocket.getLocalPort();
+		}
+	}
+
+	private static void sendRunStarted(OutputStream output, RecordingListener listener) throws Exception {
+		sendMessage(output, MessageIds.TEST_RUN_START + "1 v2"); //$NON-NLS-1$
+		assertTrue("JUnit client did not report the test run start",
+				listener.started.await(TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+	}
+
+	private static void sendMessage(OutputStream output, String message) throws IOException {
+		output.write((message + '\n').getBytes(StandardCharsets.UTF_8));
+		output.flush();
+	}
+
+	private static void closeOutputAndWaitForShutdown(Socket socket, InputStream input, RemoteTestRunnerClient client) throws Exception {
+		socket.shutdownOutput();
+		waitForShutdown(input, client);
+	}
+
+	private static void waitForShutdown(InputStream input, RemoteTestRunnerClient client) throws Exception {
+		while (input.read() != -1) {
+			// Drain requests sent by the client until it closes the connection.
+		}
+		// Synchronize with RemoteTestRunnerClient.shutDown(), which uses the same monitor.
+		client.stopWaiting();
+	}
+
+	private static class RecordingListener implements ITestRunListener2 {
+
+		final CountDownLatch started= new CountDownLatch(1);
+		final AtomicInteger endedCount= new AtomicInteger();
+		final AtomicInteger stoppedCount= new AtomicInteger();
+		final AtomicInteger terminatedCount= new AtomicInteger();
+
+		@Override
+		public void testRunStarted(int testCount) {
+			started.countDown();
+		}
+
+		@Override
+		public void testRunEnded(long elapsedTime) {
+			endedCount.incrementAndGet();
+		}
+
+		@Override
+		public void testRunStopped(long elapsedTime) {
+			stoppedCount.incrementAndGet();
+		}
+
+		@Override
+		public void testRunTerminated() {
+			terminatedCount.incrementAndGet();
+		}
+
+		@Override
+		public void testStarted(String testId, String testName) {
+		}
+
+		@Override
+		public void testEnded(String testId, String testName) {
+		}
+
+		@Override
+		public void testTreeEntry(String description) {
+		}
+
+		@Override
+		public void testFailed(int status, String testId, String testName, String trace, String expected, String actual) {
+		}
+
+		@Override
+		public void testReran(String testId, String testClass, String testName, int status, String trace,
+				String expected, String actual) {
+		}
+	}
+}


### PR DESCRIPTION
## What it does

Fixes #1144.

When a running JUnit 3 or JUnit 4 test process is terminated externally,
for example through the Process Console, the socket connection can end
without a final `TEST_RUN_END` or `TEST_STOPPED` protocol message.

In that case, `RemoteTestRunnerClient` previously closed the connection
without notifying its listeners that the test run had terminated. The
JUnit view could consequently remain in its running state: its title
stayed italic, the Stop action remained enabled, and the periodic update
job was not stopped.

This change reports an unexpected end of a JUnit 3 or JUnit 4 connection
as `testRunTerminated()` after all available protocol messages have been
processed.

It also ensures that:

- a normal `TEST_RUN_END` remains a completed test run;
- an explicitly reported `TEST_STOPPED` remains a stopped test run;
- a terminal notification is emitted at most once;
- the terminal state is reset when a new test run starts.

The decision remains in the post-read shutdown path to preserve the
fast-completion race handling introduced for #2696.

Original Bugzilla report:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=94491

## How to test

Automated socket-level regression tests were added to
`RemoteTestRunnerClientTest`.

They verify that:

1. an unexpected EOF during a JUnit 4 run emits exactly one
   `testRunTerminated()` notification;
2. `TEST_RUN_END` followed by EOF is not reported as termination;
3. `TEST_STOPPED` followed by socket shutdown does not emit a duplicate
   terminal notification.

Manual verification:

1. Start a long-running JUnit 4 test.
2. Open the Process Console.
3. Terminate the test process using the Console's Terminate action.
4. Verify that the JUnit view leaves its running state.
5. Verify that the JUnit view title is no longer italic.
6. Verify that the JUnit Stop action is disabled.
7. Verify that no recurring “Update JUnit” job remains active.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)