### PR TITLE
Fix move instance method to not move when target type used as lambda

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1379,6 +1379,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String MoveInstanceMethodProcessor_no_native_methods;
 
+	public static String MoveInstanceMethodProcessor_no_lambdas;
+
 	public static String MoveInstanceMethodProcessor_no_null_argument;
 
 	public static String MoveInstanceMethodProcessor_no_resolved_target;
@@ -2550,8 +2552,6 @@ public final class RefactoringCoreMessages extends NLS {
 	public static String ConvertToRecordRefactoring_has_initializer;
 
 	public static String ConvertToRecordRefactoring_member_types_not_supported;
-
-
 
 	static {
 		NLS.initializeMessages(BUNDLE_NAME, RefactoringCoreMessages.class);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -932,6 +932,7 @@ MoveInstanceMethodProcessor_no_annotation=This refactoring cannot be used to mov
 MoveInstanceMethodProcessor_method_will_override_call_in_inner_subclass=Moving method to target will cause logic change in class: ''{0}'' that sub-classes target.
 MoveInstanceMethodProcessor_this_reference=A reference to 'this' has been found
 MoveInstanceMethodProcessor_no_resolved_target=The target of the method could not be resolved.
+MoveInstanceMethodProcessor_no_lambdas=The method invocation ''{0}'' cannot be updated due to use of lambda expression.
 MoveInstanceMethodProcessor_no_null_argument=The method invocation ''{0}'' cannot be updated, since it uses null as argument.
 MoveInstanceMethodProcessor_target_name_already_used=The name of the target conflicts with the method parameter ''{0}''.
 MoveInstanceMethodProcessor_target_null_comparison=The move will cause ''{0}'' being replaced by ''this'' and compared to null which is invalid logic and may imply an NPE can occur.

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -100,6 +100,7 @@ import org.eclipse.jdt.core.dom.IVariableBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.InfixExpression.Operator;
 import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.LambdaExpression;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.MethodInvocation;
 import org.eclipse.jdt.core.dom.MethodRef;
@@ -2500,6 +2501,9 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 						final Expression argument= (Expression) invocation.arguments().get(index);
 						if (argument instanceof NullLiteral) {
 							status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_no_null_argument, BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED)), JavaStatusContext.create(rewriter.getCu(), invocation)));
+							result= false;
+						} else if (argument instanceof LambdaExpression) {
+							status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_no_lambdas, BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED))));
 							result= false;
 						} else {
 							if (argument instanceof ThisExpression)

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail22/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail22/in/A.java
@@ -1,0 +1,22 @@
+package p1;
+
+class C {
+    public void foo() static {
+        A source = new A();
+        int result = source.m(() -> 7);
+        System.out.println(result);
+    }
+}
+
+class A {
+    // Move Instance Method target
+    // Move to parameter: target
+    int m(B target) {
+        return target.value() + 1;
+    }
+}
+
+@FunctionalInterface
+interface B {
+    int value();
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -904,4 +904,10 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 	public void testFail21() throws Exception {
 		failHelper1(new String[] { "p1.A", "p1.B" }, "p1.A", 6, 9, 6, 10, FIELD, "b", true, true);
 	}
+
+	// Issue 3124
+	@Test
+	public void testFail22() throws Exception {
+		failHelper1(new String[] { "p1.A" }, "p1.A", 14, 9, 14, 10, FIELD, "b", true, true);
+	}
 }


### PR DESCRIPTION
- modify MoveInstanceMethodProcessor.createInlineMethodInvocation() to recognize when the argument to modify is a lambda expression and in such a case create an error status with message
- add new test to MoveInstanceMethodTests
- fixes #3124

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
