### PR TITLE
Fix move refactoring to avoid reversing call order

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/RefactoringCoreMessages.java
@@ -1401,6 +1401,8 @@ public final class RefactoringCoreMessages extends NLS {
 
 	public static String MoveInstanceMethodProcessor_remove_original_method;
 
+	public static String MoveInstanceMethodProcessor_reverse_call;
+
 	public static String MoveInstanceMethodProcessor_single_implementation;
 
 	public static String MoveInstanceMethodProcessor_target_element_pattern;

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/refactoring.properties
@@ -935,6 +935,7 @@ MoveInstanceMethodProcessor_no_resolved_target=The target of the method could no
 MoveInstanceMethodProcessor_no_lambdas=The method invocation ''{0}'' cannot be updated due to use of lambda expression.
 MoveInstanceMethodProcessor_no_null_argument=The method invocation ''{0}'' cannot be updated, since it uses null as argument.
 MoveInstanceMethodProcessor_target_name_already_used=The name of the target conflicts with the method parameter ''{0}''.
+MoveInstanceMethodProcessor_reverse_call=Moving ''{0}'' will cause call order reversal of ''{1}'' and ''{2}'' which may change program logic. 
 MoveInstanceMethodProcessor_target_null_comparison=The move will cause ''{0}'' being replaced by ''this'' and compared to null which is invalid logic and may imply an NPE can occur.
 MoveInstanceMethodProcessor_target_element_pattern=Target element: ''{0}''
 MoveInstanceMethodProcessor_present_type_parameter_warning=The type parameter ''{0}'' is already present in the target type ''{1}'' and will be removed from the method.

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -2503,13 +2503,42 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 							status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_no_null_argument, BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED)), JavaStatusContext.create(rewriter.getCu(), invocation)));
 							result= false;
 						} else if (argument instanceof LambdaExpression) {
-							status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_no_lambdas, BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED))));
+							status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_no_lambdas, BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED)), JavaStatusContext.create(rewriter.getCu(), invocation)));
 							result= false;
 						} else {
 							if (argument instanceof ThisExpression)
 								rewrite.remove(invocation.getExpression(), null);
-							else
+							else if (argument instanceof MethodInvocation ||
+									argument instanceof SuperMethodInvocation ||
+									argument instanceof ClassInstanceCreation) {
+								Expression expression= invocation.getExpression();
+								if (needsTargetNode() &&
+										(expression instanceof MethodInvocation
+												|| expression instanceof SuperMethodInvocation
+												|| expression instanceof ClassInstanceCreation)) {
+									String name1= switch (expression) {
+										case MethodInvocation methodInvocation -> methodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
+										case SuperMethodInvocation superMethodInvocation -> superMethodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
+										case ClassInstanceCreation classCreation -> classCreation.getType().resolveBinding() == null
+												? "" //$NON-NLS-1$
+												: "new " + classCreation.getType().resolveBinding().getName() + "()"; //$NON-NLS-1$ //$NON-NLS-2$
+										default -> ""; //$NON-NLS-1$
+									};
+									String name2= switch (argument) {
+										case MethodInvocation methodInvocation -> methodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
+										case SuperMethodInvocation superMethodInvocation -> superMethodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
+										case ClassInstanceCreation classCreation -> classCreation.getType().resolveBinding() == null
+												? "" //$NON-NLS-1$
+												: "new " + classCreation.getType().resolveBinding().getName() + "()"; //$NON-NLS-1$ //$NON-NLS-2$
+										default -> ""; //$NON-NLS-1$
+									};
+									status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_reverse_call,  new Object[] {BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED),
+											name1, name2}),
+											JavaStatusContext.create(rewriter.getCu(), invocation)));
+								}
+							} else {
 								rewrite.set(invocation, MethodInvocation.EXPRESSION_PROPERTY, rewrite.createCopyTarget(argument), group);
+							}
 							if (needsTargetNode()) {
 								if (invocation.getExpression() != null)
 									list.replace(argument, rewrite.createCopyTarget(invocation.getExpression()), group);

--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -2509,30 +2509,22 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 							if (argument instanceof ThisExpression)
 								rewrite.remove(invocation.getExpression(), null);
 							else if (argument instanceof MethodInvocation ||
-									argument instanceof SuperMethodInvocation ||
-									argument instanceof ClassInstanceCreation) {
+									argument instanceof SuperMethodInvocation) {
 								Expression expression= invocation.getExpression();
 								if (needsTargetNode() &&
 										(expression instanceof MethodInvocation
-												|| expression instanceof SuperMethodInvocation
-												|| expression instanceof ClassInstanceCreation)) {
+												|| expression instanceof SuperMethodInvocation)) {
 									String name1= switch (expression) {
 										case MethodInvocation methodInvocation -> methodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
 										case SuperMethodInvocation superMethodInvocation -> superMethodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
-										case ClassInstanceCreation classCreation -> classCreation.getType().resolveBinding() == null
-												? "" //$NON-NLS-1$
-												: "new " + classCreation.getType().resolveBinding().getName() + "()"; //$NON-NLS-1$ //$NON-NLS-2$
 										default -> ""; //$NON-NLS-1$
 									};
 									String name2= switch (argument) {
 										case MethodInvocation methodInvocation -> methodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
 										case SuperMethodInvocation superMethodInvocation -> superMethodInvocation.getName().getFullyQualifiedName() + "()"; //$NON-NLS-1$
-										case ClassInstanceCreation classCreation -> classCreation.getType().resolveBinding() == null
-												? "" //$NON-NLS-1$
-												: "new " + classCreation.getType().resolveBinding().getName() + "()"; //$NON-NLS-1$ //$NON-NLS-2$
 										default -> ""; //$NON-NLS-1$
 									};
-									status.merge(RefactoringStatus.createErrorStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_reverse_call,  new Object[] {BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED),
+									status.merge(RefactoringStatus.createWarningStatus(Messages.format(RefactoringCoreMessages.MoveInstanceMethodProcessor_reverse_call,  new Object[] {BindingLabelProviderCore.getBindingLabel(declaration.resolveBinding(), JavaElementLabelsCore.ALL_FULLY_QUALIFIED),
 											name1, name2}),
 											JavaStatusContext.create(rewriter.getCu(), invocation)));
 								}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/in/C.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/in/C.java
@@ -5,7 +5,9 @@ import p2.B;
 
 class C {
     C() {
-		getA().mA1(getB());
+    	A a = getA();
+    	B b = getB();
+		a.mA1(b);
 	}
 
 	A getA() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/out/C.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/out/C.java
@@ -5,7 +5,9 @@ import p2.B;
 
 class C {
     C() {
-		getB().mA1(getA());
+    	A a = getA();
+    	B b = getB();
+		b.mA1(a);
 	}
 
 	A getA() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail23/in/A.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/cannotMove/testFail23/in/A.java
@@ -1,0 +1,26 @@
+package p1;
+
+class C {
+    static String trace = "";
+    public static void main(String[] args) {
+        createSource().m(createTarget()); // Move Instance Method: m()
+        System.out.println(trace);
+    }
+    static A createSource() {
+        trace += "S";
+        return new Impl();
+    }
+    static B createTarget() {
+        trace += "T";
+        return new B();
+    }
+}
+interface A {
+    default void m(B b) {
+        this.toString();
+    }
+}
+class Impl implements A {
+}
+class B {
+}

--- a/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/test cases/org/eclipse/jdt/ui/tests/refactoring/MoveInstanceMethodTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -910,4 +910,11 @@ public class MoveInstanceMethodTests extends GenericRefactoringTest {
 	public void testFail22() throws Exception {
 		failHelper1(new String[] { "p1.A" }, "p1.A", 14, 9, 14, 10, FIELD, "b", true, true);
 	}
+
+	// Issue 3123
+	@Test
+	public void testFail23() throws Exception {
+		failHelper1(new String[] { "p1.A" }, "p1.A", 19, 18, 19, 19, PARAMETER, "b", true, true);
+	}
+
 }


### PR DESCRIPTION
- modify MoveInstanceMethodProcessor.createInlinedMethodInvocation() to check when there is a case where replacing a method invocation after a move will cause the expression and arguments to switch and if both are calls themselves, this could change program behavior
- add new test to MoveInstanceMethodTests
- fixes #3123

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
