### PR TITLE
Use non-deprecated template context registry

### DIFF
--- a/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/templates/TemplateContributionTest.java
+++ b/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/templates/TemplateContributionTest.java
@@ -19,7 +19,8 @@ import java.util.Iterator;
 
 import org.junit.jupiter.api.Test;
 
-import org.eclipse.jface.text.templates.ContextTypeRegistry;
+import org.eclipse.text.templates.ContextTypeRegistry;
+
 import org.eclipse.jface.text.templates.Template;
 import org.eclipse.jface.text.templates.TemplateContextType;
 import org.eclipse.jface.text.templates.TemplateException;

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/TemplateSet.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/template/java/TemplateSet.java
@@ -46,7 +46,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
-import org.eclipse.jface.text.templates.ContextTypeRegistry;
+import org.eclipse.text.templates.ContextTypeRegistry;
+
 import org.eclipse.jface.text.templates.Template;
 import org.eclipse.jface.text.templates.TemplateContextType;
 import org.eclipse.jface.text.templates.TemplateException;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/JavaPlugin.java
@@ -53,6 +53,8 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 
+import org.eclipse.text.templates.ContextTypeRegistry;
+
 import org.eclipse.jface.action.GroupMarker;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
@@ -61,7 +63,6 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.jface.util.IPropertyChangeListener;
 
-import org.eclipse.jface.text.templates.ContextTypeRegistry;
 import org.eclipse.jface.text.templates.TemplateContextType;
 import org.eclipse.jface.text.templates.TemplateVariableResolver;
 import org.eclipse.jface.text.templates.persistence.TemplateStore;
@@ -173,12 +174,12 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 	 * The template context type registry for the java editor.
 	 * @since 3.0
 	 */
-	private volatile ContextTypeRegistry fContextTypeRegistry;
+	private volatile ContributionContextTypeRegistry fContextTypeRegistry;
 	/**
 	 * The code template context type registry for the java editor.
 	 * @since 3.0
 	 */
-	private volatile ContextTypeRegistry fCodeTemplateContextTypeRegistry;
+	private volatile ContributionContextTypeRegistry fCodeTemplateContextTypeRegistry;
 
 	/**
 	 * The template store for the java editor.
@@ -806,7 +807,8 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 		}
 		synchronized(this) {
 			if (fContextTypeRegistry == null) { // Second check (with locking)
-				ContributionContextTypeRegistry registry= new ContributionContextTypeRegistry(JavaUI.ID_CU_EDITOR);
+				ContributionContextTypeRegistry contributionRegistry= new ContributionContextTypeRegistry(JavaUI.ID_CU_EDITOR);
+				ContextTypeRegistry registry= contributionRegistry;
 
 				TemplateContextType all_contextType= registry.getContextType(JavaContextType.ID_ALL);
 				((AbstractJavaContextType) all_contextType).initializeContextTypeResolvers();
@@ -824,10 +826,20 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 
 				registerJavaContext(registry, JavaPostfixContextType.ID_ALL, all_contextType);
 				all_contextType= registry.getContextType(JavaPostfixContextType.ID_ALL);
-				fContextTypeRegistry= registry;
+				fContextTypeRegistry= contributionRegistry;
 			}
 			return fContextTypeRegistry;
 		}
+	}
+
+	/**
+	 * Returns the contribution registry required by the legacy UI template preference page.
+	 *
+	 * @return the contribution template context registry
+	 */
+	public ContributionContextTypeRegistry getContributionTemplateContextRegistry() {
+		getTemplateContextRegistry();
+		return fContextTypeRegistry;
 	}
 
 	/**
@@ -838,7 +850,7 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 	 * @param parent the parent context type
 	 * @since 3.4
 	 */
-	private static void registerJavaContext(ContributionContextTypeRegistry registry, String id, TemplateContextType parent) {
+	private static void registerJavaContext(ContextTypeRegistry registry, String id, TemplateContextType parent) {
 		TemplateContextType contextType= registry.getContextType(id);
 		Iterator<TemplateVariableResolver> iter= parent.resolvers();
 		while (iter.hasNext())
@@ -859,7 +871,8 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 				}
 
 				final IPreferenceStore store= getPreferenceStore();
-				ContributionTemplateStore templateStore = new ContributionTemplateStore(getTemplateContextRegistry(), store, TEMPLATES_KEY);
+				getTemplateContextRegistry();
+				ContributionTemplateStore templateStore = new ContributionTemplateStore(fContextTypeRegistry, store, TEMPLATES_KEY);
 				try {
 					templateStore.load();
 				} catch (IOException e) {
@@ -914,7 +927,8 @@ public class JavaPlugin extends AbstractUIPlugin implements DebugOptionsListener
 				}
 
 				IPreferenceStore store= getPreferenceStore();
-				ContributionTemplateStore templateStore = new ContributionTemplateStore(getCodeTemplateContextRegistry(), store, CODE_TEMPLATES_KEY);
+				getCodeTemplateContextRegistry();
+				ContributionTemplateStore templateStore = new ContributionTemplateStore(fCodeTemplateContextTypeRegistry, store, CODE_TEMPLATES_KEY);
 				try {
 					templateStore.load();
 				} catch (IOException e) {

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaTemplatesPage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/javaeditor/JavaTemplatesPage.java
@@ -20,6 +20,8 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import org.eclipse.jface.text.templates.ContextTypeRegistry;
+
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.window.Window;
@@ -35,7 +37,6 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.SourceViewer;
-import org.eclipse.jface.text.templates.ContextTypeRegistry;
 import org.eclipse.jface.text.templates.DocumentTemplateContext;
 import org.eclipse.jface.text.templates.Template;
 import org.eclipse.jface.text.templates.TemplateContextType;
@@ -77,7 +78,7 @@ public class JavaTemplatesPage extends AbstractTemplatesPage {
 	private static final String PREFERENCE_PAGE_ID= "org.eclipse.jdt.ui.preferences.JavaTemplatePreferencePage"; //$NON-NLS-1$
 	private static final TemplateStore TEMPLATE_STORE= JavaPlugin.getDefault().getTemplateStore();
 	private static final IPreferenceStore PREFERENCE_STORE= JavaPlugin.getDefault().getPreferenceStore();
-	private static final ContextTypeRegistry TEMPLATE_CONTEXT_REGISTRY= JavaPlugin.getDefault().getTemplateContextRegistry();
+	private static final ContextTypeRegistry TEMPLATE_CONTEXT_REGISTRY= JavaPlugin.getDefault().getContributionTemplateContextRegistry();
 
 	private TemplateVariableProcessor fTemplateProcessor;
 	private JavaEditor fJavaEditor;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/EditTemplateDialog.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/EditTemplateDialog.java
@@ -45,6 +45,8 @@ import org.eclipse.swt.widgets.Widget;
 
 import org.eclipse.core.expressions.Expression;
 
+import org.eclipse.text.templates.ContextTypeRegistry;
+
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.GroupMarker;
 import org.eclipse.jface.action.IAction;
@@ -67,7 +69,6 @@ import org.eclipse.jface.text.ITextOperationTarget;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.SourceViewer;
-import org.eclipse.jface.text.templates.ContextTypeRegistry;
 import org.eclipse.jface.text.templates.Template;
 import org.eclipse.jface.text.templates.TemplateContextType;
 import org.eclipse.jface.text.templates.TemplateException;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaTemplatePreferencePage.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/preferences/JavaTemplatePreferencePage.java
@@ -54,7 +54,7 @@ public class JavaTemplatePreferencePage extends TemplatePreferencePage {
 	public JavaTemplatePreferencePage() {
 		setPreferenceStore(JavaPlugin.getDefault().getPreferenceStore());
 		setTemplateStore(JavaPlugin.getDefault().getTemplateStore());
-		setContextTypeRegistry(JavaPlugin.getDefault().getTemplateContextRegistry());
+		setContextTypeRegistry(JavaPlugin.getDefault().getContributionTemplateContextRegistry());
 		fTemplateProcessor= new TemplateVariableProcessor();
 	}
 

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/SWTTemplateCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/SWTTemplateCompletionProposalComputer.java
@@ -15,7 +15,8 @@ package org.eclipse.jdt.internal.ui.text.java;
 
 import org.eclipse.core.runtime.Assert;
 
-import org.eclipse.jface.text.templates.ContextTypeRegistry;
+import org.eclipse.text.templates.ContextTypeRegistry;
+
 import org.eclipse.jface.text.templates.TemplateContextType;
 
 import org.eclipse.jdt.core.CompletionContext;

--- a/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/TemplateCompletionProposalComputer.java
+++ b/org.eclipse.jdt.ui/ui/org/eclipse/jdt/internal/ui/text/java/TemplateCompletionProposalComputer.java
@@ -15,9 +15,10 @@ package org.eclipse.jdt.internal.ui.text.java;
 
 import org.eclipse.core.runtime.Assert;
 
+import org.eclipse.text.templates.ContextTypeRegistry;
+
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.TextUtilities;
-import org.eclipse.jface.text.templates.ContextTypeRegistry;
 import org.eclipse.jface.text.templates.TemplateContextType;
 
 import org.eclipse.jdt.core.CompletionContext;


### PR DESCRIPTION
## What it does

Migrates JDT UI template-registry usage from the deprecated `org.eclipse.jface.text.templates.ContextTypeRegistry` to `org.eclipse.text.templates.ContextTypeRegistry` where Eclipse Platform already provides the replacement API.

The compatibility boundary is kept deliberately narrow: `ContributionContextTypeRegistry` is retained as the concrete implementation because current Platform `TemplatePreferencePage` and `ContributionTemplateStore` still require the legacy JFace registry type. JDT-facing accessors and consumers use the new registry type, so the deprecated API is no longer propagated through JDT's own template code.

No warning suppression or compiler-setting change is introduced.

## How to test

- Build the repository with the current ECJ warning settings.
- Run the JDT text/template tests, especially `TemplateContributionTest`.
- Verify Java template content assist, SWT templates, template editing/preferences, and code-template loading.
- Verify the deprecated JFace `ContextTypeRegistry` warnings disappear from the migrated JDT classes while contributed templates remain available.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
Assisted-by: OpenAI ChatGPT
Assisted-by: GitHub Copilot