### PR TITLE
Modernize working copy handling in Java browsing

### DIFF
--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/JavaBrowsingContentProvider.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/browsing/JavaBrowsingContentProvider.java
@@ -46,7 +46,6 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IParent;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.IWorkingCopy;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 
@@ -235,7 +234,7 @@ class JavaBrowsingContentProvider extends StandardJavaElementContentProvider imp
 		final IJavaElement element= delta.getElement();
 		final boolean isElementValidForView= fBrowsingPart.isValidElement(element);
 
-		if (!getProvideWorkingCopy() && element instanceof IWorkingCopy && ((IWorkingCopy)element).isWorkingCopy())
+		if (!providesWorkingCopies() && element instanceof ICompilationUnit && ((ICompilationUnit)element).isWorkingCopy())
 			return;
 
 		if (element != null && element.getElementType() == IJavaElement.COMPILATION_UNIT && !isOnClassPath((ICompilationUnit)element))
@@ -255,14 +254,14 @@ class JavaBrowsingContentProvider extends StandardJavaElementContentProvider imp
 				} else if (element instanceof ICompilationUnit && !((ICompilationUnit)element).isWorkingCopy()) {
 						postRefresh(null);
 				} else if (element instanceof ICompilationUnit && ((ICompilationUnit)element).isWorkingCopy()) {
-					if (getProvideWorkingCopy())
+					if (providesWorkingCopies())
 						postRefresh(null);
-				} else if (parent instanceof ICompilationUnit && getProvideWorkingCopy() && !((ICompilationUnit)parent).isWorkingCopy()) {
-					if (element instanceof IWorkingCopy && ((IWorkingCopy)element).isWorkingCopy()) {
+				} else if (parent instanceof ICompilationUnit && providesWorkingCopies() && !((ICompilationUnit)parent).isWorkingCopy()) {
+					if (element instanceof ICompilationUnit && ((ICompilationUnit)element).isWorkingCopy()) {
 						// working copy removed from system - refresh
 						postRefresh(null);
 					}
-				} else if (element instanceof IWorkingCopy && ((IWorkingCopy)element).isWorkingCopy() && parent != null && parent.equals(fInput))
+				} else if (element instanceof ICompilationUnit && ((ICompilationUnit)element).isWorkingCopy() && parent != null && parent.equals(fInput))
 					// closed editor - removing working copy
 					postRefresh(null);
 				else
@@ -270,7 +269,7 @@ class JavaBrowsingContentProvider extends StandardJavaElementContentProvider imp
 			}
 
 			if (fBrowsingPart.isAncestorOf(element, fInput)) {
-				if (element instanceof IWorkingCopy && ((IWorkingCopy)element).isWorkingCopy()) {
+				if (element instanceof ICompilationUnit && ((ICompilationUnit)element).isWorkingCopy()) {
 					postAdjustInputAndSetSelection(((IJavaElement) fInput).getPrimaryElement());
 				} else
 					postAdjustInputAndSetSelection(null);
@@ -297,9 +296,9 @@ class JavaBrowsingContentProvider extends StandardJavaElementContentProvider imp
 					postAdd(parent, ((IOrdinaryClassFile)element).getType());
 				} else if (element instanceof ICompilationUnit && !((ICompilationUnit)element).isWorkingCopy()) {
 						postAdd(parent, ((ICompilationUnit)element).getTypes());
-				} else if (parent instanceof ICompilationUnit && getProvideWorkingCopy() && !((ICompilationUnit)parent).isWorkingCopy()) {
+				} else if (parent instanceof ICompilationUnit && providesWorkingCopies() && !((ICompilationUnit)parent).isWorkingCopy()) {
 					//	do nothing
-				} else if (element instanceof IWorkingCopy && ((IWorkingCopy)element).isWorkingCopy()) {
+				} else if (element instanceof ICompilationUnit && ((ICompilationUnit)element).isWorkingCopy()) {
 					// new working copy comes to live
 					postRefresh(null);
 				} else


### PR DESCRIPTION
## What it does

Removes deprecated working-copy API usage from `JavaBrowsingContentProvider` without changing behavior.

- uses `IWorkingCopyProvider#providesWorkingCopies()` instead of deprecated `StandardJavaElementContentProvider#getProvideWorkingCopy()`
- uses `ICompilationUnit` instead of the deprecated `IWorkingCopy` interface, as recommended by JDT Core
- keeps the same `isWorkingCopy()` checks and Java-model delta handling
- does not add suppressions or weaken compiler warning settings

This branch is based directly on the current upstream `master` and is intended for an upstream Eclipse JDT UI PR after CI validation.

## How to test

- Build the repository with the current ECJ warning settings.
- Verify that the `JavaBrowsingContentProvider` deprecation warnings for `IWorkingCopy` and `getProvideWorkingCopy()` disappear.
- Exercise the Java Browsing views while opening and closing compilation-unit editors and verify working-copy delta refresh behavior.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
Assisted-by: OpenAI ChatGPT
Assisted-by: GitHub Copilot