### PR TITLE
Add IO templates for Java 25 simplified main and output

### DIFF
--- a/org.eclipse.jdt.ui/templates/default-postfixtemplates.xml
+++ b/org.eclipse.jdt.ui/templates/default-postfixtemplates.xml
@@ -2,7 +2,7 @@
 
 <!--
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Nicolaj Hoess.
+ * Copyright (c) 2019, 2026 Nicolaj Hoess.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -65,6 +65,8 @@
 	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.snull" context="postfix" deleted="false" description="%PostfixTemplates.snull" enabled="true" name="snull">(${i:inner_expression(java.lang.Object,array)} == null) ? ${} : ${inner_expression}${cursor}</template>
 
 	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.sysout" context="postfix" deleted="false" description="%PostfixTemplates.sysout" enabled="true" name="sysout">System.out.println(${i:inner_expression(java.lang.String)}${});${cursor}</template>
+	
+	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.ioprt" context="postfix" deleted="false" description="%PostfixTemplates.ioprt" enabled="true" name="ioprt">IO.println(${i:inner_expression(java.lang.String)}${});${cursor}</template>
 
 	<template autoinsert="true" id="org.eclipse.jdt.postfixcompletion.throw" context="postfix" deleted="false" description="%PostfixTemplates.throw" enabled="true" name="throw">throw ${true:inner_expression(java.lang.Throwable)};</template>
 

--- a/org.eclipse.jdt.ui/templates/default-templates.xml
+++ b/org.eclipse.jdt.ui/templates/default-templates.xml
@@ -2,7 +2,7 @@
 
 <!--
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -144,6 +144,11 @@
 	${cursor}
 }</template>
 
+
+<template name="mainvoid" description="%Templates.main" id="org.eclipse.jdt.ui.templates.mainvoid" context="java-members" enabled="true" autoinsert="false">void main() {
+	${cursor}
+}</template>
+
 <template name="public_method" description="%Templates.public_method" id="org.eclipse.jdt.ui.templates.public_method" context="java-members" enabled="true" autoinsert="false">public ${void} ${name}(${}) {
 	${cursor}
 }</template>
@@ -184,9 +189,13 @@ return ${name};</template>
 
 <template name="sysout" description="%Templates.sysout" id="org.eclipse.jdt.ui.templates.sysout" context="java-statements" enabled="true" autoinsert="true">System.out.println(${word_selection}${});${cursor}</template>
 
+<template name="ioprt" description="%Templates.sysout" id="org.eclipse.jdt.ui.templates.ioprt" context="java-statements" enabled="true" autoinsert="true">IO.println(${word_selection}${});${cursor}</template>
+
 <template name="syserr" description="%Templates.syserr" id="org.eclipse.jdt.ui.templates.syserr" context="java-statements" enabled="true" autoinsert="true">System.err.println(${word_selection}${});${cursor}</template>
 
 <template name="systrace" description="%Templates.systrace" id="org.eclipse.jdt.ui.templates.systrace" context="java-statements" enabled="true" autoinsert="true">System.out.println(&quot;${enclosing_type}.${enclosing_method}()&quot;);</template>
+
+<template name="iotrace" description="%Templates.systrace" id="org.eclipse.jdt.ui.templates.iotrace" context="java-statements" enabled="true" autoinsert="true">IO.println(&quot;${enclosing_type}.${enclosing_method}()&quot;);</template>
 
 <template name="&lt;code&gt;" description="%Templates.code_tag" id="org.eclipse.jdt.ui.templates.code_tag" context="javadoc" enabled="true" autoinsert="true">&lt;code&gt;${word_selection}${}&lt;/code&gt;${cursor}</template>
 


### PR DESCRIPTION
Add templates for the java.io.IO API, including IO.println() and IO-based trace output. Also add a template for the simplified void main() entry point introduced by Java 25 and an IO println postfix completion.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
