### PR TITLE
Fix: external markdown inline links navigation in Javadoc comments

### DIFF
--- a/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
+++ b/org.eclipse.jdt.core.manipulation/common/org/eclipse/jdt/core/manipulation/internal/javadoc/CoreJavadocAccessImpl.java
@@ -1528,12 +1528,16 @@ public class CoreJavadocAccessImpl implements IJavadocAccess {
 
 			if (refTypeName != null) {
 				fBuf.append("<a href='"); //$NON-NLS-1$
-				try {
-					String scheme= CoreJavaElementLinks.JAVADOC_SCHEME;
-					String uri= createLinkURI(scheme, fElement, refTypeName, refMemberName, refMethodParamTypes);
-					fBuf.append(uri);
-				} catch (URISyntaxException e) {
-					JavaManipulationPlugin.log(e);
+				if (refTypeName.startsWith("http://") || refTypeName.startsWith("https://")) { //$NON-NLS-1$ //$NON-NLS-2$
+					fBuf.append(refTypeName);
+				} else {
+					try {
+						String scheme= CoreJavaElementLinks.JAVADOC_SCHEME;
+						String uri= createLinkURI(scheme, fElement, refTypeName, refMemberName, refMethodParamTypes);
+						fBuf.append(uri);
+					} catch (URISyntaxException e) {
+						JavaManipulationPlugin.log(e);
+					}
 				}
 				fBuf.append("'>"); //$NON-NLS-1$
 				if (fs > 1 && ((fs != 2) || !CoreJavadocContentAccessUtility.isWhitespaceTextElement(fragments.get(1)))) {

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/hover/MarkdownCommentTests.java
@@ -1168,4 +1168,20 @@ public class MarkdownCommentTests extends CoreTests {
 		assertTrue("Doesn't contain expected content", actualHtmlContent.contains(expectedContent));
 	}
 
+	@Test
+	public void testMarkdownInlineLinkToExternalSite_GH3160() throws CoreException {
+		String source= """
+				/// [Eclipse](https://www.eclipse.org)
+				public class Markdown {}
+				""";
+		ICompilationUnit cu= getWorkingCopy("/TestSetupProject/src/p/Markdown.java", source, null);
+		assertNotNull("Markdown.java", cu);
+		String expectedContent= "<a href='https://www.eclipse.org'>Eclipse</a>";
+		IType type= cu.getType("Markdown");
+		String actualHtmlContent= getHoverHtmlContent(cu, type);
+		int index= actualHtmlContent.lastIndexOf("<a href=");
+		assertNotEquals(-1, index);
+		String actualSnippet= actualHtmlContent.substring(index, index + expectedContent.length());
+		assertEquals("external markdown link should navigate directly to the site", expectedContent, actualSnippet);
+	}
 }


### PR DESCRIPTION
Markdown Javadoc links to external websites (e.g. `[Eclipse](https://www.eclipse.org)`) were incorrectly converted into internal eclipse-javadoc: URIs, breaking navigation. This fix preserves raw http:// and https:// URLs in generated HTML anchor tags so the Javadoc view and hover can open them properly.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3160

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
