### PR TITLE
[JUnit] Extend JUnitCore API to export any kind of ITestElement

### DIFF
--- a/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.junit.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.jdt.junit.core
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.junit.core;singleton:=true
-Bundle-Version: 3.15.100.qualifier
+Bundle-Version: 3.16.0.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.junit.JUnitCorePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/BasicElementLabels.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/BasicElementLabels.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.junit;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.eclipse.osgi.util.TextProcessor;
 
@@ -68,6 +69,16 @@ public class BasicElementLabels {
 	 */
 	public static String getPathLabel(File file) {
 		return markLTR(file.getAbsolutePath(), "/\\:.");  //$NON-NLS-1$
+	}
+
+	/**
+	 * Returns the label of the path of a file.
+	 *
+	 * @param file the file
+	 * @return the label of the file path to be used in the UI.
+	 */
+	public static String getPathLabel(Path file) {
+		return markLTR(file.toAbsolutePath().toString(), "/\\:.");  //$NON-NLS-1$
 	}
 
 	/**

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/IXMLTags.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/IXMLTags.java
@@ -65,6 +65,10 @@ public interface IXMLTags {
 	 */
 	String ATTR_IGNORED= "ignored"; //$NON-NLS-1$
 	/**
+	 * value: Boolean
+	 */
+	String ATTR_SKIPPED= "skipped"; //$NON-NLS-1$
+	/**
 	 * value: String
 	 */
 	String ATTR_PACKAGE= "package"; //$NON-NLS-1$

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/JUnitModel.java
@@ -17,7 +17,6 @@
 package org.eclipse.jdt.internal.junit.model;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
@@ -34,7 +33,6 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.sax.SAXSource;
@@ -45,6 +43,7 @@ import org.xml.sax.SAXException;
 
 import org.eclipse.jdt.junit.ITestRunListener;
 import org.eclipse.jdt.junit.TestRunListener;
+import org.eclipse.jdt.junit.model.ITestElement;
 
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
@@ -499,29 +498,12 @@ public final class JUnitModel {
 		}
 	}
 
-	/**
-	 * Exports the given test run session.
-	 *
-	 * @param testRunSession the test run session
-	 * @param file the destination
-	 * @throws CoreException if an error occurred
-	 */
-	public static void exportTestRunSession(TestRunSession testRunSession, File file) throws CoreException {
-		try (FileOutputStream out= new FileOutputStream(file)) {
-			exportTestRunSession(testRunSession, out);
-		} catch (IOException | TransformerConfigurationException e) {
-			throwExportError(file, e);
-		} catch (TransformerException e) {
-			throwExportError(file, e);
-		}
-	}
-
-	public static void exportTestRunSession(TestRunSession testRunSession, OutputStream out)
+	public static void exportTestElement(ITestElement testElement, OutputStream out)
 			throws TransformerFactoryConfigurationError, TransformerException {
 
 		Transformer transformer= XmlProcessorFactoryJdtJunit.createTransformerFactoryWithErrorOnDOCTYPE().newTransformer();
 		InputSource inputSource= new InputSource();
-		SAXSource source= new SAXSource(new TestRunSessionSerializer(testRunSession), inputSource);
+		SAXSource source= new SAXSource(new TestRunSessionSerializer(testElement), inputSource);
 		StreamResult result= new StreamResult(out);
 		transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8"); //$NON-NLS-1$
 		transformer.setOutputProperty(OutputKeys.INDENT, "yes"); //$NON-NLS-1$
@@ -538,13 +520,6 @@ public final class JUnitModel {
 			// no indentation today...
 		}
 		transformer.transform(source, result);
-	}
-
-	private static void throwExportError(File file, Exception e) throws CoreException {
-		throw new CoreException(new org.eclipse.core.runtime.Status(IStatus.ERROR,
-				JUnitCorePlugin.getPluginId(),
-				Messages.format(ModelMessages.JUnitModel_could_not_write, BasicElementLabels.getPathLabel(file)),
-				e));
 	}
 
 	private static void throwImportError(File file, Exception e) throws CoreException {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionHistory.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.junit.JUnitCore;
 import org.eclipse.jdt.junit.model.ITestElement.Result;
 
 import org.eclipse.core.runtime.CoreException;
@@ -261,7 +262,7 @@ public final class TestRunSessionHistory {
 		Files.createDirectories(directory.toPath());
 		File temporaryFile= Files.createTempFile(directory.toPath(), targetFile.getName() + '.', TEMP_SUFFIX).toFile();
 		try {
-			JUnitModel.exportTestRunSession(session, temporaryFile);
+			JUnitCore.exportTestRunSession(session, temporaryFile);
 			if (session.hasSwapInFailed())
 				throw new IOException("Could not load the complete JUnit test tree"); //$NON-NLS-1$
 			moveReplacing(temporaryFile, targetFile);

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionSerializer.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/internal/junit/model/TestRunSessionSerializer.java
@@ -21,8 +21,11 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -34,10 +37,12 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.AttributesImpl;
 
+import org.eclipse.jdt.junit.model.ITestCaseElement;
 import org.eclipse.jdt.junit.model.ITestElement;
 import org.eclipse.jdt.junit.model.ITestElement.FailureTrace;
 import org.eclipse.jdt.junit.model.ITestElement.ProgressState;
 import org.eclipse.jdt.junit.model.ITestElement.Result;
+import org.eclipse.jdt.junit.model.ITestElementContainer;
 
 import org.eclipse.core.runtime.Assert;
 
@@ -50,18 +55,18 @@ public class TestRunSessionSerializer implements XMLReader {
 	private static final Attributes NO_ATTS= new AttributesImpl();
 
 
-	private final TestRunSession fTestRunSession;
+	private final ITestElement fTestElement;
 	private ContentHandler fHandler;
 	private ErrorHandler fErrorHandler;
 
 	private final NumberFormat timeFormat= new DecimalFormat("0.0##", new DecimalFormatSymbols(Locale.US)); //$NON-NLS-1$ // not localized, parseable by Double.parseDouble(..)
 
 	/**
-	 * @param testRunSession the test run session to serialize
+	 * @param testElement the test element to serialize
 	 */
-	public TestRunSessionSerializer(TestRunSession testRunSession) {
-		Assert.isNotNull(testRunSession);
-		fTestRunSession= testRunSession;
+	public TestRunSessionSerializer(ITestElement testElement) {
+		Assert.isNotNull(testElement);
+		fTestElement= testElement;
 	}
 
 	@Override
@@ -70,11 +75,15 @@ public class TestRunSessionSerializer implements XMLReader {
 			throw new SAXException("ContentHandler missing"); //$NON-NLS-1$
 
 		fHandler.startDocument();
-		handleTestRun();
+		if (fTestElement instanceof TestRunSession runSession) {
+			handleTestRun(runSession);
+		} else {
+			handleTestElement(fTestElement, true);
+		}
 		fHandler.endDocument();
 	}
 
-	private void handleTestRun() throws SAXException {
+	private void handleTestRun(TestRunSession fTestRunSession) throws SAXException {
 		AttributesImpl atts= new AttributesImpl();
 		addCDATA(atts, IXMLTags.ATTR_NAME, fTestRunSession.getTestRunName());
 		IJavaProject project= fTestRunSession.getLaunchedProject();
@@ -85,6 +94,7 @@ public class TestRunSessionSerializer implements XMLReader {
 		addCDATA(atts, IXMLTags.ATTR_FAILURES, fTestRunSession.getFailureCount());
 		addCDATA(atts, IXMLTags.ATTR_ERRORS, fTestRunSession.getErrorCount());
 		addCDATA(atts, IXMLTags.ATTR_IGNORED, fTestRunSession.getIgnoredCount());
+		addCDATA(atts, IXMLTags.ATTR_SKIPPED, fTestRunSession.getIgnoredCount());
 		String includeTags= fTestRunSession.getIncludeTags();
 		if (includeTags != null && !includeTags.trim().isEmpty()) {
 			addCDATA(atts, IXMLTags.ATTR_INCLUDE_TAGS, includeTags);
@@ -98,13 +108,13 @@ public class TestRunSessionSerializer implements XMLReader {
 		TestRoot testRoot= fTestRunSession.getTestRoot();
 		ITestElement[] topSuites= testRoot.getChildren();
 		for (ITestElement topSuite : topSuites) {
-			handleTestElement(topSuite);
+			handleTestElement(topSuite, false);
 		}
 
 		endElement(IXMLTags.NODE_TESTRUN);
 	}
 
-	private void handleTestElement(ITestElement testElement) throws SAXException {
+	private void handleTestElement(ITestElement testElement, boolean isRootOfDocument) throws SAXException {
 		if (testElement instanceof TestSuiteElement) {
 			TestSuiteElement testSuiteElement= (TestSuiteElement) testElement;
 
@@ -118,6 +128,20 @@ public class TestRunSessionSerializer implements XMLReader {
 			if (testSuiteElement.getDisplayName() != null) {
 				addCDATA(atts, IXMLTags.ATTR_DISPLAY_NAME, testSuiteElement.getDisplayName());
 			}
+
+			if (isRootOfDocument) {
+				Map<Result, Long> accumluatedResults= allTestCaseChildren(testSuiteElement).map(c -> c.getTestResult(false)) //
+						.collect(Collectors.groupingBy(r -> r, HashMap::new, Collectors.counting()));
+
+				Long testCount= accumluatedResults.values().stream().reduce(0L, Long::sum);
+				addCDATA(atts, IXMLTags.ATTR_TESTS, testCount.toString());
+				addCDATA(atts, IXMLTags.ATTR_FAILURES, accumluatedResults.getOrDefault(Result.FAILURE, 0L).toString());
+				addCDATA(atts, IXMLTags.ATTR_ERRORS, accumluatedResults.getOrDefault(Result.ERROR, 0L).toString());
+				String ignored= accumluatedResults.getOrDefault(Result.IGNORED, 0L).toString();
+				addCDATA(atts, IXMLTags.ATTR_IGNORED, ignored);
+				addCDATA(atts, IXMLTags.ATTR_SKIPPED, ignored);
+			}
+
 			String[] paramTypes= testSuiteElement.getParameterTypes();
 			if (paramTypes != null) {
 				String paramTypesStr= Arrays.stream(paramTypes).collect(Collectors.joining(",")); //$NON-NLS-1$
@@ -131,7 +155,7 @@ public class TestRunSessionSerializer implements XMLReader {
 
 			ITestElement[] children= testSuiteElement.getChildren();
 			for (ITestElement child : children) {
-				handleTestElement(child);
+				handleTestElement(child, false);
 			}
 			endElement(IXMLTags.NODE_TESTSUITE);
 
@@ -170,6 +194,17 @@ public class TestRunSessionSerializer implements XMLReader {
 			throw new IllegalStateException(String.valueOf(testElement));
 		}
 
+	}
+
+	private static Stream<ITestCaseElement> allTestCaseChildren(ITestElementContainer testContainer) {
+		return Arrays.stream(testContainer.getChildren()).flatMap(element -> {
+			if (element instanceof ITestCaseElement testCase) {
+				return Stream.of(testCase);
+			} else if (element instanceof ITestElementContainer container) {
+				return allTestCaseChildren(container);
+			}
+			return Stream.empty();
+		});
 	}
 
 	private void addFailure(TestElement testElement) throws SAXException {

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/JUnitCore.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/JUnitCore.java
@@ -17,13 +17,16 @@ package org.eclipse.jdt.junit;
 
 
 import java.io.File;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 
 import javax.xml.transform.TransformerException;
 
+import org.eclipse.jdt.junit.model.ITestElement;
 import org.eclipse.jdt.junit.model.ITestRunSession;
 
 import org.eclipse.core.runtime.CoreException;
@@ -38,12 +41,13 @@ import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 
+import org.eclipse.jdt.internal.junit.BasicElementLabels;
 import org.eclipse.jdt.internal.junit.JUnitCorePlugin;
+import org.eclipse.jdt.internal.junit.Messages;
 import org.eclipse.jdt.internal.junit.launcher.ITestFinder;
 import org.eclipse.jdt.internal.junit.launcher.TestKindRegistry;
 import org.eclipse.jdt.internal.junit.model.JUnitModel;
 import org.eclipse.jdt.internal.junit.model.ModelMessages;
-import org.eclipse.jdt.internal.junit.model.TestRunSession;
 
 /**
  * Class for accessing JUnit support; all functionality is provided by
@@ -183,7 +187,7 @@ public class JUnitCore {
 	 * @since 3.7
 	 */
 	public static void exportTestRunSession(ITestRunSession testRunSession, File file) throws CoreException {
-		JUnitModel.exportTestRunSession((TestRunSession)testRunSession, file);
+		exportTestElement(testRunSession, file.toPath());
 	}
 
 	/**
@@ -196,13 +200,42 @@ public class JUnitCore {
 	 * @since 3.7
 	 */
 	public static void exportTestRunSession(ITestRunSession testRunSession, OutputStream output) throws CoreException {
-		try {
-			JUnitModel.exportTestRunSession((TestRunSession)testRunSession, output);
+		exportTestElement(testRunSession, output);
+	}
 
+	/**
+	 * Exports the given test run session into an XML report file.
+	 *
+	 * @param testElement the test run element
+	 * @param file the destination
+	 * @throws CoreException if an error occurred
+	 *
+	 * @since 3.16
+	 */
+	public static void exportTestElement(ITestElement testElement, java.nio.file.Path file) throws CoreException {
+		try (OutputStream out= Files.newOutputStream(file)) {
+			JUnitModel.exportTestElement(testElement, out);
+		} catch (IOException | TransformerException e) {
+			throw new CoreException(Status.error(
+					Messages.format(ModelMessages.JUnitModel_could_not_write, BasicElementLabels.getPathLabel(file)),
+					e));
+		}
+	}
+
+	/**
+	 * Exports the given test run session to an output stream.
+	 *
+	 * @param testElement the test run element
+	 * @param output the output stream
+	 * @throws CoreException if an error occurred
+	 *
+	 * @since 3.16
+	 */
+	public static void exportTestElement(ITestElement testElement, OutputStream output) throws CoreException {
+		try {
+			JUnitModel.exportTestElement(testElement, output);
 		} catch (TransformerException exception) {
-			String pluginID= JUnitCorePlugin.getPluginId();
-			String message= ModelMessages.JUnitModel_could_not_export;
-			throw new CoreException(new Status(IStatus.ERROR, pluginID, message, exception));
+			throw new CoreException(Status.error(ModelMessages.JUnitModel_could_not_export, exception));
 		}
 	}
 

--- a/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
+++ b/org.eclipse.jdt.junit.core/src/org/eclipse/jdt/junit/launcher/JUnitLaunchConfigurationDelegate.java
@@ -135,7 +135,7 @@ public class JUnitLaunchConfigurationDelegate extends AbstractJavaLaunchConfigur
 	 * @param monitor the progress monitor
 	 * @return the VM runner configuration, or {@code null} if the operation was canceled
 	 * @throws CoreException if the launch configuration cannot be resolved
-	 * @since 3.15
+	 * @since 3.16
 	 */
 	protected final VMRunnerConfiguration getVMRunnerConfiguration(ILaunchConfiguration configuration, ILaunch launch, String mode, IProgressMonitor monitor) throws CoreException {
 		SubMonitor subMon= SubMonitor.convert(monitor, JUnitMessages.JUnitLaunchConfigurationDelegate_verifying_attriburtes_description, 4);

--- a/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
+++ b/org.eclipse.jdt.junit/src/org/eclipse/jdt/internal/junit/ui/TestRunnerViewPart.java
@@ -42,6 +42,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import org.eclipse.jdt.junit.JUnitCore;
 import org.eclipse.jdt.junit.model.ITestElement.Result;
 
 import org.eclipse.swt.SWT;
@@ -670,9 +671,8 @@ public class TestRunnerViewPart extends ViewPart {
 
 			//TODO: MULTI: getFileNames()
 			File file= new File(path);
-
 			try {
-				JUnitModel.exportTestRunSession(fTestRunSession, file);
+				JUnitCore.exportTestRunSession(fTestRunSession, file);
 			} catch (CoreException e) {
 				JUnitPlugin.log(e);
 				ErrorDialog.openError(fShell, JUnitMessages.TestRunnerViewPart_ExportTestRunSessionAction_error_title, e.getStatus().getMessage(), e.getStatus());

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/AbstractTestRunSessionSerializationTests.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/junit/tests/AbstractTestRunSessionSerializationTests.java
@@ -97,7 +97,7 @@ public class AbstractTestRunSessionSerializationTests {
 		}
 
 		ByteArrayOutputStream out= new ByteArrayOutputStream();
-		JUnitModel.exportTestRunSession(result.fTestRunSession, out);
+		JUnitCore.exportTestElement(result.fTestRunSession, out);
 
 		result.fSerialized= out.toString("UTF-8");
 		return result;


### PR DESCRIPTION
## What it does
Extend JUnitCore API to export any kind of ITestElement.

This allows to export for example a test-suite as root element of a result JUnit XML file. That aligns better with the de-facto standard for JUnit result files, e.g. established by the Maven Surefire plugin: https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd

That schema is widely supported by external tools, while a top level 'testrun' can cause problems.

Additionally this adds the number of ignored tests additionally under the attribute name `skipped`, which is also used in the mentioned schema.

## How to test

An adjusted test case is pending, but I can look into it if there is consensus about the proposed new API.

## Author checklist
- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
