### PR TITLE
Cancel ClassFileEditor background work on disposal

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/ClassFileEditorTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/editor/ClassFileEditorTests.java
@@ -15,6 +15,12 @@ package org.eclipse.jdt.ui.tests.editor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +33,12 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.StyledTextContent;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 
@@ -143,6 +154,54 @@ public class ClassFileEditorTests {
 		classEditor.highlightInstruction("b", "()V", 3);
 		assertEquals("    3  ldc <String \"b\"> [21]", getSingleHighlightedRange(classEditor));
 
+	}
+
+	@Test
+	void testClosingEditorCancelsPendingOverrideIndicatorInstallationJob() throws Exception {
+		createHelloWorldClass();
+		CountDownLatch aboutToRun= new CountDownLatch(1);
+		CountDownLatch releaseJob= new CountDownLatch(1);
+		CountDownLatch jobDone= new CountDownLatch(1);
+		AtomicReference<Job> capturedJob= new AtomicReference<>();
+		IJobManager jobManager= Job.getJobManager();
+		JobChangeAdapter listener= new JobChangeAdapter() {
+			@Override
+			public void aboutToRun(IJobChangeEvent event) {
+				Job job= event.getJob();
+				if (job.getClass().isAnonymousClass() && job.getClass().getEnclosingClass() == ClassFileEditor.class && capturedJob.compareAndSet(null, job)) {
+					aboutToRun.countDown();
+					try {
+						releaseJob.await(30, TimeUnit.SECONDS);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}
+			}
+
+			@Override
+			public void done(IJobChangeEvent event) {
+				if (event.getJob() == capturedJob.get()) {
+					jobDone.countDown();
+				}
+			}
+		};
+		jobManager.addJobChangeListener(listener);
+		try {
+			ClassFileEditor editor= createClassFileEditor(TYPE_NAME);
+			assertTrue(aboutToRun.await(30, TimeUnit.SECONDS), "Expected override indicator installation job to be scheduled");
+			Job job= capturedJob.get();
+			assertNotNull(job);
+
+			assertTrue(JavaPlugin.getActivePage().closeEditor(editor, false));
+			releaseJob.countDown();
+
+			assertTrue(jobDone.await(30, TimeUnit.SECONDS), "Expected override indicator installation job to finish");
+			assertNotNull(job.getResult());
+			assertEquals(IStatus.CANCEL, job.getResult().getSeverity());
+		} finally {
+			releaseJob.countDown();
+			jobManager.removeJobChangeListener(listener);
+		}
 	}
 
 	private String getSingleHighlightedRange(ClassFileEditor classEditor) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditor.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/ClassFileEditor.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -96,6 +97,7 @@ import org.eclipse.jdt.core.IOrdinaryClassFile;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.ToolFactory;
@@ -603,6 +605,7 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 	private StyledText fNoSourceTextWidget;
 	private StyleRange currentSelection;
 	private volatile boolean disposed;
+	private final AtomicReference<Job> fInstallSemanticHighlightingJob= new AtomicReference<>();
 	private Color instructionPointerColor = new Color(0, 255, 0);
 	private Map<MethodIdentifier, LineRegion> methodsToInstructionRegions;
 
@@ -803,33 +806,64 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 	 */
 	@Override
 	protected void installSemanticHighlighting() {
+		cancelInstallSemanticHighlightingJob();
 		super.installSemanticHighlighting();
+
+		ITypeRoot inputElement= getInputJavaElement();
+		if (inputElement == null || disposed) {
+			return;
+		}
+
 		Job job= new Job(JavaEditorMessages.OverrideIndicatorManager_intallJob) {
-			/*
-			 * @see org.eclipse.core.runtime.jobs.Job#run(org.eclipse.core.runtime.IProgressMonitor)
-			 * @since 3.0
-			 */
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				CompilationUnit ast= SharedASTProviderCore.getAST(getInputJavaElement(), SharedASTProviderCore.WAIT_YES, null);
-				if (fOverrideIndicatorManager != null) {
-					fOverrideIndicatorManager.reconciled(ast, true, monitor);
-				}
-				if (fSemanticManager != null) {
-					SemanticHighlightingReconciler reconciler= fSemanticManager.getReconciler();
-					if (reconciler != null) {
-						reconciler.reconciled(ast, false, monitor);
+				try {
+					if (!isCurrentInstallSemanticHighlightingJob(this, monitor)) {
+						return Status.CANCEL_STATUS;
 					}
+					CompilationUnit ast= SharedASTProviderCore.getAST(inputElement, SharedASTProviderCore.WAIT_YES, monitor);
+					if (!isCurrentInstallSemanticHighlightingJob(this, monitor)) {
+						return Status.CANCEL_STATUS;
+					}
+					if (fOverrideIndicatorManager != null) {
+						fOverrideIndicatorManager.reconciled(ast, true, monitor);
+					}
+					if (!isCurrentInstallSemanticHighlightingJob(this, monitor)) {
+						return Status.CANCEL_STATUS;
+					}
+					if (fSemanticManager != null) {
+						SemanticHighlightingReconciler reconciler= fSemanticManager.getReconciler();
+						if (reconciler != null) {
+							reconciler.reconciled(ast, false, monitor);
+						}
+					}
+					if (!isCurrentInstallSemanticHighlightingJob(this, monitor)) {
+						return Status.CANCEL_STATUS;
+					}
+					if (isMarkingOccurrences()) {
+						installOccurrencesFinder(false);
+					}
+					return Status.OK_STATUS;
+				} finally {
+					fInstallSemanticHighlightingJob.compareAndSet(this, null);
 				}
-				if (isMarkingOccurrences()) {
-					installOccurrencesFinder(false);
-				}
-				return Status.OK_STATUS;
 			}
 		};
+		fInstallSemanticHighlightingJob.set(job);
 		job.setPriority(Job.DECORATE);
 		job.setSystem(true);
 		job.schedule();
+	}
+
+	private boolean isCurrentInstallSemanticHighlightingJob(Job job, IProgressMonitor monitor) {
+		return !disposed && !monitor.isCanceled() && fInstallSemanticHighlightingJob.get() == job;
+	}
+
+	private void cancelInstallSemanticHighlightingJob() {
+		Job job= fInstallSemanticHighlightingJob.getAndSet(null);
+		if (job != null) {
+			job.cancel();
+		}
 	}
 
 	@Override
@@ -1141,7 +1175,8 @@ public class ClassFileEditor extends JavaEditor implements ClassFileDocumentProv
 	 */
 	@Override
 	public void dispose() {
-		disposed = true;
+		disposed= true;
+		cancelInstallSemanticHighlightingJob();
 		// http://bugs.eclipse.org/bugs/show_bug.cgi?id=18510
 		IDocumentProvider documentProvider= getDocumentProvider();
 		if (documentProvider instanceof ClassFileDocumentProvider) {


### PR DESCRIPTION
## What it does

<!-- Include relevant issues and describe how they are addressed. -->

`ClassFileEditor.installSemanticHighlighting()` schedules editor-specific
background work, but the job was previously kept only in a local variable.
Consequently, closing or reusing the editor could not cancel or invalidate
that work.

The job obtains an AST for the editor input and subsequently updates
editor-owned state, including override indicators, semantic highlighting,
and occurrence handling. `JavaEditor.dispose()` tears these facilities down,
but the independently running `ClassFileEditor` job could continue after that
teardown had already started.

This change makes the installation job explicitly owned by the
`ClassFileEditor` lifecycle:

* keep the currently valid installation job in an `AtomicReference<Job>`
* invalidate and cancel an older installation job before scheduling a new one
* invalidate and cancel the job when the editor is disposed
* capture the `ITypeRoot` for which the job was created instead of obtaining a
  possibly changed editor input later
* pass the job's `IProgressMonitor` to
  `SharedASTProviderCore.getAST(...)` instead of `null`
* stop processing when the job has been cancelled, the editor has been
  disposed, or the job has been superseded
* perform lifecycle checks before and after AST acquisition and before
  subsequent editor-state updates
* use `compareAndSet(this, null)` when a job finishes so that an older job
  cannot accidentally clear the reference to a newer replacement job

The normal successful path remains unchanged while the editor is alive and
the job is still the currently owned installation job.

### Why this is a lifecycle problem

The background work is not independent from the editor.

Among other things, the job interacts with:

* the editor input
* `fOverrideIndicatorManager`
* `fSemanticManager`
* `installOccurrencesFinder(false)`

The corresponding facilities are normally removed as part of editor
disposal.

Previously there was no lifecycle relationship between that teardown and the
background installation job. In particular, the job could be waiting in

```java
SharedASTProviderCore.getAST(...)
```

while the editor was closed and then continue processing after the AST
request returned.

That permits an ordering such as:

1. a `ClassFileEditor` schedules its highlighting installation job
2. the job starts obtaining the AST
3. the editor is closed
4. `JavaEditor.dispose()` removes editor-specific infrastructure
5. the old job resumes
6. it continues accessing or installing state for the editor that initiated it

The patch invalidates the job when ownership of that editor state ends.
Obsolete work therefore cannot proceed past the next lifecycle check before
subsequent editor-state updates.

Cancellation remains deliberately cooperative. `dispose()` does not
synchronously wait for the background job to terminate. Doing so could make
editor shutdown block on AST acquisition and would introduce a substantially
less desirable UI-thread dependency.

### Why `AtomicReference` is used

Using only a `volatile Job` would still leave a replacement race.

For example:

1. job A is about to finish
2. job B is scheduled and replaces A
3. A executes its cleanup
4. A clears the field
5. the reference to B is lost

The finishing job therefore clears itself with:

```java
fInstallSemanticHighlightingJob.compareAndSet(this, null);
```

Cancellation invalidates the currently owned job with `getAndSet(null)`
before requesting cancellation.

This makes replacement and cleanup of job ownership atomic: an obsolete job
cannot remove ownership of a newer job.

### Historical context

This code path is old.

An asynchronously scheduled `ClassFileEditor` job without disposal ownership
is visible at least in the April 13, 2010 change for Eclipse Bug 308898:

https://bugs.eclipse.org/bugs/show_bug.cgi?id=308898

https://github.com/eclipse-jdt/eclipse.jdt.ui/commit/68747f1a984c22aa8a58fcbe4e7e5ac2170a5a6e

The current `installSemanticHighlighting()` structure was introduced as part
of the January 24, 2011 change for Eclipse Bug 332124:

https://bugs.eclipse.org/bugs/show_bug.cgi?id=332124

https://github.com/eclipse-jdt/eclipse.jdt.ui/commit/66f3a3c1216483b2de235487522317109009a12b

Those changes addressed class-file AST/reconciliation and semantic
highlighting behavior, but the scheduled job remained local to
`installSemanticHighlighting()`. There was therefore no job reference
available to `dispose()`.

Semantic highlighting support for `ClassFileEditor` predates even those
changes and can be traced back to 2004:

https://github.com/eclipse-jdt/eclipse.jdt.ui/commit/5e2552aebb38d08f0e925fc4b9e54931f23dd17b

This PR does not claim that the exact lifecycle defect has existed unchanged
since 2004. The relevant unmanaged asynchronous-job pattern is demonstrably
present from at least April 2010, and the current method structure dates from
January 2011.

### Relation to previous class-file/source failures

The investigation was prompted by observing that a `ClassFileEditor`
installation job started by one test could still be alive after that editor
had been closed and execution had moved on.

This is relevant to earlier investigations of intermittent class-file and
source-related failures, in particular:

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/736

Issue #736 collected intermittent failures involving class-file/source state,
including `source=null`, unexpected proposal counts, inconsistent class-file
parents, and editor-selection failures.

During that investigation, a `source=null` failure was narrowed down to a
missing class-file buffer, and possible interaction with
`AbstractClassFile.validateClassFile()` and buffer management was discussed.

The issue also references the older Eclipse Bug 550180:

https://bugs.eclipse.org/bugs/show_bug.cgi?id=550180

Tracing performed during that earlier investigation had shown buffers being
reused for files in JARs recreated between test methods.

JDT Core subsequently received synchronization changes for possible
concurrent `Buffer` access, explicitly referring to #736:

https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2596

Those changes addressed a real concurrency concern in the buffer
implementation, but the collection of failures tracked in #736 did not
establish one single root cause.

Issue #736 was eventually closed on July 20, 2026 because the failure had not
been observed recently, rather than because every previously reported failure
had been explained by a demonstrated root cause.

This PR therefore deliberately does not claim to "fix #736".

What can be demonstrated independently is the narrower lifecycle defect:

> Editor-specific `ClassFileEditor` background work can survive disposal of
> the editor that started it.

The job includes AST/class-file processing. Removing that overlap also
removes one plausible way for stale work from an earlier editor to continue
while project, JAR, source attachment, Java-model, or buffer state is being
changed by later work.

That makes the change relevant to the historical failures without claiming
an unproven one-to-one causal relationship.

### Scope

The change does not modify:

* JDT Core buffer management
* Java model cache semantics
* `SharedASTProviderCore`
* AST creation semantics
* semantic-highlighting results for a live editor
* annotation assist behavior
* test project naming or test isolation

It only establishes lifecycle ownership for the already existing
`ClassFileEditor` installation job. Once that ownership is invalidated,
obsolete work is prevented from proceeding past its next lifecycle check
before subsequent editor-state updates.

## How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

A deterministic regression test was added to `ClassFileEditorTests`:

`testClosingEditorCancelsPendingOverrideIndicatorInstallationJob`

The test uses a job listener and latches rather than timing sleeps:

1. open a `ClassFileEditor`
2. identify its installation job
3. hold that job in `aboutToRun`, before `run()` starts
4. close/dispose the owning editor
5. release the pending job
6. wait for it to finish
7. verify that its result is `IStatus.CANCEL`

This directly tests the relevant lifecycle ordering rather than depending on
a historical intermittent failure to reproduce.

### Focused A/B validation

A focused negative-control workflow was run on Ubuntu 22.04 with Java 21 and
Xvfb against the immutable PR head:

https://github.com/carstenartur/eclipse.jdt.ui/actions/runs/34060150021

Candidate:

`141d4e9ca5ebf2930db2e4f233fda3b6f0aad2de`

Upstream base:

`6312a1cc907ad0a5ac5dd42e998eb0cbac686205`

Both variants use exactly the same new regression test.

For the negative-control variant, only
`ClassFileEditor.java` is restored from the upstream base; the regression test
remains unchanged.

| Variant | Tests | Failures | Errors | Skipped |
| --- | ---: | ---: | ---: | ---: |
| patched production code | 1 | 0 | 0 | 0 |
| upstream production code + new test | 1 | 1 | 0 | 0 |

The failure in the negative control is exactly:

`testClosingEditorCancelsPendingOverrideIndicatorInstallationJob`

The test expects:

`IStatus.CANCEL == 8`

while the unmodified production implementation returns:

`IStatus.OK == 0`

reported by the assertion as:

`expected: <8> but was: <0>`

The workflow verifies the Surefire XML rather than merely accepting Maven's
exit status. It requires the target test to run exactly once, rejects errors
and skipped tests, requires no failure for the patched variant, and requires
exactly this lifecycle-test failure for the negative control.

This demonstrates that the regression test distinguishes the original
lifecycle behavior from the fix without relying on unrelated PDE/UI test
failures.

### Additional validation

The current PR head also passes the upstream GitHub checks:

* Pull-Request Checks
* CodeQL

The branch is based directly on the current upstream `master` base and
contains only the production lifecycle change and its regression test.

A separate implementation-specific test for the internal job-A/job-B CAS
interleaving was considered during QA. Forcing that exact interleaving is not
available through the public editor behavior and would require reflection
into private state or a production test hook. Such a test would primarily
verify the chosen `AtomicReference` implementation rather than the observable
editor lifecycle contract, so no additional test-only coupling was introduced.

## Author checklist

* [ ] I have thoroughly tested my changes
* [x] The change is following the coding conventions
* [x] I have signed the Eclipse Contributor Agreement (ECA)
