### PR TITLE
Fix regression in move refactoring

### DIFF
--- a/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
+++ b/org.eclipse.jdt.core.manipulation/core extension/org/eclipse/jdt/internal/corext/refactoring/structure/MoveInstanceMethodProcessor.java
@@ -2528,6 +2528,7 @@ public final class MoveInstanceMethodProcessor extends MoveProcessor implements 
 											name1, name2}),
 											JavaStatusContext.create(rewriter.getCu(), invocation)));
 								}
+								rewrite.set(invocation, MethodInvocation.EXPRESSION_PROPERTY, rewrite.createCopyTarget(argument), group);
 							} else {
 								rewrite.set(invocation, MethodInvocation.EXPRESSION_PROPERTY, rewrite.createCopyTarget(argument), group);
 							}

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/in/C.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/in/C.java
@@ -6,8 +6,7 @@ import p2.B;
 class C {
     C() {
     	A a = getA();
-    	B b = getB();
-		a.mA1(b);
+		a.mA1(getB());
 	}
 
 	A getA() {

--- a/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/out/C.java
+++ b/org.eclipse.jdt.ui.tests.refactoring/resources/MoveInstanceMethod/canMove/test1/out/C.java
@@ -6,8 +6,7 @@ import p2.B;
 class C {
     C() {
     	A a = getA();
-    	B b = getB();
-		b.mA1(a);
+		getB().mA1(a);
 	}
 
 	A getA() {


### PR DESCRIPTION
- modify MoveInstanceMethodProcessor.createInlinedMethodInvocation() to add missing expression copy caused by latest logic changes
- modify MoverInstanceMethodTests.test1 to verify fix
- fixes #3173

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or modified test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
