### PR TITLE
[Build] Build with Java 25 in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
 	}
 	tools {
 		maven 'apache-maven-latest'
-		jdk 'temurin-jdk21-latest'
+		jdk 'temurin-jdk25-latest'
 	}
 	stages {
 		stage('Build') {


### PR DESCRIPTION
## What it does
Build with Java 25 in Jenkins now that Java-25 is generally the baseline for the Eclipse SDK.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
