### PR TITLE
Revert "Fix Package Explorer View filter not filtering non-archive plug-ins part 2 (#3041)"

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filters/ContainedLibraryFilter.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/filters/ContainedLibraryFilter.java
@@ -30,13 +30,16 @@ public class ContainedLibraryFilter extends ViewerFilter {
 
 	@Override
 	public boolean select(Viewer viewer, Object parentElement, Object element) {
-		if (element instanceof IPackageFragmentRoot root) {
-			// don't filter out libraries contained in the project itself
-			IResource resource= root.getResource();
-			if (resource != null) {
-				IProject project= resource.getProject();
-				IProject container= root.getJavaProject().getProject();
-				return !container.equals(project);
+		if (element instanceof IPackageFragmentRoot) {
+			IPackageFragmentRoot root= (IPackageFragmentRoot)element;
+			if (root.isArchive()) {
+				// don't filter out JARs contained in the project itself
+				IResource resource= root.getResource();
+				if (resource != null) {
+					IProject jarProject= resource.getProject();
+					IProject container= root.getJavaProject().getProject();
+					return !container.equals(jarProject);
+				}
 			}
 		}
 		return true;


### PR DESCRIPTION
This caused a regression in also hiding src folders. See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3164

This reverts commit 0c7a0a1ce444b71bb6e57ad49650b9556a8e710d.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
