### PR TITLE
Bug 570024 - Enable JUnit rename participants for Jupiter projects

### DIFF
--- a/org.eclipse.jdt.junit/plugin.xml
+++ b/org.eclipse.jdt.junit/plugin.xml
@@ -322,7 +322,10 @@
            </with>
            <with variable="element">
              <instanceof value="org.eclipse.jdt.core.IType"/>
- 	         <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="junit.framework.Test"/>
+             <or>
+               <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="junit.framework.Test"/>
+               <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="org.junit.platform.commons.annotation.Testable"/>
+             </or>
             </with>
          </enablement>
       </renameParticipant>
@@ -338,7 +341,10 @@
            </with>
            <with variable="element">
    	         <instanceof value="org.eclipse.jdt.core.IJavaProject"/>
-	         <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="junit.framework.Test"/>
+             <or>
+               <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="junit.framework.Test"/>
+               <test property="org.eclipse.jdt.core.hasTypeOnClasspath" value="org.junit.platform.commons.annotation.Testable"/>
+             </or>
            </with>
          </enablement>
       </renameParticipant>

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitJUnitTests.java
@@ -48,6 +48,7 @@ JUnit4TestFinderTest16.class,
 JUnit5TestFinderJupiterTest.class,
 JUnit6TestFinderJupiterTest.class,
 JUnitStandaloneDetectionTest.class,
+JUnitRenameParticipantTest.class,
 
 JUnitQuickAssistTest.class,
 

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitRenameParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitRenameParticipantTest.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial tests
+ *******************************************************************************/
+package org.eclipse.jdt.junit.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import org.eclipse.jdt.junit.JUnitCore;
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
+
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CheckConditionsOperation;
+import org.eclipse.ltk.core.refactoring.CreateChangeOperation;
+import org.eclipse.ltk.core.refactoring.PerformChangeOperation;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.participants.ParticipantManager;
+import org.eclipse.ltk.core.refactoring.participants.RenameArguments;
+import org.eclipse.ltk.core.refactoring.participants.RenameParticipant;
+import org.eclipse.ltk.core.refactoring.participants.RenameRefactoring;
+import org.eclipse.ltk.core.refactoring.participants.SharableParticipants;
+
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+
+import org.eclipse.jdt.internal.corext.refactoring.rename.RenameJavaProjectProcessor;
+import org.eclipse.jdt.internal.corext.refactoring.rename.RenameTypeProcessor;
+import org.eclipse.jdt.internal.junit.buildpath.BuildPathSupport;
+import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
+
+import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
+
+public class JUnitRenameParticipantTest {
+
+	private IJavaProject fProject;
+	private IJavaProject fRenamedProject;
+	private IPackageFragmentRoot fSourceFolder;
+	private IPackageFragment fPackage;
+	private final List<ILaunchConfiguration> fLaunchConfigurations= new ArrayList<>();
+	private Change fUndoChange;
+
+	@AfterEach
+	public void tearDown() throws Exception {
+		if (fUndoChange != null) {
+			fUndoChange.dispose();
+		}
+		for (ILaunchConfiguration configuration : fLaunchConfigurations) {
+			configuration.delete();
+		}
+		if (fProject != null && fProject.exists()) {
+			JavaProjectHelper.delete(fProject);
+		}
+		if (fRenamedProject != null && fRenamedProject.exists()) {
+			JavaProjectHelper.delete(fRenamedProject);
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints= { 4, 5, 6 })
+	public void testProjectRenameUpdatesTestContainers(int junitVersion) throws Exception {
+		createProject(junitVersion);
+		List<IJavaElement> originalContainers= List.of(fProject, fSourceFolder, fPackage);
+		for (IJavaElement container : originalContainers) {
+			createLaunchConfiguration(container, junitVersion);
+		}
+		String newName= fProject.getElementName() + "Renamed";
+		fRenamedProject= fProject.getJavaModel().getJavaProject(newName);
+		assertFalse(fRenamedProject.exists());
+		IPackageFragmentRoot renamedSourceFolder= fRenamedProject.getPackageFragmentRoot("src");
+		List<IJavaElement> renamedContainers= List.of(fRenamedProject, renamedSourceFolder,
+				renamedSourceFolder.getPackageFragment(fPackage.getElementName()));
+
+		RenameJavaProjectProcessor processor= new RenameJavaProjectProcessor(fProject);
+		processor.setNewElementName(newName);
+		processor.setUpdateReferences(true);
+		CreateChangeOperation create= new CreateChangeOperation(
+				new CheckConditionsOperation(new RenameRefactoring(processor), CheckConditionsOperation.ALL_CONDITIONS), RefactoringStatus.FATAL);
+		PerformChangeOperation perform= new PerformChangeOperation(create);
+		Change undo= perform(perform);
+		assertTrue(create.getConditionCheckingStatus().isOK(), () -> create.getConditionCheckingStatus().toString());
+		assertFalse(fProject.exists());
+		assertTestContainers(renamedContainers);
+
+		Change redo= perform(new PerformChangeOperation(undo));
+		assertFalse(fRenamedProject.exists());
+		assertTestContainers(originalContainers);
+
+		perform(new PerformChangeOperation(redo));
+		assertFalse(fProject.exists());
+		assertTestContainers(renamedContainers);
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints= { 4, 5, 6 })
+	public void testTypeRenameParticipantIsLoaded(int junitVersion) throws Exception {
+		IType type= createProject(junitVersion);
+		RenameRefactoring refactoring= new RenameRefactoring(new RenameTypeProcessor(type));
+		RefactoringStatus status= new RefactoringStatus();
+		RenameParticipant[] participants= ParticipantManager.loadRenameParticipants(status, refactoring.getProcessor(), type,
+				new RenameArguments("RenamedTest", true),
+				(configuration, participantStatus) -> "org.eclipse.jdt.junit.renameTypeParticipant".equals(configuration.getAttribute("id")),
+				new String[] { JavaCore.NATURE_ID }, new SharableParticipants());
+		assertTrue(status.isOK(), status::toString);
+		// The general debug participant also updates type names, so a successful rename alone
+		// would not prove that the JUnit participant's enablement works.
+		assertEquals(1, participants.length, "The JUnit type rename participant must be loaded");
+	}
+
+	private IType createProject(int junitVersion) throws Exception {
+		fProject= JavaProjectHelper.createJavaProject("JUnitRenameParticipantTest" + junitVersion, "bin");
+		JavaProjectHelper.addRTJar_17(fProject, false);
+		JavaProjectHelper.set17CompilerOptions(fProject, false);
+		if (junitVersion == 5) {
+			// Use only Jupiter's API dependencies: the JUnit 5 container can also supply
+			// JUnit 4, which would hide bug 570024.
+			JavaProjectHelper.addToClasspath(fProject, BuildPathSupport.getJUnitJupiterApiLibraryEntry());
+			JavaProjectHelper.addToClasspath(fProject, BuildPathSupport.getJUnitPlatformCommonsLibraryEntry());
+			JavaProjectHelper.addToClasspath(fProject, BuildPathSupport.getJUnitOpentest4jLibraryEntry());
+			JavaProjectHelper.addToClasspath(fProject, BuildPathSupport.getJUnitApiGuardianLibraryEntry());
+		} else {
+			JavaProjectHelper.addToClasspath(fProject, JavaCore.newContainerEntry(new Path(JUnitCore.JUNIT_CONTAINER_ID).append(Integer.toString(junitVersion))));
+		}
+		if (junitVersion == 4) {
+			assertNotNull(fProject.findType("junit.framework.Test"));
+		} else {
+			assertNull(fProject.findType("junit.framework.Test"), "This must be a pure JUnit Jupiter project");
+			assertNotNull(fProject.findType("org.junit.platform.commons.annotation.Testable"));
+		}
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fProject, "src");
+		fPackage= fSourceFolder.createPackageFragment("tests", true, null);
+		String annotation= junitVersion == 4 ? "org.junit.Test" : "org.junit.jupiter.api.Test";
+		return fPackage.createCompilationUnit("SampleTest.java", """
+				package tests;
+				public class SampleTest {
+				    @%s
+				    public void test() {}
+				}
+				""".formatted(annotation), true, null).getType("SampleTest");
+	}
+
+	private void createLaunchConfiguration(IJavaElement container, int junitVersion) throws CoreException {
+		ILaunchManager manager= DebugPlugin.getDefault().getLaunchManager();
+		ILaunchConfigurationWorkingCopy configuration= manager.getLaunchConfigurationType(JUnitLaunchConfigurationConstants.ID_JUNIT_APPLICATION)
+				.newInstance(null, manager.generateLaunchConfigurationName("JUnit rename " + container.getElementName()));
+		configuration.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProject.getElementName());
+		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, container.getHandleIdentifier());
+		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, "org.eclipse.jdt.junit.loader.junit" + junitVersion);
+		fLaunchConfigurations.add(configuration.doSave());
+	}
+
+	private void assertTestContainers(List<IJavaElement> containers) throws CoreException {
+		for (int i= 0; i < containers.size(); i++) {
+			IJavaElement expected= containers.get(i);
+			ILaunchConfiguration configuration= fLaunchConfigurations.get(i);
+			assertEquals(expected.getJavaProject().getElementName(), configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, ""));
+			String handle= configuration.getAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, "");
+			assertEquals(expected.getHandleIdentifier(), handle, configuration.getName());
+			IJavaElement actual= JavaCore.create(handle);
+			assertNotNull(actual);
+			assertTrue(actual.exists(), "The launch target must still exist");
+		}
+	}
+
+	private Change perform(PerformChangeOperation operation) throws CoreException {
+		ResourcesPlugin.getWorkspace().run(operation, new NullProgressMonitor());
+		fUndoChange= operation.getUndoChange();
+		assertTrue(operation.changeExecuted(), () -> String.valueOf(operation.getConditionCheckingStatus()));
+		assertFalse(operation.getValidationStatus().hasFatalError(), () -> operation.getValidationStatus().toString());
+		assertNotNull(fUndoChange);
+		return fUndoChange;
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitRenameParticipantTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/JUnitRenameParticipantTest.java
@@ -62,6 +62,7 @@ import org.eclipse.jdt.internal.corext.refactoring.rename.RenameJavaProjectProce
 import org.eclipse.jdt.internal.corext.refactoring.rename.RenameTypeProcessor;
 import org.eclipse.jdt.internal.junit.buildpath.BuildPathSupport;
 import org.eclipse.jdt.internal.junit.launcher.JUnitLaunchConfigurationConstants;
+import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants;
 
@@ -179,7 +180,13 @@ public class JUnitRenameParticipantTest {
 				.newInstance(null, manager.generateLaunchConfigurationName("JUnit rename " + container.getElementName()));
 		configuration.setAttribute(IJavaLaunchConfigurationConstants.ATTR_PROJECT_NAME, fProject.getElementName());
 		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER, container.getHandleIdentifier());
-		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, "org.eclipse.jdt.junit.loader.junit" + junitVersion);
+		String testKindId= switch (junitVersion) {
+			case 4 -> TestKindRegistry.JUNIT4_TEST_KIND_ID;
+			case 5 -> TestKindRegistry.JUNIT5_TEST_KIND_ID;
+			case 6 -> TestKindRegistry.JUNIT6_TEST_KIND_ID;
+			default -> throw new IllegalArgumentException("Unsupported JUnit version: " + junitVersion);
+		};
+		configuration.setAttribute(JUnitLaunchConfigurationConstants.ATTR_TEST_RUNNER_KIND, testKindId);
 		fLaunchConfigurations.add(configuration.doSave());
 	}
 
@@ -197,8 +204,16 @@ public class JUnitRenameParticipantTest {
 	}
 
 	private Change perform(PerformChangeOperation operation) throws CoreException {
-		ResourcesPlugin.getWorkspace().run(operation, new NullProgressMonitor());
-		fUndoChange= operation.getUndoChange();
+		try {
+			ResourcesPlugin.getWorkspace().run(operation, new NullProgressMonitor());
+		} finally {
+			// PerformChangeOperation disposes executed changes, including intermediate undo/redo
+			// changes. Keep the unperformed inverse for tearDown(), even if workspace.run fails.
+			fUndoChange= operation.getUndoChange();
+			if (!operation.changeExecuted() && operation.getChange() != null) {
+				operation.getChange().dispose();
+			}
+		}
 		assertTrue(operation.changeExecuted(), () -> String.valueOf(operation.getConditionCheckingStatus()));
 		assertFalse(operation.getValidationStatus().hasFatalError(), () -> operation.getValidationStatus().toString());
 		assertNotNull(fUndoChange);


### PR DESCRIPTION
## What it does

Fixes [Bug 570024](https://bugs.eclipse.org/bugs/show_bug.cgi?id=570024).

The JUnit type and project rename participants are enabled only when
`junit.framework.Test` is on the affected project's classpath. Pure JUnit
Jupiter projects do not require that legacy API, so their JUnit rename
participants are never loaded.

For project renames, this leaves
`JUnitLaunchConfigurationConstants.ATTR_TEST_CONTAINER` pointing to the
old Java element handle. An existing launch configuration targeting all
tests in a project, source folder, or package can therefore lose its test
target, even when the general Java debug participant has updated the
project-name attribute.

This change enables both participants when either type is present:

- `junit.framework.Test` for JUnit 3/4.
- `org.junit.platform.commons.annotation.Testable` for JUnit Platform,
  including Jupiter 5/6.

There is no single mandatory JUnit API type shared by standalone JUnit 3/4
and pure Jupiter projects. Legacy classes may appear through Vintage, but
relying on that optional compatibility support excludes pure Jupiter
projects.

The two-marker condition matches the JUnit launch shortcut's existing
enablement in the same `plugin.xml`. `Testable` has been a stable Platform
API since 1.0 and is intended to support IDE/tooling test detection.
Here, its presence enables the participant; the type participant then
checks the selected type through the existing test discovery logic.

## How to test

Run `org.eclipse.jdt.junit.tests.JUnitRenameParticipantTest` as a JUnit
plug-in test, or execute the following from the repository root with
Java 21 and a graphical display (Xvfb on headless Linux):

```sh
mvn -Pbuild-individual-bundles -pl org.eclipse.jdt.ui.tests -am \
  -Dtest=org.eclipse.jdt.junit.tests.JUnitRenameParticipantTest \
  -Dtycho.baseline.replace=none \
  -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipTests=false -DleakTestsArgLine= verify
```

`-Dtycho.baseline.replace=none` ensures that local changes are tested
instead of being replaced by a prebuilt baseline bundle.

The six parameterized cases cover JUnit 4, 5, and 6:

- Perform an actual Java project rename and verify saved launch
  configurations for project, source-folder, and package targets.
  Check the project name, container handle, and existence of the target
  after rename, undo, and redo.
- Load the JUnit type rename participant through the extension registry.
  A successful type rename alone would be insufficient evidence because
  the general Java debug participant can also update the main type name.

The Jupiter fixtures explicitly assert that `junit.framework.Test` is
absent, so compatibility dependencies cannot hide the regression.
The JUnit 4 cases exercise the existing legacy condition.

Locally verified with the new regression class retained in both runs:

| Enablement | Result |
| --- | --- |
| Original `plugin.xml` condition | 4 failures (JUnit 5/6), 2 passes (JUnit 4) |
| Updated condition | All 6 cases pass |

Validation covered this regression class in the Eclipse UI test harness
and the required reactor build. The class is registered in
`JUnitJUnitTests` for normal suite execution.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
