### PR TITLE
Fix rename method to account for super class and invalid changes

### DIFF
--- a/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/refactoring/org/eclipse/jdt/internal/corext/refactoring/rename/RenameMethodProcessor.java
@@ -696,6 +696,7 @@ public abstract class RenameMethodProcessor extends JavaRenameProcessor implemen
 		Set<IMethod> result= new HashSet<>();
 		IType type= method.getDeclaringType();
 		List<IType> subtypes= Arrays.asList(hier.getAllSubtypes(type));
+		List<IType> supertypes= Arrays.asList(hier.getAllSupertypes(type));
 
 		int parameterCount= method.getParameterTypes().length;
 		boolean isMethodPrivate= JdtFlags.isPrivate(method);
@@ -706,6 +707,7 @@ public abstract class RenameMethodProcessor extends JavaRenameProcessor implemen
 			// may cause a model exception when the class is created in a lambda expression and the file is unopen
 			if (!clazz.isAnonymous()) {
 				boolean isSubclass= subtypes.contains(clazz);
+				boolean isSuperclass= supertypes.contains(clazz);
 				for (IMethod m : clazz.getMethods()) {
 					IMethod foundMethod= Checks.findMethod(newName, parameterCount, false, new IMethod[]{m});
 					if (foundMethod == null)
@@ -714,6 +716,15 @@ public abstract class RenameMethodProcessor extends JavaRenameProcessor implemen
 							|| type.equals(clazz)
 							|| (!isMethodPrivate && !JdtFlags.isPrivate(m))) {
 						result.add(foundMethod);
+					}
+					if (isSuperclass) {
+						String retType= foundMethod.getReturnType();
+						String methodType= method.getReturnType();
+						if (!retType.equals(methodType)
+								|| (isMethodPrivate && !JdtFlags.isPrivate(m))
+								|| (!JdtFlags.isPublic(method) && JdtFlags.isPublic(m))) {
+							result.add(foundMethod);
+						}
 					}
 				}
 			}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/RenamePrivateMethod/testFail3/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/RenamePrivateMethod/testFail3/in/A.java
@@ -1,0 +1,9 @@
+package p;
+
+class B {
+	protected void k(){}
+}
+//can't rename m to k
+class A extends B {
+ 	private void m(){}
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenamePrivateMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/RenamePrivateMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -123,6 +123,11 @@ public class RenamePrivateMethodTests extends GenericRefactoringTest {
 
 	@Test
 	public void testFail2() throws Exception{
+		helper1();
+	}
+
+	@Test
+	public void testFail3() throws Exception{
 		helper1();
 	}
 


### PR DESCRIPTION
- modify RenameMethodProcessor.classesDeclareMethodName() to look at super class types and note cases where the same method with same parameters either reduces visibility or has different return type
- add new test to RenamePrivateMethodTests
- fixes #3034

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
