### PR TITLE
Enable launch configuration prototypes for classic JUnit

### DIFF
--- a/org.eclipse.jdt.junit.core/plugin.xml
+++ b/org.eclipse.jdt.junit.core/plugin.xml
@@ -12,6 +12,7 @@
             delegateDescription="%JUnitLaunchDelegate.description"
             delegateName="%JUnitLaunchDelegate.name"
             allowCommandLine="true"
+            allowPrototypes="true"
             delegate="org.eclipse.jdt.junit.launcher.AdvancedJUnitLaunchConfigurationDelegate"
             modes="run, debug"
             id="org.eclipse.jdt.junit.launchconfig"

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/launcher/JUnitTabGroup.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/launcher/JUnitTabGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -30,6 +30,7 @@ import org.eclipse.debug.ui.DebugUITools;
 import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.debug.ui.PrototypeTab;
 import org.eclipse.debug.ui.sourcelookup.SourceLookupTab;
 
 import org.eclipse.jdt.launching.JavaRuntime;
@@ -48,7 +49,8 @@ public class JUnitTabGroup extends AbstractLaunchConfigurationTabGroup {
 			isModularConfiguration ? new JavaDependenciesTab() : new JavaClasspathTab(),
 			new SourceLookupTab(),
 			new EnvironmentTab(),
-			new CommonTab()
+			new CommonTab(),
+			new PrototypeTab()
 		};
 		setTabs(tabs);
 	}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -25,6 +25,7 @@ import org.junit.platform.suite.api.Suite;
 //WrappingUnitTest.class,
 
 TestEnableAssertions.class,
+JUnitLaunchConfigurationPrototypeTest.class,
 TestPriorization.class,
 TestTestSearchEngine.class,
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitLaunchConfigurationPrototypeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitLaunchConfigurationPrototypeTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,6 +80,18 @@ public class JUnitLaunchConfigurationPrototypeTest {
 		ILaunchConfiguration prototype= createPrototype();
 		assertTrue(prototype.isPrototype());
 		assertTrue(Arrays.asList(fType.getPrototypes()).contains(prototype));
+	}
+
+	@Test
+	public void testPrototypeAttributeVisibility() throws CoreException {
+		ILaunchConfiguration prototype= createPrototype();
+		Set<String> visibleAttributes= prototype.getPrototypeVisibleAttributes();
+		assertTrue(visibleAttributes.contains(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS));
+		assertTrue(visibleAttributes.contains(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES));
+		assertFalse(visibleAttributes.contains(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME));
+		assertFalse(visibleAttributes.contains(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME));
+		assertFalse(visibleAttributes.contains(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME));
+		assertFalse(visibleAttributes.contains(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND));
 	}
 
 	@Test
@@ -209,6 +222,8 @@ public class JUnitLaunchConfigurationPrototypeTest {
 		prototype.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "example.PrototypeTest");
 		prototype.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, "prototypeMethod");
 		prototype.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, TestKindRegistry.JUNIT3_TEST_KIND_ID);
+		// Initialize the lazily populated visibility set before changing individual entries.
+		prototype.getPrototypeVisibleAttributes();
 		prototype.setPrototypeAttributeVisibility(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, true);
 		prototype.setPrototypeAttributeVisibility(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, true);
 		prototype.setPrototypeAttributeVisibility(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, false);

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitLaunchConfigurationPrototypeTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitLaunchConfigurationPrototypeTest.java
@@ -1,0 +1,250 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.core.runtime.CoreException;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationType;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+
+import org.eclipse.debug.ui.ILaunchConfigurationTab;
+import org.eclipse.debug.ui.PrototypeTab;
+
+import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
+import org.eclipse.jdt.internal.junit.launcher.JUnitTabGroup;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
+
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+
+public class JUnitLaunchConfigurationPrototypeTest {
+
+	private static final String VM_ARGUMENTS= "-ea -Dprototype=true";
+	private static final Map<String, String> ENVIRONMENT= Map.of("SWT_GTK3", "1", "GDK_BACKEND", "x11");
+
+	private final List<ILaunchConfiguration> fConfigurations= new ArrayList<>();
+	private ILaunchManager fLaunchManager;
+	private ILaunchConfigurationType fType;
+
+	@BeforeEach
+	public void setUp() {
+		fLaunchManager= DebugPlugin.getDefault().getLaunchManager();
+		fType= fLaunchManager.getLaunchConfigurationType(JUnitLaunchConfigurationConstants.ID_JUNIT_APPLICATION);
+		assertNotNull(fType);
+	}
+
+	@AfterEach
+	public void tearDown() throws CoreException {
+		// Delete linked configurations before their prototypes.
+		for (int i= fConfigurations.size() - 1; i >= 0; i--) {
+			ILaunchConfiguration configuration= fConfigurations.get(i);
+			if (configuration.exists()) {
+				configuration.delete();
+			}
+		}
+	}
+
+	@Test
+	public void testSupportsPrototypes() throws CoreException {
+		assertTrue(fType.supportsPrototypes());
+		ILaunchConfiguration prototype= createPrototype();
+		assertTrue(prototype.isPrototype());
+		assertTrue(Arrays.asList(fType.getPrototypes()).contains(prototype));
+	}
+
+	@Test
+	public void testPrototypeTabForRunAndDebug() {
+		for (String mode : new String[] { ILaunchManager.RUN_MODE, ILaunchManager.DEBUG_MODE }) {
+			JUnitTabGroup tabGroup= new JUnitTabGroup();
+			try {
+				tabGroup.createTabs(null, mode);
+				ILaunchConfigurationTab[] tabs= tabGroup.getTabs();
+				assertEquals(1L, Arrays.stream(tabs).filter(PrototypeTab.class::isInstance).count());
+				assertInstanceOf(PrototypeTab.class, tabs[tabs.length - 1]);
+			} finally {
+				tabGroup.dispose();
+			}
+		}
+	}
+
+	@Test
+	public void testLinkCopiesOnlySharedAttributes() throws CoreException {
+		ILaunchConfiguration prototype= createPrototype();
+		ILaunchConfigurationWorkingCopy workingCopy= newTestConfiguration();
+		workingCopy.setPrototype(prototype, true);
+		ILaunchConfiguration configuration= save(workingCopy);
+
+		assertFalse(configuration.isPrototype());
+		assertEquals(prototype, configuration.getPrototype());
+		assertSharedValues(configuration, VM_ARGUMENTS, ENVIRONMENT);
+		assertTestSelection(configuration);
+	}
+
+	@Test
+	public void testLocalOverridesAndReset() throws CoreException {
+		ILaunchConfiguration prototype= createPrototype();
+		ILaunchConfigurationWorkingCopy workingCopy= newTestConfiguration();
+		workingCopy.setPrototype(prototype, true);
+		workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, "-Dlocal=true");
+		workingCopy.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, Map.of("LOCAL_ONLY", "true"));
+		ILaunchConfiguration configuration= save(workingCopy);
+		assertSharedValues(configuration, "-Dlocal=true", Map.of("LOCAL_ONLY", "true"));
+		assertTrue(configuration.isAttributeModified(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS));
+		assertTrue(configuration.isAttributeModified(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES));
+
+		workingCopy= configuration.getWorkingCopy();
+		// Use the same operation as the Prototype tab's reset action.
+		workingCopy.setPrototype(configuration.getPrototype(), true);
+		configuration= save(workingCopy);
+		assertSharedValues(configuration, VM_ARGUMENTS, ENVIRONMENT);
+		assertFalse(configuration.isAttributeModified(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS));
+		assertFalse(configuration.isAttributeModified(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES));
+		assertTestSelection(configuration);
+	}
+
+	@Test
+	public void testLinkWithoutCopyPreservesLocalValues() throws CoreException {
+		ILaunchConfiguration prototype= createPrototype();
+		ILaunchConfigurationWorkingCopy workingCopy= newTestConfiguration();
+		workingCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, "-Dlocal=true");
+		workingCopy.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, Map.of("LOCAL_ONLY", "true"));
+		workingCopy.setPrototype(prototype, false);
+		ILaunchConfiguration configuration= save(workingCopy);
+
+		assertEquals(prototype, configuration.getPrototype());
+		assertSharedValues(configuration, "-Dlocal=true", Map.of("LOCAL_ONLY", "true"));
+		assertTestSelection(configuration);
+	}
+
+	@Test
+	public void testUnlinkPreservesValues() throws CoreException {
+		ILaunchConfiguration prototype= createPrototype();
+		ILaunchConfigurationWorkingCopy workingCopy= newTestConfiguration();
+		workingCopy.setPrototype(prototype, true);
+		ILaunchConfiguration configuration= save(workingCopy);
+
+		workingCopy= configuration.getWorkingCopy();
+		workingCopy.setPrototype(null, false);
+		configuration= save(workingCopy);
+		assertNull(configuration.getPrototype());
+		assertSharedValues(configuration, VM_ARGUMENTS, ENVIRONMENT);
+		assertTestSelection(configuration);
+	}
+
+	@Test
+	public void testResetUsesUpdatedPrototypeValues() throws CoreException {
+		ILaunchConfiguration prototype= createPrototype();
+		ILaunchConfigurationWorkingCopy workingCopy= newTestConfiguration();
+		workingCopy.setPrototype(prototype, true);
+		ILaunchConfiguration configuration= save(workingCopy);
+
+		ILaunchConfigurationWorkingCopy prototypeCopy= prototype.getWorkingCopy();
+		prototypeCopy.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, "-Dupdated=true");
+		Map<String, String> updatedEnvironment= Map.of("GDK_BACKEND", "wayland");
+		prototypeCopy.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, updatedEnvironment);
+		prototype= save(prototypeCopy);
+
+		workingCopy= configuration.getWorkingCopy();
+		workingCopy.setPrototype(prototype, true);
+		configuration= save(workingCopy);
+		assertSharedValues(configuration, "-Dupdated=true", updatedEnvironment);
+		assertTestSelection(configuration);
+	}
+
+	@Test
+	public void testJUnitAttributesCanBeShared() throws CoreException {
+		ILaunchConfigurationWorkingCopy prototypeCopy= createPrototype().getWorkingCopy();
+		prototypeCopy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_KEEPRUNNING, true);
+		prototypeCopy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_HAS_INCLUDE_TAGS, true);
+		prototypeCopy.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_INCLUDE_TAGS, "fast");
+		prototypeCopy.setPrototypeAttributeVisibility(JUnitLaunchConfigurationConstants.ATTR_KEEPRUNNING, true);
+		prototypeCopy.setPrototypeAttributeVisibility(JUnitLaunchConfigurationConstants.ATTR_TEST_HAS_INCLUDE_TAGS, true);
+		prototypeCopy.setPrototypeAttributeVisibility(JUnitLaunchConfigurationConstants.ATTR_TEST_INCLUDE_TAGS, true);
+		ILaunchConfiguration prototype= save(prototypeCopy);
+
+		ILaunchConfigurationWorkingCopy workingCopy= newTestConfiguration();
+		workingCopy.setPrototype(prototype, true);
+		ILaunchConfiguration configuration= save(workingCopy);
+		assertTrue(configuration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_KEEPRUNNING, false));
+		assertTrue(configuration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_HAS_INCLUDE_TAGS, false));
+		assertEquals("fast", configuration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_INCLUDE_TAGS, ""));
+		assertTestSelection(configuration);
+	}
+
+	private ILaunchConfiguration createPrototype() throws CoreException {
+		String name= fLaunchManager.generateLaunchConfigurationName("JUnit prototype test");
+		ILaunchConfigurationWorkingCopy prototype= fType.newPrototypeInstance(null, name);
+		prototype.setAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, VM_ARGUMENTS);
+		prototype.setAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, ENVIRONMENT);
+		prototype.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, "PrototypeProject");
+		prototype.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "example.PrototypeTest");
+		prototype.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, "prototypeMethod");
+		prototype.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, TestKindRegistry.JUNIT3_TEST_KIND_ID);
+		prototype.setPrototypeAttributeVisibility(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, true);
+		prototype.setPrototypeAttributeVisibility(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, true);
+		prototype.setPrototypeAttributeVisibility(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, false);
+		prototype.setPrototypeAttributeVisibility(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, false);
+		prototype.setPrototypeAttributeVisibility(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, false);
+		prototype.setPrototypeAttributeVisibility(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, false);
+		return save(prototype);
+	}
+
+	private ILaunchConfigurationWorkingCopy newTestConfiguration() throws CoreException {
+		String name= fLaunchManager.generateLaunchConfigurationName("JUnit linked configuration test");
+		ILaunchConfigurationWorkingCopy configuration= fType.newInstance(null, name);
+		configuration.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, "TestProject");
+		configuration.setAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, "example.MyTest");
+		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, "testMethod");
+		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, TestKindRegistry.JUNIT4_TEST_KIND_ID);
+		return configuration;
+	}
+
+	private ILaunchConfiguration save(ILaunchConfigurationWorkingCopy workingCopy) throws CoreException {
+		ILaunchConfiguration configuration= workingCopy.doSave();
+		if (!fConfigurations.contains(configuration)) {
+			fConfigurations.add(configuration);
+		}
+		return configuration;
+	}
+
+	private void assertSharedValues(ILaunchConfiguration configuration, String vmArguments, Map<String, String> environment) throws CoreException {
+		assertEquals(vmArguments, configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_VM_ARGUMENTS, ""));
+		assertEquals(environment, configuration.getAttribute(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES, Map.<String, String>of()));
+	}
+
+	private void assertTestSelection(ILaunchConfiguration configuration) throws CoreException {
+		assertEquals("TestProject", configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, ""));
+		assertEquals("example.MyTest", configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_MAIN_TYPE_NAME, ""));
+		assertEquals("testMethod", configuration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_NAME, ""));
+		assertEquals(TestKindRegistry.JUNIT4_TEST_KIND_ID, configuration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, ""));
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest5.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/TestRunListenerTest5.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2020 IBM Corporation and others.
+ * Copyright (c) 2006, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -65,6 +65,8 @@ import org.eclipse.jdt.internal.junit.model.TestElement;
 import org.eclipse.jdt.internal.junit.model.TestElement.Status;
 import org.eclipse.jdt.internal.junit.model.TestRunSession;
 import org.eclipse.jdt.internal.junit.ui.JUnitMessages;
+import org.eclipse.jdt.internal.junit.ui.JUnitPlugin;
+import org.eclipse.jdt.internal.junit.ui.TestRunnerViewPart;
 
 public class TestRunListenerTest5 extends AbstractTestRunListenerTest {
 
@@ -319,6 +321,9 @@ public class TestRunListenerTest5 extends AbstractTestRunListenerTest {
 		IType aTestCase= createType(project, source, "pack", "ATestCaseTerminate.java");
 		buildTestCase(aTestCase);
 
+		// Update jobs belong to the view; do not depend on it being opened by an earlier test.
+		JUnitPlugin.getActivePage().showView(TestRunnerViewPart.NAME);
+
 		LaunchesListener launchesListener= new LaunchesListener();
 		ILaunchConfigurationWorkingCopy configuration= createLaunchConfiguration(aTestCase, testKindId, null, launchesListener);
 
@@ -331,7 +336,13 @@ public class TestRunListenerTest5 extends AbstractTestRunListenerTest {
 		JUnitCorePlugin.getModel().addTestRunSessionListener(runSessionListener);
 		try {
 			configuration.launch(ILaunchManager.RUN_MODE, null);
-			waitForCondition(launchesListener.fLaunchChanged::get, 30 * 1000, 1000);
+			boolean changedLaunch= waitForCondition(launchesListener.fLaunchChanged::get, 30 * 1000, 1000);
+			assertTrue("Unexpected timeout on JUnit launch change", changedLaunch);
+
+			// A launch change does not mean the remote runner has started the test session yet.
+			boolean runningSession= waitForCondition(() -> runSessionListener.fTestRunSession != null
+					&& runSessionListener.fTestRunSession.isRunning(), 30 * 1000, 100);
+			assertTrue("Unexpected timeout on JUnit session start", runningSession);
 
 			long scheduledJobsCount = jobListener.scheduledCount.get();
 			boolean jobCountIncrease= waitForCondition(() -> jobListener.scheduledCount.get() > scheduledJobsCount, 5 * 1000, 100);
@@ -351,6 +362,9 @@ public class TestRunListenerTest5 extends AbstractTestRunListenerTest {
 		} finally {
 			jm.removeJobChangeListener(jobListener);
 			JUnitCorePlugin.getModel().removeTestRunSessionListener(runSessionListener);
+			if (runSessionListener.fTestRunSession != null) {
+				runSessionListener.fTestRunSession.removeTestSessionListener(sessionListener);
+			}
 			terminateLaunches();
 			cleanUp(configuration, launchesListener);
 		}
@@ -387,7 +401,7 @@ public class TestRunListenerTest5 extends AbstractTestRunListenerTest {
 
 	private static class TestRunSessionListener implements ITestRunSessionListener  {
 
-		private TestRunSession fTestRunSession;
+		private volatile TestRunSession fTestRunSession;
 
 		public TestRunSessionListener() {
 		}


### PR DESCRIPTION
Enable prototypes for org.eclipse.jdt.junit.launchconfig and add the Prototype tab to the classic JUnit launch configuration tab group.

Add regression tests for prototype registration, run/debug tab setup, selective copying of environment variables and VM arguments, local overrides, reset, unlinking, updated prototypes and shared JUnit options. Register the tests in JUnitJUnitTests.

Fixes eclipse-jdt/eclipse.jdt.ui#1333

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
