### PR TITLE
Do not cache canceled occurrence annotation updates

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
@@ -255,11 +255,17 @@ public class MarkOccurrenceTest {
 			IRegion match= fFindReplaceDocumentAdapter.find(0, "TestResult", true, true, true, false);
 			assertNotNull(match);
 			ITextSelection selection= new TextSelection(fDocument, match.getOffset(), match.getLength());
+			Object previousAnnotations= editorAccessor.get("fOccurrenceAnnotations");
+			Object previousTargetRegion= editorAccessor.get("fMarkOccurrenceTargetRegion");
+			Object previousModificationStamp= editorAccessor.get("fMarkOccurrenceModificationStamp");
 			// The AST callback arrives before the selection validator has seen this
 			// selection object. The finder must discard this update without caching it.
 			assertFalse(validator.isValid(selection));
 			editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
 			assertEquals(withExistingAnnotations ? 9 : 0, countOccurrenceAnnotations());
+			assertSame(previousAnnotations, editorAccessor.get("fOccurrenceAnnotations"), "Cancellation must preserve the installed annotations");
+			assertSame(previousTargetRegion, editorAccessor.get("fMarkOccurrenceTargetRegion"), "Cancellation must preserve the last successful target region");
+			assertEquals(previousModificationStamp, editorAccessor.get("fMarkOccurrenceModificationStamp"), "Cancellation must preserve the last successful modification stamp");
 
 			selectionListener.selectionChanged(new SelectionChangedEvent(fEditor.getSelectionProvider(), selection));
 			assertTrue(validator.isValid(selection));

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
@@ -17,11 +17,14 @@ package org.eclipse.jdt.text.tests;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +54,7 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.FindReplaceDocumentAdapter;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentExtension4;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ISelectionValidator;
 import org.eclipse.jface.text.ITextSelection;
@@ -265,6 +269,91 @@ public class MarkOccurrenceTest {
 			Object annotations= editorAccessor.get("fOccurrenceAnnotations");
 			editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
 			assertSame(annotations, editorAccessor.get("fOccurrenceAnnotations"), "A successful update should still be cached");
+		} finally {
+			manager.addListener(fEditor, occurrencesListener);
+		}
+	}
+
+	@Test
+	public void markOccurrencesAfterConcurrentRemoval() throws Exception {
+		assertOccurrencesAfterConcurrentRemoval(false);
+	}
+
+	@Test
+	public void markOccurrencesAfterConcurrentRemovalWithExistingAnnotations() throws Exception {
+		assertOccurrencesAfterConcurrentRemoval(true);
+	}
+
+	private void assertOccurrencesAfterConcurrentRemoval(boolean withExistingAnnotations) throws Exception {
+		Accessor editorAccessor= new Accessor(fEditor, JavaEditor.class);
+		ISelectionListenerWithAST occurrencesListener= (ISelectionListenerWithAST) editorAccessor.get("fPostSelectionListenerWithAST");
+		SelectionListenerWithASTManager manager= SelectionListenerWithASTManager.getDefault();
+		manager.removeListener(fEditor, occurrencesListener);
+		try {
+			// Drive updates explicitly so background callbacks cannot restore the
+			// annotations and hide a stale cache left behind by removal.
+			EditorTestHelper.joinBackgroundActivities(fEditor);
+			ICompilationUnit unit= JavaUI.getWorkingCopyManager().getWorkingCopy(fEditor.getEditorInput());
+			assertNotNull(unit);
+			ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+			parser.setSource(unit);
+			parser.setResolveBindings(true);
+			CompilationUnit ast= (CompilationUnit) parser.createAST(null);
+			editorAccessor.invoke("removeOccurrenceAnnotations", new Object[0]);
+
+			ISelectionChangedListener selectionListener= (ISelectionChangedListener) new Accessor(fEditor, AbstractTextEditor.class).get("fSelectionListener");
+			ISelectionValidator validator= (ISelectionValidator) fEditor.getSelectionProvider();
+			Class<?>[] parameterTypes= { ITextSelection.class, CompilationUnit.class };
+
+			if (withExistingAnnotations) {
+				IRegion match= fFindReplaceDocumentAdapter.find(0, "fName", true, true, true, false);
+				assertNotNull(match);
+				ITextSelection selection= new TextSelection(fDocument, match.getOffset(), match.getLength());
+				selectionListener.selectionChanged(new SelectionChangedEvent(fEditor.getSelectionProvider(), selection));
+				assertTrue(validator.isValid(selection));
+				editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
+				assertEquals(9, countOccurrenceAnnotations());
+			}
+
+			IRegion match= fFindReplaceDocumentAdapter.find(0, "TestResult", true, true, true, false);
+			assertNotNull(match);
+			ITextSelection selection= new TextSelection(fDocument, match.getOffset(), match.getLength());
+			selectionListener.selectionChanged(new SelectionChangedEvent(fEditor.getSelectionProvider(), selection));
+			assertTrue(validator.isValid(selection));
+
+			Object lock= editorAccessor.invoke("getLockObject", new Class<?>[] { IAnnotationModel.class }, new Object[] { fAnnotationModel });
+			FutureTask<Void> removal= new FutureTask<>(() -> {
+				editorAccessor.invoke("removeOccurrenceAnnotations", new Object[0]);
+				return null;
+			});
+			Thread removalThread= new Thread(removal, "Remove occurrence annotations");
+			removalThread.setDaemon(true);
+			try {
+				synchronized (lock) {
+					removalThread.start();
+					// Wait for actual lock contention, not an assumed scheduling delay.
+					// Do not dispatch UI events while holding the annotation-model lock.
+					long deadline= System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+					while (removalThread.isAlive() && removalThread.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline)
+						Thread.sleep(1);
+					assertEquals(Thread.State.BLOCKED, removalThread.getState(), "Removal must wait for an in-flight annotation update");
+
+					editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
+					assertEquals(8, countOccurrenceAnnotations());
+				}
+				removal.get(10, TimeUnit.SECONDS);
+			} finally {
+				removalThread.join(10000);
+				assertFalse(removalThread.isAlive(), "The annotation removal thread must finish before editor teardown");
+			}
+
+			assertEquals(0, countOccurrenceAnnotations());
+			assertNull(editorAccessor.get("fOccurrenceAnnotations"));
+			assertNull(editorAccessor.get("fMarkOccurrenceTargetRegion"), "Removal must invalidate the cache published by the in-flight update");
+			assertEquals(Long.valueOf(IDocumentExtension4.UNKNOWN_MODIFICATION_STAMP), editorAccessor.get("fMarkOccurrenceModificationStamp"));
+
+			editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
+			assertEquals(8, countOccurrenceAnnotations(), "A selection in the same word must restore annotations after removal");
 		} finally {
 			manager.addListener(fEditor, occurrencesListener);
 		}

--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/MarkOccurrenceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -15,7 +15,9 @@
 package org.eclipse.jdt.text.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -39,16 +41,22 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 
+import org.eclipse.text.tests.Accessor;
+
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.FindReplaceDocumentAdapter;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ISelectionValidator;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 
@@ -56,12 +64,17 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 
+import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.eclipse.ui.texteditor.AnnotationPreference;
 
 import org.eclipse.ui.editors.text.EditorsUI;
 
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
+import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.jdt.ui.PreferenceConstants;
 
 import org.eclipse.jdt.internal.ui.JavaPlugin;
@@ -120,17 +133,7 @@ public class MarkOccurrenceTest {
 
 			private void countOccurrences() {
 				synchronized (MarkOccurrenceTest.this) {
-					int occurrences= 0;
-					Iterator<Annotation> iter= fAnnotationModel.getAnnotationIterator();
-					while (iter.hasNext()) {
-						Annotation annotation= iter.next();
-						if (OCCURRENCE_ANNOTATION.equals(annotation.getType()))
-							occurrences++;
-						if (OCCURRENCE_WRITE_ANNOTATION.equals(annotation.getType()))
-							occurrences++;
-
-					}
-					fOccurrences= occurrences;
+					fOccurrences= countOccurrenceAnnotations();
 				}
 			}
 		};
@@ -201,6 +204,69 @@ public class MarkOccurrenceTest {
 		} finally {
 			store.setValue("REUSE_OPEN_EDITORS_BOOLEAN", false);
 			store.setValue("REUSE_OPEN_EDITORS", reuseOpenEditors);
+		}
+	}
+
+	@Test
+	public void markOccurrencesAfterCanceledUpdate() throws Exception {
+		assertOccurrencesAfterCanceledUpdate(false);
+	}
+
+	@Test
+	public void markOccurrencesAfterCanceledUpdateWithExistingAnnotations() throws Exception {
+		assertOccurrencesAfterCanceledUpdate(true);
+	}
+
+	private void assertOccurrencesAfterCanceledUpdate(boolean withExistingAnnotations) throws Exception {
+		Accessor editorAccessor= new Accessor(fEditor, JavaEditor.class);
+		ISelectionListenerWithAST occurrencesListener= (ISelectionListenerWithAST) editorAccessor.get("fPostSelectionListenerWithAST");
+		SelectionListenerWithASTManager manager= SelectionListenerWithASTManager.getDefault();
+		manager.removeListener(fEditor, occurrencesListener);
+		try {
+			// Let any earlier callbacks finish, then drive the update and selection
+			// validation explicitly so no background update can mask the regression.
+			EditorTestHelper.joinBackgroundActivities(fEditor);
+			ICompilationUnit unit= JavaUI.getWorkingCopyManager().getWorkingCopy(fEditor.getEditorInput());
+			assertNotNull(unit);
+			ASTParser parser= ASTParser.newParser(AST.getJLSLatest());
+			parser.setSource(unit);
+			parser.setResolveBindings(true);
+			CompilationUnit ast= (CompilationUnit) parser.createAST(null);
+			editorAccessor.invoke("removeOccurrenceAnnotations", new Object[0]);
+
+			ISelectionChangedListener selectionListener= (ISelectionChangedListener) new Accessor(fEditor, AbstractTextEditor.class).get("fSelectionListener");
+			ISelectionValidator validator= (ISelectionValidator) fEditor.getSelectionProvider();
+			Class<?>[] parameterTypes= { ITextSelection.class, CompilationUnit.class };
+
+			if (withExistingAnnotations) {
+				IRegion match= fFindReplaceDocumentAdapter.find(0, "fName", true, true, true, false);
+				assertNotNull(match);
+				ITextSelection selection= new TextSelection(fDocument, match.getOffset(), match.getLength());
+				selectionListener.selectionChanged(new SelectionChangedEvent(fEditor.getSelectionProvider(), selection));
+				assertTrue(validator.isValid(selection));
+				editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
+				assertEquals(9, countOccurrenceAnnotations());
+			}
+
+			IRegion match= fFindReplaceDocumentAdapter.find(0, "TestResult", true, true, true, false);
+			assertNotNull(match);
+			ITextSelection selection= new TextSelection(fDocument, match.getOffset(), match.getLength());
+			// The AST callback arrives before the selection validator has seen this
+			// selection object. The finder must discard this update without caching it.
+			assertFalse(validator.isValid(selection));
+			editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
+			assertEquals(withExistingAnnotations ? 9 : 0, countOccurrenceAnnotations());
+
+			selectionListener.selectionChanged(new SelectionChangedEvent(fEditor.getSelectionProvider(), selection));
+			assertTrue(validator.isValid(selection));
+			editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
+			assertEquals(8, countOccurrenceAnnotations(), "A canceled update must allow a valid retry in the same word");
+
+			Object annotations= editorAccessor.get("fOccurrenceAnnotations");
+			editorAccessor.invoke("updateOccurrenceAnnotations", parameterTypes, new Object[] { selection, ast });
+			assertSame(annotations, editorAccessor.get("fOccurrenceAnnotations"), "A successful update should still be cached");
+		} finally {
+			manager.addListener(fEditor, occurrencesListener);
 		}
 	}
 
@@ -358,19 +424,31 @@ public class MarkOccurrenceTest {
 		return null;
 	}
 
+	private int countOccurrenceAnnotations() {
+		int occurrences= 0;
+		Iterator<Annotation> iter= fAnnotationModel.getAnnotationIterator();
+		while (iter.hasNext()) {
+			Annotation annotation= iter.next();
+			if (OCCURRENCE_ANNOTATION.equals(annotation.getType()) || OCCURRENCE_WRITE_ANNOTATION.equals(annotation.getType()))
+				occurrences++;
+		}
+		return occurrences;
+	}
+
 	private void assertOccurrences(final int expected) {
 		DisplayHelper helper= new DisplayHelper() {
 			@Override
 			protected boolean condition() {
 				synchronized (MarkOccurrenceTest.this) {
-					if (fOccurrences != -1) {
-						assertEquals(expected, fOccurrences);
-						return true;
-					}
-					return false;
+					// Even when expecting no annotations, first wait for a matching AST callback.
+					if (fOccurrences == -1)
+						return false;
+					fOccurrences= countOccurrenceAnnotations();
+					return fOccurrences == expected;
 				}
 			}
 		};
-		assertTrue(helper.waitForCondition(EditorTestHelper.getActiveDisplay(), 80000));
+		assertTrue(helper.waitForCondition(EditorTestHelper.getActiveDisplay(), 80000),
+				() -> "Expected " + expected + " occurrence annotations, last count: " + fOccurrences);
 	}
 }

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
@@ -1472,7 +1472,6 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 			fInvalidSelection= new TextSelection(0, 0);
 
 			SelectionChangedEvent event= new SelectionChangedEvent(this, fInvalidSelection);
-
 			for (ISelectionChangedListener listener : fSelectionListeners) {
 				listener.selectionChanged(event);
 			}
@@ -3469,18 +3468,22 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 	}
 
 	void removeOccurrenceAnnotations() {
-		fMarkOccurrenceModificationStamp= IDocumentExtension4.UNKNOWN_MODIFICATION_STAMP;
-		fMarkOccurrenceTargetRegion= null;
-
 		IDocumentProvider documentProvider= getDocumentProvider();
-		if (documentProvider == null)
+		IAnnotationModel annotationModel= documentProvider == null ? null : documentProvider.getAnnotationModel(getEditorInput());
+		if (annotationModel == null) {
+			fMarkOccurrenceModificationStamp= IDocumentExtension4.UNKNOWN_MODIFICATION_STAMP;
+			fMarkOccurrenceTargetRegion= null;
 			return;
-
-		IAnnotationModel annotationModel= documentProvider.getAnnotationModel(getEditorInput());
-		if (annotationModel == null || fOccurrenceAnnotations == null)
-			return;
+		}
 
 		synchronized (getLockObject(annotationModel)) {
+			// Invalidate the cache under the same lock used to install annotations.
+			// Otherwise a concurrent update can republish the cache before removal.
+			fMarkOccurrenceModificationStamp= IDocumentExtension4.UNKNOWN_MODIFICATION_STAMP;
+			fMarkOccurrenceTargetRegion= null;
+			if (fOccurrenceAnnotations == null)
+				return;
+
 			if (annotationModel instanceof IAnnotationModelExtension) {
 				((IAnnotationModelExtension)annotationModel).replaceAnnotations(fOccurrenceAnnotations, null);
 			} else {
@@ -4227,7 +4230,6 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 		// use this as the preferred class for comparing objects.
 		return new NonLocalUndoUserApprover(undoContext, this, new Object [] { getInputJavaElement() }, IResource.class);
 	}
-
 	/**
 	 * Resets the foldings structure according to the folding
 	 * preferences.

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3187,12 +3187,16 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 		private final ISelectionValidator fPostSelectionValidator;
 		private boolean fCanceled= false;
 		private final OccurrenceLocation[] fLocations;
+		private final IRegion fTargetRegion;
+		private final long fModificationStamp;
 
-		public OccurrencesFinderJob(IDocument document, OccurrenceLocation[] locations, ISelection selection) {
+		public OccurrencesFinderJob(IDocument document, OccurrenceLocation[] locations, ISelection selection, IRegion targetRegion, long modificationStamp) {
 			super(JavaEditorMessages.JavaEditor_markOccurrences_job_name);
 			fDocument= document;
 			fSelection= selection;
 			fLocations= locations;
+			fTargetRegion= targetRegion;
+			fModificationStamp= modificationStamp;
 
 			if (getSelectionProvider() instanceof ISelectionValidator)
 				fPostSelectionValidator= (ISelectionValidator)getSelectionProvider();
@@ -3267,6 +3271,10 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 					}
 				}
 				fOccurrenceAnnotations= annotationMap.keySet().toArray(new Annotation[annotationMap.size()]);
+				// Only cache successfully installed annotations. A canceled update must not
+				// prevent a later selection in the same word from updating the annotations.
+				fMarkOccurrenceTargetRegion= fTargetRegion;
+				fMarkOccurrenceModificationStamp= fModificationStamp;
 			}
 
 			return Status.OK_STATUS;
@@ -3297,17 +3305,18 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 			return;
 
 		boolean hasChanged= false;
+		IRegion targetRegion= null;
+		long currentModificationStamp= IDocumentExtension4.UNKNOWN_MODIFICATION_STAMP;
 		if (document instanceof IDocumentExtension4) {
 			int offset= selection.getOffset();
-			long currentModificationStamp= ((IDocumentExtension4)document).getModificationStamp();
+			currentModificationStamp= ((IDocumentExtension4)document).getModificationStamp();
 			IRegion markOccurrenceTargetRegion= fMarkOccurrenceTargetRegion;
 			hasChanged= currentModificationStamp != fMarkOccurrenceModificationStamp;
 			if (markOccurrenceTargetRegion != null && !hasChanged) {
 				if (markOccurrenceTargetRegion.getOffset() <= offset && offset <= markOccurrenceTargetRegion.getOffset() + markOccurrenceTargetRegion.getLength())
 					return;
 			}
-			fMarkOccurrenceTargetRegion= JavaWordFinder.findWord(document, offset);
-			fMarkOccurrenceModificationStamp= currentModificationStamp;
+			targetRegion= JavaWordFinder.findWord(document, offset);
 		}
 
 		OccurrenceLocation[] locations= null;
@@ -3359,7 +3368,7 @@ public abstract class JavaEditor extends AbstractDecoratedTextEditor implements 
 			return;
 		}
 
-		fOccurrencesFinderJob= new OccurrencesFinderJob(document, locations, selection);
+		fOccurrencesFinderJob= new OccurrencesFinderJob(document, locations, selection, targetRegion, currentModificationStamp);
 		//fOccurrencesFinderJob.setPriority(Job.DECORATE);
 		//fOccurrencesFinderJob.setSystem(true);
 		//fOccurrencesFinderJob.schedule();


### PR DESCRIPTION
## What it does

Fixes occurrence-marking cache inconsistencies in `JavaEditor` that can prevent a valid selection in the same word from installing annotations.

Related to #1095. This addresses a reproduced cache-consistency problem; it does not establish that every failure reported in that issue has the same cause.

### Canceled updates

The target region and document modification stamp are published only after successful annotation installation, under the annotation-model lock.

A rejected update neither caches an unsuccessful result nor invalidates the last successfully installed result.

### Concurrent removal

`removeOccurrenceAnnotations()` clears both cache fields under the same lock used for installation and removal. The check for existing annotations is also inside the lock, so removal waits for an in-flight first installation.

Cache invalidation is retained when the document provider or annotation model is unavailable.

### Regression coverage

Tests cover cancellation and concurrent removal, each with and without existing annotations, followed by a valid retry in the same word.

They also verify successful cache reuse and preservation of annotation identity, target-region identity and modification stamp after cancellation.

Concurrent-removal tests force lock contention and use bounded thread waits. The occurrence-count helper waits for a matching AST callback and then the expected current annotation count; its existing 80-second timeout is unchanged.

The independent JUnit-session fix is reviewed in #3154 and is not included here. Diagnostic workflows remain on a fork-only QA branch.

## How to test

Run `org.eclipse.jdt.text.tests.MarkOccurrenceTest` as a JUnit Plug-in Test.

The focused regression methods are:

- `markOccurrencesAfterCanceledUpdate`
- `markOccurrencesAfterCanceledUpdateWithExistingAnnotations`
- `markOccurrencesAfterConcurrentRemoval`
- `markOccurrencesAfterConcurrentRemovalWithExistingAnnotations`

Run the complete class to include ordinary occurrence marking, disabled marking and editor reuse.

## Validation

Real Eclipse/PDE tests were run with Maven/Tycho, Java 21 and Xvfb on Ubuntu 22.04, independently of #3154.

- The isolated fix passed three clean runs of all 15 tests without skips.
- With the additional cache-preservation assertions in `6222df7`, two further clean runs passed all 15 tests without skips.
- Restoring only the original `JavaEditor` produced exactly the four expected regression failures in every negative-control run: three before and one after strengthening the assertions.
- XML reports were checked for actual execution, counts, failures and skips. The committed test-file blob matches the tested source.

[Independent repeated QA](https://github.com/carstenartur/eclipse.jdt.ui/actions/runs/33972336050)

[Expanded QA and strengthened assertions](https://github.com/carstenartur/eclipse.jdt.ui/actions/runs/33972634092)

These results do not replace the full upstream Jenkins run for the latest commit.

## Author checklist

- [ ] Full upstream CI validation for the latest commit is complete; scoped test results are documented above.
- [x] The change follows the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions).
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php).