### PR TITLE
Use the new bundle name of the JSch library

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/PluginsNotLoadedTest.java
@@ -61,7 +61,7 @@ public class PluginsNotLoadedTest {
 			"org.eclipse.reftracker",
 			"org.eclipse.swt.sleak",
 			"org.eclipse.swt.spy",
-			"com.jcraft.jsch",
+			"com.github.mwiede.jsch",
 			"javax.servlet",
 			"javax.servlet.jsp-api",
 			"org.apache.ant",

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/activation/JavaActivationTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/activation/JavaActivationTest.java
@@ -48,7 +48,7 @@ public class JavaActivationTest {
 			"org.eclipse.reftracker",
 			"org.eclipse.swt.sleak",
 			"org.eclipse.swt.spy",
-			"com.jcraft.jsch",
+			"com.github.mwiede.jsch",
 			"javax.servlet",
 			"javax.servlet.jsp-api",
 			"org.apache.ant",


### PR DESCRIPTION
The Platform switched from com.jcraft.jsch to com.github.mwiede.jsch. An unknown name is silently skipped, so the assertion was lost.

https://github.com/eclipse-platform/eclipse.platform/issues/958

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])

